### PR TITLE
fix optional param filtering

### DIFF
--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
@@ -192,6 +192,7 @@ public final class JerseyServiceGenerator implements ServiceGenerator {
             TypeMapper returnTypeMapper,
             TypeMapper methodTypeMapper,
             List<ArgumentDefinition> extraArgs) {
+        // ensure the correct ordering of parameters by creating the complete sorted parameter list
         List<ParameterSpec> sortedParams = createServiceMethodParameters(endpointDef, methodTypeMapper, false);
         List<Optional<ArgumentDefinition>> sortedMaybeExtraArgs = sortedParams.stream().map(param ->
                 extraArgs.stream()
@@ -199,6 +200,7 @@ public final class JerseyServiceGenerator implements ServiceGenerator {
                         .findFirst())
                 .collect(Collectors.toList());
 
+        // omit extraArgs from the back fill method signature
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(endpointDef.getEndpointName().get())
                 .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
                 .addAnnotation(Deprecated.class)
@@ -209,6 +211,7 @@ public final class JerseyServiceGenerator implements ServiceGenerator {
 
         endpointDef.getReturns().ifPresent(type -> methodBuilder.returns(returnTypeMapper.getClassName(type)));
 
+        // replace extraArgs with default values when invoking the complete method
         StringBuilder sb = new StringBuilder("return $N(");
         List<Object> values = IntStream.range(0, sortedParams.size()).mapToObj(i -> {
             Optional<ArgumentDefinition> maybeArgDef = sortedMaybeExtraArgs.get(i);

--- a/conjure-java-core/src/test/resources/example-service.yml
+++ b/conjure-java-core/src/test/resources/example-service.yml
@@ -149,8 +149,9 @@ services:
         returns: optional<string>
 
       testQueryParams:
-        http: GET /test-query-params
+        http: POST /test-query-params
         args:
+          query: string
           something:
             type: ResourceIdentifier
             param-id: different

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
@@ -100,7 +100,7 @@ public interface TestService {
             @HeaderParam("Authorization") AuthHeader authHeader,
             @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
-    @GET
+    @POST
     @Path("catalog/test-query-params")
     int testQueryParams(
             @HeaderParam("Authorization") AuthHeader authHeader,
@@ -108,7 +108,8 @@ public interface TestService {
             @QueryParam("implicit") ResourceIdentifier implicit,
             @QueryParam("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @QueryParam("setEnd") Set<String> setEnd,
-            @QueryParam("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
+            @QueryParam("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
+            String query);
 
     @GET
     @Path("catalog/boolean")
@@ -124,29 +125,21 @@ public interface TestService {
 
     @Deprecated
     default int testQueryParams(
-            AuthHeader authHeader, ResourceIdentifier something, ResourceIdentifier implicit) {
+            AuthHeader authHeader,
+            ResourceIdentifier something,
+            ResourceIdentifier implicit,
+            Optional<ResourceIdentifier> optionalMiddle,
+            Set<String> setEnd,
+            Optional<ResourceIdentifier> optionalEnd,
+            String query) {
         return testQueryParams(
                 authHeader,
                 something,
                 implicit,
                 Optional.empty(),
                 Collections.emptySet(),
-                Optional.empty());
-    }
-
-    @Deprecated
-    default int testQueryParams(
-            AuthHeader authHeader,
-            ResourceIdentifier something,
-            ResourceIdentifier implicit,
-            Optional<ResourceIdentifier> optionalMiddle) {
-        return testQueryParams(
-                authHeader,
-                something,
-                implicit,
-                optionalMiddle,
-                Collections.emptySet(),
-                Optional.empty());
+                Optional.empty(),
+                query);
     }
 
     @Deprecated
@@ -155,8 +148,29 @@ public interface TestService {
             ResourceIdentifier something,
             ResourceIdentifier implicit,
             Optional<ResourceIdentifier> optionalMiddle,
-            Set<String> setEnd) {
+            Set<String> setEnd,
+            Optional<ResourceIdentifier> optionalEnd,
+            String query) {
         return testQueryParams(
-                authHeader, something, implicit, optionalMiddle, setEnd, Optional.empty());
+                authHeader,
+                something,
+                implicit,
+                optionalMiddle,
+                Collections.emptySet(),
+                Optional.empty(),
+                query);
+    }
+
+    @Deprecated
+    default int testQueryParams(
+            AuthHeader authHeader,
+            ResourceIdentifier something,
+            ResourceIdentifier implicit,
+            Optional<ResourceIdentifier> optionalMiddle,
+            Set<String> setEnd,
+            Optional<ResourceIdentifier> optionalEnd,
+            String query) {
+        return testQueryParams(
+                authHeader, something, implicit, optionalMiddle, setEnd, Optional.empty(), query);
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
@@ -128,9 +128,6 @@ public interface TestService {
             AuthHeader authHeader,
             ResourceIdentifier something,
             ResourceIdentifier implicit,
-            Optional<ResourceIdentifier> optionalMiddle,
-            Set<String> setEnd,
-            Optional<ResourceIdentifier> optionalEnd,
             String query) {
         return testQueryParams(
                 authHeader,
@@ -148,8 +145,6 @@ public interface TestService {
             ResourceIdentifier something,
             ResourceIdentifier implicit,
             Optional<ResourceIdentifier> optionalMiddle,
-            Set<String> setEnd,
-            Optional<ResourceIdentifier> optionalEnd,
             String query) {
         return testQueryParams(
                 authHeader,
@@ -168,7 +163,6 @@ public interface TestService {
             ResourceIdentifier implicit,
             Optional<ResourceIdentifier> optionalMiddle,
             Set<String> setEnd,
-            Optional<ResourceIdentifier> optionalEnd,
             String query) {
         return testQueryParams(
                 authHeader, something, implicit, optionalMiddle, setEnd, Optional.empty(), query);

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
@@ -88,9 +88,10 @@ public interface TestServiceRetrofit {
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
-    @GET("./catalog/test-query-params")
+    @POST("./catalog/test-query-params")
     Call<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
+            @Body String query,
             @Query("different") ResourceIdentifier something,
             @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("implicit") ResourceIdentifier implicit,

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
@@ -88,9 +88,10 @@ public interface TestServiceRetrofit {
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
-    @GET("./catalog/test-query-params")
+    @POST("./catalog/test-query-params")
     CompletableFuture<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
+            @Body String query,
             @Query("different") ResourceIdentifier something,
             @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("implicit") ResourceIdentifier implicit,


### PR DESCRIPTION
Closes #27.

## Before this PR
There was an issue where the generated services would not compile if they had optional path params and body params
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->

## After this PR
<!-- Describe at a high-level why this approach is better. -->
The issue is resolved and we preserve ordering of parameters 

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
