### PR TITLE
[improvement] Retrofit2 clients should also set hr-path-template

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceRetrofit.java
@@ -4,9 +4,11 @@ import java.lang.Boolean;
 import javax.annotation.Generated;
 import retrofit2.Call;
 import retrofit2.http.GET;
+import retrofit2.http.Headers;
 
 @Generated("com.palantir.conjure.java.services.Retrofit2ServiceGenerator")
 public interface EmptyPathServiceRetrofit {
     @GET("./")
+    @Headers("hr-path-template: /")
     Call<Boolean> emptyPath();
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
@@ -16,46 +16,59 @@ import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
 import retrofit2.http.Header;
+import retrofit2.http.Headers;
 import retrofit2.http.POST;
 import retrofit2.http.Streaming;
 
 @Generated("com.palantir.conjure.java.services.Retrofit2ServiceGenerator")
 public interface EteServiceRetrofit {
     @GET("./base/string")
+    @Headers("hr-path-template: /base/string")
     Call<String> string(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/integer")
+    @Headers("hr-path-template: /base/integer")
     Call<Integer> integer(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/double")
+    @Headers("hr-path-template: /base/double")
     Call<Double> double_(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/boolean")
+    @Headers("hr-path-template: /base/boolean")
     Call<Boolean> boolean_(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/safelong")
+    @Headers("hr-path-template: /base/safelong")
     Call<SafeLong> safelong(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/rid")
+    @Headers("hr-path-template: /base/rid")
     Call<ResourceIdentifier> rid(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/bearertoken")
+    @Headers("hr-path-template: /base/bearertoken")
     Call<BearerToken> bearertoken(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/optionalString")
+    @Headers("hr-path-template: /base/optionalString")
     Call<Optional<String>> optionalString(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/optionalEmpty")
+    @Headers("hr-path-template: /base/optionalEmpty")
     Call<Optional<String>> optionalEmpty(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/datetime")
+    @Headers("hr-path-template: /base/datetime")
     Call<OffsetDateTime> datetime(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/binary")
+    @Headers("hr-path-template: /base/binary")
     @Streaming
     Call<ResponseBody> binary(@Header("Authorization") AuthHeader authHeader);
 
     @POST("./base/notNullBody")
+    @Headers("hr-path-template: /base/notNullBody")
     Call<StringAliasExample> notNullBody(
             @Header("Authorization") AuthHeader authHeader, @Body StringAliasExample notNullBody);
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
@@ -125,6 +125,9 @@ public final class Retrofit2ServiceGenerator implements ServiceGenerator {
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                 .addAnnotation(AnnotationSpec.builder(httpMethodToClassName(endpointDef.getHttpMethod().get().name()))
                         .addMember("value", "$S", "." + endpointPathWithoutRegex)
+                        .build())
+                .addAnnotation(AnnotationSpec.builder(ClassName.get("retrofit2.http", "Headers"))
+                        .addMember("value", "$S", "hr-path-template: " + endpointPathWithoutRegex)
                         .build());
 
         if (endpointDef.getReturns().map(type -> type.accept(TypeVisitor.IS_BINARY)).orElse(false)) {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/Retrofit2ServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/Retrofit2ServiceEteTest.java
@@ -25,6 +25,7 @@ import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.conjure.java.services.Retrofit2ServiceGenerator;
 import com.palantir.conjure.spec.ConjureDefinition;
 import com.palantir.product.EteServiceRetrofit;
+import com.palantir.product.StringAliasExample;
 import com.palantir.remoting3.retrofit2.Retrofit2Client;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/Retrofit2ServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/Retrofit2ServiceEteTest.java
@@ -25,7 +25,6 @@ import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.conjure.java.services.Retrofit2ServiceGenerator;
 import com.palantir.conjure.spec.ConjureDefinition;
 import com.palantir.product.EteServiceRetrofit;
-import com.palantir.product.StringAliasExample;
 import com.palantir.remoting3.retrofit2.Retrofit2Client;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
@@ -23,6 +23,7 @@ import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
 import retrofit2.http.Header;
+import retrofit2.http.Headers;
 import retrofit2.http.POST;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
@@ -33,46 +34,55 @@ import retrofit2.http.Streaming;
 public interface TestServiceRetrofit {
     /** Returns a mapping from file system id to backing file system configuration. */
     @GET("./catalog/fileSystems")
+    @Headers("hr-path-template: /catalog/fileSystems")
     Call<Map<String, BackingFileSystem>> getFileSystems(
             @Header("Authorization") AuthHeader authHeader);
 
     @POST("./catalog/datasets")
+    @Headers("hr-path-template: /catalog/datasets")
     Call<Dataset> createDataset(
             @Header("Authorization") AuthHeader authHeader,
             @Body CreateDatasetRequest request,
             @Header("Test-Header") String testHeaderArg);
 
     @GET("./catalog/datasets/{datasetRid}")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}")
     Call<Optional<Dataset>> getDataset(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/raw")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/raw")
     @Streaming
     Call<ResponseBody> getRawData(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/raw-aliased")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/raw-aliased")
     Call<ResponseBody> getAliasedRawData(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/raw-maybe")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/raw-maybe")
     Call<Optional<ByteBuffer>> maybeGetRawData(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/string-aliased")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/string-aliased")
     Call<AliasedString> getAliasedString(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @POST("./catalog/datasets/upload-raw")
+    @Headers("hr-path-template: /catalog/datasets/upload-raw")
     Call<Void> uploadRawData(
             @Header("Authorization") AuthHeader authHeader, @Body RequestBody input);
 
     @GET("./catalog/datasets/{datasetRid}/branches")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/branches")
     Call<Set<String>> getBranches(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
@@ -83,23 +93,27 @@ public interface TestServiceRetrofit {
      * @deprecated use getBranches instead
      */
     @GET("./catalog/datasets/{datasetRid}/branchesDeprecated")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/branchesDeprecated")
     @Deprecated
     Call<Set<String>> getBranchesDeprecated(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/branches/{branch}/resolve")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/branches/{branch}/resolve")
     Call<Optional<String>> resolveBranch(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid,
             @Path(value = "branch", encoded = true) String branch);
 
     @GET("./catalog/datasets/{datasetRid}/testParam")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/testParam")
     Call<Optional<String>> testParam(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @POST("./catalog/test-query-params")
+    @Headers("hr-path-template: /catalog/test-query-params")
     Call<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
             @Body String query,
@@ -110,6 +124,7 @@ public interface TestServiceRetrofit {
             @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
 
     @POST("./catalog/test-no-response-query-params")
+    @Headers("hr-path-template: /catalog/test-no-response-query-params")
     Call<Void> testNoResponseQueryParams(
             @Header("Authorization") AuthHeader authHeader,
             @Body String query,
@@ -120,15 +135,19 @@ public interface TestServiceRetrofit {
             @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
 
     @GET("./catalog/boolean")
+    @Headers("hr-path-template: /catalog/boolean")
     Call<Boolean> testBoolean(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./catalog/double")
+    @Headers("hr-path-template: /catalog/double")
     Call<Double> testDouble(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./catalog/integer")
+    @Headers("hr-path-template: /catalog/integer")
     Call<Integer> testInteger(@Header("Authorization") AuthHeader authHeader);
 
     @POST("./catalog/optional")
+    @Headers("hr-path-template: /catalog/optional")
     Call<Optional<String>> testPostOptional(
             @Header("Authorization") AuthHeader authHeader, @Body Optional<String> maybeString);
 }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
@@ -23,6 +23,7 @@ import okhttp3.ResponseBody;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
 import retrofit2.http.Header;
+import retrofit2.http.Headers;
 import retrofit2.http.POST;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
@@ -33,46 +34,55 @@ import retrofit2.http.Streaming;
 public interface TestServiceRetrofit {
     /** Returns a mapping from file system id to backing file system configuration. */
     @GET("./catalog/fileSystems")
+    @Headers("hr-path-template: /catalog/fileSystems")
     CompletableFuture<Map<String, BackingFileSystem>> getFileSystems(
             @Header("Authorization") AuthHeader authHeader);
 
     @POST("./catalog/datasets")
+    @Headers("hr-path-template: /catalog/datasets")
     CompletableFuture<Dataset> createDataset(
             @Header("Authorization") AuthHeader authHeader,
             @Body CreateDatasetRequest request,
             @Header("Test-Header") String testHeaderArg);
 
     @GET("./catalog/datasets/{datasetRid}")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}")
     CompletableFuture<Optional<Dataset>> getDataset(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/raw")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/raw")
     @Streaming
     CompletableFuture<ResponseBody> getRawData(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/raw-aliased")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/raw-aliased")
     CompletableFuture<ResponseBody> getAliasedRawData(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/raw-maybe")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/raw-maybe")
     CompletableFuture<Optional<ByteBuffer>> maybeGetRawData(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/string-aliased")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/string-aliased")
     CompletableFuture<AliasedString> getAliasedString(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @POST("./catalog/datasets/upload-raw")
+    @Headers("hr-path-template: /catalog/datasets/upload-raw")
     CompletableFuture<Void> uploadRawData(
             @Header("Authorization") AuthHeader authHeader, @Body RequestBody input);
 
     @GET("./catalog/datasets/{datasetRid}/branches")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/branches")
     CompletableFuture<Set<String>> getBranches(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
@@ -83,23 +93,27 @@ public interface TestServiceRetrofit {
      * @deprecated use getBranches instead
      */
     @GET("./catalog/datasets/{datasetRid}/branchesDeprecated")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/branchesDeprecated")
     @Deprecated
     CompletableFuture<Set<String>> getBranchesDeprecated(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/branches/{branch}/resolve")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/branches/{branch}/resolve")
     CompletableFuture<Optional<String>> resolveBranch(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid,
             @Path(value = "branch", encoded = true) String branch);
 
     @GET("./catalog/datasets/{datasetRid}/testParam")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/testParam")
     CompletableFuture<Optional<String>> testParam(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @POST("./catalog/test-query-params")
+    @Headers("hr-path-template: /catalog/test-query-params")
     CompletableFuture<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
             @Body String query,
@@ -110,6 +124,7 @@ public interface TestServiceRetrofit {
             @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
 
     @POST("./catalog/test-no-response-query-params")
+    @Headers("hr-path-template: /catalog/test-no-response-query-params")
     CompletableFuture<Void> testNoResponseQueryParams(
             @Header("Authorization") AuthHeader authHeader,
             @Body String query,
@@ -120,15 +135,19 @@ public interface TestServiceRetrofit {
             @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
 
     @GET("./catalog/boolean")
+    @Headers("hr-path-template: /catalog/boolean")
     CompletableFuture<Boolean> testBoolean(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./catalog/double")
+    @Headers("hr-path-template: /catalog/double")
     CompletableFuture<Double> testDouble(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./catalog/integer")
+    @Headers("hr-path-template: /catalog/integer")
     CompletableFuture<Integer> testInteger(@Header("Authorization") AuthHeader authHeader);
 
     @POST("./catalog/optional")
+    @Headers("hr-path-template: /catalog/optional")
     CompletableFuture<Optional<String>> testPostOptional(
             @Header("Authorization") AuthHeader authHeader, @Body Optional<String> maybeString);
 }


### PR DESCRIPTION
Feign does this, and Retrofit does not. Let's make our retrofit
interfaces contain this header, too!

I've traced this through with a debugger and verified that it does the
right thing.

## Before this PR

For tracing purposes (and soon, also concurrency limiting) the Feign
contract sets the hr-path-template header to the path template for
tracing purposes. An OkHttp interceptor removes this header, and
uses it to start a span.

## After this PR

Retrofit generated interfaces also contain the hr-path-template header.

Relevant to https://github.com/palantir/http-remoting/pull/786.