### PR TITLE
[Experiment] Try linting markdown on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,11 +50,13 @@ jobs:
           name: Format all markdown files with remark-cli (https://github.com/remarkjs/remark-lint)
           command: |
             find . -name '*.md' -exec remark -o {} {} \;
-      - run: |
-          if [ ! -z "$(git status --porcelain)" ]; then
-            printf "Run 'find . -name '*.md' -exec remark -o {} {} \;' to fix the following files:\n`git status --porcelain`"
-            exit 1
-          fi
+      - run:
+          name: Verify git tree is clean
+          command: |
+            if [ ! -z "$(git status --porcelain)" ]; then
+              printf "Run 'find . -name '*.md' -exec remark -o {} {} \;' to fix the following files:\n`git status --porcelain`"
+              exit 1
+            fi
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
             find . -name '*.md' -exec remark -o {} {} \;
       - run: |
           if [ ! -z "$(git status --porcelain)" ]; then
-            echo "Run 'find . -name '*.md' -exec remark -o {} {} \;' to fix the following files:\n`git status --porcelain`"
+            printf "Run 'find . -name '*.md' -exec remark -o {} {} \;' to fix the following files:\n`git status --porcelain`"
             exit 1
           fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,10 +50,11 @@ jobs:
           name: Format all markdown files with remark-cli (https://github.com/remarkjs/remark-lint)
           command: |
             find . -name '*.md' -exec remark -o {} {} \;
-      - run:
-          name: Ensure git tree is clean
-          command: |
-            [ -z "$(git status --porcelain)" ]
+      - run: |
+          if [ ! -z "$(git status --porcelain)" ]; then
+            echo "Run 'find . -name '*.md' -exec remark -o {} {} \;' to fix the following files:\n`git status --porcelain`"
+            exit 1
+          fi
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,22 @@ jobs:
               ./gradlew --stacktrace --continue publish
             fi
 
+  markdown:
+    docker:
+      - image: circleci/openjdk:8u171-jdk-node-browsers
+    steps:
+      - checkout
+      - run: npm install -g remark-cli@5.0.0
+      - run:
+          name: Format all markdown files with remark-cli (https://github.com/remarkjs/remark-lint)
+          command: |
+            find . -name '*.md' -exec remark -o {} {} \;
+      - run:
+          name: Ensure git tree is clean
+          command: |
+            [ -z "$(git status --porcelain)" ]
+
+
 workflows:
   version: 2
   build:
@@ -47,5 +63,10 @@ workflows:
       - build:
           filters:
             # CircleCI2 will ignore tags without this. https://circleci.com/docs/2.0/workflows/#git-tag-job-execution
+            tags:
+              only: /.*/
+
+      - markdown:
+          filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,10 @@ jobs:
 
   markdown:
     docker:
-      - image: circleci/openjdk:8u171-jdk-node-browsers
+      - image: circleci/node:10.3.0
     steps:
       - checkout
-      - run: npm install -g remark-cli@5.0.0
+      - run: sudo npm install -g remark-cli@5.0.0
       - run:
           name: Format all markdown files with remark-cli (https://github.com/remarkjs/remark-lint)
           command: |

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,3 @@
-Conjure-Java
-=======
+# Conjure-Java
+
 The java implementation of Conjure generator for java.


### PR DESCRIPTION
To save code reviewers the job of leaving "nit" comments about indenting etc, I thought it might be worth setting up some kind of autoformatter / linter.

This one seems very extensible (almost too extensible)... you run it locally on one file by running `remark -o readme.md readme.md`.

https://github.com/remarkjs/remark-lint

If we find one that's convenient enough (especially if it has some VSCode integration), I vote we roll it out across more repos!