### PR TITLE
Fix bintray publishing

### DIFF
--- a/gradle/publish-dist.gradle
+++ b/gradle/publish-dist.gradle
@@ -12,7 +12,7 @@ bintray {
     publish = true
     pkg {
         repo = 'releases'
-        name = rootProject.name
+        name = 'conjure-java'
         userOrg = 'palantir'
         licenses = ['Apache-2.0']
         publications = ['dist']

--- a/gradle/publish-jar.gradle
+++ b/gradle/publish-jar.gradle
@@ -17,7 +17,7 @@ bintray {
     publish = true
     pkg {
         repo = 'releases'
-        name = rootProject.name
+        name = 'conjure-java'
         userOrg = 'palantir'
         licenses = ['Apache-2.0']
         publications = ['nebula']


### PR DESCRIPTION
@cakofony noticed our 2.9.0 publish failed.  I SSH'd into the build and realised it was trying to create a bintray pkg called 'palantir-conjure-java', but we only have perms to write to 'conjure-java'.

This is an unintended side effect of https://github.com/palantir/conjure-java/pull/222