### PR TITLE
[WIP][break] remove support for Nan/Inf

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
@@ -77,6 +77,10 @@ public final class DoubleExample {
 
         @JsonSetter("doubleValue")
         public Builder doubleValue(double doubleValue) {
+            if (Double.isNaN(doubleValue) || Double.isInfinite(doubleValue)) {
+                throw new IllegalArgumentException(
+                        "NaN or Infinity for double type, doubleValue, is not allowed.");
+            }
             this.doubleValue = doubleValue;
             this._doubleValueInitialized = true;
             return this;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -262,6 +262,10 @@ public final class ManyFieldExample {
         /** docs for doubleValue field */
         @JsonSetter("doubleValue")
         public Builder doubleValue(double doubleValue) {
+            if (Double.isNaN(doubleValue) || Double.isInfinite(doubleValue)) {
+                throw new IllegalArgumentException(
+                        "NaN or Infinity for double type, doubleValue, is not allowed.");
+            }
             this.doubleValue = doubleValue;
             this._doubleValueInitialized = true;
             return this;

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.types;
 
+import static com.squareup.javapoet.TypeName.DOUBLE;
 import static java.util.stream.Collectors.toList;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -53,6 +54,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
@@ -319,6 +321,19 @@ public final class BeanBuilderGenerator {
                             ByteBuffer.class)
                     .addStatement("this.$1N.rewind()", spec.name)
                     .build();
+        } else if (Objects.equals(spec.type, DOUBLE)) {
+            // ban `NaN` and `Infinity` for double
+            CodeBlock.Builder codeBlockBuilder = CodeBlock.builder();
+            codeBlockBuilder
+                    .beginControlFlow(
+                            "if ($1T.isNaN($2N) || $1T.isInfinite($2N))",
+                            Double.class, spec.name)
+                    .addStatement("throw new $T(\"NaN or Infinity for double type, $N, is not allowed.\")",
+                            IllegalArgumentException.class, spec.name)
+                    .endControlFlow();
+
+            codeBlockBuilder.add(CodeBlocks.statement("this.$N = $N", spec.name, spec.name));
+            return codeBlockBuilder.build();
         } else {
             CodeBlock nullCheckedValue = spec.type.isPrimitive()
                     ? CodeBlock.of("$N", spec.name) // primitive types can't be null, so no need for requireNonNull!

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.java.types;
 
-import static com.squareup.javapoet.TypeName.DOUBLE;
 import static java.util.stream.Collectors.toList;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -321,7 +320,7 @@ public final class BeanBuilderGenerator {
                             ByteBuffer.class)
                     .addStatement("this.$1N.rewind()", spec.name)
                     .build();
-        } else if (Objects.equals(spec.type, DOUBLE)) {
+        } else if (Objects.equals(spec.type, TypeName.DOUBLE)) {
             // ban `NaN` and `Infinity` for double
             CodeBlock.Builder codeBlockBuilder = CodeBlock.builder();
             codeBlockBuilder

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -60,7 +60,7 @@ public final class WireFormatTests {
     public void testOptionalSerialization() throws Exception {
         assertThat(mapper.writeValueAsString(OptionalExample.of("a"))).isEqualTo("{\"item\":\"a\"}");
     }
-    
+
     @Test
     public void deserializing_double_nan_fields_should_throw_an_error() {
         assertThatThrownBy(() -> mapper.readValue("{\"doubleValue\":\"NaN\"}", DoubleExample.class))
@@ -257,6 +257,7 @@ public final class WireFormatTests {
         assertThat(mapper.readValue("{\"datetime\":\"2017-01-02T03:04:05.000000Z\"}", DateTimeExample.class))
                 .isEqualTo(secondsOnly);
     }
+
     @Test
     public void testDateTimeType_equality() throws Exception {
         ZonedDateTime aa = ZonedDateTime.parse("2017-01-02T03:04:05.000000006Z");

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -5,7 +5,9 @@
 package com.palantir.conjure.java.types;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.product.BinaryAliasExample;
@@ -58,17 +60,12 @@ public final class WireFormatTests {
     public void testOptionalSerialization() throws Exception {
         assertThat(mapper.writeValueAsString(OptionalExample.of("a"))).isEqualTo("{\"item\":\"a\"}");
     }
-
+    
     @Test
-    public void double_nan_fields_should_be_serialized_as_a_string() throws Exception {
-        assertThat(mapper.writeValueAsString(DoubleExample.of(Double.NaN)))
-                .isEqualTo("{\"doubleValue\":\"NaN\"}");
-    }
-
-    @Test
-    public void double_nan_fields_should_deserialize_from_a_string() throws Exception {
-        DoubleExample deserialized = mapper.readValue("{\"doubleValue\":\"NaN\"}", DoubleExample.class);
-        assertThat(deserialized.getDoubleValue()).isNaN();
+    public void deserializing_double_nan_fields_should_throw_an_error() {
+        assertThatThrownBy(() -> mapper.readValue("{\"doubleValue\":\"NaN\"}", DoubleExample.class))
+                .isExactlyInstanceOf(JsonMappingException.class)
+                .hasMessageContaining("NaN or Infinity for double type, doubleValue, is not allowed.");
     }
 
     @Test

--- a/conjure-java-verifier/src/test/resources/ignored-test-cases.yml
+++ b/conjure-java-verifier/src/test/resources/ignored-test-cases.yml
@@ -14,6 +14,7 @@ client:
     receiveDoubleExample:
       - "{\"value\":\"1.23\"}" # jackson coerces things to other types
       - "{\"value\":13}" # verification-server is overly strict, these are perfectly fine
+      - "{\"value\":\"NaN\"}" # `NaN` or infinity is banned
     receiveDoubleAliasExample:
       - "10" # verification-server is overly strict, these are perfectly fine
       - "null" # TODO(dfox): palantir/http-remoting#758 - make http-remoting reject null bodies


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
Generated Double types allow `NaN` and `Infinity` as values

## After this PR
`NaN` and `Infinity` are now banned in generated Double types to be compliant with the [spec(to be updated)](https://github.com/palantir/conjure/blob/develop/docs/specification.md)
