### PR TITLE
[improvement] Refactor ConjureRoutingRegistry to ConjureHandler

### DIFF
--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -30,11 +30,9 @@ import com.palantir.conjure.java.okhttp.HostMetricsRegistry;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.conjure.java.services.UndertowServiceGenerator;
 import com.palantir.conjure.java.undertow.lib.HandlerContext;
-import com.palantir.conjure.java.undertow.lib.RoutingRegistry;
 import com.palantir.conjure.java.undertow.lib.SerializerRegistry;
-import com.palantir.conjure.java.undertow.runtime.ConjureRoutingRegistry;
+import com.palantir.conjure.java.undertow.runtime.ConjureHandler;
 import com.palantir.conjure.java.undertow.runtime.Serializers;
-import com.palantir.conjure.java.undertow.runtime.Undertow1460Handler;
 import com.palantir.conjure.spec.ConjureDefinition;
 import com.palantir.product.EmptyPathService;
 import com.palantir.product.EmptyPathServiceEndpoint;
@@ -45,7 +43,6 @@ import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
 import io.undertow.Handlers;
 import io.undertow.Undertow;
-import io.undertow.server.RoutingHandler;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -93,15 +90,13 @@ public final class UndertowServiceEteTest extends TestBase {
                 .serializerRegistry(serializers)
                 .build();
 
-        RoutingHandler handler = Handlers.routing();
-
-        RoutingRegistry routingRegistry = new ConjureRoutingRegistry(handler);
-        EteServiceEndpoint.of(new UndertowEteResource()).create(context).register(routingRegistry);
-        EmptyPathServiceEndpoint.of(() -> true).create(context).register(routingRegistry);
+        ConjureHandler handler = new ConjureHandler();
+        EteServiceEndpoint.of(new UndertowEteResource()).create(context).register(handler);
+        EmptyPathServiceEndpoint.of(() -> true).create(context).register(handler);
 
         server = Undertow.builder()
                 .addHttpListener(8080, "0.0.0.0")
-                .setHandler(Handlers.path().addPrefixPath("/test-example/api", new Undertow1460Handler(handler)))
+                .setHandler(Handlers.path().addPrefixPath("/test-example/api", handler))
                 .build();
         server.start();
     }

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Undertow1460Handler.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Undertow1460Handler.java
@@ -23,11 +23,11 @@ import io.undertow.server.HttpServerExchange;
  * Workaround for UNDERTOW-1460, this class can be removed once 1.4.17.Final is released.
  * @see <a href="https://issues.jboss.org/browse/UNDERTOW-1460">UNDERTOW-1460</a>
  */
-public final class Undertow1460Handler implements HttpHandler {
+final class Undertow1460Handler implements HttpHandler {
 
     private final HttpHandler delegate;
 
-    public Undertow1460Handler(HttpHandler delegate) {
+    Undertow1460Handler(HttpHandler delegate) {
         this.delegate = delegate;
     }
 

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/demo/MyServiceUndertowHandlerTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/demo/MyServiceUndertowHandlerTest.java
@@ -22,14 +22,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
 import com.palantir.conjure.java.undertow.lib.Routable;
 import com.palantir.conjure.java.undertow.lib.Serializer;
-import com.palantir.conjure.java.undertow.runtime.ConjureRoutingRegistry;
+import com.palantir.conjure.java.undertow.runtime.ConjureHandler;
 import com.palantir.conjure.java.undertow.runtime.Serializers;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.tracing.Tracers;
 import com.palantir.tracing.api.TraceHttpHeaders;
-import io.undertow.Handlers;
 import io.undertow.Undertow;
-import io.undertow.server.RoutingHandler;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.Map;
@@ -57,16 +55,15 @@ public final class MyServiceUndertowHandlerTest {
 
     @Before
     public void before() {
-        Routable handler = new MyServiceUndertowHandler(
+        Routable routable = new MyServiceUndertowHandler(
                 new MyServiceImpl(),
                 serializer
         );
-        RoutingHandler routingHandler = Handlers.routing();
-
-        handler.register(new ConjureRoutingRegistry(routingHandler));
+        ConjureHandler handler = new ConjureHandler();
+        routable.register(handler);
         server = Undertow.builder()
                 .addHttpListener(12345, "localhost")
-                .setHandler(routingHandler)
+                .setHandler(handler)
                 .build();
         server.start();
     }

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureHandlerTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureHandlerTest.java
@@ -20,11 +20,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.palantir.conjure.java.undertow.lib.RoutingRegistry;
-import io.undertow.Handlers;
 import io.undertow.Undertow;
 import io.undertow.server.HttpHandler;
-import io.undertow.server.RoutingHandler;
 import java.io.IOException;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -60,13 +57,11 @@ public final class ConjureHandlerTest {
                 innerObserver.control();
             }
         };
-        RoutingHandler routingHandler = Handlers.routing();
-
-        RoutingRegistry routingRegistry = new ConjureRoutingRegistry(routingHandler);
-        routingRegistry.get("/test", httpHandler);
+        ConjureHandler handler = new ConjureHandler();
+        handler.get("/test", httpHandler);
         server = Undertow.builder()
                 .addHttpListener(12345, "localhost")
-                .setHandler(routingHandler)
+                .setHandler(handler)
                 .build();
         server.start();
     }

--- a/readme.md
+++ b/readme.md
@@ -190,12 +190,12 @@ _This feature is experimental and subject to change._
 
 ```java
 public static void main(String[] args) {
-    RoutingHandler handler = Handlers.routing();
+    ConjureHandler handler = new ConjureHandler();
     RecipeBookServiceEndpoint.of(new RecipeBookResource())
         .create(HandlerContext.builder()
             .serializerRegistry(new SerializerRegistry(Serializers.json()))
             .build())
-        .register(new ConjureRoutingRegistry(handler));
+        .register(handler);
 
     Undertow server = Undertow.builder()
             .addHttpListener(8080, "0.0.0.0")


### PR DESCRIPTION
Implementing both HttpHandler and RoutingRegistry provides more
leverage to make changes in the future without breaking API
or requiring additional code changes.