### PR TITLE
[improvement] Annotate getters with required = true/false in addition to value = name

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
@@ -49,37 +49,37 @@ public final class AliasAsMapKeyExample {
         this.uuids = Collections.unmodifiableMap(uuids);
     }
 
-    @JsonProperty("strings")
+    @JsonProperty(value = "strings", required = true)
     public Map<StringAliasExample, ManyFieldExample> getStrings() {
         return this.strings;
     }
 
-    @JsonProperty("rids")
+    @JsonProperty(value = "rids", required = true)
     public Map<RidAliasExample, ManyFieldExample> getRids() {
         return this.rids;
     }
 
-    @JsonProperty("bearertokens")
+    @JsonProperty(value = "bearertokens", required = true)
     public Map<BearerTokenAliasExample, ManyFieldExample> getBearertokens() {
         return this.bearertokens;
     }
 
-    @JsonProperty("integers")
+    @JsonProperty(value = "integers", required = true)
     public Map<IntegerAliasExample, ManyFieldExample> getIntegers() {
         return this.integers;
     }
 
-    @JsonProperty("safelongs")
+    @JsonProperty(value = "safelongs", required = true)
     public Map<SafeLongAliasExample, ManyFieldExample> getSafelongs() {
         return this.safelongs;
     }
 
-    @JsonProperty("datetimes")
+    @JsonProperty(value = "datetimes", required = true)
     public Map<DateTimeAliasExample, ManyFieldExample> getDatetimes() {
         return this.datetimes;
     }
 
-    @JsonProperty("uuids")
+    @JsonProperty(value = "uuids", required = true)
     public Map<UuidAliasExample, ManyFieldExample> getUuids() {
         return this.uuids;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
@@ -21,7 +21,7 @@ public final class AnyExample {
         this.any = any;
     }
 
-    @JsonProperty("any")
+    @JsonProperty(value = "any", required = true)
     public Object getAny() {
         return this.any;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
@@ -24,7 +24,7 @@ public final class AnyMapExample {
         this.items = Collections.unmodifiableMap(items);
     }
 
-    @JsonProperty("items")
+    @JsonProperty(value = "items", required = true)
     public Map<String, Object> getItems() {
         return this.items;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
@@ -22,7 +22,7 @@ public final class BearerTokenExample {
         this.bearerTokenValue = bearerTokenValue;
     }
 
-    @JsonProperty("bearerTokenValue")
+    @JsonProperty(value = "bearerTokenValue", required = true)
     public BearerToken getBearerTokenValue() {
         return this.bearerTokenValue;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
@@ -22,7 +22,7 @@ public final class BinaryExample {
         this.binary = binary;
     }
 
-    @JsonProperty("binary")
+    @JsonProperty(value = "binary", required = true)
     public ByteBuffer getBinary() {
         return this.binary.asReadOnlyBuffer();
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
@@ -20,7 +20,7 @@ public final class BooleanExample {
         this.coin = coin;
     }
 
-    @JsonProperty("coin")
+    @JsonProperty(value = "coin", required = true)
     public boolean getCoin() {
         return this.coin;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
@@ -27,12 +27,12 @@ public final class CovariantListExample {
         this.externalItems = Collections.unmodifiableList(externalItems);
     }
 
-    @JsonProperty("items")
+    @JsonProperty(value = "items", required = true)
     public List<Object> getItems() {
         return this.items;
     }
 
-    @JsonProperty("externalItems")
+    @JsonProperty(value = "externalItems", required = true)
     public List<ExampleExternalReference> getExternalItems() {
         return this.externalItems;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
@@ -22,7 +22,7 @@ public final class CovariantOptionalExample {
         this.item = item;
     }
 
-    @JsonProperty("item")
+    @JsonProperty(value = "item", required = false)
     public Optional<Object> getItem() {
         return this.item;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
@@ -22,7 +22,7 @@ public final class DateTimeExample {
         this.datetime = datetime;
     }
 
-    @JsonProperty("datetime")
+    @JsonProperty(value = "datetime", required = true)
     public OffsetDateTime getDatetime() {
         return this.datetime;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
@@ -20,7 +20,7 @@ public final class DoubleExample {
         this.doubleValue = doubleValue;
     }
 
-    @JsonProperty("doubleValue")
+    @JsonProperty(value = "doubleValue", required = true)
     public double getDoubleValue() {
         return this.doubleValue;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
@@ -21,7 +21,7 @@ public final class EnumFieldExample {
         this.enum_ = enum_;
     }
 
-    @JsonProperty("enum")
+    @JsonProperty(value = "enum", required = true)
     public EnumExample getEnum() {
         return this.enum_;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
@@ -20,7 +20,7 @@ public final class IntegerExample {
         this.integer = integer;
     }
 
-    @JsonProperty("integer")
+    @JsonProperty(value = "integer", required = true)
     public int getInteger() {
         return this.integer;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
@@ -30,17 +30,17 @@ public final class ListExample {
         this.doubleItems = Collections.unmodifiableList(doubleItems);
     }
 
-    @JsonProperty("items")
+    @JsonProperty(value = "items", required = true)
     public List<String> getItems() {
         return this.items;
     }
 
-    @JsonProperty("primitiveItems")
+    @JsonProperty(value = "primitiveItems", required = true)
     public List<Integer> getPrimitiveItems() {
         return this.primitiveItems;
     }
 
-    @JsonProperty("doubleItems")
+    @JsonProperty(value = "doubleItems", required = true)
     public List<Double> getDoubleItems() {
         return this.doubleItems;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -58,49 +58,49 @@ public final class ManyFieldExample {
     }
 
     /** docs for string field */
-    @JsonProperty("string")
+    @JsonProperty(value = "string", required = true)
     public String getString() {
         return this.string;
     }
 
     /** docs for integer field */
-    @JsonProperty("integer")
+    @JsonProperty(value = "integer", required = true)
     public int getInteger() {
         return this.integer;
     }
 
     /** docs for doubleValue field */
-    @JsonProperty("doubleValue")
+    @JsonProperty(value = "doubleValue", required = true)
     public double getDoubleValue() {
         return this.doubleValue;
     }
 
     /** docs for optionalItem field */
-    @JsonProperty("optionalItem")
+    @JsonProperty(value = "optionalItem", required = false)
     public Optional<String> getOptionalItem() {
         return this.optionalItem;
     }
 
     /** docs for items field */
-    @JsonProperty("items")
+    @JsonProperty(value = "items", required = true)
     public List<String> getItems() {
         return this.items;
     }
 
     /** docs for set field */
-    @JsonProperty("set")
+    @JsonProperty(value = "set", required = true)
     public Set<String> getSet() {
         return this.set;
     }
 
     /** docs for map field */
-    @JsonProperty("map")
+    @JsonProperty(value = "map", required = true)
     public Map<String, String> getMap() {
         return this.map;
     }
 
     /** docs for alias field */
-    @JsonProperty("alias")
+    @JsonProperty(value = "alias", required = true)
     public StringAliasExample getAlias() {
         return this.alias;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
@@ -24,7 +24,7 @@ public final class MapExample {
         this.items = Collections.unmodifiableMap(items);
     }
 
-    @JsonProperty("items")
+    @JsonProperty(value = "items", required = true)
     public Map<String, String> getItems() {
         return this.items;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
@@ -22,7 +22,7 @@ public final class OptionalExample {
         this.item = item;
     }
 
-    @JsonProperty("item")
+    @JsonProperty(value = "item", required = false)
     public Optional<String> getItem() {
         return this.item;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
@@ -53,37 +53,37 @@ public final class PrimitiveOptionalsExample {
         this.uuid = uuid;
     }
 
-    @JsonProperty("num")
+    @JsonProperty(value = "num", required = false)
     public OptionalDouble getNum() {
         return this.num;
     }
 
-    @JsonProperty("bool")
+    @JsonProperty(value = "bool", required = false)
     public Optional<Boolean> getBool() {
         return this.bool;
     }
 
-    @JsonProperty("integer")
+    @JsonProperty(value = "integer", required = false)
     public OptionalInt getInteger() {
         return this.integer;
     }
 
-    @JsonProperty("safelong")
+    @JsonProperty(value = "safelong", required = false)
     public Optional<SafeLong> getSafelong() {
         return this.safelong;
     }
 
-    @JsonProperty("rid")
+    @JsonProperty(value = "rid", required = false)
     public Optional<ResourceIdentifier> getRid() {
         return this.rid;
     }
 
-    @JsonProperty("bearertoken")
+    @JsonProperty(value = "bearertoken", required = false)
     public Optional<BearerToken> getBearertoken() {
         return this.bearertoken;
     }
 
-    @JsonProperty("uuid")
+    @JsonProperty(value = "uuid", required = false)
     public Optional<UUID> getUuid() {
         return this.uuid;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -38,27 +38,27 @@ public final class ReservedKeyExample {
         this.memoizedHashCode_ = memoizedHashCode_;
     }
 
-    @JsonProperty("package")
+    @JsonProperty(value = "package", required = true)
     public String getPackage() {
         return this.package_;
     }
 
-    @JsonProperty("interface")
+    @JsonProperty(value = "interface", required = true)
     public String getInterface() {
         return this.interface_;
     }
 
-    @JsonProperty("field-name-with-dashes")
+    @JsonProperty(value = "field-name-with-dashes", required = true)
     public String getFieldNameWithDashes() {
         return this.fieldNameWithDashes;
     }
 
-    @JsonProperty("primitve-field-name-with-dashes")
+    @JsonProperty(value = "primitve-field-name-with-dashes", required = true)
     public int getPrimitveFieldNameWithDashes() {
         return this.primitveFieldNameWithDashes;
     }
 
-    @JsonProperty("memoizedHashCode")
+    @JsonProperty(value = "memoizedHashCode", required = true)
     public int getMemoizedHashCode() {
         return this.memoizedHashCode_;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
@@ -22,7 +22,7 @@ public final class RidExample {
         this.ridValue = ridValue;
     }
 
-    @JsonProperty("ridValue")
+    @JsonProperty(value = "ridValue", required = true)
     public ResourceIdentifier getRidValue() {
         return this.ridValue;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
@@ -22,7 +22,7 @@ public final class SafeLongExample {
         this.safeLongValue = safeLongValue;
     }
 
-    @JsonProperty("safeLongValue")
+    @JsonProperty(value = "safeLongValue", required = true)
     public SafeLong getSafeLongValue() {
         return this.safeLongValue;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
@@ -28,12 +28,12 @@ public final class SetExample {
         this.doubleItems = Collections.unmodifiableSet(doubleItems);
     }
 
-    @JsonProperty("items")
+    @JsonProperty(value = "items", required = true)
     public Set<String> getItems() {
         return this.items;
     }
 
-    @JsonProperty("doubleItems")
+    @JsonProperty(value = "doubleItems", required = true)
     public Set<Double> getDoubleItems() {
         return this.doubleItems;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
@@ -21,7 +21,7 @@ public final class StringExample {
         this.string = string;
     }
 
-    @JsonProperty("string")
+    @JsonProperty(value = "string", required = true)
     public String getString() {
         return this.string;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
@@ -22,7 +22,7 @@ public final class UuidExample {
         this.uuid = uuid;
     }
 
-    @JsonProperty("uuid")
+    @JsonProperty(value = "uuid", required = true)
     public UUID getUuid() {
         return this.uuid;
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -185,6 +185,7 @@ public final class BeanGenerator {
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(AnnotationSpec.builder(JsonProperty.class)
                         .addMember("value", "$S", field.fieldName().get())
+                        .addMember("required", "$L", !isOptional(field.poetSpec()))
                         .build())
                 .returns(field.poetSpec().type);
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -27,8 +27,6 @@ import com.palantir.conjure.java.util.JavaNameSanitizer;
 import com.palantir.conjure.spec.FieldDefinition;
 import com.palantir.conjure.spec.FieldName;
 import com.palantir.conjure.spec.ObjectDefinition;
-import com.palantir.conjure.spec.OptionalType;
-import com.palantir.conjure.spec.Type;
 import com.palantir.conjure.visitor.TypeVisitor;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
@@ -43,11 +41,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.OptionalInt;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
-import org.checkerframework.checker.nullness.Opt;
 import org.immutables.value.Value;
 
 public final class BeanGenerator {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -185,7 +185,7 @@ public final class BeanGenerator {
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(AnnotationSpec.builder(JsonProperty.class)
                         .addMember("value", "$S", field.fieldName().get())
-                        .addMember("required", "$L", !isOptionalField(field))
+                        .addMember("required", "$L", isRequiredField(field))
                         .build())
                 .returns(field.poetSpec().type);
 
@@ -292,13 +292,13 @@ public final class BeanGenerator {
         return ((ParameterizedTypeName) spec.type).rawType.simpleName().equals("Optional");
     }
 
-    private static boolean isOptionalField(EnrichedField field) {
+    private static boolean isRequiredField(EnrichedField field) {
         if (!(field.poetSpec().type instanceof ParameterizedTypeName)) {
             // spec isn't a wrapper class, check for OptionalInt or OptionalDouble
-            return field.poetSpec().type.toString().equals("java.util.OptionalInt")
-                    || field.poetSpec().type.toString().equals("java.util.OptionalDouble");
+            return !field.poetSpec().type.toString().equals("java.util.OptionalInt")
+                    && !field.poetSpec().type.toString().equals("java.util.OptionalDouble");
         }
-        return ((ParameterizedTypeName) field.poetSpec().type).rawType.simpleName().equals("Optional");
+        return !((ParameterizedTypeName) field.poetSpec().type).rawType.simpleName().equals("Optional");
     }
 
     /**


### PR DESCRIPTION
## Before this PR
We were trying to use [this library](https://github.com/mbknor/mbknor-jackson-jsonSchema) to generate a jsonSchema from our Conjure spec and ran into an issue where it couldn't handle Conjure optionals, as it expects required fields to be marked in the `jsonProperty` annotation. To be useful, we need the generator to properly designate things as required for validation of our Python-generated payloads. We are using Python because the Delta Sierras use Python to interact run their models.

## After this PR
This got me thinking, why doesn't Conjure designate required fields in the `jsonProperty` annotation ( it defaults to `required=false`)? This PR decorates the getters of optional fields as `required=false` and the other getters as `required=true`. It accomplishes this by checking for an `Optional` wrapper as well as `OptionalInt` and `OptionalDouble` types. The files located at `src/integrationInput/java` that tests are run against were updated with the newly generated classes and look good so far.