### PR TITLE
[fix] ConjureExceptionHandler understands QosExceptions

### DIFF
--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptionHandler.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptionHandler.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
+import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnio.IoUtils;
@@ -64,124 +65,107 @@ final class ConjureExceptionHandler implements HttpHandler {
         try {
             delegate.handleRequest(exchange);
         } catch (Throwable throwable) {
-            final Optional<SerializableError> maybeBody;
-            final int statusCode;
-
             if (throwable instanceof ServiceException) {
-                ServiceException exception = (ServiceException) throwable;
-                statusCode = exception.getErrorType().httpErrorCode();
-                maybeBody = Optional.of(SerializableError.forException(exception));
-                log(exception);
+                serviceException(exchange, (ServiceException) throwable);
             } else if (throwable instanceof QosException) {
-                QosException exception = (QosException) throwable;
-                maybeBody = Optional.empty();
-                statusCode = exception.accept(new QosException.Visitor<Integer>() {
-                    @Override
-                    public Integer visit(QosException.Throttle exception) {
-                        return 429;
-                    }
-
-                    @Override
-                    public Integer visit(QosException.RetryOther exception) {
-                        return 308;
-                    }
-
-                    @Override
-                    public Integer visit(QosException.Unavailable exception) {
-                        return 503;
-                    }
-                });
-                exception.accept(new QosException.Visitor<Void>() {
-                    @Override
-                    public Void visit(QosException.Throttle exception) {
-                        exception.getRetryAfter().ifPresent(duration -> {
-                            exchange.getResponseHeaders()
-                                    .put(Headers.RETRY_AFTER, Long.toString(duration.get(ChronoUnit.SECONDS)));
-                        });
-                        return null;
-                    }
-
-                    @Override
-                    public Void visit(QosException.RetryOther exception) {
-                        exchange.getResponseHeaders()
-                                .put(Headers.LOCATION, exception.getRedirectTo().toString());
-                        return null;
-                    }
-
-                    @Override
-                    public Void visit(QosException.Unavailable exception) {
-                        return null;
-                    }
-                });
-                logQosException(exception);
-
+                qosException(exchange, (QosException) throwable);
             } else if (throwable instanceof RemoteException) {
-                // RemoteExceptions are thrown by Conjure clients to indicate a remote/service-side problem.
-                // We forward these exceptions, but change the ErrorType to INTERNAL, i.e., the problem is now
-                // considered internal to *this* service rather than the originating service. This means in particular
-                // that Conjure errors are defined only local to a given service and these error types don't
-                // propagate through other services.
-                RemoteException exception = (RemoteException) throwable;
-
-                // log at WARN instead of ERROR because although this indicates an issue in a remote server
-                log.warn(
-                        "Encountered a remote exception. Mapping to an internal error before propagating",
-                        SafeArg.of("errorInstanceId", exception.getError().errorInstanceId()),
-                        SafeArg.of("errorName", exception.getError().errorName()),
-                        SafeArg.of("statusCode", exception.getStatus()),
-                        exception);
-
-                ErrorType errorType = ErrorType.INTERNAL;
-                statusCode = errorType.httpErrorCode();
-
-                // Override only the name and code of the error
-                maybeBody = Optional.of(SerializableError.builder()
-                        .from(exception.getError())
-                        .errorName(errorType.name())
-                        .errorCode(errorType.code().toString())
-                        .build());
+                remoteException(exchange, (RemoteException) throwable);
             } else if (throwable instanceof IllegalArgumentException) {
-                ServiceException exception = new ServiceException(ErrorType.INVALID_ARGUMENT, throwable);
-                maybeBody = Optional.of(SerializableError.forException(exception));
-                statusCode = exception.getErrorType().httpErrorCode();
-                log(exception);
+                illegalArgumentException(exchange, throwable);
             } else if (throwable instanceof FrameworkException) {
-                FrameworkException frameworkException = (FrameworkException) throwable;
-                statusCode = frameworkException.getStatusCode();
-                ErrorType errorType = statusCode / 100 == 4 ? ErrorType.INVALID_ARGUMENT : ErrorType.INTERNAL;
-                ServiceException exception = new ServiceException(errorType, frameworkException);
-                maybeBody = Optional.of(SerializableError.forException(exception));
-                log(exception);
+                frameworkException(exchange, (FrameworkException) throwable);
             } else if (throwable instanceof Error) {
                 throw (Error) throwable;
             } else {
                 ServiceException exception = new ServiceException(ErrorType.INTERNAL, throwable);
-                statusCode = exception.getErrorType().httpErrorCode();
-                maybeBody = Optional.of(SerializableError.forException(exception));
                 log(exception);
-            }
-
-            // Do not attempt to write the failure if data has already been written
-            if (!isResponseStarted(exchange)) {
-                exchange.setStatusCode(statusCode);
-                try {
-                    if (maybeBody.isPresent()) {
-                        serializers.serialize(maybeBody.get(), exchange);
-                    }
-                } catch (IOException | RuntimeException e) {
-                    log.info("Failed to write error response", e);
-                }
-            } else {
-                // This prevents the server from sending the final null chunk, alerting
-                // clients that the response was terminated prior to receiving full contents.
-                // Note that in the case of http/2 this does not close a connection, which
-                // would break other active requests, only resets the stream.
-                log.warn("Closing the connection to alert the client of an error");
-                IoUtils.safeClose(exchange.getConnection());
+                writeResponse(
+                        exchange,
+                        Optional.of(SerializableError.forException(exception)),
+                        exception.getErrorType().httpErrorCode());
             }
         }
     }
 
+    private void serviceException(HttpServerExchange exchange, ServiceException exception) {
+        log(exception);
+        writeResponse(
+                exchange,
+                Optional.of(SerializableError.forException(exception)),
+                exception.getErrorType().httpErrorCode());
+    }
+
+    private void qosException(HttpServerExchange exchange, QosException exception) {
+        exception.accept(QOS_EXCEPTION_HEADERS).accept(exchange);
+        log.debug("Possible quality-of-service intervention", exception);
+        writeResponse(
+                exchange,
+                Optional.empty(),
+                exception.accept(QOS_EXCEPTION_STATUS_CODE));
+    }
+
+    // RemoteExceptions are thrown by Conjure clients to indicate a remote/service-side problem.
+    // We forward these exceptions, but change the ErrorType to INTERNAL, i.e., the problem is now
+    // considered internal to *this* service rather than the originating service. This means in particular
+    // that Conjure errors are defined only local to a given service and these error types don't
+    // propagate through other services.
+    private void remoteException(HttpServerExchange exchange, RemoteException exception) {
+        // log at WARN instead of ERROR because although this indicates an issue in a remote server
+        log.warn("Encountered a remote exception. Mapping to an internal error before propagating",
+                SafeArg.of("errorInstanceId", exception.getError().errorInstanceId()),
+                SafeArg.of("errorName", exception.getError().errorName()),
+                SafeArg.of("statusCode", exception.getStatus()),
+                exception);
+
+        ErrorType errorType = ErrorType.INTERNAL;
+        writeResponse(exchange,
+                // Override only the name and code of the error
+                Optional.of(SerializableError.builder()
+                        .from(exception.getError())
+                        .errorName(errorType.name())
+                        .errorCode(errorType.code().toString())
+                        .build()),
+                errorType.httpErrorCode());
+    }
+
+    private void illegalArgumentException(HttpServerExchange exchange, Throwable throwable) {
+        ServiceException exception = new ServiceException(ErrorType.INVALID_ARGUMENT, throwable);
+        log(exception);
+        writeResponse(
+                exchange,
+                Optional.of(SerializableError.forException(exception)),
+                exception.getErrorType().httpErrorCode());
+    }
+
+    private void frameworkException(HttpServerExchange exchange, FrameworkException frameworkException) {
+        int statusCode = frameworkException.getStatusCode();
+        ErrorType errorType = statusCode / 100 == 4 ? ErrorType.INVALID_ARGUMENT : ErrorType.INTERNAL;
+        ServiceException exception = new ServiceException(errorType, frameworkException);
+        log(exception);
+        writeResponse(exchange, Optional.of(SerializableError.forException(exception)), statusCode);
+    }
+
+    private void writeResponse(HttpServerExchange exchange, Optional<SerializableError> maybeBody, int statusCode) {
+        // Do not attempt to write the failure if data has already been written
+        if (!isResponseStarted(exchange)) {
+            exchange.setStatusCode(statusCode);
+            try {
+                if (maybeBody.isPresent()) {
+                    serializers.serialize(maybeBody.get(), exchange);
+                }
+            } catch (IOException | RuntimeException e) {
+                log.info("Failed to write error response", e);
+            }
+        } else {
+            // This prevents the server from sending the final null chunk, alerting
+            // clients that the response was terminated prior to receiving full contents.
+            // Note that in the case of http/2 this does not close a connection, which
+            // would break other active requests, only resets the stream.
+            log.warn("Closing the connection to alert the client of an error");
+            IoUtils.safeClose(exchange.getConnection());
+        }
+    }
 
     private static boolean isResponseStarted(HttpServerExchange exchange) {
         if (exchange.isResponseStarted()) {
@@ -196,10 +180,6 @@ final class ConjureExceptionHandler implements HttpHandler {
         return false;
     }
 
-    private static void logQosException(QosException exception) {
-        log.debug("Possible quality-of-service intervention", exception);
-    }
-
     private static void log(ServiceException exception) {
         if (exception.getErrorType().httpErrorCode() / 100 == 4 /* client error */) {
             log.info("Error handling request",
@@ -209,4 +189,45 @@ final class ConjureExceptionHandler implements HttpHandler {
                     SafeArg.of("errorInstanceId", exception.getErrorInstanceId()), exception);
         }
     }
+
+    private static final QosException.Visitor<Integer> QOS_EXCEPTION_STATUS_CODE = new QosException.Visitor<Integer>() {
+        @Override
+        public Integer visit(QosException.Throttle exception) {
+            return 429;
+        }
+
+        @Override
+        public Integer visit(QosException.RetryOther exception) {
+            return 308;
+        }
+
+        @Override
+        public Integer visit(QosException.Unavailable exception) {
+            return 503;
+        }
+    };
+
+    private static final QosException.Visitor<Consumer<HttpServerExchange>>
+            QOS_EXCEPTION_HEADERS = new QosException.Visitor<Consumer<HttpServerExchange>>() {
+                @Override
+                public Consumer<HttpServerExchange> visit(QosException.Throttle exception) {
+                    return exchange -> exception.getRetryAfter().ifPresent(duration -> {
+                        exchange.getResponseHeaders()
+                                .put(Headers.RETRY_AFTER, Long.toString(duration.get(ChronoUnit.SECONDS)));
+                    });
+                }
+
+                @Override
+                public Consumer<HttpServerExchange> visit(QosException.RetryOther exception) {
+                    return exchange -> exchange.getResponseHeaders()
+                            .put(Headers.LOCATION, exception.getRedirectTo().toString());
+                }
+
+                @Override
+                public Consumer<HttpServerExchange> visit(QosException.Unavailable exception) {
+                    return exchange -> {
+
+                    };
+                }
+            };
 }


### PR DESCRIPTION
## Before this PR

There are three kinds of QosException in conjure-java-runtime-api, but the ConjureExceptionHandler currently sends them all over the wire as 500 errors.

(See the full list of available [exceptions here](https://github.com/palantir/conjure-java-runtime-api/tree/develop/errors/src/main/java/com/palantir/conjure/java/api/errors))

## After this PR

The Undertow behaviour matches the old Jersey behaviour ([QosExceptionMapper](https://github.com/palantir/conjure-java-runtime/blob/develop/conjure-java-jersey-server/src/main/java/com/palantir/conjure/java/server/jersey/QosExceptionMapper.java))


<!-- Describe at a high-level why this approach is better. -->

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
