### PR TITLE
Remove TraceHandler iothread check

### DIFF
--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/TraceHandler.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/TraceHandler.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.java.undertow.runtime;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.palantir.tracing.Tracer;
 import com.palantir.tracing.Tracers;
@@ -54,8 +53,6 @@ final class TraceHandler implements HttpHandler {
 
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
-        Preconditions.checkArgument(!exchange.isInIoThread(), "TraceHandler must not be used in IO thread");
-
         String traceId = initializeTrace(exchange);
         // Populate response before calling delegate since delegate might commit the response.
         exchange.getResponseHeaders().put(TRACE_ID, traceId);

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/HttpServerExchanges.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/HttpServerExchanges.java
@@ -16,8 +16,8 @@
 
 package com.palantir.conjure.java.undertow;
 
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.ServerConnection;
@@ -43,12 +43,12 @@ public final class HttpServerExchanges {
     private static StreamConnection createStreamConnection() {
         StreamConnection streamConnection = mock(StreamConnection.class);
         ConduitStreamSinkChannel sinkChannel = new ConduitStreamSinkChannel(null, mock(StreamSinkConduit.class));
-        when(streamConnection.getSinkChannel()).thenReturn(sinkChannel);
+        lenient().when(streamConnection.getSinkChannel()).thenReturn(sinkChannel);
         ConduitStreamSourceChannel sourceChannel =
                 new ConduitStreamSourceChannel(null, mock(StreamSourceConduit.class));
-        when(streamConnection.getSourceChannel()).thenReturn(sourceChannel);
+        lenient().when(streamConnection.getSourceChannel()).thenReturn(sourceChannel);
         XnioIoThread ioThread = mock(XnioIoThread.class);
-        when(streamConnection.getIoThread()).thenReturn(ioThread);
+        lenient().when(streamConnection.getIoThread()).thenReturn(ioThread);
         return streamConnection;
     }
 

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/TraceHandlerTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/TraceHandlerTest.java
@@ -37,7 +37,6 @@ import io.undertow.util.HttpString;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -81,10 +80,6 @@ public final class TraceHandlerTest {
     public void after() {
         Tracer.unsubscribe("TEST_OBSERVER");
     }
-
-    @Ignore("TODO(rfink): This is pretty hard to mock")
-    @Test
-    public void failsWhenRunOnIoThread() {}
 
     @Test
     public void whenNoTraceIsInHeader_generatesNewTrace() throws Exception {


### PR DESCRIPTION
We do not allow these handlers to run on io threads, there's no
reason to push this validation to runtime. Furthermore there's
no reason not to allow tracing on handlers which run asynchronously.