### PR TITLE
[improvement] Generating Visitors for conjure enums

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -38,6 +38,17 @@ public final class EnumExample {
         return this.value;
     }
 
+    public <T> T accept(Visitor<T> visitor) {
+        switch (this.get()) {
+            case ONE:
+                return visitor.visitOne();
+            case TWO:
+                return visitor.visitTwo();
+            default:
+                return visitor.visitUnknown(this.toString());
+        }
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -77,5 +88,13 @@ public final class EnumExample {
         TWO,
 
         UNKNOWN
+    }
+
+    public interface Visitor<T> {
+        T visitOne();
+
+        T visitTwo();
+
+        T visitUnknown(String unknownValue);
     }
 }


### PR DESCRIPTION
## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
Although Conjure Unions support the visitor pattern out of the box, Enums did not. It is error-prone for server developers, as it's too easy to add an extra value to an enum and forget to update one of the `switch` clauses referring to it.
## After this PR
<!-- Describe at a high-level why this approach is better. -->
Server and client maintainers have flexibility in choosing whether they want enum updates to cause a compile break.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
