### PR TITLE
[fix] Use correct optional type for primitives

### DIFF
--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
@@ -38,6 +38,7 @@ import com.palantir.conjure.spec.OptionalType;
 import com.palantir.conjure.spec.ParameterId;
 import com.palantir.conjure.spec.ParameterType;
 import com.palantir.conjure.spec.PathParameterType;
+import com.palantir.conjure.spec.PrimitiveType;
 import com.palantir.conjure.spec.QueryParameterType;
 import com.palantir.conjure.spec.ServiceDefinition;
 import com.palantir.conjure.spec.SetType;
@@ -58,6 +59,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -456,6 +459,18 @@ public final class JerseyServiceGenerator implements ServiceGenerator {
     private static final Type.Visitor<CodeBlock> TYPE_DEFAULT_VALUE = new TypeVisitor.Default<CodeBlock>() {
         @Override
         public CodeBlock visitOptional(OptionalType value) {
+            if (value.getItemType().accept(TypeVisitor.IS_PRIMITIVE)) {
+                PrimitiveType primitiveType = value.getItemType().accept(TypeVisitor.PRIMITIVE);
+                // special handling for primitive optionals with Java 8
+                switch (primitiveType.get()) {
+                    case DOUBLE:
+                        return CodeBlock.of("$T.empty()", OptionalDouble.class);
+                    case INTEGER:
+                        return CodeBlock.of("$T.empty()", OptionalInt.class);
+                    default:
+                        // not other optional types
+                }
+            }
             return CodeBlock.of("$T.empty()", Optional.class);
         }
 

--- a/conjure-java-core/src/test/resources/example-service.yml
+++ b/conjure-java-core/src/test/resources/example-service.yml
@@ -225,3 +225,13 @@ services:
         args:
           maybeString: optional<string>
         returns: optional<string>
+
+      testOptionalIntegerAndDouble:
+        http: GET /optional-integer-double
+        args:
+          maybeInteger:
+            type: optional<integer>
+            param-type: query
+          maybeDouble:
+            type: optional<double>
+            param-type: query

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
@@ -14,6 +14,8 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
 import java.util.Set;
 import javax.annotation.Generated;
 import javax.ws.rs.Consumes;
@@ -152,6 +154,13 @@ public interface TestService {
     Optional<String> testPostOptional(
             @HeaderParam("Authorization") AuthHeader authHeader, Optional<String> maybeString);
 
+    @GET
+    @Path("catalog/optional-integer-double")
+    void testOptionalIntegerAndDouble(
+            @HeaderParam("Authorization") AuthHeader authHeader,
+            @QueryParam("maybeInteger") OptionalInt maybeInteger,
+            @QueryParam("maybeDouble") OptionalDouble maybeDouble);
+
     @Deprecated
     default int testQueryParams(
             AuthHeader authHeader,
@@ -240,5 +249,15 @@ public interface TestService {
             String query) {
         testNoResponseQueryParams(
                 authHeader, something, implicit, optionalMiddle, setEnd, Optional.empty(), query);
+    }
+
+    @Deprecated
+    default void testOptionalIntegerAndDouble(AuthHeader authHeader) {
+        testOptionalIntegerAndDouble(authHeader, OptionalInt.empty(), OptionalDouble.empty());
+    }
+
+    @Deprecated
+    default void testOptionalIntegerAndDouble(AuthHeader authHeader, OptionalInt maybeInteger) {
+        testOptionalIntegerAndDouble(authHeader, maybeInteger, OptionalDouble.empty());
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
@@ -14,6 +14,8 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
 import java.util.Set;
 import javax.annotation.Generated;
 import javax.validation.constraints.NotNull;
@@ -156,6 +158,13 @@ public interface TestService {
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             Optional<String> maybeString);
 
+    @GET
+    @Path("catalog/optional-integer-double")
+    void testOptionalIntegerAndDouble(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @QueryParam("maybeInteger") OptionalInt maybeInteger,
+            @QueryParam("maybeDouble") OptionalDouble maybeDouble);
+
     @Deprecated
     default int testQueryParams(
             AuthHeader authHeader,
@@ -244,5 +253,15 @@ public interface TestService {
             String query) {
         testNoResponseQueryParams(
                 authHeader, something, implicit, optionalMiddle, setEnd, Optional.empty(), query);
+    }
+
+    @Deprecated
+    default void testOptionalIntegerAndDouble(AuthHeader authHeader) {
+        testOptionalIntegerAndDouble(authHeader, OptionalInt.empty(), OptionalDouble.empty());
+    }
+
+    @Deprecated
+    default void testOptionalIntegerAndDouble(AuthHeader authHeader, OptionalInt maybeInteger) {
+        testOptionalIntegerAndDouble(authHeader, maybeInteger, OptionalDouble.empty());
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
@@ -15,6 +15,8 @@ import java.lang.Void;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
 import java.util.Set;
 import javax.annotation.Generated;
 import okhttp3.RequestBody;
@@ -131,4 +133,10 @@ public interface TestServiceRetrofit {
     @POST("./catalog/optional")
     Call<Optional<String>> testPostOptional(
             @Header("Authorization") AuthHeader authHeader, @Body Optional<String> maybeString);
+
+    @GET("./catalog/optional-integer-double")
+    Call<Void> testOptionalIntegerAndDouble(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("maybeInteger") OptionalInt maybeInteger,
+            @Query("maybeDouble") OptionalDouble maybeDouble);
 }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
@@ -15,6 +15,8 @@ import java.lang.Void;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Generated;
@@ -131,4 +133,10 @@ public interface TestServiceRetrofit {
     @POST("./catalog/optional")
     CompletableFuture<Optional<String>> testPostOptional(
             @Header("Authorization") AuthHeader authHeader, @Body Optional<String> maybeString);
+
+    @GET("./catalog/optional-integer-double")
+    CompletableFuture<Void> testOptionalIntegerAndDouble(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("maybeInteger") OptionalInt maybeInteger,
+            @Query("maybeDouble") OptionalDouble maybeDouble);
 }


### PR DESCRIPTION
Compatibility backfill methods do not currently work when the full implementation uses `optional<integer>` or `optional<double>` since these generate `OptionalInt` and `OptionalDouble` of which it is not valid to use `Optional.empty()`.