### PR TITLE
[fix] Make the generated Union equals method symmetric

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -44,11 +44,7 @@ public final class SingleUnion {
 
     @Override
     public boolean equals(Object other) {
-        return this == other
-                || (other instanceof SingleUnion && equalTo((SingleUnion) other))
-                || (other instanceof String
-                        && value instanceof FooWrapper
-                        && Objects.equals(((FooWrapper) value).value, other));
+        return this == other || (other instanceof SingleUnion && equalTo((SingleUnion) other));
     }
 
     private boolean equalTo(SingleUnion other) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -50,14 +50,7 @@ public final class Union {
 
     @Override
     public boolean equals(Object other) {
-        return this == other
-                || (other instanceof Union && equalTo((Union) other))
-                || (other instanceof String
-                        && value instanceof FooWrapper
-                        && Objects.equals(((FooWrapper) value).value, other))
-                || (other instanceof Integer
-                        && value instanceof BarWrapper
-                        && Objects.equals(((BarWrapper) value).value, other));
+        return this == other || (other instanceof Union && equalTo((Union) other));
     }
 
     private boolean equalTo(Union other) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -84,28 +84,7 @@ public final class UnionTypeExample {
     @Override
     public boolean equals(Object other) {
         return this == other
-                || (other instanceof UnionTypeExample && equalTo((UnionTypeExample) other))
-                || (other instanceof StringExample
-                        && value instanceof StringExampleWrapper
-                        && Objects.equals(((StringExampleWrapper) value).value, other))
-                || (other instanceof Set
-                        && value instanceof SetWrapper
-                        && Objects.equals(((SetWrapper) value).value, other))
-                || (other instanceof Integer
-                        && value instanceof ThisFieldIsAnIntegerWrapper
-                        && Objects.equals(((ThisFieldIsAnIntegerWrapper) value).value, other))
-                || (other instanceof Integer
-                        && value instanceof AlsoAnIntegerWrapper
-                        && Objects.equals(((AlsoAnIntegerWrapper) value).value, other))
-                || (other instanceof Integer
-                        && value instanceof IfWrapper
-                        && Objects.equals(((IfWrapper) value).value, other))
-                || (other instanceof Integer
-                        && value instanceof NewWrapper
-                        && Objects.equals(((NewWrapper) value).value, other))
-                || (other instanceof Integer
-                        && value instanceof InterfaceWrapper
-                        && Objects.equals(((InterfaceWrapper) value).value, other));
+                || (other instanceof UnionTypeExample && equalTo((UnionTypeExample) other));
     }
 
     private boolean equalTo(UnionTypeExample other) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -46,7 +46,6 @@ import com.squareup.javapoet.TypeVariableName;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
@@ -183,9 +182,6 @@ public final class UnionGenerator {
         ParameterSpec other = ParameterSpec.builder(TypeName.OBJECT, "other").build();
         CodeBlock.Builder codeBuilder = CodeBlock.builder()
                 .add("return this == $1N || ($1N instanceof $2T && equalTo(($2T) $1N))", other, unionClass);
-        memberTypes.forEach((memberName, memberType) -> codeBuilder.add(
-                "\n|| ($1N instanceof $2T && $3L instanceof $4T && $5T.equals((($4T) $3L).$3L, $1N))", other,
-                rawBoxedType(memberType), VALUE_FIELD_NAME, wrapperClass(unionClass, memberName), Objects.class));
 
         return MethodSpec.methodBuilder("equals")
                 .addModifiers(Modifier.PUBLIC)

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -199,10 +199,6 @@ public final class WireFormatTests {
         assertThat(mapper.readValue(serializedUnionTypeSet, UnionTypeExample.class)).isEqualTo(unionTypeSet);
         assertThat(mapper.readValue(serializedUnionTypeInt, UnionTypeExample.class)).isEqualTo(unionTypeInt);
 
-        assertThat(unionTypeStringExample).isEqualTo(stringExample);
-        assertThat(unionTypeSet).isEqualTo(ImmutableSet.of("item"));
-        assertThat(unionTypeInt).isEqualTo(5);
-
         // visitor
         UnionTypeExample.Visitor<Integer> visitor = new TestVisitor();
         assertThat(unionTypeStringExample.accept(visitor)).isEqualTo("foo".length());


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
https://github.com/palantir/conjure-java/issues/61
The generated union equals method is not symmetric with the wrapper equals methods as described in the ticket above.

## After this PR
<!-- Describe at a high-level why this approach is better. -->
The new generated method is only equal to other Union objects and not the wrapped types.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
