### PR TITLE
Correctly declare task outputs for conjureJavaObjects and conjureJavaJersey tasks

### DIFF
--- a/conjure-java-verifier/build.gradle
+++ b/conjure-java-verifier/build.gradle
@@ -92,7 +92,7 @@ task conjureJavaObjects(type: JavaExec) {
     args 'generate',  "${-> configurations.verificationApi.singleFile}", 'src/generatedObjects/java', '--objects'
 
     inputs.file "${-> configurations.verificationApi.singleFile}"
-    outputs.files "src/generatedObjects/java"
+    outputs.dir "src/generatedObjects/java"
     doFirst { delete "src/generatedObjects/java/*" }
 }
 
@@ -102,7 +102,7 @@ task conjureJavaJersey(type: JavaExec) {
     args 'generate',  "${-> configurations.verificationApi.singleFile}", 'src/generatedJersey/java', '--jersey'
 
     inputs.file "${-> configurations.verificationApi.singleFile}"
-    outputs.files "src/generatedJersey/java"
+    outputs.dir "src/generatedJersey/java"
     doFirst { delete "src/generatedJersey/java/*" }
 }
 


### PR DESCRIPTION
Files has to point to files, dir is the right call here. For reference 

```
> Task :conjure-java-verifier:conjureJavaJersey UP-TO-DATE
Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. A problem was found with the configuration of task ':conjure-java-verifier:conjureJavaJersey'.
 - Cannot write to file '/Volumes/git/conjure-java/conjure-java-verifier/src/generatedJersey/java' specified for property '$1' as it is a directory.

> Task :conjure-java-verifier:conjureJavaObjects UP-TO-DATE
Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. A problem was found with the configuration of task ':conjure-java-verifier:conjureJavaObjects'.
 - Cannot write to file '/Volumes/git/conjure-java/conjure-java-verifier/src/generatedObjects/java' specified for property '$1' as it is a directory.
```