### PR TITLE
Opt-in to managed CircleCI config

### DIFF
--- a/.circleci/template.sh
+++ b/.circleci/template.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+export CIRCLECI_TEMPLATE=java-library-oss


### PR DESCRIPTION
Excavator can keep these up-to-date, even on OSS repo! (See example: https://github.com/palantir/go-ptimports/pull/17)