### PR TITLE
[undertow] Wrappable RoutingRegistry and Endpoint

### DIFF
--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/EndpointDetails.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/EndpointDetails.java
@@ -28,6 +28,6 @@ public interface EndpointDetails {
     String template();
 
     static EndpointDetails of(HttpString method, String template) {
-        return ImmutableEndpointDetails.builder().build();
+        return ImmutableEndpointDetails.builder().method(method).template(template).build();
     }
 }

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/EndpointDetails.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/EndpointDetails.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,20 @@
  * limitations under the License.
  */
 
-apply from: "$rootDir/gradle/publish-jar.gradle"
+package com.palantir.conjure.java.undertow.lib;
 
-dependencies {
-    api project(':conjure-lib')
-    // Generated code depends on Undertow APIs
-    api 'io.undertow:undertow-core'
-    // Generated code uses guava TypeToken
-    api 'com.google.guava:guava'
-    implementation 'com.palantir.safe-logging:preconditions'
-    implementation 'org.slf4j:slf4j-api'
+import com.palantir.tokens.auth.ImmutablesStyle;
+import io.undertow.util.HttpString;
+import org.immutables.value.Value;
 
-    annotationProcessor 'org.immutables:value'
-    compileOnly 'org.immutables:value::annotations'
+@Value.Immutable
+@ImmutablesStyle
+public interface EndpointDetails {
+
+    HttpString method();
+    String template();
+
+    static EndpointDetails of(HttpString method, String template) {
+        return ImmutableEndpointDetails.builder().build();
+    }
 }

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/WrappedEndpoint.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/WrappedEndpoint.java
@@ -1,0 +1,51 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.lib;
+
+import io.undertow.server.HandlerWrapper;
+import io.undertow.server.HttpHandler;
+import java.util.function.BiFunction;
+
+/**
+ * Wraps all the {@link HttpHandler} of an {@link Endpoint} with an {@link HandlerWrapper}.
+ * Useful when you need to add a custom wrapper to an individual endpoint.
+ */
+public final class WrappedEndpoint implements Endpoint {
+
+    private final Endpoint endpoint;
+    private final BiFunction<EndpointDetails, HttpHandler, HttpHandler> wrapper;
+
+    private WrappedEndpoint(Endpoint endpoint, BiFunction<EndpointDetails, HttpHandler, HttpHandler> wrapper) {
+        this.endpoint = endpoint;
+        this.wrapper = wrapper;
+    }
+
+    public WrappedEndpoint(Endpoint endpoint, HandlerWrapper wrapper) {
+        this(endpoint, (ignored, handler) -> wrapper.wrap(handler));
+    }
+
+    public static WrappedEndpoint of(Endpoint endpoint, HandlerWrapper wrapper) {
+        return new WrappedEndpoint(endpoint, wrapper);
+    }
+
+    @Override
+    public Routable create(HandlerContext context) {
+        return routingRegistry ->
+                endpoint.create(context)
+                        .register(new WrappedRoutingRegistry(routingRegistry, wrapper));
+    }
+}

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/WrappedEndpoint.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/WrappedEndpoint.java
@@ -21,7 +21,8 @@ import io.undertow.server.HttpHandler;
 import java.util.function.BiFunction;
 
 /**
- * Wraps all the {@link HttpHandler} of an {@link Endpoint} with an {@link HandlerWrapper}.
+ * Wraps all the {@link HttpHandler} of an {@link Endpoint} with an HandlerWrapper defined as a function
+ * that takes an {@link EndpointDetails} and a {@link HttpHandler} and return the wrapped (or not) {@link HttpHandler}.
  * Useful when you need to add a custom wrapper to an individual endpoint.
  */
 public final class WrappedEndpoint implements Endpoint {

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/WrappedRoutingRegistry.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/WrappedRoutingRegistry.java
@@ -1,0 +1,63 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.lib;
+
+import io.undertow.server.HandlerWrapper;
+import io.undertow.server.HttpHandler;
+import io.undertow.util.Methods;
+import java.util.function.BiFunction;
+
+public final class WrappedRoutingRegistry implements RoutingRegistry {
+
+    private final RoutingRegistry routingRegistry;
+    private final BiFunction<EndpointDetails, HttpHandler, HttpHandler> wrapper;
+
+    public WrappedRoutingRegistry(RoutingRegistry routingRegistry,
+            BiFunction<EndpointDetails, HttpHandler, HttpHandler> wrapper) {
+        this.routingRegistry = routingRegistry;
+        this.wrapper = wrapper;
+    }
+
+    public WrappedRoutingRegistry(RoutingRegistry routingRegistry, HandlerWrapper wrapper) {
+        this(routingRegistry, (endpoint, handler) -> wrapper.wrap(handler));
+    }
+
+    @Override
+    public WrappedRoutingRegistry get(String template, HttpHandler handler) {
+        routingRegistry.get(template, wrapper.apply(EndpointDetails.of(Methods.GET, template), handler));
+        return this;
+    }
+
+    @Override
+    public WrappedRoutingRegistry post(String template, HttpHandler handler) {
+        routingRegistry.post(template, wrapper.apply(EndpointDetails.of(Methods.POST, template), handler));
+        return this;
+    }
+
+    @Override
+    public WrappedRoutingRegistry put(String template, HttpHandler handler) {
+        routingRegistry.put(template, wrapper.apply(EndpointDetails.of(Methods.PUT, template), handler));
+        return this;
+    }
+
+    @Override
+    public WrappedRoutingRegistry delete(String template, HttpHandler handler) {
+        routingRegistry.delete(template, wrapper.apply(EndpointDetails.of(Methods.DELETE, template), handler));
+        return this;
+    }
+
+}


### PR DESCRIPTION
## Before this PR

One could not simply add an HandlerWrapper to an endpoint.

## After this PR

One can use a `WrappedEndpoint` to easily wrap all handlers of an endpoint.

