### PR TITLE
Undertow team can approve undertow-specific PRs

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -3,6 +3,7 @@ policy:
     - or:
       - infra team approval
       - infra team co-approval
+      - undertow team approval
       - excavator only touched baseline, gradle files or versions.props
       - excavator only touched package.json and lock files
   disapproval:
@@ -24,6 +25,19 @@ approval_rules:
       count: 2
       teams:
         - "palantir/infrastructure"
+
+  - name: undertow team approval
+    requires:
+      count: 1
+      users:
+        - "cakofony"
+        - "rubenfiszel"
+        - "uschi2000"
+    if:
+      only_changed_files:
+        paths:
+          - "^.*undertow.*$"
+          - "^.*Undertow.*$"
 
   - name: excavator only touched baseline, gradle files or versions.props
     requires:


### PR DESCRIPTION
## Before this PR

This repo has lots of Undertow-specific PRs landing, but they can get bottlenecked on CRs from the infra team.

## After this PR

Given that the undertow generator is more experimental, this policy bot change should allow @uschi2000 @cakofony @rubenfiszel to approve your own undertow-specific PRs.  This should work if you touch files in `:conjure-undertow-lib` and also paths inside conjure-java, like:

```
conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceGenerator.java
```