### PR TITLE
[fix] Deserialize NaN and infinities into double aliases

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
@@ -26,7 +26,7 @@ public final class DoubleAliasExample {
     public boolean equals(Object other) {
         return this == other
                 || (other instanceof DoubleAliasExample
-                        && this.value == ((DoubleAliasExample) other).value);
+                && this.value == ((DoubleAliasExample) other).value);
     }
 
     @Override
@@ -47,4 +47,19 @@ public final class DoubleAliasExample {
     public static DoubleAliasExample of(int value) {
         return new DoubleAliasExample((double) value);
     }
+
+    @JsonCreator
+    public static DoubleAliasExample of(String value) {
+        switch (value) {
+            case "NaN":
+               return DoubleAliasExample.of(Double.NaN);
+            case "Infinity":
+                return DoubleAliasExample.of(Double.POSITIVE_INFINITY);
+            case "-Infinity":
+                return DoubleAliasExample.of(Double.NEGATIVE_INFINITY);
+            default:
+                throw new IllegalArgumentException("Cannot deserialize string to double");
+        }
+    }
 }
+

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
@@ -26,7 +26,7 @@ public final class DoubleAliasExample {
     public boolean equals(Object other) {
         return this == other
                 || (other instanceof DoubleAliasExample
-                && this.value == ((DoubleAliasExample) other).value);
+                        && this.value == ((DoubleAliasExample) other).value);
     }
 
     @Override
@@ -52,14 +52,14 @@ public final class DoubleAliasExample {
     public static DoubleAliasExample of(String value) {
         switch (value) {
             case "NaN":
-               return DoubleAliasExample.of(Double.NaN);
+                return DoubleAliasExample.of(Double.NaN);
             case "Infinity":
                 return DoubleAliasExample.of(Double.POSITIVE_INFINITY);
             case "-Infinity":
                 return DoubleAliasExample.of(Double.NEGATIVE_INFINITY);
             default:
-                throw new IllegalArgumentException("Cannot deserialize string to double");
+                throw new IllegalArgumentException(
+                        "Cannot deserialize string into double: " + value);
         }
     }
 }
-

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -109,6 +109,37 @@ public final class AliasGenerator {
                     .returns(thisClass)
                     .addCode(codeBlock)
                     .build());
+
+            CodeBlock doubleFromStringCodeBlock = CodeBlock.builder()
+                    .beginControlFlow("switch (value)")
+                    .add("case \"NaN\":\n")
+                    .indent()
+                    .addStatement("return $T.of($T.NaN)", thisClass, Double.class)
+                    .unindent()
+                    .add("case \"Infinity\":\n")
+                    .indent()
+                    .addStatement("return $T.of($T.POSITIVE_INFINITY)", thisClass, Double.class)
+                    .unindent()
+                    .add("case \"-Infinity\":\n")
+                    .indent()
+                    .addStatement("return $T.of($T.NEGATIVE_INFINITY)", thisClass, Double.class)
+                    .unindent()
+                    .add("default:\n")
+                    .indent()
+                    .addStatement(
+                            "throw new $T(\"Cannot deserialize string into double: \" + value)",
+                            IllegalArgumentException.class)
+                    .unindent()
+                    .endControlFlow()
+                    .build();
+
+            spec.addMethod(MethodSpec.methodBuilder("of")
+                    .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                    .addAnnotation(JsonCreator.class)
+                    .addParameter(ClassName.get(String.class), "value")
+                    .returns(thisClass)
+                    .addCode(doubleFromStringCodeBlock)
+                    .build());
         }
 
         typeDef.getDocs().ifPresent(docs -> spec.addJavadoc("$L", StringUtils.appendIfMissing(docs.get(), "\n")));

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -6,7 +6,6 @@ package com.palantir.conjure.java.types;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -59,6 +59,15 @@ public final class WireFormatTests {
     }
 
     @Test
+    public void double_alias_should_deserialize_infinity() throws IOException {
+        assertThat(mapper.readValue("\"Infinity\"", DoubleAliasExample.class).get())
+                .isEqualTo(Double.POSITIVE_INFINITY);
+
+        assertThat(mapper.readValue("\"-Infinity\"", DoubleAliasExample.class).get())
+                .isEqualTo(Double.NEGATIVE_INFINITY);
+    }
+
+    @Test
     public void testPresentOptionalDeserializesWithElement() throws Exception {
         assertThat(mapper.readValue("{\"item\": \"a\"}", OptionalExample.class).getItem()).contains("a");
     }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -6,6 +6,7 @@ package com.palantir.conjure.java.types;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
@@ -26,6 +27,7 @@ import com.palantir.product.StringAliasExample;
 import com.palantir.product.StringExample;
 import com.palantir.product.UnionTypeExample;
 import com.palantir.product.UuidExample;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -48,6 +50,12 @@ public final class WireFormatTests {
         assertThat(mapper.readValue("{\"items\": [\"a\", \"b\"]}", ListExample.class).getItems()).contains("a", "b");
         assertThat(mapper.readValue("{\"items\": {\"a\": \"b\"}}", MapExample.class).getItems())
                 .containsEntry("a", "b");
+    }
+
+    @Test
+    public void double_alias_should_deserialize_nan() throws IOException {
+        assertThat(mapper.readValue("\"NaN\"", DoubleAliasExample.class).get())
+                .isNaN();
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
Double aliases failed to deserialize when the double was NaN or infinity because no proper constructor was generated to deserialize a double from a string.

## After this PR
Double aliases now generate a constructor that takes a string and checks for the cases "NaN", "Infinity" and "-Infinity".
