### PR TITLE
generate defensive name for inner union class

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -21,10 +21,10 @@ import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class Union {
-    @JsonUnwrapped private final Inner_Union union;
+    @JsonUnwrapped private final _Union_ union;
 
     @JsonCreator
-    private Union(Inner_Union union) {
+    private Union(_Union_ union) {
         Objects.requireNonNull(union, "union must not be null");
         this.union = union;
     }
@@ -58,11 +58,11 @@ public final class Union {
     }
 
     public static Union foo(String value) {
-        return new Union(Inner_Union.builder().type("foo").foo(value).build());
+        return new Union(_Union_.builder().type("foo").foo(value).build());
     }
 
     public static Union bar(int value) {
-        return new Union(Inner_Union.builder().type("bar").bar(value).build());
+        return new Union(_Union_.builder().type("bar").bar(value).build());
     }
 
     public interface Visitor<T> {
@@ -73,10 +73,10 @@ public final class Union {
         T visitUnknown(String unknownType);
     }
 
-    @JsonDeserialize(builder = Inner_Union.Builder.class)
+    @JsonDeserialize(builder = _Union_.Builder.class)
     @Generated("com.palantir.conjure.java.types.BeanGenerator")
     @JsonInclude(JsonInclude.Include.NON_ABSENT)
-    private static final class Inner_Union {
+    private static final class _Union_ {
         private final String type;
 
         private final Optional<String> foo;
@@ -87,7 +87,7 @@ public final class Union {
 
         private volatile int memoizedHashCode;
 
-        private Inner_Union(
+        private _Union_(
                 String type,
                 Optional<String> foo,
                 OptionalInt bar,
@@ -121,10 +121,10 @@ public final class Union {
 
         @Override
         public boolean equals(Object other) {
-            return this == other || (other instanceof Inner_Union && equalTo((Inner_Union) other));
+            return this == other || (other instanceof _Union_ && equalTo((_Union_) other));
         }
 
-        private boolean equalTo(Inner_Union other) {
+        private boolean equalTo(_Union_ other) {
             return this.type.equals(other.type)
                     && this.foo.equals(other.foo)
                     && this.bar.equals(other.bar)
@@ -141,7 +141,7 @@ public final class Union {
 
         @Override
         public String toString() {
-            return new StringBuilder("Inner_Union")
+            return new StringBuilder("_Union_")
                     .append("{")
                     .append("type")
                     .append(": ")
@@ -198,7 +198,7 @@ public final class Union {
 
             private Builder() {}
 
-            public Builder from(Inner_Union other) {
+            public Builder from(_Union_ other) {
                 type(other.getType());
                 foo(other.getFoo());
                 bar(other.getBar());
@@ -233,8 +233,8 @@ public final class Union {
                 return this;
             }
 
-            public Inner_Union build() {
-                return new Inner_Union(type, foo, bar, __unknownProperties);
+            public _Union_ build() {
+                return new _Union_(type, foo, bar, __unknownProperties);
             }
 
             @JsonAnySetter

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -1,0 +1,246 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.types.UnionGenerator")
+public final class Union {
+    @JsonUnwrapped private final Inner_Union union;
+
+    @JsonCreator
+    private Union(Inner_Union union) {
+        Objects.requireNonNull(union, "union must not be null");
+        this.union = union;
+    }
+
+    public <T> T accept(Visitor<T> visitor) {
+        if (union.getFoo().isPresent()) {
+            return visitor.visitFoo(union.getFoo().get());
+        } else if (union.getBar().isPresent()) {
+            return visitor.visitBar(union.getBar().getAsInt());
+        }
+        return visitor.visitUnknown(union.getType());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other || (other instanceof Union && equalTo((Union) other));
+    }
+
+    private boolean equalTo(Union other) {
+        return this.union.equals(other.union);
+    }
+
+    @Override
+    public int hashCode() {
+        return union.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return union.toString();
+    }
+
+    public static Union foo(String value) {
+        return new Union(Inner_Union.builder().type("foo").foo(value).build());
+    }
+
+    public static Union bar(int value) {
+        return new Union(Inner_Union.builder().type("bar").bar(value).build());
+    }
+
+    public interface Visitor<T> {
+        T visitFoo(String value);
+
+        T visitBar(int value);
+
+        T visitUnknown(String unknownType);
+    }
+
+    @JsonDeserialize(builder = Inner_Union.Builder.class)
+    @Generated("com.palantir.conjure.java.types.BeanGenerator")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    private static final class Inner_Union {
+        private final String type;
+
+        private final Optional<String> foo;
+
+        private final OptionalInt bar;
+
+        private final Map<String, Object> __unknownProperties;
+
+        private volatile int memoizedHashCode;
+
+        private Inner_Union(
+                String type,
+                Optional<String> foo,
+                OptionalInt bar,
+                Map<String, Object> __unknownProperties) {
+            validateFields(type, foo, bar);
+            this.type = type;
+            this.foo = foo;
+            this.bar = bar;
+            this.__unknownProperties = Collections.unmodifiableMap(__unknownProperties);
+        }
+
+        @JsonProperty("type")
+        public String getType() {
+            return this.type;
+        }
+
+        @JsonProperty("foo")
+        public Optional<String> getFoo() {
+            return this.foo;
+        }
+
+        @JsonProperty("bar")
+        public OptionalInt getBar() {
+            return this.bar;
+        }
+
+        @JsonAnyGetter
+        Map<String, Object> unknownProperties() {
+            return __unknownProperties;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof Inner_Union && equalTo((Inner_Union) other));
+        }
+
+        private boolean equalTo(Inner_Union other) {
+            return this.type.equals(other.type)
+                    && this.foo.equals(other.foo)
+                    && this.bar.equals(other.bar)
+                    && this.__unknownProperties.equals(other.__unknownProperties);
+        }
+
+        @Override
+        public int hashCode() {
+            if (memoizedHashCode == 0) {
+                memoizedHashCode = Objects.hash(type, foo, bar, __unknownProperties);
+            }
+            return memoizedHashCode;
+        }
+
+        @Override
+        public String toString() {
+            return new StringBuilder("Inner_Union")
+                    .append("{")
+                    .append("type")
+                    .append(": ")
+                    .append(type)
+                    .append(", ")
+                    .append("foo")
+                    .append(": ")
+                    .append(foo)
+                    .append(", ")
+                    .append("bar")
+                    .append(": ")
+                    .append(bar)
+                    .append("}")
+                    .toString();
+        }
+
+        private static void validateFields(String type, Optional<String> foo, OptionalInt bar) {
+            List<String> missingFields = null;
+            missingFields = addFieldIfMissing(missingFields, type, "type");
+            missingFields = addFieldIfMissing(missingFields, foo, "foo");
+            missingFields = addFieldIfMissing(missingFields, bar, "bar");
+            if (missingFields != null) {
+                throw new IllegalArgumentException(
+                        "Some required fields have not been set: " + missingFields);
+            }
+        }
+
+        private static List<String> addFieldIfMissing(
+                List<String> prev, Object fieldValue, String fieldName) {
+            List<String> missingFields = prev;
+            if (fieldValue == null) {
+                if (missingFields == null) {
+                    missingFields = new ArrayList<>(3);
+                }
+                missingFields.add(fieldName);
+            }
+            return missingFields;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static final class Builder {
+            private String type;
+
+            private Optional<String> foo = Optional.empty();
+
+            private OptionalInt bar = OptionalInt.empty();
+
+            Map<String, Object> __unknownProperties = new LinkedHashMap<>();
+
+            private Builder() {}
+
+            public Builder from(Inner_Union other) {
+                type(other.getType());
+                foo(other.getFoo());
+                bar(other.getBar());
+                return this;
+            }
+
+            @JsonSetter("type")
+            public Builder type(String type) {
+                this.type = Objects.requireNonNull(type, "type cannot be null");
+                return this;
+            }
+
+            @JsonSetter("foo")
+            public Builder foo(Optional<String> foo) {
+                this.foo = Objects.requireNonNull(foo, "foo cannot be null");
+                return this;
+            }
+
+            public Builder foo(String foo) {
+                this.foo = Optional.of(Objects.requireNonNull(foo, "foo cannot be null"));
+                return this;
+            }
+
+            @JsonSetter("bar")
+            public Builder bar(OptionalInt bar) {
+                this.bar = Objects.requireNonNull(bar, "bar cannot be null");
+                return this;
+            }
+
+            public Builder bar(int bar) {
+                this.bar = OptionalInt.of(bar);
+                return this;
+            }
+
+            public Inner_Union build() {
+                return new Inner_Union(type, foo, bar, __unknownProperties);
+            }
+
+            @JsonAnySetter
+            private void setUnknownProperties(String key, Object value) {
+                __unknownProperties.put(key, value);
+            }
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -21,10 +21,10 @@ import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class Union {
-    @JsonUnwrapped private final _Union_ union;
+    @JsonUnwrapped private final Union_ union;
 
     @JsonCreator
-    private Union(_Union_ union) {
+    private Union(Union_ union) {
         Objects.requireNonNull(union, "union must not be null");
         this.union = union;
     }
@@ -58,11 +58,11 @@ public final class Union {
     }
 
     public static Union foo(String value) {
-        return new Union(_Union_.builder().type("foo").foo(value).build());
+        return new Union(Union_.builder().type("foo").foo(value).build());
     }
 
     public static Union bar(int value) {
-        return new Union(_Union_.builder().type("bar").bar(value).build());
+        return new Union(Union_.builder().type("bar").bar(value).build());
     }
 
     public interface Visitor<T> {
@@ -73,10 +73,10 @@ public final class Union {
         T visitUnknown(String unknownType);
     }
 
-    @JsonDeserialize(builder = _Union_.Builder.class)
+    @JsonDeserialize(builder = Union_.Builder.class)
     @Generated("com.palantir.conjure.java.types.BeanGenerator")
     @JsonInclude(JsonInclude.Include.NON_ABSENT)
-    private static final class _Union_ {
+    private static final class Union_ {
         private final String type;
 
         private final Optional<String> foo;
@@ -87,7 +87,7 @@ public final class Union {
 
         private volatile int memoizedHashCode;
 
-        private _Union_(
+        private Union_(
                 String type,
                 Optional<String> foo,
                 OptionalInt bar,
@@ -121,10 +121,10 @@ public final class Union {
 
         @Override
         public boolean equals(Object other) {
-            return this == other || (other instanceof _Union_ && equalTo((_Union_) other));
+            return this == other || (other instanceof Union_ && equalTo((Union_) other));
         }
 
-        private boolean equalTo(_Union_ other) {
+        private boolean equalTo(Union_ other) {
             return this.type.equals(other.type)
                     && this.foo.equals(other.foo)
                     && this.bar.equals(other.bar)
@@ -141,7 +141,7 @@ public final class Union {
 
         @Override
         public String toString() {
-            return new StringBuilder("_Union_")
+            return new StringBuilder("Union_")
                     .append("{")
                     .append("type")
                     .append(": ")
@@ -198,7 +198,7 @@ public final class Union {
 
             private Builder() {}
 
-            public Builder from(_Union_ other) {
+            public Builder from(Union_ other) {
                 type(other.getType());
                 foo(other.getFoo());
                 bar(other.getBar());
@@ -233,8 +233,8 @@ public final class Union {
                 return this;
             }
 
-            public _Union_ build() {
-                return new _Union_(type, foo, bar, __unknownProperties);
+            public Union_ build() {
+                return new Union_(type, foo, bar, __unknownProperties);
             }
 
             @JsonAnySetter

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -23,10 +23,10 @@ import javax.annotation.Generated;
 /** A type which can either be a StringExample, a set of strings, or an integer. */
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class UnionTypeExample {
-    @JsonUnwrapped private final Union union;
+    @JsonUnwrapped private final Inner_Union union;
 
     @JsonCreator
-    private UnionTypeExample(Union union) {
+    private UnionTypeExample(Inner_Union union) {
         Objects.requireNonNull(union, "union must not be null");
         this.union = union;
     }
@@ -73,33 +73,37 @@ public final class UnionTypeExample {
     /** Docs for when UnionTypeExample is of type StringExample. */
     public static UnionTypeExample stringExample(StringExample value) {
         return new UnionTypeExample(
-                Union.builder().type("stringExample").stringExample(value).build());
+                Inner_Union.builder().type("stringExample").stringExample(value).build());
     }
 
     public static UnionTypeExample set(Set<String> value) {
-        return new UnionTypeExample(Union.builder().type("set").set(value).build());
+        return new UnionTypeExample(Inner_Union.builder().type("set").set(value).build());
     }
 
     public static UnionTypeExample thisFieldIsAnInteger(int value) {
         return new UnionTypeExample(
-                Union.builder().type("thisFieldIsAnInteger").thisFieldIsAnInteger(value).build());
+                Inner_Union.builder()
+                        .type("thisFieldIsAnInteger")
+                        .thisFieldIsAnInteger(value)
+                        .build());
     }
 
     public static UnionTypeExample alsoAnInteger(int value) {
         return new UnionTypeExample(
-                Union.builder().type("alsoAnInteger").alsoAnInteger(value).build());
+                Inner_Union.builder().type("alsoAnInteger").alsoAnInteger(value).build());
     }
 
     public static UnionTypeExample if_(int value) {
-        return new UnionTypeExample(Union.builder().type("if").if_(value).build());
+        return new UnionTypeExample(Inner_Union.builder().type("if").if_(value).build());
     }
 
     public static UnionTypeExample new_(int value) {
-        return new UnionTypeExample(Union.builder().type("new").new_(value).build());
+        return new UnionTypeExample(Inner_Union.builder().type("new").new_(value).build());
     }
 
     public static UnionTypeExample interface_(int value) {
-        return new UnionTypeExample(Union.builder().type("interface").interface_(value).build());
+        return new UnionTypeExample(
+                Inner_Union.builder().type("interface").interface_(value).build());
     }
 
     public interface Visitor<T> {
@@ -120,10 +124,10 @@ public final class UnionTypeExample {
         T visitUnknown(String unknownType);
     }
 
-    @JsonDeserialize(builder = Union.Builder.class)
+    @JsonDeserialize(builder = Inner_Union.Builder.class)
     @Generated("com.palantir.conjure.java.types.BeanGenerator")
     @JsonInclude(JsonInclude.Include.NON_ABSENT)
-    private static final class Union {
+    private static final class Inner_Union {
         private final String type;
 
         private final Optional<StringExample> stringExample;
@@ -144,7 +148,7 @@ public final class UnionTypeExample {
 
         private volatile int memoizedHashCode;
 
-        private Union(
+        private Inner_Union(
                 String type,
                 Optional<StringExample> stringExample,
                 Optional<Set<String>> set,
@@ -221,10 +225,10 @@ public final class UnionTypeExample {
 
         @Override
         public boolean equals(Object other) {
-            return this == other || (other instanceof Union && equalTo((Union) other));
+            return this == other || (other instanceof Inner_Union && equalTo((Inner_Union) other));
         }
 
-        private boolean equalTo(Union other) {
+        private boolean equalTo(Inner_Union other) {
             return this.type.equals(other.type)
                     && this.stringExample.equals(other.stringExample)
                     && this.set.equals(other.set)
@@ -256,7 +260,7 @@ public final class UnionTypeExample {
 
         @Override
         public String toString() {
-            return new StringBuilder("Union")
+            return new StringBuilder("Inner_Union")
                     .append("{")
                     .append("type")
                     .append(": ")
@@ -357,7 +361,7 @@ public final class UnionTypeExample {
 
             private Builder() {}
 
-            public Builder from(Union other) {
+            public Builder from(Inner_Union other) {
                 type(other.getType());
                 stringExample(other.getStringExample());
                 set(other.getSet());
@@ -459,8 +463,8 @@ public final class UnionTypeExample {
                 return this;
             }
 
-            public Union build() {
-                return new Union(
+            public Inner_Union build() {
+                return new Inner_Union(
                         type,
                         stringExample,
                         set,

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -23,10 +23,10 @@ import javax.annotation.Generated;
 /** A type which can either be a StringExample, a set of strings, or an integer. */
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class UnionTypeExample {
-    @JsonUnwrapped private final Inner_Union union;
+    @JsonUnwrapped private final _Union_ union;
 
     @JsonCreator
-    private UnionTypeExample(Inner_Union union) {
+    private UnionTypeExample(_Union_ union) {
         Objects.requireNonNull(union, "union must not be null");
         this.union = union;
     }
@@ -73,37 +73,33 @@ public final class UnionTypeExample {
     /** Docs for when UnionTypeExample is of type StringExample. */
     public static UnionTypeExample stringExample(StringExample value) {
         return new UnionTypeExample(
-                Inner_Union.builder().type("stringExample").stringExample(value).build());
+                _Union_.builder().type("stringExample").stringExample(value).build());
     }
 
     public static UnionTypeExample set(Set<String> value) {
-        return new UnionTypeExample(Inner_Union.builder().type("set").set(value).build());
+        return new UnionTypeExample(_Union_.builder().type("set").set(value).build());
     }
 
     public static UnionTypeExample thisFieldIsAnInteger(int value) {
         return new UnionTypeExample(
-                Inner_Union.builder()
-                        .type("thisFieldIsAnInteger")
-                        .thisFieldIsAnInteger(value)
-                        .build());
+                _Union_.builder().type("thisFieldIsAnInteger").thisFieldIsAnInteger(value).build());
     }
 
     public static UnionTypeExample alsoAnInteger(int value) {
         return new UnionTypeExample(
-                Inner_Union.builder().type("alsoAnInteger").alsoAnInteger(value).build());
+                _Union_.builder().type("alsoAnInteger").alsoAnInteger(value).build());
     }
 
     public static UnionTypeExample if_(int value) {
-        return new UnionTypeExample(Inner_Union.builder().type("if").if_(value).build());
+        return new UnionTypeExample(_Union_.builder().type("if").if_(value).build());
     }
 
     public static UnionTypeExample new_(int value) {
-        return new UnionTypeExample(Inner_Union.builder().type("new").new_(value).build());
+        return new UnionTypeExample(_Union_.builder().type("new").new_(value).build());
     }
 
     public static UnionTypeExample interface_(int value) {
-        return new UnionTypeExample(
-                Inner_Union.builder().type("interface").interface_(value).build());
+        return new UnionTypeExample(_Union_.builder().type("interface").interface_(value).build());
     }
 
     public interface Visitor<T> {
@@ -124,10 +120,10 @@ public final class UnionTypeExample {
         T visitUnknown(String unknownType);
     }
 
-    @JsonDeserialize(builder = Inner_Union.Builder.class)
+    @JsonDeserialize(builder = _Union_.Builder.class)
     @Generated("com.palantir.conjure.java.types.BeanGenerator")
     @JsonInclude(JsonInclude.Include.NON_ABSENT)
-    private static final class Inner_Union {
+    private static final class _Union_ {
         private final String type;
 
         private final Optional<StringExample> stringExample;
@@ -148,7 +144,7 @@ public final class UnionTypeExample {
 
         private volatile int memoizedHashCode;
 
-        private Inner_Union(
+        private _Union_(
                 String type,
                 Optional<StringExample> stringExample,
                 Optional<Set<String>> set,
@@ -225,10 +221,10 @@ public final class UnionTypeExample {
 
         @Override
         public boolean equals(Object other) {
-            return this == other || (other instanceof Inner_Union && equalTo((Inner_Union) other));
+            return this == other || (other instanceof _Union_ && equalTo((_Union_) other));
         }
 
-        private boolean equalTo(Inner_Union other) {
+        private boolean equalTo(_Union_ other) {
             return this.type.equals(other.type)
                     && this.stringExample.equals(other.stringExample)
                     && this.set.equals(other.set)
@@ -260,7 +256,7 @@ public final class UnionTypeExample {
 
         @Override
         public String toString() {
-            return new StringBuilder("Inner_Union")
+            return new StringBuilder("_Union_")
                     .append("{")
                     .append("type")
                     .append(": ")
@@ -361,7 +357,7 @@ public final class UnionTypeExample {
 
             private Builder() {}
 
-            public Builder from(Inner_Union other) {
+            public Builder from(_Union_ other) {
                 type(other.getType());
                 stringExample(other.getStringExample());
                 set(other.getSet());
@@ -463,8 +459,8 @@ public final class UnionTypeExample {
                 return this;
             }
 
-            public Inner_Union build() {
-                return new Inner_Union(
+            public _Union_ build() {
+                return new _Union_(
                         type,
                         stringExample,
                         set,

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -23,10 +23,10 @@ import javax.annotation.Generated;
 /** A type which can either be a StringExample, a set of strings, or an integer. */
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class UnionTypeExample {
-    @JsonUnwrapped private final _Union_ union;
+    @JsonUnwrapped private final Union_ union;
 
     @JsonCreator
-    private UnionTypeExample(_Union_ union) {
+    private UnionTypeExample(Union_ union) {
         Objects.requireNonNull(union, "union must not be null");
         this.union = union;
     }
@@ -73,33 +73,33 @@ public final class UnionTypeExample {
     /** Docs for when UnionTypeExample is of type StringExample. */
     public static UnionTypeExample stringExample(StringExample value) {
         return new UnionTypeExample(
-                _Union_.builder().type("stringExample").stringExample(value).build());
+                Union_.builder().type("stringExample").stringExample(value).build());
     }
 
     public static UnionTypeExample set(Set<String> value) {
-        return new UnionTypeExample(_Union_.builder().type("set").set(value).build());
+        return new UnionTypeExample(Union_.builder().type("set").set(value).build());
     }
 
     public static UnionTypeExample thisFieldIsAnInteger(int value) {
         return new UnionTypeExample(
-                _Union_.builder().type("thisFieldIsAnInteger").thisFieldIsAnInteger(value).build());
+                Union_.builder().type("thisFieldIsAnInteger").thisFieldIsAnInteger(value).build());
     }
 
     public static UnionTypeExample alsoAnInteger(int value) {
         return new UnionTypeExample(
-                _Union_.builder().type("alsoAnInteger").alsoAnInteger(value).build());
+                Union_.builder().type("alsoAnInteger").alsoAnInteger(value).build());
     }
 
     public static UnionTypeExample if_(int value) {
-        return new UnionTypeExample(_Union_.builder().type("if").if_(value).build());
+        return new UnionTypeExample(Union_.builder().type("if").if_(value).build());
     }
 
     public static UnionTypeExample new_(int value) {
-        return new UnionTypeExample(_Union_.builder().type("new").new_(value).build());
+        return new UnionTypeExample(Union_.builder().type("new").new_(value).build());
     }
 
     public static UnionTypeExample interface_(int value) {
-        return new UnionTypeExample(_Union_.builder().type("interface").interface_(value).build());
+        return new UnionTypeExample(Union_.builder().type("interface").interface_(value).build());
     }
 
     public interface Visitor<T> {
@@ -120,10 +120,10 @@ public final class UnionTypeExample {
         T visitUnknown(String unknownType);
     }
 
-    @JsonDeserialize(builder = _Union_.Builder.class)
+    @JsonDeserialize(builder = Union_.Builder.class)
     @Generated("com.palantir.conjure.java.types.BeanGenerator")
     @JsonInclude(JsonInclude.Include.NON_ABSENT)
-    private static final class _Union_ {
+    private static final class Union_ {
         private final String type;
 
         private final Optional<StringExample> stringExample;
@@ -144,7 +144,7 @@ public final class UnionTypeExample {
 
         private volatile int memoizedHashCode;
 
-        private _Union_(
+        private Union_(
                 String type,
                 Optional<StringExample> stringExample,
                 Optional<Set<String>> set,
@@ -221,10 +221,10 @@ public final class UnionTypeExample {
 
         @Override
         public boolean equals(Object other) {
-            return this == other || (other instanceof _Union_ && equalTo((_Union_) other));
+            return this == other || (other instanceof Union_ && equalTo((Union_) other));
         }
 
-        private boolean equalTo(_Union_ other) {
+        private boolean equalTo(Union_ other) {
             return this.type.equals(other.type)
                     && this.stringExample.equals(other.stringExample)
                     && this.set.equals(other.set)
@@ -256,7 +256,7 @@ public final class UnionTypeExample {
 
         @Override
         public String toString() {
-            return new StringBuilder("_Union_")
+            return new StringBuilder("Union_")
                     .append("{")
                     .append("type")
                     .append(": ")
@@ -357,7 +357,7 @@ public final class UnionTypeExample {
 
             private Builder() {}
 
-            public Builder from(_Union_ other) {
+            public Builder from(Union_ other) {
                 type(other.getType());
                 stringExample(other.getStringExample());
                 set(other.getSet());
@@ -459,8 +459,8 @@ public final class UnionTypeExample {
                 return this;
             }
 
-            public _Union_ build() {
-                return new _Union_(
+            public Union_ build() {
+                return new Union_(
                         type,
                         stringExample,
                         set,

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -52,7 +52,7 @@ import org.apache.commons.lang3.StringUtils;
 public final class UnionGenerator {
 
     private static final String UNION_FIELD_NAME = "union";
-    private static final String INNER_UNION_TYPE_NAME = "Inner_Union";
+    private static final String INNER_UNION_TYPE_NAME = "_Union_";
     private static final String TYPE_FIELD_NAME = "type";
     private static final String VALUE_PARAM = "value";
     private static final String VISIT_METHOD_NAME = "visit";

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -52,6 +52,7 @@ import org.apache.commons.lang3.StringUtils;
 public final class UnionGenerator {
 
     private static final String UNION_FIELD_NAME = "union";
+    private static final String INNER_UNION_TYPE_NAME = "Inner_Union";
     private static final String TYPE_FIELD_NAME = "type";
     private static final String VALUE_PARAM = "value";
     private static final String VISIT_METHOD_NAME = "visit";
@@ -107,7 +108,7 @@ public final class UnionGenerator {
             ClassName unionClass) {
         return BeanGenerator.generateBeanTypeSpec(typeMapper, ObjectDefinition.builder()
                 .typeName(com.palantir.conjure.spec.TypeName.of(
-                        "Union", typePackage + "." + unionClass.simpleName()))
+                        INNER_UNION_TYPE_NAME, typePackage + "." + unionClass.simpleName()))
                 .fields(FieldDefinition.builder()
                         .fieldName(FieldName.of("type"))
                         .type(Type.primitive(PrimitiveType.STRING))
@@ -129,7 +130,11 @@ public final class UnionGenerator {
 
     private static List<FieldSpec> generateFields(ClassName unionClass) {
         return ImmutableList.of(
-                FieldSpec.builder(unionClass.nestedClass("Union"), UNION_FIELD_NAME, Modifier.PRIVATE, Modifier.FINAL)
+                FieldSpec.builder(
+                        unionClass.nestedClass(INNER_UNION_TYPE_NAME),
+                        UNION_FIELD_NAME,
+                        Modifier.PRIVATE,
+                        Modifier.FINAL)
                         .addAnnotation(JsonUnwrapped.class)
                         .build());
     }
@@ -138,7 +143,8 @@ public final class UnionGenerator {
         return MethodSpec.constructorBuilder()
                 .addModifiers(Modifier.PRIVATE)
                 .addAnnotation(AnnotationSpec.builder(JsonCreator.class).build())
-                .addParameter(ParameterSpec.builder(unionClass.nestedClass("Union"), UNION_FIELD_NAME).build())
+                .addParameter(ParameterSpec.builder(
+                        unionClass.nestedClass(INNER_UNION_TYPE_NAME), UNION_FIELD_NAME).build())
                 .addStatement(Expressions.requireNonNull(UNION_FIELD_NAME, "union must not be null"))
                 .addStatement("this.$1L = $1L", UNION_FIELD_NAME)
                 .build();
@@ -156,7 +162,11 @@ public final class UnionGenerator {
                     .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                     .addParameter(memberType, VALUE_PARAM)
                     .addStatement("return new $1T($2T.builder().type($3S).$4N($5N).build())",
-                            unionClass, unionClass.nestedClass("Union"), memberName, safeName, VALUE_PARAM)
+                            unionClass,
+                            unionClass.nestedClass(INNER_UNION_TYPE_NAME),
+                            memberName,
+                            safeName,
+                            VALUE_PARAM)
                     .returns(unionClass);
             memberTypeDef.getDocs()
                     .ifPresent(docs -> builder.addJavadoc("$L", StringUtils.appendIfMissing(docs.get(), "\n")));

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -52,7 +52,7 @@ import org.apache.commons.lang3.StringUtils;
 public final class UnionGenerator {
 
     private static final String UNION_FIELD_NAME = "union";
-    private static final String INNER_UNION_TYPE_NAME = "_Union_";
+    private static final String INNER_UNION_TYPE_NAME = "Union_";
     private static final String TYPE_FIELD_NAME = "type";
     private static final String VALUE_PARAM = "value";
     private static final String VISIT_METHOD_NAME = "visit";

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -156,3 +156,7 @@ types:
             type: string
           memoizedHashCode:
             type: integer
+      Union:
+        union:
+          foo: string
+          bar: integer


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
If a conjure definition included a type with the name `Union` the generated code would fail to compile due to duplicate classes

## After this PR
<!-- Describe at a high-level why this approach is better. -->
We generate an inner class named `Inner_Union` which is guaranteed to not collide since conjure objects names must match `^[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$`
<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
