### PR TITLE
Tag (Alias).valueOf(String) with JsonCreator

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenAliasExample.java
@@ -37,6 +37,7 @@ public final class BearerTokenAliasExample {
         return value.hashCode();
     }
 
+    @JsonCreator
     public static BearerTokenAliasExample valueOf(String value) {
         return new BearerTokenAliasExample(BearerToken.valueOf(value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanAliasExample.java
@@ -34,6 +34,7 @@ public final class BooleanAliasExample {
         return Boolean.hashCode(value);
     }
 
+    @JsonCreator
     public static BooleanAliasExample valueOf(String value) {
         return new BooleanAliasExample(Boolean.parseBoolean(value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeAliasExample.java
@@ -37,6 +37,7 @@ public final class DateTimeAliasExample {
         return value.hashCode();
     }
 
+    @JsonCreator
     public static DateTimeAliasExample valueOf(String value) {
         return new DateTimeAliasExample(ZonedDateTime.parse(value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
@@ -34,6 +34,7 @@ public final class DoubleAliasExample {
         return Double.hashCode(value);
     }
 
+    @JsonCreator
     public static DoubleAliasExample valueOf(String value) {
         return new DoubleAliasExample(Double.parseDouble(value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerAliasExample.java
@@ -34,6 +34,7 @@ public final class IntegerAliasExample {
         return Integer.hashCode(value);
     }
 
+    @JsonCreator
     public static IntegerAliasExample valueOf(String value) {
         return new IntegerAliasExample(Integer.parseInt(value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RidAliasExample.java
@@ -37,6 +37,7 @@ public final class RidAliasExample {
         return value.hashCode();
     }
 
+    @JsonCreator
     public static RidAliasExample valueOf(String value) {
         return new RidAliasExample(ResourceIdentifier.valueOf(value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongAliasExample.java
@@ -37,6 +37,7 @@ public final class SafeLongAliasExample {
         return value.hashCode();
     }
 
+    @JsonCreator
     public static SafeLongAliasExample valueOf(String value) {
         return new SafeLongAliasExample(SafeLong.valueOf(value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasExample.java
@@ -36,6 +36,7 @@ public final class StringAliasExample {
         return value.hashCode();
     }
 
+    @JsonCreator
     public static StringAliasExample valueOf(String value) {
         return new StringAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidAliasExample.java
@@ -37,6 +37,7 @@ public final class UuidAliasExample {
         return value.hashCode();
     }
 
+    @JsonCreator
     public static UuidAliasExample valueOf(String value) {
         return new UuidAliasExample(UUID.fromString(value));
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -82,6 +82,7 @@ public final class AliasGenerator {
         if (maybeValueOfFactoryMethod.isPresent()) {
             spec.addMethod(MethodSpec.methodBuilder("valueOf")
                     .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                    .addAnnotation(JsonCreator.class)
                     .addParameter(String.class, "value")
                     .returns(thisClass)
                     .addCode(maybeValueOfFactoryMethod.get())

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -162,6 +162,12 @@ public final class WireFormatTests {
     }
 
     @Test
+    public void testPrimitiveAliasTypesCanBeDeserializedFromString() throws Exception {
+        assertThat(mapper.readValue("\"123\"", IntegerAliasExample.class)).isEqualTo(IntegerAliasExample.of(123));
+        assertThat(mapper.readValue("\"123.0\"", DoubleAliasExample.class)).isEqualTo(DoubleAliasExample.of(123.0));
+    }
+
+    @Test
     public void testAliasTypesHashCodeEqualWhenInnerTypeEqual() throws Exception {
         assertThat(StringAliasExample.of("a").hashCode()).isEqualTo(StringAliasExample.of("a").hashCode());
         assertThat(IntegerAliasExample.of(103).hashCode()).isEqualTo(IntegerAliasExample.of(103).hashCode());

--- a/versions.props
+++ b/versions.props
@@ -1,5 +1,4 @@
-com.fasterxml.jackson.*:jackson-* = 2.7.4
-com.fasterxml.jackson.datatype:jackson-datatype-jdk7 = 2.6.7
+com.fasterxml.jackson.*:jackson-* = 2.9.6
 com.google.code.findbugs:jsr305 = 3.0.2
 com.google.errorprone:error_prone_annotations = 2.3.1
 com.google.googlejavaformat:google-java-format = 1.5


### PR DESCRIPTION
Otherwise the method won't be used by newer jackson-databind e.g. 2.9.6

Fixes #13 

FLUPs:
- [ ] ability to run all tests against multiple versions of jackson https://github.com/palantir/conjure-java/issues/20