### PR TITLE
[improvement] add more efficient Bytes constructors

### DIFF
--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/Bytes.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/Bytes.java
@@ -115,7 +115,7 @@ public final class Bytes {
         return new Bytes(safe);
     }
 
-    /** Constructs a new {@link Bytes} from the provided {@link ByteArrayOutputStream} */
+    /** Constructs a new {@link Bytes} from the provided {@link ByteArrayOutputStream}. */
     public static Bytes from(ByteArrayOutputStream byteStream) {
         // this returns a new copy already
         byte[] safe = byteStream.toByteArray();
@@ -123,7 +123,7 @@ public final class Bytes {
         return new Bytes(safe);
     }
 
-    /** Constructs a new {@link Bytes} by reading the provided {@link InputStream} fully */
+    /** Constructs a new {@link Bytes} by reading the provided {@link InputStream} fully. */
     public static Bytes from(InputStream inputStream) throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         copy(inputStream, outputStream);
@@ -131,13 +131,13 @@ public final class Bytes {
         return from(outputStream);
     }
 
-    // more or less what IOUtils would do
+    // more or less what IOUtils would do. In Java9, you could do inputStream.transferTo(outputStream)
     private static void copy(InputStream inputStream, OutputStream outputStream) throws IOException {
         byte[] buf = new byte[4096];
-        int r;
+        int read;
 
-        while ((r = inputStream.read(buf)) != -1) {
-            outputStream.write(buf, 0, r);
+        while ((read = inputStream.read(buf)) != -1) {
+            outputStream.write(buf, 0, read);
         }
     }
 

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/Bytes.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/Bytes.java
@@ -25,8 +25,10 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
@@ -111,6 +113,32 @@ public final class Bytes {
         local.get(safe);
 
         return new Bytes(safe);
+    }
+
+    /** Constructs a new {@link Bytes} from the provided {@link ByteArrayOutputStream} */
+    public static Bytes from(ByteArrayOutputStream byteStream) {
+        // this returns a new copy already
+        byte[] safe = byteStream.toByteArray();
+
+        return new Bytes(safe);
+    }
+
+    /** Constructs a new {@link Bytes} by reading the provided {@link InputStream} fully */
+    public static Bytes from(InputStream inputStream) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        copy(inputStream, outputStream);
+
+        return from(outputStream);
+    }
+
+    // more or less what IOUtils would do
+    private static void copy(InputStream inputStream, OutputStream outputStream) throws IOException {
+        byte[] buf = new byte[4096];
+        int r;
+
+        while ((r = inputStream.read(buf)) != -1) {
+            outputStream.write(buf, 0, r);
+        }
     }
 
     static final class Serializer extends JsonSerializer<Bytes> {

--- a/conjure-lib/src/test/java/com/palantir/conjure/java/lib/BytesTests.java
+++ b/conjure-lib/src/test/java/com/palantir/conjure/java/lib/BytesTests.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -164,5 +166,37 @@ public final class BytesTests {
         assertThat(serialized).isEqualTo("\"dGVzdA==\"");
         assertThat(new String(mapper.readValue(serialized, Bytes.class).asNewByteArray(), StandardCharsets.UTF_8))
                 .isEqualTo("test");
+    }
+
+    @Test
+    public void testFromByteArrayOutputStream() throws IOException {
+        byte[] data = new byte[] {1, 2, 3};
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        stream.write(data);
+
+        Bytes bytes = Bytes.from(stream);
+
+        assertThat(bytes.asNewByteArray()).isEqualTo(data);
+
+        // mutate the baos (by writing more data to its buffer)
+        stream.write(4);
+
+        assertThat(bytes.asNewByteArray()).isEqualTo(data);
+        assertThat(bytes.asNewByteArray()).isNotEqualTo(stream.toByteArray());
+    }
+
+    @Test
+    public void testFromInputStream() throws IOException {
+        byte[] data = new byte[] {1, 2, 3};
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
+
+        Bytes bytes = Bytes.from(inputStream);
+
+        assertThat(bytes.asNewByteArray()).isEqualTo(data);
+
+        // read again from the input stream (should be empty now)
+        Bytes bytes2 = Bytes.from(inputStream);
+
+        assertThat(bytes2.size()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
Adds methods to construct Bytes from InputStreams and
ByteArrayOutputStreams to avoid extra copying.

<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
Code that constructs Bytes as part of return values often results in a lot of extra copying, when the underlying data already came from an InputStream or a ByteArrayOutputStream.

## After this PR
Using the new Bytes#from methods with an InputStream or ByteArrayOutputStream results in one less copy compared to constructing your own byte[] and using from(byte[])
