### PR TITLE
[fix] Undertow Endpoints do not use form encoding in url paths

### DIFF
--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -333,9 +333,24 @@ public final class UndertowServiceEteTest extends TestBase {
     }
 
     @Test
-    public void testSlashesInPathParam() {
+    public void testSlashesInPathParam() throws IOException  {
         String expected = "foo/bar/baz/%2F";
         assertThat(client.path(AuthHeader.valueOf("bearer"), expected)).isEqualTo(expected);
+        assertThat(retrofitClient.path(AuthHeader.valueOf("bearer"), expected).execute().body()).isEqualTo(expected);
+    }
+
+    @Test
+    public void testPlusInPathParam() throws IOException  {
+        String expected = "foo+bar";
+        assertThat(client.path(AuthHeader.valueOf("bearer"), expected)).isEqualTo(expected);
+        assertThat(retrofitClient.path(AuthHeader.valueOf("bearer"), expected).execute().body()).isEqualTo(expected);
+    }
+
+    @Test
+    public void testSpaceInPathParam() throws IOException {
+        String expected = "foo bar";
+        assertThat(client.path(AuthHeader.valueOf("bearer"), expected)).isEqualTo(expected);
+        assertThat(retrofitClient.path(AuthHeader.valueOf("bearer"), expected).execute().body()).isEqualTo(expected);
     }
 
     @Test

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/PathParamDecodingHandler.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/PathParamDecodingHandler.java
@@ -47,7 +47,7 @@ class PathParamDecodingHandler implements HttpHandler {
                     StringBuilder buffer = new StringBuilder();
                     for (Map.Entry<String, String> entry : parameters.entrySet()) {
                         entry.setValue(URLUtils.decode(
-                                entry.getValue(), "UTF-8", true, true, buffer));
+                                entry.getValue(), "UTF-8", true, false, buffer));
                     }
                 }
             }

--- a/versions.props
+++ b/versions.props
@@ -18,7 +18,10 @@ com.palantir.tokens:* = 3.3.0
 com.palantir.tracing:tracing = 2.0.1
 com.palantir.websecurity:dropwizard-web-security = 1.1.0
 com.squareup.okhttp3:* = 3.12.1
-com.squareup.retrofit2:* = 2.5.0
+# dependency-upgrader:OFF
+# https://github.com/palantir/conjure-java/issues/176
+com.squareup.retrofit2:* = 2.4.0
+# dependency-upgrader:ON
 com.squareup:javapoet = 1.11.1
 info.picocli:picocli = 3.7.0
 io.dropwizard.metrics:metrics-core = 3.2.5


### PR DESCRIPTION
This fixes a compatibility issue with retrofit clients, but feign was never affected