### PR TITLE
 Proposal: ParametersAreNonnullByDefault 

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/another/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/another/ConjureErrors.java
@@ -3,8 +3,10 @@ package com.palantir.another;
 import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.ServiceException;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.types.ErrorGenerator")
+@ParametersAreNonnullByDefault
 public final class ConjureErrors {
     /** Different package. */
     public static final ErrorType DIFFERENT_PACKAGE =

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
@@ -13,9 +13,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = AliasAsMapKeyExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class AliasAsMapKeyExample {
     private final Map<StringAliasExample, ManyFieldExample> strings;
 
@@ -187,6 +189,7 @@ public final class AliasAsMapKeyExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private Map<StringAliasExample, ManyFieldExample> strings = new LinkedHashMap<>();

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
@@ -10,9 +10,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = AnyExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class AnyExample {
     private final Object any;
 
@@ -87,6 +89,7 @@ public final class AnyExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private Object any;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
@@ -13,9 +13,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = AnyMapExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class AnyMapExample {
     private final Map<String, Object> items;
 
@@ -90,6 +92,7 @@ public final class AnyMapExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private Map<String, Object> items = new LinkedHashMap<>();

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenAliasExample.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.tokens.auth.BearerToken;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
+@ParametersAreNonnullByDefault
 public final class BearerTokenAliasExample {
     private final BearerToken value;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
@@ -11,9 +11,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = BearerTokenExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class BearerTokenExample {
     private final BearerToken bearerTokenValue;
 
@@ -89,6 +91,7 @@ public final class BearerTokenExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private BearerToken bearerTokenValue;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasExample.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
+@ParametersAreNonnullByDefault
 public final class BinaryAliasExample {
     private final ByteBuffer value;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
@@ -11,9 +11,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = BinaryExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class BinaryExample {
     private final ByteBuffer binary;
 
@@ -88,6 +90,7 @@ public final class BinaryExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private ByteBuffer binary;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanAliasExample.java
@@ -3,8 +3,10 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
+@ParametersAreNonnullByDefault
 public final class BooleanAliasExample {
     private final boolean value;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
@@ -10,9 +10,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = BooleanExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class BooleanExample {
     private final boolean coin;
 
@@ -65,6 +67,7 @@ public final class BooleanExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private boolean coin;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ConjureErrors.java
@@ -5,8 +5,10 @@ import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.types.ErrorGenerator")
+@ParametersAreNonnullByDefault
 public final class ConjureErrors {
     /** Invalid Conjure type definition. */
     public static final ErrorType INVALID_TYPE_DEFINITION =

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ConjureJavaErrors.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ConjureJavaErrors.java
@@ -3,8 +3,10 @@ package com.palantir.product;
 import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.ServiceException;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.types.ErrorGenerator")
+@ParametersAreNonnullByDefault
 public final class ConjureJavaErrors {
     /** Failed to compile Conjure definition to Java code. */
     public static final ErrorType JAVA_COMPILATION_FAILED =

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
@@ -12,10 +12,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 import test.api.ExampleExternalReference;
 
 @JsonDeserialize(builder = CovariantListExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class CovariantListExample {
     private final List<Object> items;
 
@@ -106,6 +108,7 @@ public final class CovariantListExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private List<Object> items = new ArrayList<>();

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
@@ -11,9 +11,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = CovariantOptionalExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class CovariantOptionalExample {
     private final Optional<Object> item;
 
@@ -90,6 +92,7 @@ public final class CovariantOptionalExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private Optional<Object> item = Optional.empty();

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeAliasExample.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.time.OffsetDateTime;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
+@ParametersAreNonnullByDefault
 public final class DateTimeAliasExample {
     private final OffsetDateTime value;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
@@ -11,9 +11,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = DateTimeExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class DateTimeExample {
     private final OffsetDateTime datetime;
 
@@ -89,6 +91,7 @@ public final class DateTimeExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private OffsetDateTime datetime;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
@@ -3,8 +3,10 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
+@ParametersAreNonnullByDefault
 public final class DoubleAliasExample {
     private final double value;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
@@ -10,9 +10,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = DoubleExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class DoubleExample {
     private final double doubleValue;
 
@@ -64,6 +66,7 @@ public final class DoubleExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private double doubleValue;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyObjectExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyObjectExample.java
@@ -3,9 +3,11 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonSerialize
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class EmptyObjectExample {
     private static final EmptyObjectExample INSTANCE = new EmptyObjectExample();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathService.java
@@ -1,6 +1,7 @@
 package com.palantir.product;
 
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -11,6 +12,7 @@ import javax.ws.rs.core.MediaType;
 @Produces(MediaType.APPLICATION_JSON)
 @Path("/")
 @Generated("com.palantir.conjure.java.services.JerseyServiceGenerator")
+@ParametersAreNonnullByDefault
 public interface EmptyPathService {
     @GET
     boolean emptyPath();

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceEndpoint.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceEndpoint.java
@@ -9,8 +9,10 @@ import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import java.io.IOException;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceHandlerGenerator")
+@ParametersAreNonnullByDefault
 public final class EmptyPathServiceEndpoint implements Endpoint {
     private final UndertowEmptyPathService delegate;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceRetrofit.java
@@ -1,11 +1,13 @@
 package com.palantir.product;
 
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 import retrofit2.Call;
 import retrofit2.http.GET;
 import retrofit2.http.Headers;
 
 @Generated("com.palantir.conjure.java.services.Retrofit2ServiceGenerator")
+@ParametersAreNonnullByDefault
 public interface EmptyPathServiceRetrofit {
     @GET("./")
     @Headers({"hr-path-template: /", "Accept: application/json"})

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Locale;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * This enumerates the numbers 1:2 also 100.
@@ -20,6 +21,7 @@ import javax.annotation.Generated;
  * compile time.
  */
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
+@ParametersAreNonnullByDefault
 public final class EnumExample {
     public static final EnumExample ONE = new EnumExample(Value.ONE, "ONE");
 
@@ -89,6 +91,7 @@ public final class EnumExample {
     }
 
     @Generated("com.palantir.conjure.java.types.EnumGenerator")
+    @ParametersAreNonnullByDefault
     public enum Value {
         ONE,
 
@@ -101,6 +104,7 @@ public final class EnumExample {
     }
 
     @Generated("com.palantir.conjure.java.types.EnumGenerator")
+    @ParametersAreNonnullByDefault
     public interface Visitor<T> {
         T visitOne();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
@@ -10,9 +10,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = EnumFieldExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class EnumFieldExample {
     private final EnumExample enum_;
 
@@ -88,6 +90,7 @@ public final class EnumFieldExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private EnumExample enum_;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceEndpoint.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceEndpoint.java
@@ -20,8 +20,10 @@ import java.util.Deque;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceHandlerGenerator")
+@ParametersAreNonnullByDefault
 public final class EteBinaryServiceEndpoint implements Endpoint {
     private final UndertowEteBinaryService delegate;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceRetrofit.java
@@ -4,6 +4,7 @@ import com.palantir.tokens.auth.AuthHeader;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
@@ -16,6 +17,7 @@ import retrofit2.http.Query;
 import retrofit2.http.Streaming;
 
 @Generated("com.palantir.conjure.java.services.Retrofit2ServiceGenerator")
+@ParametersAreNonnullByDefault
 public interface EteBinaryServiceRetrofit {
     @POST("./binary")
     @Headers({"hr-path-template: /binary", "Accept: application/octet-stream"})

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
@@ -7,6 +7,7 @@ import com.palantir.tokens.auth.BearerToken;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -23,6 +24,7 @@ import javax.ws.rs.core.StreamingOutput;
 @Produces(MediaType.APPLICATION_JSON)
 @Path("/")
 @Generated("com.palantir.conjure.java.services.JerseyServiceGenerator")
+@ParametersAreNonnullByDefault
 public interface EteService {
     @GET
     @Path("base/string")

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoint.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoint.java
@@ -24,8 +24,10 @@ import java.util.Deque;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceHandlerGenerator")
+@ParametersAreNonnullByDefault
 public final class EteServiceEndpoint implements Endpoint {
     private final UndertowEteService delegate;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
@@ -7,6 +7,7 @@ import com.palantir.tokens.auth.BearerToken;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
@@ -19,6 +20,7 @@ import retrofit2.http.Query;
 import retrofit2.http.Streaming;
 
 @Generated("com.palantir.conjure.java.services.Retrofit2ServiceGenerator")
+@ParametersAreNonnullByDefault
 public interface EteServiceRetrofit {
     @GET("./base/string")
     @Headers({"hr-path-template: /base/string", "Accept: application/json"})

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerAliasExample.java
@@ -3,8 +3,10 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
+@ParametersAreNonnullByDefault
 public final class IntegerAliasExample {
     private final int value;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
@@ -10,9 +10,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = IntegerExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class IntegerExample {
     private final int integer;
 
@@ -65,6 +67,7 @@ public final class IntegerExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private int integer;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
@@ -12,9 +12,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = ListExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class ListExample {
     private final List<String> items;
 
@@ -124,6 +126,7 @@ public final class ListExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private List<String> items = new ArrayList<>();

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -17,9 +17,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = ManyFieldExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class ManyFieldExample {
     private final String string;
 
@@ -211,6 +213,7 @@ public final class ManyFieldExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private String string;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapAliasExample.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
+@ParametersAreNonnullByDefault
 public final class MapAliasExample {
     private final Map<String, Object> value;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
@@ -13,9 +13,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = MapExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class MapExample {
     private final Map<String, String> items;
 
@@ -90,6 +92,7 @@ public final class MapExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private Map<String, String> items = new LinkedHashMap<>();

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/NestedStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/NestedStringAliasExample.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
+@ParametersAreNonnullByDefault
 public final class NestedStringAliasExample {
     private final StringAliasExample value;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
@@ -11,9 +11,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = OptionalExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class OptionalExample {
     private final Optional<String> item;
 
@@ -89,6 +91,7 @@ public final class OptionalExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private Optional<String> item = Optional.empty();

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
@@ -17,9 +17,11 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.UUID;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = PrimitiveOptionalsExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class PrimitiveOptionalsExample {
     private final OptionalDouble num;
 
@@ -190,6 +192,7 @@ public final class PrimitiveOptionalsExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private OptionalDouble num = OptionalDouble.empty();

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReferenceAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReferenceAliasExample.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
+@ParametersAreNonnullByDefault
 public final class ReferenceAliasExample {
     private final AnyExample value;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -10,9 +10,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = ReservedKeyExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class ReservedKeyExample {
     private final String package_;
 
@@ -151,6 +153,7 @@ public final class ReservedKeyExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private String package_;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RidAliasExample.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.ri.ResourceIdentifier;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
+@ParametersAreNonnullByDefault
 public final class RidAliasExample {
     private final ResourceIdentifier value;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
@@ -11,9 +11,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = RidExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class RidExample {
     private final ResourceIdentifier ridValue;
 
@@ -88,6 +90,7 @@ public final class RidExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private ResourceIdentifier ridValue;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongAliasExample.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.SafeLong;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
+@ParametersAreNonnullByDefault
 public final class SafeLongAliasExample {
     private final SafeLong value;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
@@ -11,9 +11,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = SafeLongExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class SafeLongExample {
     private final SafeLong safeLongValue;
 
@@ -89,6 +91,7 @@ public final class SafeLongExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private SafeLong safeLongValue;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
@@ -14,9 +14,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = SetExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class SetExample {
     private final Set<String> items;
 
@@ -104,6 +106,7 @@ public final class SetExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private Set<String> items = new LinkedHashSet<>();

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -13,8 +13,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
+@ParametersAreNonnullByDefault
 public final class SingleUnion {
     private final Base value;
 
@@ -67,6 +69,7 @@ public final class SingleUnion {
                 .toString();
     }
 
+    @ParametersAreNonnullByDefault
     public interface Visitor<T> {
         T visitFoo(String value);
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasExample.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
+@ParametersAreNonnullByDefault
 public final class StringAliasExample {
     private final String value;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
@@ -10,9 +10,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = StringExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class StringExample {
     private final String string;
 
@@ -87,6 +89,7 @@ public final class StringExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private String string;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEmptyPathService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEmptyPathService.java
@@ -1,8 +1,10 @@
 package com.palantir.product;
 
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
+@ParametersAreNonnullByDefault
 public interface UndertowEmptyPathService {
     boolean emptyPath();
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteBinaryService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteBinaryService.java
@@ -5,8 +5,10 @@ import com.palantir.tokens.auth.AuthHeader;
 import java.io.InputStream;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
+@ParametersAreNonnullByDefault
 public interface UndertowEteBinaryService {
     BinaryResponseBody postBinary(AuthHeader authHeader, InputStream body);
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
@@ -8,8 +8,10 @@ import com.palantir.tokens.auth.BearerToken;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
+@ParametersAreNonnullByDefault
 public interface UndertowEteService {
     String string(AuthHeader authHeader);
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -13,8 +13,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
+@ParametersAreNonnullByDefault
 public final class Union {
     private final Base value;
 
@@ -73,6 +75,7 @@ public final class Union {
                 .toString();
     }
 
+    @ParametersAreNonnullByDefault
     public interface Visitor<T> {
         T visitFoo(String value);
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -14,9 +14,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** A type which can either be a StringExample, a set of strings, or an integer. */
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
+@ParametersAreNonnullByDefault
 public final class UnionTypeExample {
     private final Base value;
 
@@ -107,6 +109,7 @@ public final class UnionTypeExample {
                 .toString();
     }
 
+    @ParametersAreNonnullByDefault
     public interface Visitor<T> {
         T visitStringExample(StringExample value);
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidAliasExample.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Objects;
 import java.util.UUID;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
+@ParametersAreNonnullByDefault
 public final class UuidAliasExample {
     private final UUID value;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
@@ -11,9 +11,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @JsonDeserialize(builder = UuidExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
+@ParametersAreNonnullByDefault
 public final class UuidExample {
     private final UUID uuid;
 
@@ -88,6 +90,7 @@ public final class UuidExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @ParametersAreNonnullByDefault
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private UUID uuid;

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
@@ -64,6 +64,7 @@ import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
 
@@ -105,7 +106,8 @@ public final class JerseyServiceGenerator implements ServiceGenerator {
                 .addAnnotation(AnnotationSpec.builder(ClassName.get("javax.ws.rs", "Path"))
                         .addMember("value", "$S", "/")
                         .build())
-                .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(JerseyServiceGenerator.class));
+                .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(JerseyServiceGenerator.class))
+                .addAnnotation(ParametersAreNonnullByDefault.class);
 
         serviceDefinition.getDocs().ifPresent(docs ->
                 serviceBuilder.addJavadoc("$L", StringUtils.appendIfMissing(docs.get(), "\n")));

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
@@ -55,6 +55,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.lang.model.element.Modifier;
 import javax.ws.rs.core.MediaType;
 import org.apache.commons.lang3.StringUtils;
@@ -98,7 +99,8 @@ public final class Retrofit2ServiceGenerator implements ServiceGenerator {
             TypeMapper returnTypeMapper, TypeMapper methodTypeMapper) {
         TypeSpec.Builder serviceBuilder = TypeSpec.interfaceBuilder(serviceName(serviceDefinition))
                 .addModifiers(Modifier.PUBLIC)
-                .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(Retrofit2ServiceGenerator.class));
+                .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(Retrofit2ServiceGenerator.class))
+                .addAnnotation(ParametersAreNonnullByDefault.class);
 
         serviceDefinition.getDocs().ifPresent(docs -> {
             serviceBuilder.addJavadoc("$L", StringUtils.appendIfMissing(docs.get(), "\n"));

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -68,6 +68,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
 
@@ -146,6 +147,7 @@ final class UndertowServiceHandlerGenerator {
                 routableFactoryType.simpleName(), serviceName + "Routable");
         TypeSpec routableFactory = TypeSpec.classBuilder(routableFactoryType.simpleName())
                 .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(UndertowServiceHandlerGenerator.class))
+                .addAnnotation(ParametersAreNonnullByDefault.class)
                 .addSuperinterface(Endpoint.class)
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                 .addField(FieldSpec.builder(serviceClass, DELEGATE_VAR_NAME, Modifier.PRIVATE, Modifier.FINAL).build())

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceInterfaceGenerator.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
 
@@ -55,7 +56,8 @@ final class UndertowServiceInterfaceGenerator {
                         + serviceDefinition.getServiceName().getName())
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(
-                        ConjureAnnotations.getConjureGeneratedAnnotation(UndertowServiceInterfaceGenerator.class));
+                        ConjureAnnotations.getConjureGeneratedAnnotation(UndertowServiceInterfaceGenerator.class))
+                .addAnnotation(ParametersAreNonnullByDefault.class);
 
         serviceDefinition.getDocs().ifPresent(docs ->
                 serviceBuilder.addJavadoc("$L", StringUtils.appendIfMissing(docs.get(), "\n")));

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -32,6 +32,7 @@ import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import java.util.Objects;
 import java.util.Optional;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
 
@@ -50,6 +51,7 @@ public final class AliasGenerator {
 
         TypeSpec.Builder spec = TypeSpec.classBuilder(typeDef.getTypeName().getName())
                 .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(AliasGenerator.class))
+                .addAnnotation(ParametersAreNonnullByDefault.class)
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                 .addField(aliasTypeName, "value", Modifier.PRIVATE, Modifier.FINAL)
                 .addMethod(createConstructor(aliasTypeName))

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -56,6 +56,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
 
@@ -87,6 +88,7 @@ public final class BeanBuilderGenerator {
 
         TypeSpec.Builder builder = TypeSpec.classBuilder("Builder")
                 .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(BeanBuilderGenerator.class))
+                .addAnnotation(ParametersAreNonnullByDefault.class)
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
                 .addFields(poetFields)
                 .addFields(primitivesInitializedFields(enrichedFields))

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -44,6 +44,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
 import org.immutables.value.Value;
@@ -112,7 +113,8 @@ public final class BeanGenerator {
                             typeMapper, objectClass, builderClass, typeDef));
         }
 
-        typeBuilder.addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(BeanGenerator.class));
+        typeBuilder.addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(BeanGenerator.class))
+                .addAnnotation(ParametersAreNonnullByDefault.class);
 
         typeDef.getDocs().ifPresent(docs ->
                 typeBuilder.addJavadoc("$L", StringUtils.appendIfMissing(docs.get(), "\n")));

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -36,6 +36,7 @@ import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
 import java.util.List;
 import java.util.Locale;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
 
@@ -65,6 +66,7 @@ public final class EnumGenerator {
             EnumDefinition typeDef, ClassName thisClass, ClassName enumClass, ClassName visitorClass) {
         TypeSpec.Builder wrapper = TypeSpec.classBuilder(typeDef.getTypeName().getName())
                 .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(EnumGenerator.class))
+                .addAnnotation(ParametersAreNonnullByDefault.class)
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                 .addType(createEnum(enumClass, typeDef.getValues(), true))
                 .addType(createVisitor(visitorClass, typeDef.getValues()))
@@ -126,6 +128,7 @@ public final class EnumGenerator {
     private static TypeSpec createEnum(ClassName enumClass, Iterable<EnumValueDefinition> values, boolean withUnknown) {
         TypeSpec.Builder enumBuilder = TypeSpec.enumBuilder(enumClass.simpleName())
                 .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(EnumGenerator.class))
+                .addAnnotation(ParametersAreNonnullByDefault.class)
                 .addModifiers(Modifier.PUBLIC);
         for (EnumValueDefinition value : values) {
             TypeSpec.Builder anonymousClassBuilder = TypeSpec.anonymousClassBuilder("");
@@ -151,6 +154,7 @@ public final class EnumGenerator {
     private static TypeSpec createVisitor(ClassName visitorClass, Iterable<EnumValueDefinition> values) {
         return TypeSpec.interfaceBuilder(visitorClass.simpleName())
                 .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(EnumGenerator.class))
+                .addAnnotation(ParametersAreNonnullByDefault.class)
                 .addModifiers(Modifier.PUBLIC)
                 .addTypeVariable(TYPE_VARIABLE)
                 .addMethods(generateMemberVisitMethods(values))

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ErrorGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ErrorGenerator.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
 
@@ -160,7 +161,8 @@ public final class ErrorGenerator {
                 .addFields(fieldSpecs)
                 .addMethods(methodSpecs)
                 .addMethods(checkMethodSpecs)
-                .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(ErrorGenerator.class));
+                .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(ErrorGenerator.class))
+                .addAnnotation(ParametersAreNonnullByDefault.class);
 
         return JavaFile.builder(conjurePackage, typeBuilder.build())
                 .skipJavaLangImports(true)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
 
@@ -74,6 +75,7 @@ public final class UnionGenerator {
 
         TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(typeDef.getTypeName().getName())
                 .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(UnionGenerator.class))
+                .addAnnotation(ParametersAreNonnullByDefault.class)
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                 .addFields(fields)
                 .addMethod(generateConstructor(baseClass))
@@ -196,6 +198,7 @@ public final class UnionGenerator {
         return TypeSpec.interfaceBuilder(visitorClass)
                 .addModifiers(Modifier.PUBLIC)
                 .addTypeVariable(TYPE_VARIABLE)
+                .addAnnotation(ParametersAreNonnullByDefault.class)
                 .addMethods(generateMemberVisitMethods(memberTypes))
                 .addMethod(MethodSpec.methodBuilder(VISIT_UNKNOWN_METHOD_NAME)
                         .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceGeneratorTests.java
@@ -63,7 +63,8 @@ public final class JerseyServiceGeneratorTests extends TestBase {
 
         for (Path file : files) {
             if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
-                Path output = Paths.get("src/test/resources/test/api/" + file.getFileName() + ".jersey");
+                Path output = Paths.get("src/test/resources/test/api/"
+                        + file.getFileName() + ".jersey_require_not_null");
                 Files.delete(output);
                 Files.copy(file, output);
             }

--- a/conjure-java-core/src/test/resources/test/api/CookieService.java.jersey
+++ b/conjure-java-core/src/test/resources/test/api/CookieService.java.jersey
@@ -2,6 +2,7 @@ package test.api;
 
 import com.palantir.tokens.auth.BearerToken;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.CookieParam;
@@ -14,6 +15,7 @@ import javax.ws.rs.core.MediaType;
 @Produces(MediaType.APPLICATION_JSON)
 @Path("/")
 @Generated("com.palantir.conjure.java.services.JerseyServiceGenerator")
+@ParametersAreNonnullByDefault
 public interface CookieService {
     @GET
     @Path("cookies")

--- a/conjure-java-core/src/test/resources/test/api/CookieService.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/CookieService.java.undertow
@@ -2,8 +2,10 @@ package test.api;
 
 import com.palantir.tokens.auth.BearerToken;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
+@ParametersAreNonnullByDefault
 public interface CookieService {
     void eatCookies(BearerToken cookieToken);
 }

--- a/conjure-java-core/src/test/resources/test/api/CookieServiceEndpoint.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/CookieServiceEndpoint.java.undertow
@@ -12,8 +12,10 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.StatusCodes;
 import java.io.IOException;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceHandlerGenerator")
+@ParametersAreNonnullByDefault
 public final class CookieServiceEndpoint implements Endpoint {
     private final CookieService delegate;
 

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
@@ -17,6 +17,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.Set;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -34,6 +35,7 @@ import javax.ws.rs.core.StreamingOutput;
 @Produces(MediaType.APPLICATION_JSON)
 @Path("/")
 @Generated("com.palantir.conjure.java.services.JerseyServiceGenerator")
+@ParametersAreNonnullByDefault
 public interface TestService {
     /** Returns a mapping from file system id to backing file system configuration. */
     @GET

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.binary
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.binary
@@ -1,6 +1,7 @@
 package test.api;
 
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -12,6 +13,7 @@ import javax.ws.rs.core.StreamingOutput;
 @Produces(MediaType.APPLICATION_JSON)
 @Path("/")
 @Generated("com.palantir.conjure.java.services.JerseyServiceGenerator")
+@ParametersAreNonnullByDefault
 public interface TestService {
     @GET
     @Produces(MediaType.APPLICATION_OCTET_STREAM)

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.binary_as_response
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.binary_as_response
@@ -1,6 +1,7 @@
 package test.api;
 
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -12,6 +13,7 @@ import javax.ws.rs.core.Response;
 @Produces(MediaType.APPLICATION_JSON)
 @Path("/")
 @Generated("com.palantir.conjure.java.services.JerseyServiceGenerator")
+@ParametersAreNonnullByDefault
 public interface TestService {
     @GET
     @Produces(MediaType.APPLICATION_OCTET_STREAM)

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
@@ -17,6 +17,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.Set;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -34,6 +35,7 @@ import javax.ws.rs.core.StreamingOutput;
 @Produces(MediaType.APPLICATION_JSON)
 @Path("/")
 @Generated("com.palantir.conjure.java.services.JerseyServiceGenerator")
+@ParametersAreNonnullByDefault
 public interface TestService {
     /** Returns a mapping from file system id to backing file system configuration. */
     @GET

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
@@ -15,9 +15,11 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.Set;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** A Markdown description of the service. */
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
+@ParametersAreNonnullByDefault
 public interface TestService {
     /** Returns a mapping from file system id to backing file system configuration. */
     Map<String, BackingFileSystem> getFileSystems(AuthHeader authHeader);

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.binary
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.binary
@@ -2,8 +2,10 @@ package test.api;
 
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
+@ParametersAreNonnullByDefault
 public interface TestService {
     BinaryResponseBody getBinary();
 }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoint.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoint.java.undertow
@@ -31,8 +31,10 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.Set;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceHandlerGenerator")
+@ParametersAreNonnullByDefault
 public final class TestServiceEndpoint implements Endpoint {
     private final TestService delegate;
 

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoint.java.undertow.binary
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoint.java.undertow.binary
@@ -11,8 +11,10 @@ import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import java.io.IOException;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceHandlerGenerator")
+@ParametersAreNonnullByDefault
 public final class TestServiceEndpoint implements Endpoint {
     private final TestService delegate;
 

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
@@ -14,6 +14,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.Set;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
@@ -28,6 +29,7 @@ import retrofit2.http.Streaming;
 
 /** A Markdown description of the service. */
 @Generated("com.palantir.conjure.java.services.Retrofit2ServiceGenerator")
+@ParametersAreNonnullByDefault
 public interface TestServiceRetrofit {
     /** Returns a mapping from file system id to backing file system configuration. */
     @GET("./catalog/fileSystems")

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
@@ -15,6 +15,7 @@ import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import retrofit2.http.Body;
@@ -28,6 +29,7 @@ import retrofit2.http.Streaming;
 
 /** A Markdown description of the service. */
 @Generated("com.palantir.conjure.java.services.Retrofit2ServiceGenerator")
+@ParametersAreNonnullByDefault
 public interface TestServiceRetrofit {
     /** Returns a mapping from file system id to backing file system configuration. */
     @GET("./catalog/fileSystems")

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_listenable_future
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_listenable_future
@@ -15,6 +15,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.Set;
 import javax.annotation.Generated;
+import javax.annotation.ParametersAreNonnullByDefault;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import retrofit2.http.Body;
@@ -28,6 +29,7 @@ import retrofit2.http.Streaming;
 
 /** A Markdown description of the service. */
 @Generated("com.palantir.conjure.java.services.Retrofit2ServiceGenerator")
+@ParametersAreNonnullByDefault
 public interface TestServiceRetrofit {
     /** Returns a mapping from file system id to backing file system configuration. */
     @GET("./catalog/fileSystems")


### PR DESCRIPTION
Annotate generated types with `@ParametersAreNonnullByDefault` for more helpful inspections.

Intellij Idea will get upset if a null value is passed to a service annotated with `ParametersAreNonnullByDefault`, which isn't the case using our opt-in `javax.validation.constraints.NotNull` annotations.