### PR TITLE
Bintray pkg is 'conjure-java' not 'conjure-lib'

### DIFF
--- a/conjure-lib/build.gradle
+++ b/conjure-lib/build.gradle
@@ -23,7 +23,7 @@ bintray {
     publish = true
     pkg {
         repo = 'releases'
-        name = project.name
+        name = 'conjure-java'
         userOrg = 'palantir'
         licenses = ['Apache-2.0']
         publications = ['nebula']


### PR DESCRIPTION
@bluekeyes suggestion to fix the 403: https://circleci.com/gh/palantir/conjure-java/13

Apparently we should still be able to publish multiple things within this 'package'