### PR TITLE
[improvement] upgrade conjure-lib's jackson from 2.6.7 -> 2.9.7

### DIFF
--- a/conjure-lib/versions.props
+++ b/conjure-lib/versions.props
@@ -1,1 +1,0 @@
-com.fasterxml.jackson.*:jackson-* = 2.6.7

--- a/versions.props
+++ b/versions.props
@@ -1,4 +1,4 @@
-com.fasterxml.jackson.*:jackson-* = 2.9.6
+com.fasterxml.jackson.*:jackson-* = 2.9.7
 com.google.code.findbugs:jsr305 = 3.0.2
 com.google.errorprone:error_prone_annotations = 2.3.2
 com.google.googlejavaformat:google-java-format = 1.5


### PR DESCRIPTION
## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
The main repo had pinned `com.fasterxml.jackson.*:jackson-* = 2.9.6`, except for `conjure-lib` which had overridden to `com.fasterxml.jackson.*:jackson-* = 2.6.7`. Given `conjure-java-runtime-api` is on `2.9.7`, thought I'd try and bump everything to that. I don't understand why `conjure-lib` had the override in the first place, but potentially there's a good reason.
It's just currently annoying for consumers of conjure who don't have a way currently of pinning versions of transitive dependencies.
## After this PR
I removed the `conjure-lib` override and set everything to use `2.9.7`
