### PR TITLE
Fix policy for baseline

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -33,7 +33,7 @@ approval_rules:
         users: [ "svc-excavator-bot" ]
       only_changed_files:
         paths:
-          - "^\\.baseline/.*$"
+          - "^\.baseline/.*$"
           - "^.*gradle$"
           - "^gradle/wrapper/.*"
           - "^gradlew$"


### PR DESCRIPTION
It seems like our current regex for baseline is causing policy-bot to fail when changes are made: https://github.com/palantir/conjure-java/pull/208 