### PR TITLE
[fix] Builders check primitives are initialized

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
@@ -77,7 +77,7 @@ public final class BooleanExample {
         @JsonSetter("coin")
         public Builder coin(boolean coin) {
             this.coin = coin;
-            _coinInitialized = true;
+            this._coinInitialized = true;
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
@@ -65,6 +65,8 @@ public final class BooleanExample {
     public static final class Builder {
         private boolean coin;
 
+        private boolean _coinInitialized;
+
         private Builder() {}
 
         public Builder from(BooleanExample other) {
@@ -75,6 +77,7 @@ public final class BooleanExample {
         @JsonSetter("coin")
         public Builder coin(boolean coin) {
             this.coin = coin;
+            _coinInitialized = true;
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
 
@@ -79,6 +81,27 @@ public final class BooleanExample {
             this.coin = coin;
             this._coinInitialized = true;
             return this;
+        }
+
+        private void validateFields() {
+            List<String> missingFields = null;
+            missingFields = addFieldIfMissing(missingFields, _coinInitialized, "coin");
+            if (missingFields != null) {
+                throw new IllegalArgumentException(
+                        "Some required fields have not been set: " + missingFields);
+            }
+        }
+
+        private static List<String> addFieldIfMissing(
+                List<String> prev, boolean initialized, String fieldName) {
+            List<String> missingFields = prev;
+            if (!initialized) {
+                if (missingFields == null) {
+                    missingFields = new ArrayList<>(1);
+                }
+                missingFields.add(fieldName);
+            }
+            return missingFields;
         }
 
         public BooleanExample build() {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
@@ -65,7 +65,7 @@ public final class BooleanExample {
     public static final class Builder {
         private boolean coin;
 
-        private boolean _coinInitialized;
+        private boolean _coinInitialized = false;
 
         private Builder() {}
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
@@ -83,7 +83,7 @@ public final class BooleanExample {
             return this;
         }
 
-        private void validateFields() {
+        private void validatePrimitiveFieldsHaveBeenInitialized() {
             List<String> missingFields = null;
             missingFields = addFieldIfMissing(missingFields, _coinInitialized, "coin");
             if (missingFields != null) {
@@ -105,7 +105,7 @@ public final class BooleanExample {
         }
 
         public BooleanExample build() {
-            validateFields();
+            validatePrimitiveFieldsHaveBeenInitialized();
             return new BooleanExample(coin);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
@@ -105,6 +105,7 @@ public final class BooleanExample {
         }
 
         public BooleanExample build() {
+            validateFields();
             return new BooleanExample(coin);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
@@ -64,6 +64,8 @@ public final class DoubleExample {
     public static final class Builder {
         private double doubleValue;
 
+        private boolean _doubleValueInitialized;
+
         private Builder() {}
 
         public Builder from(DoubleExample other) {
@@ -74,6 +76,7 @@ public final class DoubleExample {
         @JsonSetter("doubleValue")
         public Builder doubleValue(double doubleValue) {
             this.doubleValue = doubleValue;
+            _doubleValueInitialized = true;
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
@@ -76,7 +76,7 @@ public final class DoubleExample {
         @JsonSetter("doubleValue")
         public Builder doubleValue(double doubleValue) {
             this.doubleValue = doubleValue;
-            _doubleValueInitialized = true;
+            this._doubleValueInitialized = true;
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
 
@@ -78,6 +80,28 @@ public final class DoubleExample {
             this.doubleValue = doubleValue;
             this._doubleValueInitialized = true;
             return this;
+        }
+
+        private void validateFields() {
+            List<String> missingFields = null;
+            missingFields =
+                    addFieldIfMissing(missingFields, _doubleValueInitialized, "doubleValue");
+            if (missingFields != null) {
+                throw new IllegalArgumentException(
+                        "Some required fields have not been set: " + missingFields);
+            }
+        }
+
+        private static List<String> addFieldIfMissing(
+                List<String> prev, boolean initialized, String fieldName) {
+            List<String> missingFields = prev;
+            if (!initialized) {
+                if (missingFields == null) {
+                    missingFields = new ArrayList<>(1);
+                }
+                missingFields.add(fieldName);
+            }
+            return missingFields;
         }
 
         public DoubleExample build() {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
@@ -105,6 +105,7 @@ public final class DoubleExample {
         }
 
         public DoubleExample build() {
+            validateFields();
             return new DoubleExample(doubleValue);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
@@ -64,7 +64,7 @@ public final class DoubleExample {
     public static final class Builder {
         private double doubleValue;
 
-        private boolean _doubleValueInitialized;
+        private boolean _doubleValueInitialized = false;
 
         private Builder() {}
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
@@ -82,7 +82,7 @@ public final class DoubleExample {
             return this;
         }
 
-        private void validateFields() {
+        private void validatePrimitiveFieldsHaveBeenInitialized() {
             List<String> missingFields = null;
             missingFields =
                     addFieldIfMissing(missingFields, _doubleValueInitialized, "doubleValue");
@@ -105,7 +105,7 @@ public final class DoubleExample {
         }
 
         public DoubleExample build() {
-            validateFields();
+            validatePrimitiveFieldsHaveBeenInitialized();
             return new DoubleExample(doubleValue);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
@@ -65,6 +65,8 @@ public final class IntegerExample {
     public static final class Builder {
         private int integer;
 
+        private boolean _integerInitialized;
+
         private Builder() {}
 
         public Builder from(IntegerExample other) {
@@ -75,6 +77,7 @@ public final class IntegerExample {
         @JsonSetter("integer")
         public Builder integer(int integer) {
             this.integer = integer;
+            _integerInitialized = true;
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
@@ -105,6 +105,7 @@ public final class IntegerExample {
         }
 
         public IntegerExample build() {
+            validateFields();
             return new IntegerExample(integer);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
@@ -77,7 +77,7 @@ public final class IntegerExample {
         @JsonSetter("integer")
         public Builder integer(int integer) {
             this.integer = integer;
-            _integerInitialized = true;
+            this._integerInitialized = true;
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
 
@@ -79,6 +81,27 @@ public final class IntegerExample {
             this.integer = integer;
             this._integerInitialized = true;
             return this;
+        }
+
+        private void validateFields() {
+            List<String> missingFields = null;
+            missingFields = addFieldIfMissing(missingFields, _integerInitialized, "integer");
+            if (missingFields != null) {
+                throw new IllegalArgumentException(
+                        "Some required fields have not been set: " + missingFields);
+            }
+        }
+
+        private static List<String> addFieldIfMissing(
+                List<String> prev, boolean initialized, String fieldName) {
+            List<String> missingFields = prev;
+            if (!initialized) {
+                if (missingFields == null) {
+                    missingFields = new ArrayList<>(1);
+                }
+                missingFields.add(fieldName);
+            }
+            return missingFields;
         }
 
         public IntegerExample build() {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
@@ -65,7 +65,7 @@ public final class IntegerExample {
     public static final class Builder {
         private int integer;
 
-        private boolean _integerInitialized;
+        private boolean _integerInitialized = false;
 
         private Builder() {}
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
@@ -83,7 +83,7 @@ public final class IntegerExample {
             return this;
         }
 
-        private void validateFields() {
+        private void validatePrimitiveFieldsHaveBeenInitialized() {
             List<String> missingFields = null;
             missingFields = addFieldIfMissing(missingFields, _integerInitialized, "integer");
             if (missingFields != null) {
@@ -105,7 +105,7 @@ public final class IntegerExample {
         }
 
         public IntegerExample build() {
-            validateFields();
+            validatePrimitiveFieldsHaveBeenInitialized();
             return new IntegerExample(integer);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -351,7 +351,7 @@ public final class ManyFieldExample {
             return this;
         }
 
-        private void validateFields() {
+        private void validatePrimitiveFieldsHaveBeenInitialized() {
             List<String> missingFields = null;
             missingFields = addFieldIfMissing(missingFields, _integerInitialized, "integer");
             missingFields =
@@ -375,7 +375,7 @@ public final class ManyFieldExample {
         }
 
         public ManyFieldExample build() {
-            validateFields();
+            validatePrimitiveFieldsHaveBeenInitialized();
             return new ManyFieldExample(
                     string, integer, doubleValue, optionalItem, items, set, map, alias);
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -375,6 +375,7 @@ public final class ManyFieldExample {
         }
 
         public ManyFieldExample build() {
+            validateFields();
             return new ManyFieldExample(
                     string, integer, doubleValue, optionalItem, items, set, map, alias);
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -226,9 +226,9 @@ public final class ManyFieldExample {
 
         private StringAliasExample alias;
 
-        private boolean _integerInitialized;
+        private boolean _integerInitialized = false;
 
-        private boolean _doubleValueInitialized;
+        private boolean _doubleValueInitialized = false;
 
         private Builder() {}
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -226,6 +226,10 @@ public final class ManyFieldExample {
 
         private StringAliasExample alias;
 
+        private boolean _integerInitialized;
+
+        private boolean _doubleValueInitialized;
+
         private Builder() {}
 
         public Builder from(ManyFieldExample other) {
@@ -251,6 +255,7 @@ public final class ManyFieldExample {
         @JsonSetter("integer")
         public Builder integer(int integer) {
             this.integer = integer;
+            _integerInitialized = true;
             return this;
         }
 
@@ -258,6 +263,7 @@ public final class ManyFieldExample {
         @JsonSetter("doubleValue")
         public Builder doubleValue(double doubleValue) {
             this.doubleValue = doubleValue;
+            _doubleValueInitialized = true;
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -351,6 +351,29 @@ public final class ManyFieldExample {
             return this;
         }
 
+        private void validateFields() {
+            List<String> missingFields = null;
+            missingFields = addFieldIfMissing(missingFields, _integerInitialized, "integer");
+            missingFields =
+                    addFieldIfMissing(missingFields, _doubleValueInitialized, "doubleValue");
+            if (missingFields != null) {
+                throw new IllegalArgumentException(
+                        "Some required fields have not been set: " + missingFields);
+            }
+        }
+
+        private static List<String> addFieldIfMissing(
+                List<String> prev, boolean initialized, String fieldName) {
+            List<String> missingFields = prev;
+            if (!initialized) {
+                if (missingFields == null) {
+                    missingFields = new ArrayList<>(2);
+                }
+                missingFields.add(fieldName);
+            }
+            return missingFields;
+        }
+
         public ManyFieldExample build() {
             return new ManyFieldExample(
                     string, integer, doubleValue, optionalItem, items, set, map, alias);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -255,7 +255,7 @@ public final class ManyFieldExample {
         @JsonSetter("integer")
         public Builder integer(int integer) {
             this.integer = integer;
-            _integerInitialized = true;
+            this._integerInitialized = true;
             return this;
         }
 
@@ -263,7 +263,7 @@ public final class ManyFieldExample {
         @JsonSetter("doubleValue")
         public Builder doubleValue(double doubleValue) {
             this.doubleValue = doubleValue;
-            _doubleValueInitialized = true;
+            this._doubleValueInitialized = true;
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -136,6 +136,8 @@ public final class ReservedKeyExample {
 
         private int memoizedHashCode_;
 
+        private boolean _memoizedHashCodeInitialized;
+
         private Builder() {}
 
         public Builder from(ReservedKeyExample other) {
@@ -169,6 +171,7 @@ public final class ReservedKeyExample {
         @JsonSetter("memoizedHashCode")
         public Builder memoizedHashCode_(int memoizedHashCode_) {
             this.memoizedHashCode_ = memoizedHashCode_;
+            _memoizedHashCodeInitialized = true;
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -175,6 +175,29 @@ public final class ReservedKeyExample {
             return this;
         }
 
+        private void validateFields() {
+            List<String> missingFields = null;
+            missingFields =
+                    addFieldIfMissing(
+                            missingFields, _memoizedHashCodeInitialized, "memoizedHashCode");
+            if (missingFields != null) {
+                throw new IllegalArgumentException(
+                        "Some required fields have not been set: " + missingFields);
+            }
+        }
+
+        private static List<String> addFieldIfMissing(
+                List<String> prev, boolean initialized, String fieldName) {
+            List<String> missingFields = prev;
+            if (!initialized) {
+                if (missingFields == null) {
+                    missingFields = new ArrayList<>(1);
+                }
+                missingFields.add(fieldName);
+            }
+            return missingFields;
+        }
+
         public ReservedKeyExample build() {
             return new ReservedKeyExample(
                     package_, interface_, fieldNameWithDashes, memoizedHashCode_);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -199,6 +199,7 @@ public final class ReservedKeyExample {
         }
 
         public ReservedKeyExample build() {
+            validateFields();
             return new ReservedKeyExample(
                     package_, interface_, fieldNameWithDashes, memoizedHashCode_);
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -171,7 +171,7 @@ public final class ReservedKeyExample {
         @JsonSetter("memoizedHashCode")
         public Builder memoizedHashCode_(int memoizedHashCode_) {
             this.memoizedHashCode_ = memoizedHashCode_;
-            _memoizedHashCodeInitialized = true;
+            this._memoizedHashCodeInitialized = true;
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -175,7 +175,7 @@ public final class ReservedKeyExample {
             return this;
         }
 
-        private void validateFields() {
+        private void validatePrimitiveFieldsHaveBeenInitialized() {
             List<String> missingFields = null;
             missingFields =
                     addFieldIfMissing(
@@ -199,7 +199,7 @@ public final class ReservedKeyExample {
         }
 
         public ReservedKeyExample build() {
-            validateFields();
+            validatePrimitiveFieldsHaveBeenInitialized();
             return new ReservedKeyExample(
                     package_, interface_, fieldNameWithDashes, memoizedHashCode_);
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -136,7 +136,7 @@ public final class ReservedKeyExample {
 
         private int memoizedHashCode_;
 
-        private boolean _memoizedHashCodeInitialized;
+        private boolean _memoizedHashCodeInitialized = false;
 
         private Builder() {}
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -134,7 +134,7 @@ public final class BeanBuilderGenerator {
     }
 
     private static MethodSpec createValidateFieldsMethod(List<EnrichedField> primitives) {
-        MethodSpec.Builder builder = MethodSpec.methodBuilder("validateFields")
+        MethodSpec.Builder builder = MethodSpec.methodBuilder("validatePrimitiveFieldsHaveBeenInitialized")
                 .addModifiers(Modifier.PRIVATE);
 
         builder.addStatement("$T missingFields = null", ParameterizedTypeName.get(List.class, String.class));
@@ -426,7 +426,7 @@ public final class BeanBuilderGenerator {
                 .returns(objectClass);
 
         if (enrichedFields.stream().filter(EnrichedField::isPrimitive).count() != 0) {
-            method.addStatement("validateFields()");
+            method.addStatement("validatePrimitiveFieldsHaveBeenInitialized()");
         }
 
         return method

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -124,7 +124,7 @@ public final class BeanBuilderGenerator {
                 .map(field -> FieldSpec.builder(
                         TypeName.BOOLEAN,
                         deriveFieldInitializedName(field),
-                        Modifier.PRIVATE).build())
+                        Modifier.PRIVATE).initializer("false").build())
                 .collect(toList());
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -199,7 +199,7 @@ public final class BeanBuilderGenerator {
                 .addCode(typeAwareAssignment(enriched, type, shouldClearFirst));
 
         if (enriched.isPrimitive()) {
-            setterBuilder.addCode("$L = true;", deriveFieldInitializedName(enriched));
+            setterBuilder.addCode("this.$L = true;", deriveFieldInitializedName(enriched));
         }
 
         return setterBuilder

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -91,7 +91,7 @@ public final class BeanGenerator {
         }
 
         Collection<EnrichedField> nonPrimitiveEnrichedFields = fields.stream()
-                .filter(f -> !f.poetSpec().type.isPrimitive())
+                .filter(field -> !field.isPrimitive())
                 .collect(Collectors.toList());
 
         TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(typeDef.getTypeName().getName())
@@ -348,6 +348,11 @@ public final class BeanGenerator {
 
         @Value.Parameter
         FieldSpec poetSpec();
+
+        @Value.Derived
+        default boolean isPrimitive() {
+            return poetSpec().type.isPrimitive();
+        }
 
         static EnrichedField of(FieldName fieldName, FieldDefinition conjureDef, FieldSpec poetSpec) {
             return ImmutableEnrichedField.of(fieldName, conjureDef, poetSpec);

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/MissingFieldWireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/MissingFieldWireFormatTests.java
@@ -25,7 +25,6 @@ import com.palantir.product.SetExample;
 import com.palantir.product.StringExample;
 import com.palantir.product.UuidExample;
 import com.palantir.remoting3.ext.jackson.ObjectMappers;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class MissingFieldWireFormatTests {
@@ -39,7 +38,6 @@ public class MissingFieldWireFormatTests {
                 .hasMessage("Some required fields have not been set: [string]");
     }
 
-    @Ignore // integer and double primitives do not throw if fields unset
     @Test
     public void missing_integer_field_should_throw() throws Exception {
         assertThatThrownBy(() -> mapper.readValue("{}", IntegerExample.class))
@@ -75,7 +73,6 @@ public class MissingFieldWireFormatTests {
                 .hasMessage("Some required fields have not been set: [datetime]");
     }
 
-    @Ignore // integer and double primitives do not throw if fields unset
     @Test
     public void missing_double_field_should_throw() throws Exception {
         assertThatThrownBy(() -> mapper.readValue("{}", DoubleExample.class))
@@ -109,7 +106,6 @@ public class MissingFieldWireFormatTests {
                 .hasMessage("Some required fields have not been set: [enum]");
     }
 
-    @Ignore // integer and double primitives do not throw if fields unset
     @Test
     public void missing_boolean_field_should_throw() throws Exception {
         assertThatThrownBy(() -> mapper.readValue("{}", BooleanExample.class))

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/NullFieldWireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/NullFieldWireFormatTests.java
@@ -26,7 +26,6 @@ import com.palantir.product.SetExample;
 import com.palantir.product.StringExample;
 import com.palantir.product.UuidExample;
 import com.palantir.remoting3.ext.jackson.ObjectMappers;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class NullFieldWireFormatTests {
@@ -40,12 +39,11 @@ public class NullFieldWireFormatTests {
                 .hasMessageContaining("string cannot be null");
     }
 
-    @Ignore // not implemented
     @Test
     public void null_integer_field_should_throw() throws Exception {
         assertThatThrownBy(() -> mapper.readValue("{\"integer\":null}", IntegerExample.class))
                 .isInstanceOf(JsonMappingException.class)
-                .hasMessageContaining("integer cannot be null");
+                .hasMessageContaining("Cannot map `null` into type int");
     }
 
     @Test
@@ -76,12 +74,11 @@ public class NullFieldWireFormatTests {
                 .hasMessageContaining("datetime cannot be null");
     }
 
-    @Ignore // not implemented
     @Test
     public void null_double_field_should_throw() throws Exception {
         assertThatThrownBy(() -> mapper.readValue("{\"double\":null}", DoubleExample.class))
-                .isInstanceOf(JsonMappingException.class)
-                .hasMessageContaining("double cannot be null");
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Some required fields have not been set: [doubleValue]");
     }
 
     @Test
@@ -110,12 +107,11 @@ public class NullFieldWireFormatTests {
                 .hasMessageContaining("enum cannot be null");
     }
 
-    @Ignore // not implemented
     @Test
     public void null_boolean_field_should_throw() throws Exception {
         assertThatThrownBy(() -> mapper.readValue("{\"coin\":null}", BooleanExample.class))
                 .isInstanceOf(JsonMappingException.class)
-                .hasMessageContaining("coin cannot be null");
+                .hasMessageContaining("Cannot map `null` into type boolean");
     }
 
     @Test

--- a/versions.props
+++ b/versions.props
@@ -1,4 +1,4 @@
-com.fasterxml.jackson.*:jackson-* = 2.7.4
+com.fasterxml.jackson.*:jackson-* = 2.9.6
 com.fasterxml.jackson.datatype:jackson-datatype-jdk7 = 2.6.7
 com.google.code.findbugs:jsr305 = 3.0.2
 com.google.errorprone:error_prone_annotations = 2.3.1
@@ -8,7 +8,7 @@ com.netflix.nebula:nebula-test = 6.7.0
 com.palantir.conjure:* = 0.1.1
 com.palantir.baseline:* = 0.20.1
 com.palantir.remoting-*:* = 1.8.0
-com.palantir.remoting3:* = 3.22.0
+com.palantir.remoting3:* = 3.37.0
 com.palantir.ri:resource-identifier = 1.0.1
 com.palantir.safe-logging:safe-logging = 1.4.0
 com.palantir.syntactic-paths:syntactic-paths = 0.6.1


### PR DESCRIPTION
## Before this PR

Conjure POJOs containing primitives (e.g. int, boolean) would be coerced from JSON in which the fields were actually missing.  This was not compliant with the wire spec and could lead to nasty bugs, where a field was unintentionally initialized to `0` or `false`. For example, consider this type:

```yaml
UpdateSalaryRequest:
  salary: integer
  shares: integer
```

The following request would result in dfox's salary being set to 0, because the the 'salary' field was missing and is initialized to 0!!
```
curl -XPOST https://some-api/update-salary/dfox --data '{"shares":20}'
```


## After this PR

Trying to deserialize a type with booleans, integers or doubles from `{}` will now fail.

## Concerns

People may have been relying on this behaviour, so there's a chance this might break people's servers... In theory, we could put this behaviour behind a feature flag, and then phase it in slowly?? EDIT not gonna do this as it's not actually a wire-break and people's servers can be trivially fixed by updating their conjure defs:

```diff
 UpdateSalaryRequest:
-  salary: integer
+  salary: optional<integer>
   shares: integer
```


_Future work: unify this `validatePrimitivesHaveBeenInitialized` method with the other `validateFields` method_

fixes #14 