### PR TITLE
Fix #65: Publish conjure-java-core

### DIFF
--- a/conjure-java-core/build.gradle
+++ b/conjure-java-core/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+apply from: "$rootDir/gradle/publish-jar.gradle"
+
 sourceSets {
     integrationInput
     test {


### PR DESCRIPTION
The `conjure-java-core` jar is published to allow us to prototype new generators without checking in library code.