### PR TITLE
Publish a source jar alongside tgz

### DIFF
--- a/conjure-java/build.gradle
+++ b/conjure-java/build.gradle
@@ -28,3 +28,21 @@ dependencies {
 
     processor 'org.immutables:value'
 }
+
+// Need to publish a source jar to be accepted on JCenter
+// see https://www.jfrog.com/confluence/display/BT/Central+Repositories#CentralRepositories-IncludingyourPackageinJCenter
+task sourceJar(type: Jar) {
+    dependsOn 'classes'
+    from project.sourceSets.main.allSource
+    classifier 'sources'
+    extension 'jar'
+    group 'build'
+}
+
+publishing {
+    publications {
+        dist {
+            artifact sourceJar
+        }
+    }
+}


### PR DESCRIPTION
Seems we need to publish a source jar to be admissible into JCenter:

https://www.jfrog.com/confluence/display/BT/Central+Repositories#CentralRepositories-IncludingyourPackageinJCenter

Couldn't use `nebula.source-jar` directly because it adds the artifact to the `nebula` publication, but we use a `dist` publication (and have automation that expects that name). https://github.com/nebula-plugins/nebula-publishing-plugin/blob/master/src/main/groovy/nebula/plugin/publishing/publications/SourceJarPlugin.groovy