### PR TITLE
Suppress unchecked warnings in generated builders

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryExample.java
@@ -90,6 +90,7 @@ public final class BinaryExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private ByteBuffer binary;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
@@ -92,6 +92,7 @@ public final class OptionalExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private Optional<ByteBuffer> item = Optional.empty();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
@@ -189,6 +189,7 @@ public final class AliasAsMapKeyExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private Map<StringAliasExample, ManyFieldExample> strings = new LinkedHashMap<>();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
@@ -89,6 +89,7 @@ public final class AnyExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private Object any;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
@@ -92,6 +92,7 @@ public final class AnyMapExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private Map<String, Object> items = new LinkedHashMap<>();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
@@ -91,6 +91,7 @@ public final class BearerTokenExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private BearerToken bearerTokenValue;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
@@ -90,6 +90,7 @@ public final class BinaryExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private Bytes binary;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
@@ -66,6 +66,7 @@ public final class BooleanExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private boolean coin;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
@@ -108,6 +108,7 @@ public final class CovariantListExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private List<Object> items = new ArrayList<>();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
@@ -92,6 +92,7 @@ public final class CovariantOptionalExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private Optional<Object> item = Optional.empty();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
@@ -91,6 +91,7 @@ public final class DateTimeExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private OffsetDateTime datetime;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
@@ -65,6 +65,7 @@ public final class DoubleExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private double doubleValue;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
@@ -90,6 +90,7 @@ public final class EnumFieldExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private EnumExample enum_;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
@@ -66,6 +66,7 @@ public final class IntegerExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private int integer;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
@@ -126,6 +126,7 @@ public final class ListExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private List<String> items = new ArrayList<>();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -213,6 +213,7 @@ public final class ManyFieldExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private String string;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
@@ -92,6 +92,7 @@ public final class MapExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private Map<String, String> items = new LinkedHashMap<>();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
@@ -91,6 +91,7 @@ public final class OptionalExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private Optional<String> item = Optional.empty();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
@@ -192,6 +192,7 @@ public final class PrimitiveOptionalsExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private OptionalDouble num = OptionalDouble.empty();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -153,6 +153,7 @@ public final class ReservedKeyExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private String package_;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
@@ -90,6 +90,7 @@ public final class RidExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private ResourceIdentifier ridValue;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
@@ -91,6 +91,7 @@ public final class SafeLongExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private SafeLong safeLongValue;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
@@ -106,6 +106,7 @@ public final class SetExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private Set<String> items = new LinkedHashSet<>();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
@@ -89,6 +89,7 @@ public final class StringExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private String string;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
@@ -90,6 +90,7 @@ public final class UuidExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("unchecked")
     public static final class Builder {
         private UUID uuid;
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -106,6 +106,10 @@ public final class BeanBuilderGenerator {
                 .addAnnotation(
                         AnnotationSpec.builder(JsonIgnoreProperties.class)
                                 .addMember("ignoreUnknown", "$L", true)
+                                .build())
+                .addAnnotation(
+                        AnnotationSpec.builder(SuppressWarnings.class)
+                                .addMember("value", "$S", "unchecked")
                                 .build());
 
         return builder.build();


### PR DESCRIPTION
## Before this PR
Conjure generated projects with covariant optional setters can not be compile with `-Xlint:unchecked`. This is because the improvements made in #9 requires casting optionals in certain cases.

## After this PR
Conjure generated builders now suppress unchecked warnings. This seems reasonable since we control the code generation here.

We could attempt to be more targeted and only add this annotation to covariant optional setters but:
- The builder generator code has relatively pure functions so passing this information back to the method level is not easy.
- Adding the annotation to the builder level prevents regression if we require casting in other setters in the future.
