### PR TITLE
[fix] 'useInsensitiveEnums' feature flag fully restores old behaviour

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/insensitive/InsensitiveEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/insensitive/InsensitiveEnum.java
@@ -2,7 +2,6 @@ package com.palantir.insensitive;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.palantir.conjure.java.lib.internal.ConjureEnums;
 import com.palantir.logsafe.Preconditions;
 import java.util.Locale;
 import javax.annotation.Generated;
@@ -75,7 +74,6 @@ public final class InsensitiveEnum {
             case "ONE_HUNDRED":
                 return ONE_HUNDRED;
             default:
-                ConjureEnums.validate(value);
                 return new InsensitiveEnum(Value.UNKNOWN, value);
         }
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -224,11 +224,12 @@ public final class EnumGenerator {
                     .addStatement("return $L", value.getValue())
                     .unindent();
         }
-        parser.add("default:\n")
-                .indent()
-                // Only validate unknown values, matches are validated at build time.
-                .addStatement("$T.validate($N)", ConjureEnums.class, param)
-                .addStatement("return new $T(Value.UNKNOWN, $N)", thisClass, param)
+        parser.add("default:\n").indent();
+        if (!featureFlags.contains(FeatureFlags.CaseInsensitiveEnums)) {
+            // Only validate unknown values, matches are validated at build time.
+            parser.addStatement("$T.validate($N)", ConjureEnums.class, param);
+        }
+        parser.addStatement("return new $T(Value.UNKNOWN, $N)", thisClass, param)
                 .unindent()
                 .endControlFlow();
 

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
@@ -61,6 +61,18 @@ public class EnumTests {
     }
 
     @Test
+    public void testInsensitiveEnum_unknownToleratesEmptyStringsForHistoricalReasons() {
+        InsensitiveEnum value = InsensitiveEnum.valueOf("");
+        assertThat(value.get()).isEqualTo(InsensitiveEnum.Value.UNKNOWN);
+    }
+
+    @Test
+    public void testInsensitiveEnum_unknownToleratesStrangeCharactersForHistoricalReasons() {
+        InsensitiveEnum value = InsensitiveEnum.valueOf("!@£$%^&*()");
+        assertThat(value.get()).isEqualTo(InsensitiveEnum.Value.UNKNOWN);
+    }
+
+    @Test
     public void testNullValidationUsesSafeLoggable() {
         assertThatLoggableExceptionThrownBy(() -> EnumExample.valueOf(null)).hasLogMessage("value cannot be null");
     }


### PR DESCRIPTION
## Before this PR

@jcvitanovic reported problems on an internal product where empty strings were persisted to a database, but trying to opt in to the old behaviour using this feature flag would still break.

```gradle
conjure {
    java {
        useInsensitiveEnums = true
    }
}
```

## After this PR

The feature flag brings back exactly the old pre-2.8.0 behavour, where strings are leniently deserialized.


_A full revert is still being considered here: https://github.com/palantir/conjure-java/pull/238_