### PR TITLE
bintray 1.8.0 -> 1.8.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:9.0.2'
         classpath 'com.palantir.baseline:gradle-baseline-java:0.36.1'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.11.0'


### PR DESCRIPTION
Seems like publishing is broken on develop.  Upgrading to latest bintray in the hope this will solve everything!

<img width="1220" alt="screen shot 2018-10-12 at 17 11 59" src="https://user-images.githubusercontent.com/3473798/46880922-f2698d80-ce41-11e8-9abb-0e274e41437c.png">

https://bintray.com/palantir/releases/conjure-java/2.3.1#files