### PR TITLE
[fix] Unexpected null request bodies result in 400 response status

### DIFF
--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -248,6 +248,21 @@ public final class UndertowServiceEteTest extends TestBase {
     }
 
     @Test
+    public void java_url_client_receives_bad_request_with_json_null() throws IOException {
+        HttpURLConnection connection = preparePostRequest();
+        connection.setRequestProperty("Authorization", "Bearer authheader");
+        connection.setRequestProperty(HttpHeaders.CONTENT_TYPE, "application/json");
+        connection.setRequestProperty(HttpHeaders.ACCEPT, "application/json");
+        sendPostRequestData(connection, "null");
+        assertThat(connection.getResponseCode()).isEqualTo(400);
+        try (InputStream responseBody = connection.getErrorStream()) {
+            SerializableError error = CLIENT_OBJECT_MAPPER.readValue(responseBody, SerializableError.class);
+            assertThat(error.errorCode()).isEqualTo("INVALID_ARGUMENT");
+            assertThat(error.errorName()).isEqualTo("Default:InvalidArgument");
+        }
+    }
+
+    @Test
     public void java_url_client_receives_unprocessable_entity_with_null_body() throws IOException {
         HttpURLConnection httpUrlConnection = preparePostRequest();
         httpUrlConnection.setRequestProperty("Authorization", "Bearer authheader");

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Serializers.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Serializers.java
@@ -54,7 +54,8 @@ public final class Serializers {
         public final <T> T deserialize(InputStream input, TypeToken<T> type) throws IOException {
             try {
                 T value = mapper.readValue(input, mapper.constructType(type.getType()));
-                Preconditions.checkNotNull(value, "cannot deserialize a JSON null value");
+                // Bad input should result in a 4XX response status, throw IAE rather than NPE.
+                Preconditions.checkArgument(value != null, "cannot deserialize a JSON null value");
                 return value;
             } catch (MismatchedInputException e) {
                 throw FrameworkException.unprocessableEntity("Failed to deserialize response stream. Syntax error?",

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/SerializersTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/SerializersTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.reflect.TypeToken;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.exceptions.SafeNullPointerException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -57,7 +58,7 @@ public final class SerializersTest {
     public void json_deserialize_rejectsNulls() throws IOException {
         // TODO(rfink): Do we need to test this for all primitive types?
         assertThatThrownBy(() -> json.deserialize(asStream("null"), new TypeToken<String>() {}))
-                .isInstanceOf(SafeNullPointerException.class);
+                .isInstanceOf(SafeIllegalArgumentException.class);
         assertThat(json.deserialize(asStream("null"), new TypeToken<Optional<String>>() {})).isEmpty();
     }
 


### PR DESCRIPTION
Previously this resulted in a `SafeNullPointerException`, which mapped
to a 500 response status.