### PR TITLE
[Undertow] Remove unnecessary Undertow binary string deserializers

### DIFF
--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowTypeFunctions.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowTypeFunctions.java
@@ -86,7 +86,6 @@ final class UndertowTypeFunctions {
     private static final ImmutableMap<PrimitiveType.Value, String> PRIMITIVE_TO_TYPE_NAME =
             new ImmutableMap.Builder<PrimitiveType.Value, String>()
                     .put(PrimitiveType.Value.BEARERTOKEN, "BearerToken")
-                    .put(PrimitiveType.Value.BINARY, "Binary")
                     .put(PrimitiveType.Value.BOOLEAN, "Boolean")
                     .put(PrimitiveType.Value.DATETIME, "DateTime")
                     .put(PrimitiveType.Value.DOUBLE, "Double")

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/lib/internal/StringDeserializersTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/lib/internal/StringDeserializersTest.java
@@ -22,8 +22,6 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.BearerToken;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -37,11 +35,6 @@ public final class StringDeserializersTest {
     @Test
     public void testDeserializeBearerToken() throws Exception {
         runDeserializerTest("BearerToken", "token", BearerToken.valueOf("token"));
-    }
-
-    @Test
-    public void testDeserializeBinary() throws Exception {
-        runDeserializerTest("Binary", "binary", ByteBuffer.wrap("binary" .getBytes(StandardCharsets.UTF_8)));
     }
 
     @Test

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/internal/StringDeserializers.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/internal/StringDeserializers.java
@@ -23,8 +23,6 @@ import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.BearerToken;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -40,8 +38,6 @@ import java.util.UUID;
 public final class StringDeserializers {
 
     private StringDeserializers() {}
-
-    // TODO(nmiyake): verify that "any" is not supported
 
     public static BearerToken deserializeBearerToken(String in) {
         try {
@@ -86,29 +82,6 @@ public final class StringDeserializers {
             builder.add(deserializeBearerToken(item));
         }
         return builder.build();
-    }
-
-    public static ByteBuffer deserializeBinary(String in) {
-        try {
-            return ByteBuffer.wrap(in.getBytes(StandardCharsets.UTF_8));
-        } catch (RuntimeException ex) {
-            throw new SafeIllegalArgumentException("failed to deserialize binary", ex);
-        }
-    }
-
-    public static ByteBuffer deserializeBinary(Iterable<String> in) {
-        return deserializeBinary(Iterables.getOnlyElement(in));
-    }
-
-    public static Optional<ByteBuffer> deserializeOptionalBinary(String in) {
-        return Optional.of(deserializeBinary(in));
-    }
-
-    public static Optional<ByteBuffer> deserializeOptionalBinary(Iterable<String> in) {
-        if (in == null || Iterables.isEmpty(in)) {
-            return Optional.empty();
-        }
-        return Optional.of(deserializeBinary(Iterables.getOnlyElement(in)));
     }
 
     public static boolean deserializeBoolean(String in) {


### PR DESCRIPTION
Conjure does not allow binary data outside of request and response
bodies.