### PR TITLE
[fix] Properly sanitize primitive initialization variable names

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -18,16 +18,23 @@ public final class ReservedKeyExample {
 
     private final String fieldNameWithDashes;
 
+    private final int primitveFieldNameWithDashes;
+
     private final int memoizedHashCode_;
 
     private volatile int memoizedHashCode;
 
     private ReservedKeyExample(
-            String package_, String interface_, String fieldNameWithDashes, int memoizedHashCode_) {
+            String package_,
+            String interface_,
+            String fieldNameWithDashes,
+            int primitveFieldNameWithDashes,
+            int memoizedHashCode_) {
         validateFields(package_, interface_, fieldNameWithDashes);
         this.package_ = package_;
         this.interface_ = interface_;
         this.fieldNameWithDashes = fieldNameWithDashes;
+        this.primitveFieldNameWithDashes = primitveFieldNameWithDashes;
         this.memoizedHashCode_ = memoizedHashCode_;
     }
 
@@ -46,6 +53,11 @@ public final class ReservedKeyExample {
         return this.fieldNameWithDashes;
     }
 
+    @JsonProperty("primitve-field-name-with-dashes")
+    public int getPrimitveFieldNameWithDashes() {
+        return this.primitveFieldNameWithDashes;
+    }
+
     @JsonProperty("memoizedHashCode")
     public int getMemoizedHashCode() {
         return this.memoizedHashCode_;
@@ -61,6 +73,7 @@ public final class ReservedKeyExample {
         return this.package_.equals(other.package_)
                 && this.interface_.equals(other.interface_)
                 && this.fieldNameWithDashes.equals(other.fieldNameWithDashes)
+                && this.primitveFieldNameWithDashes == other.primitveFieldNameWithDashes
                 && this.memoizedHashCode_ == other.memoizedHashCode_;
     }
 
@@ -68,7 +81,12 @@ public final class ReservedKeyExample {
     public int hashCode() {
         if (memoizedHashCode == 0) {
             memoizedHashCode =
-                    Objects.hash(package_, interface_, fieldNameWithDashes, memoizedHashCode_);
+                    Objects.hash(
+                            package_,
+                            interface_,
+                            fieldNameWithDashes,
+                            primitveFieldNameWithDashes,
+                            memoizedHashCode_);
         }
         return memoizedHashCode;
     }
@@ -88,6 +106,10 @@ public final class ReservedKeyExample {
                 .append("field-name-with-dashes")
                 .append(": ")
                 .append(fieldNameWithDashes)
+                .append(", ")
+                .append("primitve-field-name-with-dashes")
+                .append(": ")
+                .append(primitveFieldNameWithDashes)
                 .append(", ")
                 .append("memoizedHashCode")
                 .append(": ")
@@ -134,9 +156,13 @@ public final class ReservedKeyExample {
 
         private String fieldNameWithDashes;
 
+        private int primitveFieldNameWithDashes;
+
         private int memoizedHashCode_;
 
-        private boolean _memoizedHashCodeInitialized = false;
+        private boolean _primitveFieldNameWithDashesInitialized = false;
+
+        private boolean _memoizedHashCode_Initialized = false;
 
         private Builder() {}
 
@@ -144,6 +170,7 @@ public final class ReservedKeyExample {
             package_(other.getPackage());
             interface_(other.getInterface());
             fieldNameWithDashes(other.getFieldNameWithDashes());
+            primitveFieldNameWithDashes(other.getPrimitveFieldNameWithDashes());
             memoizedHashCode_(other.getMemoizedHashCode());
             return this;
         }
@@ -168,10 +195,17 @@ public final class ReservedKeyExample {
             return this;
         }
 
+        @JsonSetter("primitve-field-name-with-dashes")
+        public Builder primitveFieldNameWithDashes(int primitveFieldNameWithDashes) {
+            this.primitveFieldNameWithDashes = primitveFieldNameWithDashes;
+            this._primitveFieldNameWithDashesInitialized = true;
+            return this;
+        }
+
         @JsonSetter("memoizedHashCode")
         public Builder memoizedHashCode_(int memoizedHashCode_) {
             this.memoizedHashCode_ = memoizedHashCode_;
-            this._memoizedHashCodeInitialized = true;
+            this._memoizedHashCode_Initialized = true;
             return this;
         }
 
@@ -179,7 +213,12 @@ public final class ReservedKeyExample {
             List<String> missingFields = null;
             missingFields =
                     addFieldIfMissing(
-                            missingFields, _memoizedHashCodeInitialized, "memoizedHashCode");
+                            missingFields,
+                            _primitveFieldNameWithDashesInitialized,
+                            "primitve-field-name-with-dashes");
+            missingFields =
+                    addFieldIfMissing(
+                            missingFields, _memoizedHashCode_Initialized, "memoizedHashCode");
             if (missingFields != null) {
                 throw new IllegalArgumentException(
                         "Some required fields have not been set: " + missingFields);
@@ -191,7 +230,7 @@ public final class ReservedKeyExample {
             List<String> missingFields = prev;
             if (!initialized) {
                 if (missingFields == null) {
-                    missingFields = new ArrayList<>(1);
+                    missingFields = new ArrayList<>(2);
                 }
                 missingFields.add(fieldName);
             }
@@ -201,7 +240,11 @@ public final class ReservedKeyExample {
         public ReservedKeyExample build() {
             validatePrimitiveFieldsHaveBeenInitialized();
             return new ReservedKeyExample(
-                    package_, interface_, fieldNameWithDashes, memoizedHashCode_);
+                    package_,
+                    interface_,
+                    fieldNameWithDashes,
+                    primitveFieldNameWithDashes,
+                    memoizedHashCode_);
         }
     }
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -168,7 +168,7 @@ public final class BeanBuilderGenerator {
     }
 
     private static String deriveFieldInitializedName(EnrichedField field) {
-        return "_" + field.conjureDef().getFieldName() + "Initialized";
+        return "_" + JavaNameSanitizer.sanitize(field.conjureDef().getFieldName()) + "Initialized";
     }
 
     private Collection<EnrichedField> enrichFields(List<FieldDefinition> fields) {

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -166,6 +166,8 @@ types:
             type: string
           field-name-with-dashes:
             type: string
+          primitve-field-name-with-dashes:
+            type: integer
           memoizedHashCode:
             type: integer
       Union:


### PR DESCRIPTION
Fixes #66

<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
Conjure primitive with kebab-cased field name caused java-poet exception

## After this PR
<!-- Describe at a high-level why this approach is better. -->

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
Generating Conjure primitive with kebab-cased field name no longer throws exception