### PR TITLE
Only publish from clean tags

### DIFF
--- a/conjure-lib/build.gradle
+++ b/conjure-lib/build.gradle
@@ -1,8 +1,8 @@
-apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
+apply plugin: 'maven-publish'
 apply plugin: 'nebula.maven-publish'
-apply plugin: 'nebula.source-jar'
 apply plugin: 'nebula.publish-verification'
+apply plugin: 'nebula.source-jar'
 
 dependencies {
     compile 'com.fasterxml.jackson.core:jackson-databind'
@@ -22,7 +22,7 @@ bintray {
     key = System.env.BINTRAY_PASSWORD
     publish = true
     pkg {
-        repo = System.env.CIRCLE_TAG ? 'releases' : 'snapshots'
+        repo = 'releases'
         name = project.name
         userOrg = 'palantir'
         licenses = ['Apache-2.0']
@@ -31,3 +31,6 @@ bintray {
 }
 
 publish.dependsOn bintrayUpload
+bintrayUpload.onlyIf {
+    versionDetails().isCleanTag
+}


### PR DESCRIPTION
Follow-up to https://github.com/palantir/conjure-java/pull/1

I think we should tag 0.1.0 to test this, as the internal repo has no 0.X releases.