### PR TITLE
[fix] Add Accept header to Retrofit clients

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceRetrofit.java
@@ -9,6 +9,6 @@ import retrofit2.http.Headers;
 @Generated("com.palantir.conjure.java.services.Retrofit2ServiceGenerator")
 public interface EmptyPathServiceRetrofit {
     @GET("./")
-    @Headers("hr-path-template: /")
+    @Headers({"hr-path-template: /", "Accept: application/json"})
     Call<Boolean> emptyPath();
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
@@ -24,63 +24,63 @@ import retrofit2.http.Streaming;
 @Generated("com.palantir.conjure.java.services.Retrofit2ServiceGenerator")
 public interface EteServiceRetrofit {
     @GET("./base/string")
-    @Headers("hr-path-template: /base/string")
+    @Headers({"hr-path-template: /base/string", "Accept: application/json"})
     Call<String> string(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/integer")
-    @Headers("hr-path-template: /base/integer")
+    @Headers({"hr-path-template: /base/integer", "Accept: application/json"})
     Call<Integer> integer(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/double")
-    @Headers("hr-path-template: /base/double")
+    @Headers({"hr-path-template: /base/double", "Accept: application/json"})
     Call<Double> double_(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/boolean")
-    @Headers("hr-path-template: /base/boolean")
+    @Headers({"hr-path-template: /base/boolean", "Accept: application/json"})
     Call<Boolean> boolean_(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/safelong")
-    @Headers("hr-path-template: /base/safelong")
+    @Headers({"hr-path-template: /base/safelong", "Accept: application/json"})
     Call<SafeLong> safelong(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/rid")
-    @Headers("hr-path-template: /base/rid")
+    @Headers({"hr-path-template: /base/rid", "Accept: application/json"})
     Call<ResourceIdentifier> rid(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/bearertoken")
-    @Headers("hr-path-template: /base/bearertoken")
+    @Headers({"hr-path-template: /base/bearertoken", "Accept: application/json"})
     Call<BearerToken> bearertoken(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/optionalString")
-    @Headers("hr-path-template: /base/optionalString")
+    @Headers({"hr-path-template: /base/optionalString", "Accept: application/json"})
     Call<Optional<String>> optionalString(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/optionalEmpty")
-    @Headers("hr-path-template: /base/optionalEmpty")
+    @Headers({"hr-path-template: /base/optionalEmpty", "Accept: application/json"})
     Call<Optional<String>> optionalEmpty(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/datetime")
-    @Headers("hr-path-template: /base/datetime")
+    @Headers({"hr-path-template: /base/datetime", "Accept: application/json"})
     Call<OffsetDateTime> datetime(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./base/binary")
-    @Headers("hr-path-template: /base/binary")
+    @Headers({"hr-path-template: /base/binary", "Accept: application/octet-stream"})
     @Streaming
     Call<ResponseBody> binary(@Header("Authorization") AuthHeader authHeader);
 
     @POST("./base/notNullBody")
-    @Headers("hr-path-template: /base/notNullBody")
+    @Headers({"hr-path-template: /base/notNullBody", "Accept: application/json"})
     Call<StringAliasExample> notNullBody(
             @Header("Authorization") AuthHeader authHeader, @Body StringAliasExample notNullBody);
 
     @GET("./base/optionalAliasOne")
-    @Headers("hr-path-template: /base/optionalAliasOne")
+    @Headers({"hr-path-template: /base/optionalAliasOne", "Accept: application/json"})
     Call<StringAliasExample> optionalAliasOne(
             @Header("Authorization") AuthHeader authHeader,
             @Query("queryParamName") Optional<StringAliasExample> queryParamName);
 
     @GET("./base/aliasTwo")
-    @Headers("hr-path-template: /base/aliasTwo")
+    @Headers({"hr-path-template: /base/aliasTwo", "Accept: application/json"})
     Call<NestedStringAliasExample> aliasTwo(
             @Header("Authorization") AuthHeader authHeader,
             @Query("queryParamName") NestedStringAliasExample queryParamName);

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
@@ -36,44 +36,56 @@ import retrofit2.http.Streaming;
 public interface TestServiceRetrofit {
     /** Returns a mapping from file system id to backing file system configuration. */
     @GET("./catalog/fileSystems")
-    @Headers("hr-path-template: /catalog/fileSystems")
+    @Headers({"hr-path-template: /catalog/fileSystems", "Accept: application/json"})
     Call<Map<String, BackingFileSystem>> getFileSystems(
             @Header("Authorization") AuthHeader authHeader);
 
     @POST("./catalog/datasets")
-    @Headers("hr-path-template: /catalog/datasets")
+    @Headers({"hr-path-template: /catalog/datasets", "Accept: application/json"})
     Call<Dataset> createDataset(
             @Header("Authorization") AuthHeader authHeader,
             @Body CreateDatasetRequest request,
             @Header("Test-Header") String testHeaderArg);
 
     @GET("./catalog/datasets/{datasetRid}")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}")
+    @Headers({"hr-path-template: /catalog/datasets/{datasetRid}", "Accept: application/json"})
     Call<Optional<Dataset>> getDataset(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/raw")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/raw")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/raw",
+        "Accept: application/octet-stream"
+    })
     @Streaming
     Call<ResponseBody> getRawData(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/raw-aliased")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/raw-aliased")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/raw-aliased",
+        "Accept: application/json"
+    })
     Call<ResponseBody> getAliasedRawData(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/raw-maybe")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/raw-maybe")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/raw-maybe",
+        "Accept: application/json"
+    })
     Call<Optional<ByteBuffer>> maybeGetRawData(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/string-aliased")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/string-aliased")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/string-aliased",
+        "Accept: application/json"
+    })
     Call<AliasedString> getAliasedString(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
@@ -84,7 +96,10 @@ public interface TestServiceRetrofit {
             @Header("Authorization") AuthHeader authHeader, @Body RequestBody input);
 
     @GET("./catalog/datasets/{datasetRid}/branches")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/branches")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/branches",
+        "Accept: application/json"
+    })
     Call<Set<String>> getBranches(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
@@ -95,27 +110,36 @@ public interface TestServiceRetrofit {
      * @deprecated use getBranches instead
      */
     @GET("./catalog/datasets/{datasetRid}/branchesDeprecated")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/branchesDeprecated")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/branchesDeprecated",
+        "Accept: application/json"
+    })
     @Deprecated
     Call<Set<String>> getBranchesDeprecated(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/branches/{branch}/resolve")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/branches/{branch}/resolve")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/branches/{branch}/resolve",
+        "Accept: application/json"
+    })
     Call<Optional<String>> resolveBranch(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid,
             @Path(value = "branch", encoded = true) String branch);
 
     @GET("./catalog/datasets/{datasetRid}/testParam")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/testParam")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/testParam",
+        "Accept: application/json"
+    })
     Call<Optional<String>> testParam(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @POST("./catalog/test-query-params")
-    @Headers("hr-path-template: /catalog/test-query-params")
+    @Headers({"hr-path-template: /catalog/test-query-params", "Accept: application/json"})
     Call<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
             @Body String query,
@@ -137,19 +161,19 @@ public interface TestServiceRetrofit {
             @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
 
     @GET("./catalog/boolean")
-    @Headers("hr-path-template: /catalog/boolean")
+    @Headers({"hr-path-template: /catalog/boolean", "Accept: application/json"})
     Call<Boolean> testBoolean(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./catalog/double")
-    @Headers("hr-path-template: /catalog/double")
+    @Headers({"hr-path-template: /catalog/double", "Accept: application/json"})
     Call<Double> testDouble(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./catalog/integer")
-    @Headers("hr-path-template: /catalog/integer")
+    @Headers({"hr-path-template: /catalog/integer", "Accept: application/json"})
     Call<Integer> testInteger(@Header("Authorization") AuthHeader authHeader);
 
     @POST("./catalog/optional")
-    @Headers("hr-path-template: /catalog/optional")
+    @Headers({"hr-path-template: /catalog/optional", "Accept: application/json"})
     Call<Optional<String>> testPostOptional(
             @Header("Authorization") AuthHeader authHeader, @Body Optional<String> maybeString);
 

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
@@ -36,44 +36,56 @@ import retrofit2.http.Streaming;
 public interface TestServiceRetrofit {
     /** Returns a mapping from file system id to backing file system configuration. */
     @GET("./catalog/fileSystems")
-    @Headers("hr-path-template: /catalog/fileSystems")
+    @Headers({"hr-path-template: /catalog/fileSystems", "Accept: application/json"})
     CompletableFuture<Map<String, BackingFileSystem>> getFileSystems(
             @Header("Authorization") AuthHeader authHeader);
 
     @POST("./catalog/datasets")
-    @Headers("hr-path-template: /catalog/datasets")
+    @Headers({"hr-path-template: /catalog/datasets", "Accept: application/json"})
     CompletableFuture<Dataset> createDataset(
             @Header("Authorization") AuthHeader authHeader,
             @Body CreateDatasetRequest request,
             @Header("Test-Header") String testHeaderArg);
 
     @GET("./catalog/datasets/{datasetRid}")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}")
+    @Headers({"hr-path-template: /catalog/datasets/{datasetRid}", "Accept: application/json"})
     CompletableFuture<Optional<Dataset>> getDataset(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/raw")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/raw")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/raw",
+        "Accept: application/octet-stream"
+    })
     @Streaming
     CompletableFuture<ResponseBody> getRawData(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/raw-aliased")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/raw-aliased")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/raw-aliased",
+        "Accept: application/json"
+    })
     CompletableFuture<ResponseBody> getAliasedRawData(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/raw-maybe")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/raw-maybe")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/raw-maybe",
+        "Accept: application/json"
+    })
     CompletableFuture<Optional<ByteBuffer>> maybeGetRawData(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/string-aliased")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/string-aliased")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/string-aliased",
+        "Accept: application/json"
+    })
     CompletableFuture<AliasedString> getAliasedString(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
@@ -84,7 +96,10 @@ public interface TestServiceRetrofit {
             @Header("Authorization") AuthHeader authHeader, @Body RequestBody input);
 
     @GET("./catalog/datasets/{datasetRid}/branches")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/branches")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/branches",
+        "Accept: application/json"
+    })
     CompletableFuture<Set<String>> getBranches(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
@@ -95,27 +110,36 @@ public interface TestServiceRetrofit {
      * @deprecated use getBranches instead
      */
     @GET("./catalog/datasets/{datasetRid}/branchesDeprecated")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/branchesDeprecated")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/branchesDeprecated",
+        "Accept: application/json"
+    })
     @Deprecated
     CompletableFuture<Set<String>> getBranchesDeprecated(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/branches/{branch}/resolve")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/branches/{branch}/resolve")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/branches/{branch}/resolve",
+        "Accept: application/json"
+    })
     CompletableFuture<Optional<String>> resolveBranch(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid,
             @Path(value = "branch", encoded = true) String branch);
 
     @GET("./catalog/datasets/{datasetRid}/testParam")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/testParam")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/testParam",
+        "Accept: application/json"
+    })
     CompletableFuture<Optional<String>> testParam(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @POST("./catalog/test-query-params")
-    @Headers("hr-path-template: /catalog/test-query-params")
+    @Headers({"hr-path-template: /catalog/test-query-params", "Accept: application/json"})
     CompletableFuture<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
             @Body String query,
@@ -137,19 +161,19 @@ public interface TestServiceRetrofit {
             @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
 
     @GET("./catalog/boolean")
-    @Headers("hr-path-template: /catalog/boolean")
+    @Headers({"hr-path-template: /catalog/boolean", "Accept: application/json"})
     CompletableFuture<Boolean> testBoolean(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./catalog/double")
-    @Headers("hr-path-template: /catalog/double")
+    @Headers({"hr-path-template: /catalog/double", "Accept: application/json"})
     CompletableFuture<Double> testDouble(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./catalog/integer")
-    @Headers("hr-path-template: /catalog/integer")
+    @Headers({"hr-path-template: /catalog/integer", "Accept: application/json"})
     CompletableFuture<Integer> testInteger(@Header("Authorization") AuthHeader authHeader);
 
     @POST("./catalog/optional")
-    @Headers("hr-path-template: /catalog/optional")
+    @Headers({"hr-path-template: /catalog/optional", "Accept: application/json"})
     CompletableFuture<Optional<String>> testPostOptional(
             @Header("Authorization") AuthHeader authHeader, @Body Optional<String> maybeString);
 

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_listenable_future
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_listenable_future
@@ -36,44 +36,56 @@ import retrofit2.http.Streaming;
 public interface TestServiceRetrofit {
     /** Returns a mapping from file system id to backing file system configuration. */
     @GET("./catalog/fileSystems")
-    @Headers("hr-path-template: /catalog/fileSystems")
+    @Headers({"hr-path-template: /catalog/fileSystems", "Accept: application/json"})
     ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(
             @Header("Authorization") AuthHeader authHeader);
 
     @POST("./catalog/datasets")
-    @Headers("hr-path-template: /catalog/datasets")
+    @Headers({"hr-path-template: /catalog/datasets", "Accept: application/json"})
     ListenableFuture<Dataset> createDataset(
             @Header("Authorization") AuthHeader authHeader,
             @Body CreateDatasetRequest request,
             @Header("Test-Header") String testHeaderArg);
 
     @GET("./catalog/datasets/{datasetRid}")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}")
+    @Headers({"hr-path-template: /catalog/datasets/{datasetRid}", "Accept: application/json"})
     ListenableFuture<Optional<Dataset>> getDataset(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/raw")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/raw")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/raw",
+        "Accept: application/octet-stream"
+    })
     @Streaming
     ListenableFuture<ResponseBody> getRawData(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/raw-aliased")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/raw-aliased")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/raw-aliased",
+        "Accept: application/json"
+    })
     ListenableFuture<ResponseBody> getAliasedRawData(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/raw-maybe")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/raw-maybe")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/raw-maybe",
+        "Accept: application/json"
+    })
     ListenableFuture<Optional<ByteBuffer>> maybeGetRawData(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/string-aliased")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/string-aliased")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/string-aliased",
+        "Accept: application/json"
+    })
     ListenableFuture<AliasedString> getAliasedString(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
@@ -84,7 +96,10 @@ public interface TestServiceRetrofit {
             @Header("Authorization") AuthHeader authHeader, @Body RequestBody input);
 
     @GET("./catalog/datasets/{datasetRid}/branches")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/branches")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/branches",
+        "Accept: application/json"
+    })
     ListenableFuture<Set<String>> getBranches(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
@@ -95,27 +110,36 @@ public interface TestServiceRetrofit {
      * @deprecated use getBranches instead
      */
     @GET("./catalog/datasets/{datasetRid}/branchesDeprecated")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/branchesDeprecated")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/branchesDeprecated",
+        "Accept: application/json"
+    })
     @Deprecated
     ListenableFuture<Set<String>> getBranchesDeprecated(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @GET("./catalog/datasets/{datasetRid}/branches/{branch}/resolve")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/branches/{branch}/resolve")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/branches/{branch}/resolve",
+        "Accept: application/json"
+    })
     ListenableFuture<Optional<String>> resolveBranch(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid,
             @Path(value = "branch", encoded = true) String branch);
 
     @GET("./catalog/datasets/{datasetRid}/testParam")
-    @Headers("hr-path-template: /catalog/datasets/{datasetRid}/testParam")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/testParam",
+        "Accept: application/json"
+    })
     ListenableFuture<Optional<String>> testParam(
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
     @POST("./catalog/test-query-params")
-    @Headers("hr-path-template: /catalog/test-query-params")
+    @Headers({"hr-path-template: /catalog/test-query-params", "Accept: application/json"})
     ListenableFuture<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
             @Body String query,
@@ -137,19 +161,19 @@ public interface TestServiceRetrofit {
             @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
 
     @GET("./catalog/boolean")
-    @Headers("hr-path-template: /catalog/boolean")
+    @Headers({"hr-path-template: /catalog/boolean", "Accept: application/json"})
     ListenableFuture<Boolean> testBoolean(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./catalog/double")
-    @Headers("hr-path-template: /catalog/double")
+    @Headers({"hr-path-template: /catalog/double", "Accept: application/json"})
     ListenableFuture<Double> testDouble(@Header("Authorization") AuthHeader authHeader);
 
     @GET("./catalog/integer")
-    @Headers("hr-path-template: /catalog/integer")
+    @Headers({"hr-path-template: /catalog/integer", "Accept: application/json"})
     ListenableFuture<Integer> testInteger(@Header("Authorization") AuthHeader authHeader);
 
     @POST("./catalog/optional")
-    @Headers("hr-path-template: /catalog/optional")
+    @Headers({"hr-path-template: /catalog/optional", "Accept: application/json"})
     ListenableFuture<Optional<String>> testPostOptional(
             @Header("Authorization") AuthHeader authHeader, @Body Optional<String> maybeString);
 


### PR DESCRIPTION
## Before this PR
The [conjure spec](https://github.com/palantir/conjure/blob/develop/docs/spec/wire.md#http-requests) states that:
> **Accept header** - Clients MUST send an Accept: application/json header for all requests UNLESS the endpoint returns binary, in which case the client MUST send Accept: application/octet-stream. This ensures changes can be made to the wire format in a non-breaking way.

Feign clients created using conjure-java-runtime correctly implement the spec because Feign [reads the JAX-RS annotations](https://github.com/OpenFeign/feign/blob/v8.17.0/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java#L68-L75) to set the `Accept` and `Content-Type` headers.

Retrofit clients created using conjure-java-runtime do not set either the `Accept` or `Content-Type` headers. The `Content-Type` header does exist on requests from Retrofit clients only because it is [set by OkHttp](https://github.com/square/okhttp/blob/parent-3.11.0/okhttp/src/main/java/okhttp3/internal/http/BridgeInterceptor.java#L53-L56).

## After this PR
This PR adds the necessary annotations so requests from conjure-java-runtime Retrofit clients include the correct `Accept` header.

This implementation deviates slightly from a literal interpretation of the conjure spec and does not set the `Accept` header for requests that return void. If this was the intention when writing the conjure spec, it should be updated to make this clear. Otherwise, we should modify this PR.