### PR TITLE
Add support for generating a ListenableFuture interface

### DIFF
--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/FeatureFlags.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/FeatureFlags.java
@@ -25,8 +25,18 @@ public enum FeatureFlags {
     /**
      * Instructs the {@link Retrofit2ServiceGenerator} to generate service
      * endpoints returning {@link java.util.concurrent.CompletableFuture} instead of {@code Call<>} objects.
+     * Incompatible with {@link FeatureFlags#RetrofitListenableFutures}.
+     * @deprecated please use {@link FeatureFlags#RetrofitListenableFutures}
      */
+    @Deprecated
     RetrofitCompletableFutures,
+
+    /**
+     * Instructs the {@link Retrofit2ServiceGenerator} to generate service
+     * endpoints returning {@link com.google.common.util.concurrent.ListenableFuture} instead of {@code Call<>} objects.
+     * Incompatible with {@link FeatureFlags#RetrofitCompletableFutures}.
+     */
+    RetrofitListenableFutures,
 
     /**
      * Instructs the {@link JerseyServiceGenerator} to generate binary response endpoints with the {@link Response}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
@@ -75,7 +75,8 @@ public final class Retrofit2ServiceGenerator implements ServiceGenerator {
         this.featureFlags = ImmutableSet.copyOf(experimentalFeatures);
         checkArgument(!featureFlags.contains(FeatureFlags.RetrofitListenableFutures)
                         || !featureFlags.contains(FeatureFlags.RetrofitCompletableFutures),
-                "Cannot return both listenable and completable futures.");
+                "Cannot enable both the RetrofitListenableFutures and RetrofitCompletableFutures "
+                        + "Conjure experimental features. Please remove one.");
     }
 
     @Override

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
@@ -62,6 +62,8 @@ import org.slf4j.LoggerFactory;
 public final class Retrofit2ServiceGenerator implements ServiceGenerator {
 
     private static final ClassName COMPLETABLE_FUTURE_TYPE = ClassName.get("java.util.concurrent", "CompletableFuture");
+    private static final ClassName LISTENABLE_FUTURE_TYPE = ClassName.get(
+            "com.google.common.util.concurrent", "ListenableFuture");
     private static final ClassName CALL_TYPE = ClassName.get("retrofit2", "Call");
     private static final String AUTH_HEADER_NAME = "Authorization";
 
@@ -71,6 +73,9 @@ public final class Retrofit2ServiceGenerator implements ServiceGenerator {
 
     public Retrofit2ServiceGenerator(Set<FeatureFlags> experimentalFeatures) {
         this.featureFlags = ImmutableSet.copyOf(experimentalFeatures);
+        checkArgument(!featureFlags.contains(FeatureFlags.RetrofitListenableFutures)
+                        || !featureFlags.contains(FeatureFlags.RetrofitCompletableFutures),
+                "Cannot return both listenable and completable futures.");
     }
 
     @Override
@@ -110,6 +115,8 @@ public final class Retrofit2ServiceGenerator implements ServiceGenerator {
     private ClassName getReturnType() {
         if (featureFlags.contains(FeatureFlags.RetrofitCompletableFutures)) {
             return COMPLETABLE_FUTURE_TYPE;
+        } else if (featureFlags.contains(FeatureFlags.RetrofitListenableFutures)) {
+            return LISTENABLE_FUTURE_TYPE;
         } else {
             return CALL_TYPE;
         }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/Retrofit2ServiceGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/Retrofit2ServiceGeneratorTests.java
@@ -80,6 +80,27 @@ public final class Retrofit2ServiceGeneratorTests extends TestBase {
     }
 
     @Test
+    public void testCompositionListenableFuture() throws IOException {
+        ConjureDefinition def = Conjure.parse(
+                ImmutableList.of(new File("src/test/resources/example-service.yml")));
+
+        List<Path> files = new Retrofit2ServiceGenerator(ImmutableSet.of(FeatureFlags.RetrofitListenableFutures))
+                .emit(def, folder.getRoot());
+
+        for (Path file : files) {
+            if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
+                Path output = Paths.get("src/test/resources/test/api/"
+                        + file.getFileName() + ".retrofit_completable_future");
+                Files.deleteIfExists(output);
+                Files.copy(file, output);
+            }
+
+            assertThat(readFromFile(file)).isEqualTo(
+                    readFromResource("/test/api/" + file.getFileName() + ".retrofit_listenable_future"));
+        }
+    }
+
+    @Test
     public void testConjureImports() throws IOException {
         ConjureDefinition conjure = Conjure.parse(
                 ImmutableList.of(

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/Retrofit2ServiceGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/Retrofit2ServiceGeneratorTests.java
@@ -90,7 +90,7 @@ public final class Retrofit2ServiceGeneratorTests extends TestBase {
         for (Path file : files) {
             if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
                 Path output = Paths.get("src/test/resources/test/api/"
-                        + file.getFileName() + ".retrofit_completable_future");
+                        + file.getFileName() + ".retrofit_listenable_future");
                 Files.deleteIfExists(output);
                 Files.copy(file, output);
             }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_listenable_future
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_listenable_future
@@ -1,0 +1,162 @@
+package com.palantir.another;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.product.AliasedString;
+import com.palantir.product.CreateDatasetRequest;
+import com.palantir.product.datasets.BackingFileSystem;
+import com.palantir.product.datasets.Dataset;
+import com.palantir.ri.ResourceIdentifier;
+import com.palantir.tokens.auth.AuthHeader;
+import java.lang.Boolean;
+import java.lang.Deprecated;
+import java.lang.Double;
+import java.lang.Integer;
+import java.lang.String;
+import java.lang.Void;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.Set;
+import javax.annotation.Generated;
+import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
+import retrofit2.http.Body;
+import retrofit2.http.GET;
+import retrofit2.http.Header;
+import retrofit2.http.Headers;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+import retrofit2.http.Streaming;
+
+/** A Markdown description of the service. */
+@Generated("com.palantir.conjure.java.services.Retrofit2ServiceGenerator")
+public interface TestServiceRetrofit {
+    /** Returns a mapping from file system id to backing file system configuration. */
+    @GET("./catalog/fileSystems")
+    @Headers("hr-path-template: /catalog/fileSystems")
+    ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(
+            @Header("Authorization") AuthHeader authHeader);
+
+    @POST("./catalog/datasets")
+    @Headers("hr-path-template: /catalog/datasets")
+    ListenableFuture<Dataset> createDataset(
+            @Header("Authorization") AuthHeader authHeader,
+            @Body CreateDatasetRequest request,
+            @Header("Test-Header") String testHeaderArg);
+
+    @GET("./catalog/datasets/{datasetRid}")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}")
+    ListenableFuture<Optional<Dataset>> getDataset(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid);
+
+    @GET("./catalog/datasets/{datasetRid}/raw")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/raw")
+    @Streaming
+    ListenableFuture<ResponseBody> getRawData(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid);
+
+    @GET("./catalog/datasets/{datasetRid}/raw-aliased")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/raw-aliased")
+    ListenableFuture<ResponseBody> getAliasedRawData(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid);
+
+    @GET("./catalog/datasets/{datasetRid}/raw-maybe")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/raw-maybe")
+    ListenableFuture<Optional<ByteBuffer>> maybeGetRawData(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid);
+
+    @GET("./catalog/datasets/{datasetRid}/string-aliased")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/string-aliased")
+    ListenableFuture<AliasedString> getAliasedString(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid);
+
+    @POST("./catalog/datasets/upload-raw")
+    @Headers("hr-path-template: /catalog/datasets/upload-raw")
+    ListenableFuture<Void> uploadRawData(
+            @Header("Authorization") AuthHeader authHeader, @Body RequestBody input);
+
+    @GET("./catalog/datasets/{datasetRid}/branches")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/branches")
+    ListenableFuture<Set<String>> getBranches(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid);
+
+    /**
+     * Gets all branches of this dataset.
+     *
+     * @deprecated use getBranches instead
+     */
+    @GET("./catalog/datasets/{datasetRid}/branchesDeprecated")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/branchesDeprecated")
+    @Deprecated
+    ListenableFuture<Set<String>> getBranchesDeprecated(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid);
+
+    @GET("./catalog/datasets/{datasetRid}/branches/{branch}/resolve")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/branches/{branch}/resolve")
+    ListenableFuture<Optional<String>> resolveBranch(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid,
+            @Path(value = "branch", encoded = true) String branch);
+
+    @GET("./catalog/datasets/{datasetRid}/testParam")
+    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/testParam")
+    ListenableFuture<Optional<String>> testParam(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid);
+
+    @POST("./catalog/test-query-params")
+    @Headers("hr-path-template: /catalog/test-query-params")
+    ListenableFuture<Integer> testQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Body String query,
+            @Query("different") ResourceIdentifier something,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Query("setEnd") Set<String> setEnd,
+            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
+
+    @POST("./catalog/test-no-response-query-params")
+    @Headers("hr-path-template: /catalog/test-no-response-query-params")
+    ListenableFuture<Void> testNoResponseQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Body String query,
+            @Query("different") ResourceIdentifier something,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Query("setEnd") Set<String> setEnd,
+            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
+
+    @GET("./catalog/boolean")
+    @Headers("hr-path-template: /catalog/boolean")
+    ListenableFuture<Boolean> testBoolean(@Header("Authorization") AuthHeader authHeader);
+
+    @GET("./catalog/double")
+    @Headers("hr-path-template: /catalog/double")
+    ListenableFuture<Double> testDouble(@Header("Authorization") AuthHeader authHeader);
+
+    @GET("./catalog/integer")
+    @Headers("hr-path-template: /catalog/integer")
+    ListenableFuture<Integer> testInteger(@Header("Authorization") AuthHeader authHeader);
+
+    @POST("./catalog/optional")
+    @Headers("hr-path-template: /catalog/optional")
+    ListenableFuture<Optional<String>> testPostOptional(
+            @Header("Authorization") AuthHeader authHeader, @Body Optional<String> maybeString);
+
+    @GET("./catalog/optional-integer-double")
+    @Headers("hr-path-template: /catalog/optional-integer-double")
+    ListenableFuture<Void> testOptionalIntegerAndDouble(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("maybeInteger") OptionalInt maybeInteger,
+            @Query("maybeDouble") OptionalDouble maybeDouble);
+}

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/CliConfiguration.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/CliConfiguration.java
@@ -30,6 +30,7 @@ public abstract class CliConfiguration {
     public static final String JERSEY_OPTION = "jersey";
     public static final String RETROFIT_OPTION = "retrofit";
     public static final String RETROFIT_COMPLETABLE_FUTURES = "retrofitCompletableFutures";
+    public static final String RETROFIT_LISTENABLE_FUTURES = "retrofitListenableFutures";
     public static final String JERSEY_BINARY_AS_RESPONSE = "jerseyBinaryAsResponse";
     public static final String REQUIRE_NOT_NULL_AUTH_AND_BODY_PARAMS = "requireNotNullAuthAndBodyParams";
 
@@ -92,6 +93,9 @@ public abstract class CliConfiguration {
                     break;
                 case RETROFIT_COMPLETABLE_FUTURES:
                     flagsBuilder.add(FeatureFlags.RetrofitCompletableFutures);
+                    break;
+                case RETROFIT_LISTENABLE_FUTURES:
+                    flagsBuilder.add(FeatureFlags.RetrofitListenableFutures);
                     break;
                 case JERSEY_BINARY_AS_RESPONSE:
                     flagsBuilder.add(FeatureFlags.JerseyBinaryAsResponse);

--- a/readme.md
+++ b/readme.md
@@ -109,7 +109,7 @@ As an alternative to the JAX-RS interfaces above, conjure-java can generate equi
     Call<ResponseBody> binary(@Header("Authorization") AuthHeader authHeader);
     ```
 
-You can also supply the `--retrofitCompletableFutures` flag if you prefer Java 8 CompletableFutures instead of OkHttp's Call.
+You can also supply the `--retrofitListenableFutures` flag if you prefer Guava ListenableFutures instead of Retrofit's Call.
 
 ## Contributing
 


### PR DESCRIPTION
blocks on support for listenable futures in conjure-java-runtime (https://github.com/palantir/conjure-java-runtime/pull/829)