### PR TITLE
[fix] nested aliased query params delegate to aliased type's valueOf static method

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
@@ -4,6 +4,7 @@ import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
+import java.lang.Deprecated;
 import java.lang.String;
 import java.time.OffsetDateTime;
 import java.util.Optional;
@@ -15,6 +16,7 @@ import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.StreamingOutput;
 
@@ -73,4 +75,21 @@ public interface EteService {
     StringAliasExample notNullBody(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @NotNull StringAliasExample notNullBody);
+
+    @GET
+    @Path("base/optionalAliasOne")
+    StringAliasExample optionalAliasOne(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @QueryParam("queryParamName") Optional<StringAliasExample> queryParamName);
+
+    @GET
+    @Path("base/aliasTwo")
+    NestedStringAliasExample aliasTwo(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @QueryParam("queryParamName") NestedStringAliasExample queryParamName);
+
+    @Deprecated
+    default StringAliasExample optionalAliasOne(AuthHeader authHeader) {
+        return optionalAliasOne(authHeader, Optional.empty());
+    }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
@@ -18,6 +18,7 @@ import retrofit2.http.GET;
 import retrofit2.http.Header;
 import retrofit2.http.Headers;
 import retrofit2.http.POST;
+import retrofit2.http.Query;
 import retrofit2.http.Streaming;
 
 @Generated("com.palantir.conjure.java.services.Retrofit2ServiceGenerator")
@@ -71,4 +72,16 @@ public interface EteServiceRetrofit {
     @Headers("hr-path-template: /base/notNullBody")
     Call<StringAliasExample> notNullBody(
             @Header("Authorization") AuthHeader authHeader, @Body StringAliasExample notNullBody);
+
+    @GET("./base/optionalAliasOne")
+    @Headers("hr-path-template: /base/optionalAliasOne")
+    Call<StringAliasExample> optionalAliasOne(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("queryParamName") Optional<StringAliasExample> queryParamName);
+
+    @GET("./base/aliasTwo")
+    @Headers("hr-path-template: /base/aliasTwo")
+    Call<NestedStringAliasExample> aliasTwo(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("queryParamName") NestedStringAliasExample queryParamName);
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/NestedStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/NestedStringAliasExample.java
@@ -1,0 +1,47 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Objects;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class NestedStringAliasExample {
+    private final StringAliasExample value;
+
+    private NestedStringAliasExample(StringAliasExample value) {
+        Objects.requireNonNull(value, "value cannot be null");
+        this.value = value;
+    }
+
+    @JsonValue
+    public StringAliasExample get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof NestedStringAliasExample
+                        && this.value.equals(((NestedStringAliasExample) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    public static NestedStringAliasExample valueOf(String value) {
+        return new NestedStringAliasExample(StringAliasExample.valueOf(value));
+    }
+
+    @JsonCreator
+    public static NestedStringAliasExample of(StringAliasExample value) {
+        return new NestedStringAliasExample(value);
+    }
+}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -133,7 +133,7 @@ public final class AliasGenerator {
                 && !conjureType.accept(TypeVisitor.IS_BINARY)) {
             return Optional.of(valueOfFactoryMethodForPrimitive(
                     conjureType.accept(TypeVisitor.PRIMITIVE), thisClass, aliasTypeName));
-        } else if (conjureType.accept(TypeVisitor.IS_REFERENCE)) {
+        } else if (conjureType.accept(TypeVisitor.IS_INTERNAL_REFERENCE)) {
             // delegate to aliased type's valueOf factory method
             Optional<AliasDefinition> aliasTypeDef = typeMapper.getType(conjureType.accept(TypeVisitor.REFERENCE))
                     .filter(type -> type.accept(TypeDefinitionVisitor.IS_ALIAS))

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -22,6 +22,7 @@ import com.palantir.conjure.java.ConjureAnnotations;
 import com.palantir.conjure.spec.AliasDefinition;
 import com.palantir.conjure.spec.PrimitiveType;
 import com.palantir.conjure.spec.Type;
+import com.palantir.conjure.visitor.TypeDefinitionVisitor;
 import com.palantir.conjure.visitor.TypeVisitor;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
@@ -41,6 +42,7 @@ public final class AliasGenerator {
     public static JavaFile generateAliasType(
             TypeMapper typeMapper,
             AliasDefinition typeDef) {
+
         TypeName aliasTypeName = typeMapper.getClassName(typeDef.getAlias());
 
         String typePackage = typeDef.getTypeName().getPackage();
@@ -78,7 +80,7 @@ public final class AliasGenerator {
                         .build());
 
         Optional<CodeBlock> maybeValueOfFactoryMethod = valueOfFactoryMethod(
-                typeDef.getAlias(), thisClass, aliasTypeName);
+                typeDef.getAlias(), thisClass, aliasTypeName, typeMapper);
         if (maybeValueOfFactoryMethod.isPresent()) {
             spec.addMethod(MethodSpec.methodBuilder("valueOf")
                     .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
@@ -122,15 +124,30 @@ public final class AliasGenerator {
     private static Optional<CodeBlock> valueOfFactoryMethod(
             Type conjureType,
             ClassName thisClass,
-            TypeName aliasTypeName) {
+            TypeName aliasTypeName,
+            TypeMapper typeMapper) {
+
         // doesn't support valueOf factories for ANY and BINARY types
         if (conjureType.accept(TypeVisitor.IS_PRIMITIVE)
                 && !conjureType.accept(TypeVisitor.IS_ANY)
                 && !conjureType.accept(TypeVisitor.IS_BINARY)) {
             return Optional.of(valueOfFactoryMethodForPrimitive(
                     conjureType.accept(TypeVisitor.PRIMITIVE), thisClass, aliasTypeName));
+        } else if (conjureType.accept(TypeVisitor.IS_REFERENCE)) {
+            // delegate to aliased type's valueOf factory method
+            Optional<AliasDefinition> aliasTypeDef = typeMapper.getTypes().stream()
+                    .filter(type -> type.accept(TypeDefinitionVisitor.IS_ALIAS))
+                    .filter(type -> Objects.equals(type.accept(TypeDefinitionVisitor.TYPE_NAME),
+                            conjureType.accept(TypeVisitor.REFERENCE)))
+                    .map(type -> type.accept(TypeDefinitionVisitor.ALIAS)).findAny();
+
+            return aliasTypeDef.map(type -> {
+                ClassName className = ClassName.get(type.getTypeName().getPackage(), type.getTypeName().getName());
+                return CodeBlock.builder()
+                        .addStatement("return new $T($T.valueOf(value))", thisClass, className).build();
+            });
         }
-        // TODO(dholanda): delegate to aliased type's valueOf factory method if it exists
+
         return Optional.empty();
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -135,11 +135,9 @@ public final class AliasGenerator {
                     conjureType.accept(TypeVisitor.PRIMITIVE), thisClass, aliasTypeName));
         } else if (conjureType.accept(TypeVisitor.IS_REFERENCE)) {
             // delegate to aliased type's valueOf factory method
-            Optional<AliasDefinition> aliasTypeDef = typeMapper.getTypes().stream()
+            Optional<AliasDefinition> aliasTypeDef = typeMapper.getType(conjureType.accept(TypeVisitor.REFERENCE))
                     .filter(type -> type.accept(TypeDefinitionVisitor.IS_ALIAS))
-                    .filter(type -> Objects.equals(type.accept(TypeDefinitionVisitor.TYPE_NAME),
-                            conjureType.accept(TypeVisitor.REFERENCE)))
-                    .map(type -> type.accept(TypeDefinitionVisitor.ALIAS)).findAny();
+                    .map(type -> type.accept(TypeDefinitionVisitor.ALIAS));
 
             return aliasTypeDef.map(type -> {
                 ClassName className = ClassName.get(type.getTypeName().getPackage(), type.getTypeName().getName());

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/TypeMapper.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/TypeMapper.java
@@ -19,12 +19,18 @@ package com.palantir.conjure.java.types;
 import com.palantir.conjure.java.types.ClassNameVisitor.Factory;
 import com.palantir.conjure.spec.Type;
 import com.palantir.conjure.spec.TypeDefinition;
+import com.palantir.conjure.visitor.TypeDefinitionVisitor;
 import com.squareup.javapoet.TypeName;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public final class TypeMapper {
 
-    private final List<TypeDefinition> types;
+    private final Map<com.palantir.conjure.spec.TypeName, TypeDefinition> types;
     private final Factory classNameVisitorFactory;
 
     public TypeMapper(List<TypeDefinition> types) {
@@ -33,15 +39,16 @@ public final class TypeMapper {
 
     public TypeMapper(List<TypeDefinition> types,
             Factory classNameVisitorFactory) {
-        this.types = types;
+        this.types = types.stream().collect(
+                Collectors.toMap(t -> t.accept(TypeDefinitionVisitor.TYPE_NAME), Function.identity()));
         this.classNameVisitorFactory = classNameVisitorFactory;
     }
 
-    public List<TypeDefinition> getTypes() {
-        return types;
+    public Optional<TypeDefinition> getType(com.palantir.conjure.spec.TypeName typeName) {
+        return Optional.ofNullable(types.get(typeName));
     }
 
     public TypeName getClassName(Type type) {
-        return type.accept(classNameVisitorFactory.create(types));
+        return type.accept(classNameVisitorFactory.create(new ArrayList<>(types.values())));
     }
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/TypeMapper.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/TypeMapper.java
@@ -37,6 +37,10 @@ public final class TypeMapper {
         this.classNameVisitorFactory = classNameVisitorFactory;
     }
 
+    public List<TypeDefinition> getTypes() {
+        return types;
+    }
+
     public TypeName getClassName(Type type) {
         return type.accept(classNameVisitorFactory.create(types));
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/visitor/TypeVisitor.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/visitor/TypeVisitor.java
@@ -42,8 +42,8 @@ public final class TypeVisitor {
     public static final IsSetTypeVisitor IS_SET = new IsSetTypeVisitor();
     public static final IsMapTypeVisitor IS_MAP = new IsMapTypeVisitor();
     public static final IsReferenceTypeVisitor IS_REFERENCE = new IsReferenceTypeVisitor();
+    public static final IsInternalReferenceTypeVisitor IS_INTERNAL_REFERENCE = new IsInternalReferenceTypeVisitor();
 
-    public static final IsPrimitiveOrReferenceType IS_PRIMITIVE_OR_REFERENCE = new IsPrimitiveOrReferenceType();
     public static final IsBinaryType IS_BINARY = new IsBinaryType();
     public static final IsAnyType IS_ANY = new IsAnyType();
 
@@ -138,19 +138,9 @@ public final class TypeVisitor {
         }
     }
 
-    private static class IsPrimitiveOrReferenceType extends IsTypeVisitor {
-        @Override
-        public Boolean visitPrimitive(PrimitiveType value) {
-            return true;
-        }
-
+    private static class IsInternalReferenceTypeVisitor extends IsTypeVisitor {
         @Override
         public Boolean visitReference(TypeName value) {
-            return true;
-        }
-
-        @Override
-        public Boolean visitExternal(ExternalReference value) {
             return true;
         }
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/visitor/TypeVisitor.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/visitor/TypeVisitor.java
@@ -43,7 +43,7 @@ public final class TypeVisitor {
     public static final IsMapTypeVisitor IS_MAP = new IsMapTypeVisitor();
     public static final IsReferenceTypeVisitor IS_REFERENCE = new IsReferenceTypeVisitor();
     public static final IsInternalReferenceTypeVisitor IS_INTERNAL_REFERENCE = new IsInternalReferenceTypeVisitor();
-
+    public static final IsPrimitiveOrReferenceType IS_PRIMITIVE_OR_REFERENCE = new IsPrimitiveOrReferenceType();
     public static final IsBinaryType IS_BINARY = new IsBinaryType();
     public static final IsAnyType IS_ANY = new IsAnyType();
 
@@ -141,6 +141,23 @@ public final class TypeVisitor {
     private static class IsInternalReferenceTypeVisitor extends IsTypeVisitor {
         @Override
         public Boolean visitReference(TypeName value) {
+            return true;
+        }
+    }
+
+    private static class IsPrimitiveOrReferenceType extends IsTypeVisitor {
+        @Override
+        public Boolean visitPrimitive(PrimitiveType value) {
+            return true;
+        }
+
+        @Override
+        public Boolean visitReference(TypeName value) {
+            return true;
+        }
+
+        @Override
+        public Boolean visitExternal(ExternalReference value) {
             return true;
         }
     }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/EteResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/EteResource.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.java;
 
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.product.EteService;
+import com.palantir.product.NestedStringAliasExample;
 import com.palantir.product.StringAliasExample;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
@@ -28,6 +29,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Optional;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.StreamingOutput;
 
 public final class EteResource implements EteService {
@@ -89,5 +91,16 @@ public final class EteResource implements EteService {
     @Override
     public StringAliasExample notNullBody(AuthHeader authHeader, StringAliasExample notNullBody) {
         return notNullBody;
+    }
+
+    @Override
+    public StringAliasExample optionalAliasOne(@NotNull AuthHeader authHeader,
+            Optional<StringAliasExample> queryParamName) {
+        return queryParamName.orElse(StringAliasExample.of("foo"));
+    }
+
+    @Override
+    public NestedStringAliasExample aliasTwo(@NotNull AuthHeader authHeader, NestedStringAliasExample queryParamName) {
+        return queryParamName;
     }
 }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceGeneratorTests.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java;
 
+import static com.palantir.conjure.java.FeatureFlags.RequireNotNullAuthAndBodyParams;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
@@ -58,7 +59,7 @@ public final class JerseyServiceGeneratorTests extends TestBase {
         ConjureDefinition def = Conjure.parse(
                 ImmutableList.of(new File("src/test/resources/example-service.yml")));
         List<Path> files = new JerseyServiceGenerator(
-                ImmutableSet.of(FeatureFlags.RequireNotNullAuthAndBodyParams)).emit(def, folder.getRoot());
+                ImmutableSet.of(RequireNotNullAuthAndBodyParams)).emit(def, folder.getRoot());
 
         for (Path file : files) {
             if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
@@ -132,7 +133,8 @@ public final class JerseyServiceGeneratorTests extends TestBase {
     private void testServiceGeneration(String conjureFile) throws IOException {
         ConjureDefinition def = Conjure.parse(
                 ImmutableList.of(new File("src/test/resources/" + conjureFile + ".yml")));
-        List<Path> files = new JerseyServiceGenerator(Collections.emptySet()).emit(def, folder.getRoot());
+        List<Path> files = new JerseyServiceGenerator(ImmutableSet.of(RequireNotNullAuthAndBodyParams)).emit(def,
+                folder.getRoot());
 
         for (Path file : files) {
             if (Boolean.valueOf(System.getProperty("recreate", "false"))) {

--- a/conjure-java-core/src/test/resources/ete-service.yml
+++ b/conjure-java-core/src/test/resources/ete-service.yml
@@ -3,6 +3,9 @@ types:
     StringAliasExample:
       external:
         java: com.palantir.product.StringAliasExample
+    NestedStringAliasExample:
+      external:
+        java: com.palantir.product.NestedStringAliasExample
 
 services:
   EmptyPathService:
@@ -72,3 +75,19 @@ services:
         args:
           notNullBody: StringAliasExample
         returns: StringAliasExample
+
+      optionalAliasOne:
+        http: GET /optionalAliasOne
+        args:
+          queryParamName:
+            param-type: query
+            type: optional<StringAliasExample>
+        returns: StringAliasExample
+
+      aliasTwo:
+        http: GET /aliasTwo
+        args:
+          queryParamName:
+            param-type: query
+            type: NestedStringAliasExample
+        returns: NestedStringAliasExample

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -77,6 +77,8 @@ types:
           uuid: uuid
       StringAliasExample:
         alias: string
+      NestedStringAliasExample:
+        alias: StringAliasExample
       DoubleAliasExample:
         alias: double
       IntegerAliasExample:

--- a/conjure-java-core/src/test/resources/test/api/CookieService.java.jersey
+++ b/conjure-java-core/src/test/resources/test/api/CookieService.java.jersey
@@ -2,6 +2,7 @@ package test.api;
 
 import com.palantir.tokens.auth.BearerToken;
 import javax.annotation.Generated;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.CookieParam;
 import javax.ws.rs.GET;
@@ -16,5 +17,5 @@ import javax.ws.rs.core.MediaType;
 public interface CookieService {
     @GET
     @Path("cookies")
-    void eatCookies(@CookieParam("PALANTIR_TOKEN") BearerToken token);
+    void eatCookies(@CookieParam("PALANTIR_TOKEN") @NotNull BearerToken token);
 }

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
@@ -18,6 +18,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.Set;
 import javax.annotation.Generated;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -39,55 +40,57 @@ public interface TestService {
     @GET
     @Path("catalog/fileSystems")
     Map<String, BackingFileSystem> getFileSystems(
-            @HeaderParam("Authorization") AuthHeader authHeader);
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader);
 
     @POST
     @Path("catalog/datasets")
     Dataset createDataset(
-            @HeaderParam("Authorization") AuthHeader authHeader,
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @HeaderParam("Test-Header") String testHeaderArg,
-            CreateDatasetRequest request);
+            @NotNull CreateDatasetRequest request);
 
     @GET
     @Path("catalog/datasets/{datasetRid}")
     Optional<Dataset> getDataset(
-            @HeaderParam("Authorization") AuthHeader authHeader,
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/raw")
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
     StreamingOutput getRawData(
-            @HeaderParam("Authorization") AuthHeader authHeader,
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/raw-aliased")
     StreamingOutput getAliasedRawData(
-            @HeaderParam("Authorization") AuthHeader authHeader,
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/raw-maybe")
     Optional<ByteBuffer> maybeGetRawData(
-            @HeaderParam("Authorization") AuthHeader authHeader,
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/string-aliased")
     AliasedString getAliasedString(
-            @HeaderParam("Authorization") AuthHeader authHeader,
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
 
     @POST
     @Path("catalog/datasets/upload-raw")
     @Consumes(MediaType.APPLICATION_OCTET_STREAM)
-    void uploadRawData(@HeaderParam("Authorization") AuthHeader authHeader, InputStream input);
+    void uploadRawData(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @NotNull InputStream input);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/branches")
     Set<String> getBranches(
-            @HeaderParam("Authorization") AuthHeader authHeader,
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
 
     /**
@@ -99,65 +102,66 @@ public interface TestService {
     @Path("catalog/datasets/{datasetRid}/branchesDeprecated")
     @Deprecated
     Set<String> getBranchesDeprecated(
-            @HeaderParam("Authorization") AuthHeader authHeader,
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
     Optional<String> resolveBranch(
-            @HeaderParam("Authorization") AuthHeader authHeader,
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid,
             @PathParam("branch") String branch);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/testParam")
     Optional<String> testParam(
-            @HeaderParam("Authorization") AuthHeader authHeader,
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @POST
     @Path("catalog/test-query-params")
     int testQueryParams(
-            @HeaderParam("Authorization") AuthHeader authHeader,
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @QueryParam("different") ResourceIdentifier something,
             @QueryParam("implicit") ResourceIdentifier implicit,
             @QueryParam("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @QueryParam("setEnd") Set<String> setEnd,
             @QueryParam("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
-            String query);
+            @NotNull String query);
 
     @POST
     @Path("catalog/test-no-response-query-params")
     void testNoResponseQueryParams(
-            @HeaderParam("Authorization") AuthHeader authHeader,
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @QueryParam("different") ResourceIdentifier something,
             @QueryParam("implicit") ResourceIdentifier implicit,
             @QueryParam("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @QueryParam("setEnd") Set<String> setEnd,
             @QueryParam("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
-            String query);
+            @NotNull String query);
 
     @GET
     @Path("catalog/boolean")
-    boolean testBoolean(@HeaderParam("Authorization") AuthHeader authHeader);
+    boolean testBoolean(@HeaderParam("Authorization") @NotNull AuthHeader authHeader);
 
     @GET
     @Path("catalog/double")
-    double testDouble(@HeaderParam("Authorization") AuthHeader authHeader);
+    double testDouble(@HeaderParam("Authorization") @NotNull AuthHeader authHeader);
 
     @GET
     @Path("catalog/integer")
-    int testInteger(@HeaderParam("Authorization") AuthHeader authHeader);
+    int testInteger(@HeaderParam("Authorization") @NotNull AuthHeader authHeader);
 
     @POST
     @Path("catalog/optional")
     Optional<String> testPostOptional(
-            @HeaderParam("Authorization") AuthHeader authHeader, Optional<String> maybeString);
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            Optional<String> maybeString);
 
     @GET
     @Path("catalog/optional-integer-double")
     void testOptionalIntegerAndDouble(
-            @HeaderParam("Authorization") AuthHeader authHeader,
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @QueryParam("maybeInteger") OptionalInt maybeInteger,
             @QueryParam("maybeDouble") OptionalDouble maybeDouble);
 


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->
fixes https://github.com/palantir/conjure-java/issues/68
## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
Conjure generated endpoints with nested aliased query params do not meet any of the following conditions for `QueryParam` annotation type:
```
1. Be a primitive type
2. Have a constructor that accepts a single String argument
3. Have a static method named valueOf or fromString that accepts a single String argument (see, for example, Integer.valueOf(String))
4. Have a registered implementation of ParamConverterProvider JAX-RS extension SPI that returns a ParamConverter instance capable of a "from string" conversion for the type.
5. Be List<T>, Set<T> or SortedSet<T>, where T satisfies 2, 3 or 4 above. The resulting collection is read-only.
```
As a result, servers with those endpoints would fail with those exceptions
```
Caused by: org.glassfish.jersey.server.model.ModelValidationException: Validation of the application resource model has failed during application initialization.
[[FATAL] No injection source found for a parameter of type public com.palantir.product.AliasTwo com.palantir.conjure.java.EteResource.aliasTwo(com.palantir.tokens.auth.AuthHeader,com.palantir.product.AliasTwo) at index 1.; source='ResourceMethod{httpMethod=GET, consumedTypes=[application/json], producedTypes=[application/json], suspended=false, suspendTimeout=0, suspendTimeoutUnit=MILLISECONDS, invocable=Invocable{handler=ClassBasedMethodHandler{handlerClass=class com.palantir.conjure.java.EteResource, handlerConstructors=[org.glassfish.jersey.server.model.HandlerConstructor@6ac4c3f7]}, definitionMethod=public abstract com.palantir.product.AliasTwo com.palantir.product.EteService.aliasTwo(com.palantir.tokens.auth.AuthHeader,com.palantir.product.AliasTwo), parameters=[Parameter [type=class com.palantir.tokens.auth.AuthHeader, source=Authorization, defaultValue=null], Parameter [type=class com.palantir.product.AliasTwo, source=queryParamName, defaultValue=null]], responseType=class com.palantir.product.AliasTwo}, nameBindings=[]}']
```

## After this PR
<!-- Describe at a high-level why this approach is better. -->
Nested aliased query params are now generated with a static method named valueOf that accepts string.

TODO:
- [ ] alias of `binary` and `any` type on query param never worked. Here is a [PR](https://github.com/palantir/conjure/pull/114) created in conjure-core to invalidate them at compile time instead of generation time
<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
