### PR TITLE
[fix] Suppress deprecation warnings in generated undertow services

### DIFF
--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
@@ -300,6 +300,7 @@ public final class TestServiceEndpoints implements Service {
 
         private class GetBranchesDeprecatedHandler implements HttpHandler {
             @Override
+            @SuppressWarnings("deprecation")
             public void handleRequest(HttpServerExchange exchange) throws IOException {
                 AuthHeader authHeader = Auth.header(exchange);
                 Map<String, String> pathParams =


### PR DESCRIPTION
## Before this PR
Undertow service handlers for deprecated endpoints fail to compile when using `-Xlint:deprecation`. This wasn't a problem for Jersey services because the deprecated methods were not called in the generated code.

## After this PR
Undertow service handlers suppress deprecation warnings when calling deprecated endpoints.
