### PR TITLE
[improvement] conjure-lib pulls in javax.annotation-api

### DIFF
--- a/conjure-lib/build.gradle
+++ b/conjure-lib/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     compile 'com.palantir.ri:resource-identifier'
     compile 'com.palantir.tokens:auth-tokens'
     compile 'com.palantir.conjure.java.api:errors'
+    compile 'javax.annotation:javax.annotation-api'
 
     testCompile 'junit:junit'
     testCompile 'org.assertj:assertj-core'


### PR DESCRIPTION
## Before this PR

New users of gradle-conjure & conjure-java encounter a scary looking error where they have to provide a version for a dependency, but this is hard if they don't use nebula.

(Gradle conjure adds this `compileOnly 'javax.annotation:javax.annotation-api'` dependency to handle the Java8 -> Java9 package rename of the `@Generated` annotation)

## After this PR

We now bundle this dependency so it just appears transitively on the classpath.  It's a tiny bit gross because technically it just needs to be a `compileOnly` dependency, but in practice it's just two annotation classes, so I think it's OK!
