### PR TITLE
[fix] Allow single character field names

### DIFF
--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/CaseConverter.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/CaseConverter.java
@@ -21,11 +21,11 @@ import java.util.regex.Pattern;
 
 public final class CaseConverter {
     private static final Pattern CAMEL_CASE_PATTERN =
-            Pattern.compile("^[a-z]([A-Z]{1,2}[a-z0-9]|[a-z0-9])+[A-Z]?$");
+            Pattern.compile("^[a-z]([A-Z]{1,2}[a-z0-9]|[a-z0-9])*[A-Z]?$");
     private static final Pattern KEBAB_CASE_PATTERN =
-            Pattern.compile("^[a-z]((-[a-z]){1,2}[a-z0-9]|[a-z0-9])+(-[a-z])?$");
+            Pattern.compile("^[a-z]((-[a-z]){1,2}[a-z0-9]|[a-z0-9])*(-[a-z])?$");
     private static final Pattern SNAKE_CASE_PATTERN =
-            Pattern.compile("^[a-z]((_[a-z]){1,2}[a-z0-9]|[a-z0-9])+(_[a-z])?$");
+            Pattern.compile("^[a-z]((_[a-z]){1,2}[a-z0-9]|[a-z0-9])*(_[a-z])?$");
 
     private CaseConverter() {}
 


### PR DESCRIPTION
## Before this PR
The CaseConverter in conjure was updated https://github.com/palantir/conjure/blob/master/conjure-generator-common/src/main/java/com/palantir/conjure/CaseConverter.java

So we need to update it here also.

## After this PR

The CaseConverter is updated, allowing single character field names. Additionally I have filed https://github.com/palantir/conjure-java/issues/244 to track using the CaseConverter from conjure