### PR TITLE
Fix inconsistency in JerseyServiceGeneratorTests

### DIFF
--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceEteTest.java
@@ -43,7 +43,6 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
@@ -172,16 +171,7 @@ public final class JerseyServiceEteTest extends TestBase {
                 ImmutableList.of(new File("src/test/resources/ete-service.yml")));
         List<Path> files = new JerseyServiceGenerator(ImmutableSet.of(FeatureFlags.RequireNotNullAuthAndBodyParams))
                 .emit(def, folder.getRoot());
-
-        for (Path file : files) {
-            Path output = Paths.get("src/integrationInput/java/com/palantir/product/" + file.getFileName());
-            if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
-                Files.deleteIfExists(output);
-                Files.copy(file, output);
-            }
-
-            assertThat(readFromFile(file)).isEqualTo(readFromFile(output));
-        }
+        validateGeneratorOutput(files, Paths.get("src/integrationInput/java/com/palantir/product"));
     }
 
     private static HttpURLConnection preparePostRequest() throws IOException {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceGeneratorTests.java
@@ -63,7 +63,8 @@ public final class JerseyServiceGeneratorTests extends TestBase {
 
         for (Path file : files) {
             if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
-                Path output = Paths.get("src/test/resources/test/api/" + file.getFileName() + ".jersey");
+                Path output = Paths.get("src/test/resources/test/api/"
+                        + file.getFileName() + ".jersey_require_not_null");
                 Files.delete(output);
                 Files.copy(file, output);
             }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceGeneratorTests.java
@@ -60,19 +60,7 @@ public final class JerseyServiceGeneratorTests extends TestBase {
                 ImmutableList.of(new File("src/test/resources/example-service.yml")));
         List<Path> files = new JerseyServiceGenerator(
                 ImmutableSet.of(RequireNotNullAuthAndBodyParams)).emit(def, folder.getRoot());
-
-        for (Path file : files) {
-            if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
-                Path output = Paths.get("src/test/resources/test/api/"
-                        + file.getFileName() + ".jersey_require_not_null");
-                Files.delete(output);
-                Files.copy(file, output);
-            }
-
-            assertThat(readFromFile(file)).isEqualTo(
-                    readFromFile(Paths.get(
-                            "src/test/resources/test/api/" + file.getFileName() + ".jersey_require_not_null")));
-        }
+        validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".jersey_require_not_null");
     }
 
     @Test
@@ -97,17 +85,7 @@ public final class JerseyServiceGeneratorTests extends TestBase {
                 ImmutableList.of(new File("src/test/resources/example-binary.yml")));
         List<Path> files = new JerseyServiceGenerator(Collections.emptySet())
                 .emit(def, folder.getRoot());
-
-        for (Path file : files) {
-            if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
-                Path output = Paths.get("src/test/resources/test/api/" + file.getFileName() + ".jersey.binary");
-                Files.delete(output);
-                Files.copy(file, output);
-            }
-
-            assertThat(readFromFile(file)).isEqualTo(
-                    readFromFile(Paths.get("src/test/resources/test/api/" + file.getFileName() + ".jersey.binary")));
-        }
+        validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".jersey.binary");
     }
 
     @Test
@@ -116,19 +94,7 @@ public final class JerseyServiceGeneratorTests extends TestBase {
                 ImmutableList.of(new File("src/test/resources/example-binary.yml")));
         List<Path> files = new JerseyServiceGenerator(ImmutableSet.of(FeatureFlags.JerseyBinaryAsResponse))
                 .emit(def, folder.getRoot());
-
-        for (Path file : files) {
-            if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
-                Path output = Paths.get(
-                        "src/test/resources/test/api/" + file.getFileName() + ".jersey.binary_as_response");
-                Files.delete(output);
-                Files.copy(file, output);
-            }
-
-            assertThat(readFromFile(file)).isEqualTo(
-                    readFromFile(Paths.get(
-                            "src/test/resources/test/api/" + file.getFileName() + ".jersey.binary_as_response")));
-        }
+        validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".jersey.binary_as_response");
     }
 
     private void testServiceGeneration(String conjureFile) throws IOException {
@@ -136,17 +102,7 @@ public final class JerseyServiceGeneratorTests extends TestBase {
                 ImmutableList.of(new File("src/test/resources/" + conjureFile + ".yml")));
         List<Path> files = new JerseyServiceGenerator(ImmutableSet.of(RequireNotNullAuthAndBodyParams)).emit(def,
                 folder.getRoot());
-
-        for (Path file : files) {
-            if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
-                Path output = Paths.get("src/test/resources/test/api/" + file.getFileName() + ".jersey");
-                Files.delete(output);
-                Files.copy(file, output);
-            }
-
-            assertThat(readFromFile(file)).isEqualTo(
-                    readFromFile(Paths.get("src/test/resources/test/api/" + file.getFileName() + ".jersey")));
-        }
+        validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".jersey");
     }
 
 }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/Retrofit2ServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/Retrofit2ServiceEteTest.java
@@ -35,7 +35,6 @@ import io.dropwizard.Configuration;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
@@ -132,15 +131,6 @@ public final class Retrofit2ServiceEteTest extends TestBase {
                 new File("src/test/resources/ete-service.yml"),
                 new File("src/test/resources/ete-binary.yml")));
         List<Path> files = new Retrofit2ServiceGenerator(ImmutableSet.of()).emit(def, folder.getRoot());
-
-        for (Path file : files) {
-            Path output = Paths.get("src/integrationInput/java/com/palantir/product/" + file.getFileName());
-            if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
-                Files.deleteIfExists(output);
-                Files.copy(file, output);
-            }
-
-            assertThat(readFromFile(file)).isEqualTo(readFromFile(output));
-        }
+        validateGeneratorOutput(files, Paths.get("src/integrationInput/java/com/palantir/product"));
     }
 }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/Retrofit2ServiceGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/Retrofit2ServiceGeneratorTests.java
@@ -46,16 +46,7 @@ public final class Retrofit2ServiceGeneratorTests extends TestBase {
 
         List<Path> files = new Retrofit2ServiceGenerator(ImmutableSet.of())
                 .emit(def, folder.getRoot());
-
-        for (Path file : files) {
-            if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
-                Path output = Paths.get("src/test/resources/test/api/" + file.getFileName() + ".retrofit");
-                Files.deleteIfExists(output);
-                Files.copy(file, output);
-            }
-
-            assertThat(readFromFile(file)).isEqualTo(readFromResource("/test/api/" + file.getFileName() + ".retrofit"));
-        }
+        validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".retrofit");
     }
 
     @Test
@@ -65,18 +56,7 @@ public final class Retrofit2ServiceGeneratorTests extends TestBase {
 
         List<Path> files = new Retrofit2ServiceGenerator(ImmutableSet.of(FeatureFlags.RetrofitCompletableFutures))
                 .emit(def, folder.getRoot());
-
-        for (Path file : files) {
-            if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
-                Path output = Paths.get("src/test/resources/test/api/"
-                        + file.getFileName() + ".retrofit_completable_future");
-                Files.deleteIfExists(output);
-                Files.copy(file, output);
-            }
-
-            assertThat(readFromFile(file)).isEqualTo(
-                    readFromResource("/test/api/" + file.getFileName() + ".retrofit_completable_future"));
-        }
+        validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".retrofit_completable_future");
     }
 
     @Test
@@ -86,18 +66,7 @@ public final class Retrofit2ServiceGeneratorTests extends TestBase {
 
         List<Path> files = new Retrofit2ServiceGenerator(ImmutableSet.of(FeatureFlags.RetrofitListenableFutures))
                 .emit(def, folder.getRoot());
-
-        for (Path file : files) {
-            if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
-                Path output = Paths.get("src/test/resources/test/api/"
-                        + file.getFileName() + ".retrofit_listenable_future");
-                Files.deleteIfExists(output);
-                Files.copy(file, output);
-            }
-
-            assertThat(readFromFile(file)).isEqualTo(
-                    readFromResource("/test/api/" + file.getFileName() + ".retrofit_listenable_future"));
-        }
+        validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".retrofit_listenable_future");
     }
 
     @Test

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/TestBase.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/TestBase.java
@@ -16,12 +16,15 @@
 
 package com.palantir.conjure.java;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.common.io.CharStreams;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 public abstract class TestBase {
 
@@ -39,6 +42,21 @@ public abstract class TestBase {
                     new InputStreamReader(getClass().getResourceAsStream(path), StandardCharsets.UTF_8));
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    protected static void validateGeneratorOutput(List<Path> files, Path outputDir) throws IOException {
+        validateGeneratorOutput(files, outputDir, "");
+    }
+
+    protected static void validateGeneratorOutput(List<Path> files, Path outputDir, String suffix) throws IOException {
+        for (Path file : files) {
+            Path output = outputDir.resolve(file.getFileName() + suffix);
+            if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
+                Files.delete(output);
+                Files.copy(file, output);
+            }
+            assertThat(readFromFile(file)).isEqualTo(readFromFile(output));
         }
     }
 }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -62,7 +62,6 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
@@ -398,16 +397,7 @@ public final class UndertowServiceEteTest extends TestBase {
                 new File("src/test/resources/ete-binary.yml")));
         List<Path> files = new UndertowServiceGenerator(ImmutableSet.of(FeatureFlags.UndertowServicePrefix))
                 .emit(def, folder.getRoot());
-
-        for (Path file : files) {
-            Path output = Paths.get("src/integrationInput/java/com/palantir/product/" + file.getFileName());
-            if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
-                Files.deleteIfExists(output);
-                Files.copy(file, output);
-            }
-
-            assertThat(readFromFile(file)).isEqualTo(readFromFile(output));
-        }
+        validateGeneratorOutput(files, Paths.get("src/integrationInput/java/com/palantir/product"));
     }
 
     private static HttpURLConnection preparePostRequest() throws IOException {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceGeneratorTests.java
@@ -76,34 +76,14 @@ public final class UndertowServiceGeneratorTests extends TestBase {
                 ImmutableList.of(new File("src/test/resources/example-binary.yml")));
         List<Path> files = new UndertowServiceGenerator(Collections.emptySet())
                 .emit(def, folder.getRoot());
-
-        for (Path file : files) {
-            if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
-                Path output = Paths.get("src/test/resources/test/api/" + file.getFileName() + ".undertow.binary");
-                Files.delete(output);
-                Files.copy(file, output);
-            }
-
-            assertThat(readFromFile(file)).isEqualTo(
-                    readFromFile(Paths.get("src/test/resources/test/api/" + file.getFileName() + ".undertow.binary")));
-        }
+        validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".undertow.binary");
     }
 
     private void testServiceGeneration(String conjureFile) throws IOException {
         ConjureDefinition def = Conjure.parse(
                 ImmutableList.of(new File("src/test/resources/" + conjureFile + ".yml")));
         List<Path> files = new UndertowServiceGenerator(ImmutableSet.of()).emit(def, folder.getRoot());
-
-        for (Path file : files) {
-            if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
-                Path output = Paths.get("src/test/resources/test/api/" + file.getFileName() + ".undertow");
-                Files.delete(output);
-                Files.copy(file, output);
-            }
-
-            assertThat(readFromFile(file)).isEqualTo(
-                    readFromFile(Paths.get("src/test/resources/test/api/" + file.getFileName() + ".undertow")));
-        }
+        validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".undertow");
     }
 
 }


### PR DESCRIPTION
recreate=true will recreate a correctly suffixed output file.