### PR TITLE
[improvement] [Undertow] Generator provides common attachment keys for jwt data

### DIFF
--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/BearerTokenLoggingTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/BearerTokenLoggingTest.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.undertow.runtime;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.conjure.java.undertow.HttpServerExchanges;
+import com.palantir.conjure.java.undertow.lib.Attachments;
 import com.palantir.conjure.java.undertow.lib.internal.Auth;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
@@ -143,6 +144,12 @@ public class BearerTokenLoggingTest {
         });
         handler.handleRequest(exchange);
         assertMdcUnset();
+        // All tokens provide a user ID. Cases which do not include a user ID should result in an empty value.
+        if (userId == null) {
+            assertThat(exchange.getAttachment(Attachments.UNVERIFIED_TOKEN)).isEmpty();
+        } else {
+            assertThat(exchange.getAttachment(Attachments.UNVERIFIED_TOKEN)).isPresent();
+        }
         assertThat(invoked).isTrue();
     }
 

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/BearerTokenLoggingTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/BearerTokenLoggingTest.java
@@ -146,9 +146,9 @@ public class BearerTokenLoggingTest {
         assertMdcUnset();
         // All tokens provide a user ID. Cases which do not include a user ID should result in an empty value.
         if (userId == null) {
-            assertThat(exchange.getAttachment(Attachments.UNVERIFIED_TOKEN)).isEmpty();
+            assertThat(exchange.getAttachment(Attachments.UNVERIFIED_JWT)).isEmpty();
         } else {
-            assertThat(exchange.getAttachment(Attachments.UNVERIFIED_TOKEN)).isPresent();
+            assertThat(exchange.getAttachment(Attachments.UNVERIFIED_JWT)).isPresent();
         }
         assertThat(invoked).isTrue();
     }

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/Attachments.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/Attachments.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.lib;
+
+import com.palantir.tokens.auth.UnverifiedJsonWebToken;
+import io.undertow.util.AttachmentKey;
+import java.util.Optional;
+
+public final class Attachments {
+
+    public static final AttachmentKey<Optional<UnverifiedJsonWebToken>> UNVERIFIED_TOKEN =
+            AttachmentKey.create(Optional.class);
+
+    private Attachments() {}
+}

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/Attachments.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/Attachments.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 
 public final class Attachments {
 
-    public static final AttachmentKey<Optional<UnverifiedJsonWebToken>> UNVERIFIED_TOKEN =
+    public static final AttachmentKey<Optional<UnverifiedJsonWebToken>> UNVERIFIED_JWT =
             AttachmentKey.create(Optional.class);
 
     private Attachments() {}

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/internal/Auth.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/internal/Auth.java
@@ -69,7 +69,7 @@ public final class Auth {
      */
     private static BearerToken setState(HttpServerExchange exchange, BearerToken token) {
         Optional<UnverifiedJsonWebToken> parsedJwt = UnverifiedJsonWebToken.tryParse(token.getToken());
-        exchange.putAttachment(Attachments.UNVERIFIED_TOKEN, parsedJwt);
+        exchange.putAttachment(Attachments.UNVERIFIED_JWT, parsedJwt);
         if (parsedJwt.isPresent()) {
             UnverifiedJsonWebToken jwt = parsedJwt.get();
             MDC.put(USER_ID_KEY, jwt.getUnverifiedUserId());

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/internal/Auth.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/internal/Auth.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.undertow.lib.internal;
 
+import com.palantir.conjure.java.undertow.lib.Attachments;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
@@ -48,7 +49,7 @@ public final class Auth {
         // We do not want credential material logged to disk, even if it's marked unsafe.
         Preconditions.checkArgument(authorization != null && authorization.size() == 1,
                 "One Authorization header value is required");
-        return setState(AuthHeader.valueOf(authorization.get(0)));
+        return setState(exchange, AuthHeader.valueOf(authorization.get(0)));
     }
 
     /**
@@ -56,7 +57,7 @@ public final class Auth {
      * {@link UnverifiedJsonWebToken} information to the {@link MDC thread state} if present.
      */
     public static BearerToken cookie(HttpServerExchange exchange, String cookieName) {
-        return setState(StringDeserializers.deserializeBearerToken(
+        return setState(exchange, StringDeserializers.deserializeBearerToken(
                 exchange.getRequestCookies().get(cookieName).getValue()));
     }
 
@@ -66,8 +67,9 @@ public final class Auth {
      * user id, session id, and token id extracted from the JWT. This is
      * best-effort and does not throw an exception in case any of these steps fail.
      */
-    private static BearerToken setState(BearerToken token) {
+    private static BearerToken setState(HttpServerExchange exchange, BearerToken token) {
         Optional<UnverifiedJsonWebToken> parsedJwt = UnverifiedJsonWebToken.tryParse(token.getToken());
+        exchange.putAttachment(Attachments.UNVERIFIED_TOKEN, parsedJwt);
         if (parsedJwt.isPresent()) {
             UnverifiedJsonWebToken jwt = parsedJwt.get();
             MDC.put(USER_ID_KEY, jwt.getUnverifiedUserId());
@@ -77,8 +79,8 @@ public final class Auth {
         return token;
     }
 
-    private static AuthHeader setState(AuthHeader authHeader) {
-        setState(authHeader.getBearerToken());
+    private static AuthHeader setState(HttpServerExchange exchange, AuthHeader authHeader) {
+        setState(exchange, authHeader.getBearerToken());
         return authHeader;
     }
 


### PR DESCRIPTION
Apply the parsed jwt to an exchange attribute for more accurate request logging.

TraceHandler sets Attachments.TRACE_ID in addition to the response header to provide trace info for request logging.