### PR TITLE
add retrofit default methods

### DIFF
--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/Parameters.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/Parameters.java
@@ -156,29 +156,29 @@ public final class Parameters {
      */
     public static final Type.Visitor<CodeBlock> TYPE_DEFAULT_VALUE_OPTIONALS_NULL
             = new TypeVisitor.Default<CodeBlock>() {
-        @Override
-        public CodeBlock visitOptional(OptionalType value) {
-            return CodeBlock.of("null", Optional.class);
-        }
+                @Override
+                public CodeBlock visitOptional(OptionalType value) {
+                    return CodeBlock.of("null", Optional.class);
+                }
 
-        @Override
-        public CodeBlock visitList(ListType value) {
-            return CodeBlock.of("$T.emptyList()", Collections.class);
-        }
+                @Override
+                public CodeBlock visitList(ListType value) {
+                    return CodeBlock.of("$T.emptyList()", Collections.class);
+                }
 
-        @Override
-        public CodeBlock visitSet(SetType value) {
-            return CodeBlock.of("$T.emptySet()", Collections.class);
-        }
+                @Override
+                public CodeBlock visitSet(SetType value) {
+                    return CodeBlock.of("$T.emptySet()", Collections.class);
+                }
 
-        @Override
-        public CodeBlock visitMap(MapType value) {
-            return CodeBlock.of("$T.emptyMap()", Collections.class);
-        }
+                @Override
+                public CodeBlock visitMap(MapType value) {
+                    return CodeBlock.of("$T.emptyMap()", Collections.class);
+                }
 
-        @Override
-        public CodeBlock visitDefault() {
-            throw new IllegalArgumentException("Cannot backfill non-defaultable parameter type.");
-        }
-    };
+                @Override
+                public CodeBlock visitDefault() {
+                    throw new IllegalArgumentException("Cannot backfill non-defaultable parameter type.");
+                }
+            };
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/Parameters.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/Parameters.java
@@ -1,0 +1,183 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.types;
+
+import com.palantir.conjure.spec.BodyParameterType;
+import com.palantir.conjure.spec.HeaderParameterType;
+import com.palantir.conjure.spec.ListType;
+import com.palantir.conjure.spec.MapType;
+import com.palantir.conjure.spec.OptionalType;
+import com.palantir.conjure.spec.ParameterType;
+import com.palantir.conjure.spec.PathParameterType;
+import com.palantir.conjure.spec.QueryParameterType;
+import com.palantir.conjure.spec.SetType;
+import com.palantir.conjure.spec.Type;
+import com.palantir.conjure.visitor.TypeVisitor;
+import com.squareup.javapoet.CodeBlock;
+import java.util.Collections;
+import java.util.Optional;
+
+public final class Parameters {
+
+    private Parameters() {}
+
+    /** Produces an ordering for ParamaterType of Header, Path, Query, Body. */
+    public static final ParameterType.Visitor<Integer> PARAM_SORT_ORDER = new ParameterType.Visitor<Integer>() {
+        @Override
+        public Integer visitBody(BodyParameterType value) {
+            return 30;
+        }
+
+        @Override
+        public Integer visitHeader(HeaderParameterType value) {
+            return 0;
+        }
+
+        @Override
+        public Integer visitPath(PathParameterType value) {
+            return 10;
+        }
+
+        @Override
+        public Integer visitQuery(QueryParameterType value) {
+            return 20;
+        }
+
+        @Override
+        public Integer visitUnknown(String unknownType) {
+            return -1;
+        }
+    };
+
+    /**
+     * Produces a type sort ordering for use with {@link #PARAM_SORT_ORDER} such that types with known defaults come
+     * after types without known defaults.
+     */
+    public static final Type.Visitor<Integer> TYPE_SORT_ORDER = new TypeVisitor.Default<Integer>() {
+        @Override
+        public Integer visitOptional(OptionalType value) {
+            return 1;
+        }
+
+        @Override
+        public Integer visitList(ListType value) {
+            return 1;
+        }
+
+        @Override
+        public Integer visitSet(SetType value) {
+            return 1;
+        }
+
+        @Override
+        public Integer visitMap(MapType value) {
+            return 1;
+        }
+
+        @Override
+        public Integer visitDefault() {
+            return 0;
+        }
+    };
+
+    /** Indicates whether a particular type has a defaultable value. */
+    public static final Type.Visitor<Boolean> TYPE_DEFAULTABLE_PREDICATE = new TypeVisitor.Default<Boolean>() {
+        @Override
+        public Boolean visitOptional(OptionalType value) {
+            return true;
+        }
+
+        @Override
+        public Boolean visitList(ListType value) {
+            return true;
+        }
+
+        @Override
+        public Boolean visitSet(SetType value) {
+            return true;
+        }
+
+        @Override
+        public Boolean visitMap(MapType value) {
+            return true;
+        }
+
+        @Override
+        public Boolean visitDefault() {
+            return false;
+        }
+    };
+
+    public static final Type.Visitor<CodeBlock> TYPE_DEFAULT_VALUE = new TypeVisitor.Default<CodeBlock>() {
+        @Override
+        public CodeBlock visitOptional(OptionalType value) {
+            return CodeBlock.of("$T.empty()", Optional.class);
+        }
+
+        @Override
+        public CodeBlock visitList(ListType value) {
+            return CodeBlock.of("$T.emptyList()", Collections.class);
+        }
+
+        @Override
+        public CodeBlock visitSet(SetType value) {
+            return CodeBlock.of("$T.emptySet()", Collections.class);
+        }
+
+        @Override
+        public CodeBlock visitMap(MapType value) {
+            return CodeBlock.of("$T.emptyMap()", Collections.class);
+        }
+
+        @Override
+        public CodeBlock visitDefault() {
+            throw new IllegalArgumentException("Cannot backfill non-defaultable parameter type.");
+        }
+    };
+
+    /**
+     * Generates default values for types, where optional has a default value of null.
+     * <p>
+     * This is required by retrofit on service methods, for example.
+     */
+    public static final Type.Visitor<CodeBlock> TYPE_DEFAULT_VALUE_OPTIONALS_NULL = new TypeVisitor.Default<CodeBlock>() {
+        @Override
+        public CodeBlock visitOptional(OptionalType value) {
+            return CodeBlock.of("null", Optional.class);
+        }
+
+        @Override
+        public CodeBlock visitList(ListType value) {
+            return CodeBlock.of("$T.emptyList()", Collections.class);
+        }
+
+        @Override
+        public CodeBlock visitSet(SetType value) {
+            return CodeBlock.of("$T.emptySet()", Collections.class);
+        }
+
+        @Override
+        public CodeBlock visitMap(MapType value) {
+            return CodeBlock.of("$T.emptyMap()", Collections.class);
+        }
+
+        @Override
+        public CodeBlock visitDefault() {
+            throw new IllegalArgumentException("Cannot backfill non-defaultable parameter type.");
+        }
+    };
+}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/Parameters.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/Parameters.java
@@ -154,7 +154,8 @@ public final class Parameters {
      * <p>
      * This is required by retrofit on service methods, for example.
      */
-    public static final Type.Visitor<CodeBlock> TYPE_DEFAULT_VALUE_OPTIONALS_NULL = new TypeVisitor.Default<CodeBlock>() {
+    public static final Type.Visitor<CodeBlock> TYPE_DEFAULT_VALUE_OPTIONALS_NULL
+            = new TypeVisitor.Default<CodeBlock>() {
         @Override
         public CodeBlock visitOptional(OptionalType value) {
             return CodeBlock.of("null", Optional.class);

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
@@ -12,6 +12,7 @@ import java.lang.Integer;
 import java.lang.String;
 import java.lang.Void;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -38,8 +39,8 @@ public interface TestServiceRetrofit {
     @POST("./catalog/datasets")
     Call<Dataset> createDataset(
             @Header("Authorization") AuthHeader authHeader,
-            @Body CreateDatasetRequest request,
-            @Header("Test-Header") String testHeaderArg);
+            @Header("Test-Header") String testHeaderArg,
+            @Body CreateDatasetRequest request);
 
     @GET("./catalog/datasets/{datasetRid}")
     Call<Optional<Dataset>> getDataset(
@@ -91,22 +92,22 @@ public interface TestServiceRetrofit {
     @POST("./catalog/test-query-params")
     Call<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
-            @Body String query,
             @Query("different") ResourceIdentifier something,
-            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("setEnd") Set<String> setEnd,
-            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
+            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
+            @Body String query);
 
     @POST("./catalog/test-no-response-query-params")
     Call<Void> testNoResponseQueryParams(
             @Header("Authorization") AuthHeader authHeader,
-            @Body String query,
             @Query("different") ResourceIdentifier something,
-            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("setEnd") Set<String> setEnd,
-            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
+            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
+            @Body String query);
 
     @GET("./catalog/boolean")
     Call<Boolean> testBoolean(@Header("Authorization") AuthHeader authHeader);
@@ -116,4 +117,82 @@ public interface TestServiceRetrofit {
 
     @GET("./catalog/integer")
     Call<Integer> testInteger(@Header("Authorization") AuthHeader authHeader);
+
+    @Deprecated
+    default int testQueryParams(
+            AuthHeader authHeader,
+            ResourceIdentifier something,
+            ResourceIdentifier implicit,
+            String query) {
+        return testQueryParams(
+                authHeader, something, implicit, null, Collections.emptySet(), null, query);
+    }
+
+    @Deprecated
+    default int testQueryParams(
+            AuthHeader authHeader,
+            ResourceIdentifier something,
+            ResourceIdentifier implicit,
+            Optional<ResourceIdentifier> optionalMiddle,
+            String query) {
+        return testQueryParams(
+                authHeader,
+                something,
+                implicit,
+                optionalMiddle,
+                Collections.emptySet(),
+                null,
+                query);
+    }
+
+    @Deprecated
+    default int testQueryParams(
+            AuthHeader authHeader,
+            ResourceIdentifier something,
+            ResourceIdentifier implicit,
+            Optional<ResourceIdentifier> optionalMiddle,
+            Set<String> setEnd,
+            String query) {
+        return testQueryParams(
+                authHeader, something, implicit, optionalMiddle, setEnd, null, query);
+    }
+
+    @Deprecated
+    default void testNoResponseQueryParams(
+            AuthHeader authHeader,
+            ResourceIdentifier something,
+            ResourceIdentifier implicit,
+            String query) {
+        testNoResponseQueryParams(
+                authHeader, something, implicit, null, Collections.emptySet(), null, query);
+    }
+
+    @Deprecated
+    default void testNoResponseQueryParams(
+            AuthHeader authHeader,
+            ResourceIdentifier something,
+            ResourceIdentifier implicit,
+            Optional<ResourceIdentifier> optionalMiddle,
+            String query) {
+        testNoResponseQueryParams(
+                authHeader,
+                something,
+                implicit,
+                optionalMiddle,
+                Collections.emptySet(),
+                null,
+                query);
+    }
+
+    @Deprecated
+    default void testNoResponseQueryParams(
+            AuthHeader authHeader,
+            ResourceIdentifier something,
+            ResourceIdentifier implicit,
+            Optional<ResourceIdentifier> optionalMiddle,
+            Set<String> setEnd,
+            String query) {
+        testNoResponseQueryParams(
+                authHeader, something, implicit, optionalMiddle, setEnd, null, query);
+    }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
@@ -12,6 +12,7 @@ import java.lang.Integer;
 import java.lang.String;
 import java.lang.Void;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -38,8 +39,8 @@ public interface TestServiceRetrofit {
     @POST("./catalog/datasets")
     CompletableFuture<Dataset> createDataset(
             @Header("Authorization") AuthHeader authHeader,
-            @Body CreateDatasetRequest request,
-            @Header("Test-Header") String testHeaderArg);
+            @Header("Test-Header") String testHeaderArg,
+            @Body CreateDatasetRequest request);
 
     @GET("./catalog/datasets/{datasetRid}")
     CompletableFuture<Optional<Dataset>> getDataset(
@@ -91,22 +92,22 @@ public interface TestServiceRetrofit {
     @POST("./catalog/test-query-params")
     CompletableFuture<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
-            @Body String query,
             @Query("different") ResourceIdentifier something,
-            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("setEnd") Set<String> setEnd,
-            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
+            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
+            @Body String query);
 
     @POST("./catalog/test-no-response-query-params")
     CompletableFuture<Void> testNoResponseQueryParams(
             @Header("Authorization") AuthHeader authHeader,
-            @Body String query,
             @Query("different") ResourceIdentifier something,
-            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("setEnd") Set<String> setEnd,
-            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
+            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
+            @Body String query);
 
     @GET("./catalog/boolean")
     CompletableFuture<Boolean> testBoolean(@Header("Authorization") AuthHeader authHeader);
@@ -116,4 +117,82 @@ public interface TestServiceRetrofit {
 
     @GET("./catalog/integer")
     CompletableFuture<Integer> testInteger(@Header("Authorization") AuthHeader authHeader);
+
+    @Deprecated
+    default int testQueryParams(
+            AuthHeader authHeader,
+            ResourceIdentifier something,
+            ResourceIdentifier implicit,
+            String query) {
+        return testQueryParams(
+                authHeader, something, implicit, null, Collections.emptySet(), null, query);
+    }
+
+    @Deprecated
+    default int testQueryParams(
+            AuthHeader authHeader,
+            ResourceIdentifier something,
+            ResourceIdentifier implicit,
+            Optional<ResourceIdentifier> optionalMiddle,
+            String query) {
+        return testQueryParams(
+                authHeader,
+                something,
+                implicit,
+                optionalMiddle,
+                Collections.emptySet(),
+                null,
+                query);
+    }
+
+    @Deprecated
+    default int testQueryParams(
+            AuthHeader authHeader,
+            ResourceIdentifier something,
+            ResourceIdentifier implicit,
+            Optional<ResourceIdentifier> optionalMiddle,
+            Set<String> setEnd,
+            String query) {
+        return testQueryParams(
+                authHeader, something, implicit, optionalMiddle, setEnd, null, query);
+    }
+
+    @Deprecated
+    default void testNoResponseQueryParams(
+            AuthHeader authHeader,
+            ResourceIdentifier something,
+            ResourceIdentifier implicit,
+            String query) {
+        testNoResponseQueryParams(
+                authHeader, something, implicit, null, Collections.emptySet(), null, query);
+    }
+
+    @Deprecated
+    default void testNoResponseQueryParams(
+            AuthHeader authHeader,
+            ResourceIdentifier something,
+            ResourceIdentifier implicit,
+            Optional<ResourceIdentifier> optionalMiddle,
+            String query) {
+        testNoResponseQueryParams(
+                authHeader,
+                something,
+                implicit,
+                optionalMiddle,
+                Collections.emptySet(),
+                null,
+                query);
+    }
+
+    @Deprecated
+    default void testNoResponseQueryParams(
+            AuthHeader authHeader,
+            ResourceIdentifier something,
+            ResourceIdentifier implicit,
+            Optional<ResourceIdentifier> optionalMiddle,
+            Set<String> setEnd,
+            String query) {
+        testNoResponseQueryParams(
+                authHeader, something, implicit, optionalMiddle, setEnd, null, query);
+    }
 }


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
Upon adding an extra optional parameter to a service method, we break java backcompat.

## After this PR
<!-- Describe at a high-level why this approach is better. -->
Generate default methods for service endpoints, with subsets of parameters.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->

This is the retrofit equivalent of the work already done here for the jersey generator.
