### PR TITLE
Publish conjure-java tgz

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@ jobs:
   build:
     docker:
       - image: circleci/openjdk:8u171-jdk-node-browsers
+    environment:
+      GRADLE_OPTS: -Dorg.gradle.console=plain -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false
 
     steps:
       - checkout

--- a/conjure-java/build.gradle
+++ b/conjure-java/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 
 mainClassName = 'com.palantir.conjure.java.cli.ConjureJavaCli'
 
+distTar.compression = Compression.GZIP
+
 publishing {
     publications {
         dist(MavenPublication) {

--- a/conjure-java/build.gradle
+++ b/conjure-java/build.gradle
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-apply plugin: 'application'
-apply plugin: 'com.jfrog.bintray'
-apply plugin: 'maven-publish'
+apply from: "$rootDir/gradle/publish-dist.gradle"
+
+mainClassName = 'com.palantir.conjure.java.cli.ConjureJavaCli'
+distTar.compression = Compression.GZIP
 
 dependencies {
     compile project(':conjure-java-core')
@@ -27,34 +28,3 @@ dependencies {
 
     processor 'org.immutables:value'
 }
-
-mainClassName = 'com.palantir.conjure.java.cli.ConjureJavaCli'
-
-distTar.compression = Compression.GZIP
-
-publishing {
-    publications {
-        dist(MavenPublication) {
-            artifact distTar
-        }
-    }
-}
-
-bintray {
-    user = System.env.BINTRAY_USERNAME
-    key = System.env.BINTRAY_PASSWORD
-    publish = true
-    pkg {
-        repo = System.env.CIRCLE_TAG ? 'releases' : 'snapshots'
-        name = 'conjure-java'
-        userOrg = 'palantir'
-        licenses = ['Apache-2.0']
-        publications = ['dist']
-    }
-}
-
-publish.dependsOn bintrayUpload
-bintrayUpload.onlyIf {
-    versionDetails().isCleanTag
-}
-

--- a/conjure-java/build.gradle
+++ b/conjure-java/build.gradle
@@ -15,6 +15,8 @@
  */
 
 apply plugin: 'application'
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'maven-publish'
 
 dependencies {
     compile project(':conjure-java-core')
@@ -27,3 +29,30 @@ dependencies {
 }
 
 mainClassName = 'com.palantir.conjure.java.cli.ConjureJavaCli'
+
+publishing {
+    publications {
+        dist(MavenPublication) {
+            artifact distTar
+        }
+    }
+}
+
+bintray {
+    user = System.env.BINTRAY_USERNAME
+    key = System.env.BINTRAY_PASSWORD
+    publish = true
+    pkg {
+        repo = System.env.CIRCLE_TAG ? 'releases' : 'snapshots'
+        name = 'conjure-java'
+        userOrg = 'palantir'
+        licenses = ['Apache-2.0']
+        publications = ['dist']
+    }
+}
+
+publish.dependsOn bintrayUpload
+bintrayUpload.onlyIf {
+    versionDetails().isCleanTag
+}
+

--- a/conjure-java/build.gradle
+++ b/conjure-java/build.gradle
@@ -17,7 +17,6 @@
 apply from: "$rootDir/gradle/publish-dist.gradle"
 
 mainClassName = 'com.palantir.conjure.java.cli.ConjureJavaCli'
-distTar.compression = Compression.GZIP
 
 dependencies {
     compile project(':conjure-java-core')

--- a/conjure-lib/build.gradle
+++ b/conjure-lib/build.gradle
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-apply plugin: 'com.jfrog.bintray'
-apply plugin: 'maven-publish'
-apply plugin: 'nebula.maven-publish'
-apply plugin: 'nebula.publish-verification'
-apply plugin: 'nebula.source-jar'
+apply from: "$rootDir/gradle/publish-jar.gradle"
 
 dependencies {
     compile 'com.fasterxml.jackson.core:jackson-databind'
@@ -33,20 +29,3 @@ dependencies {
     processor 'org.immutables:value'
 }
 
-bintray {
-    user = System.env.BINTRAY_USERNAME
-    key = System.env.BINTRAY_PASSWORD
-    publish = true
-    pkg {
-        repo = 'releases'
-        name = 'conjure-java'
-        userOrg = 'palantir'
-        licenses = ['Apache-2.0']
-        publications = ['nebula']
-    }
-}
-
-publish.dependsOn bintrayUpload
-bintrayUpload.onlyIf {
-    versionDetails().isCleanTag
-}

--- a/conjure-lib/build.gradle
+++ b/conjure-lib/build.gradle
@@ -1,3 +1,19 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 apply plugin: 'nebula.maven-publish'

--- a/gradle/publish-dist.gradle
+++ b/gradle/publish-dist.gradle
@@ -1,0 +1,29 @@
+apply plugin: 'application'
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'maven-publish'
+
+bintray {
+    user = System.env.BINTRAY_USERNAME
+    key = System.env.BINTRAY_PASSWORD
+    publish = true
+    pkg {
+        repo = 'releases'
+        name = rootProject.name
+        userOrg = 'palantir'
+        licenses = ['Apache-2.0']
+        publications = ['dist']
+    }
+}
+
+publish.dependsOn bintrayUpload
+bintrayUpload.onlyIf {
+    versionDetails().isCleanTag
+}
+
+publishing {
+    publications {
+        dist(MavenPublication) {
+            artifact distTar
+        }
+    }
+}

--- a/gradle/publish-dist.gradle
+++ b/gradle/publish-dist.gradle
@@ -2,6 +2,8 @@ apply plugin: 'application'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
+distTar.compression = Compression.GZIP
+
 bintray {
     user = System.env.BINTRAY_USERNAME
     key = System.env.BINTRAY_PASSWORD

--- a/gradle/publish-jar.gradle
+++ b/gradle/publish-jar.gradle
@@ -1,0 +1,23 @@
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'maven-publish'
+apply plugin: 'nebula.maven-publish'
+apply plugin: 'nebula.publish-verification'
+apply plugin: 'nebula.source-jar'
+
+bintray {
+    user = System.env.BINTRAY_USERNAME
+    key = System.env.BINTRAY_PASSWORD
+    publish = true
+    pkg {
+        repo = 'releases'
+        name = rootProject.name
+        userOrg = 'palantir'
+        licenses = ['Apache-2.0']
+        publications = ['nebula']
+    }
+}
+
+publish.dependsOn bintrayUpload
+bintrayUpload.onlyIf {
+    versionDetails().isCleanTag
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,5 @@
+rootProject.name = 'conjure-java'
+
 include 'conjure-java'
 include 'conjure-java-core'
 include 'conjure-lib'


### PR DESCRIPTION
I ran `/gradlew publishDistPublicationToMavenLocal` and got a 7.8MB tgz:

```
/Users/dfox/.m2/repository/com/palantir/conjure/java/conjure-java/0.2.0-1-gec97bfb.dirty/conjure-java-0.2.0-1-gec97bfb.dirty.pom
/Users/dfox/.m2/repository/com/palantir/conjure/java/conjure-java/0.2.0-1-gec97bfb.dirty/conjure-java-0.2.0-1-gec97bfb.dirty.tgz
/Users/dfox/.m2/repository/com/palantir/conjure/java/conjure-java/maven-metadata-local.xml
```

Opening up that tgz contains roughly what we expect:
```
.
├── bin
│   ├── conjure-java
│   └── conjure-java.bat
└── lib
    ├── animal-sniffer-annotations-1.14.jar
    ├── auth-tokens-3.0.1.jar
    ├── commons-cli-1.2.jar
    ├── commons-lang3-3.7.jar
    ├── conjure-java-0.2.0-1-gec97bfb.dirty.jar
    ├── conjure-java-core-0.2.0-1-gec97bfb.dirty.jar
    ├── conjure-lib-0.2.0-1-gec97bfb.dirty.jar
    ├── error_prone_annotations-2.3.1.jar
    ├── errors-1.8.0.jar
    ├── google-java-format-1.5.jar
    ├── guava-22.0.jar
    ├── j2objc-annotations-1.1.jar
    ├── jackson-annotations-2.7.4.jar
    ├── jackson-core-2.7.4.jar
    ├── jackson-databind-2.7.4.jar
    ├── jackson-dataformat-yaml-2.7.4.jar
    ├── jackson-datatype-jdk8-2.7.4.jar
    ├── javac-shaded-9-dev-r4023-3.jar
    ├── javapoet-1.11.1.jar
    ├── javax.ws.rs-api-2.0.1.jar
    ├── jsr305-3.0.2.jar
    ├── resource-identifier-1.0.1.jar
    ├── safe-logging-1.4.0.jar
    ├── slf4j-api-1.7.25.jar
    ├── snakeyaml-1.15.jar
    └── syntactic-paths-0.6.1.jar
```