### PR TITLE
[fix] real logging instead of slf4j warning

### DIFF
--- a/conjure-java/build.gradle
+++ b/conjure-java/build.gradle
@@ -21,6 +21,7 @@ mainClassName = 'com.palantir.conjure.java.cli.ConjureJavaCli'
 dependencies {
     compile project(':conjure-java-core')
     compile 'commons-cli:commons-cli'
+    runtime 'org.slf4j:slf4j-simple'
 
     testCompile 'junit:junit'
     testCompile 'org.assertj:assertj-core'


### PR DESCRIPTION
## Before this PR

Every invocation of this CLI from within gradle-conjure would result in a noisy warning (https://github.com/palantir/gradle-conjure/issues/43):
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

## After this PR

The warning will not appear. In fact, the executions will be completely silent because there are actually no `log.info` or `log.debug` lines in the Conjure codebase, only a single `log.error` line in Retrofit2ServiceGenerator.