### PR TITLE
[improvement] conjure-undertow deserializes collections to guava immutable collections

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
@@ -7,7 +7,9 @@ import com.palantir.tokens.auth.BearerToken;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Generated;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -146,6 +148,12 @@ public interface EteService {
     SimpleEnum enumHeader(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @HeaderParam("Custom-Header") SimpleEnum headerParameter);
+
+    @POST
+    @Path("base/wrappers/complex")
+    Optional<Map<String, List<Set<String>>>> complexNestedWrappers(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            Optional<Map<String, List<Set<String>>>> body);
 
     @Deprecated
     default StringAliasExample optionalAliasOne(AuthHeader authHeader) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
@@ -6,7 +6,9 @@ import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Generated;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
@@ -137,4 +139,10 @@ public interface EteServiceRetrofit {
     Call<SimpleEnum> enumHeader(
             @Header("Authorization") AuthHeader authHeader,
             @Header("Custom-Header") SimpleEnum headerParameter);
+
+    @POST("./base/wrappers/complex")
+    @Headers({"hr-path-template: /base/wrappers/complex", "Accept: application/json"})
+    Call<Optional<Map<String, List<Set<String>>>>> complexNestedWrappers(
+            @Header("Authorization") AuthHeader authHeader,
+            @Body Optional<Map<String, List<Set<String>>>> body);
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
@@ -7,7 +7,9 @@ import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
@@ -65,4 +67,7 @@ public interface UndertowEteService {
             AuthHeader authHeader, Optional<SimpleEnum> queryParamName);
 
     SimpleEnum enumHeader(AuthHeader authHeader, SimpleEnum headerParameter);
+
+    Optional<Map<String, List<Set<String>>>> complexNestedWrappers(
+            AuthHeader authHeader, Optional<Map<String, List<Set<String>>>> body);
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowRequestBodyClassNameVisitor.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowRequestBodyClassNameVisitor.java
@@ -16,28 +16,23 @@
 
 package com.palantir.conjure.java.services;
 
-import com.palantir.conjure.java.FeatureFlags;
 import com.palantir.conjure.java.types.ClassNameVisitor;
-import com.palantir.conjure.java.types.DefaultClassNameVisitor;
 import com.palantir.conjure.spec.ExternalReference;
 import com.palantir.conjure.spec.ListType;
 import com.palantir.conjure.spec.MapType;
 import com.palantir.conjure.spec.OptionalType;
 import com.palantir.conjure.spec.PrimitiveType;
 import com.palantir.conjure.spec.SetType;
-import com.palantir.conjure.spec.TypeDefinition;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.TypeName;
 import java.io.InputStream;
-import java.util.List;
-import java.util.Set;
 
 public final class UndertowRequestBodyClassNameVisitor implements ClassNameVisitor {
 
     private final ClassNameVisitor delegate;
 
-    public UndertowRequestBodyClassNameVisitor(List<TypeDefinition> types, Set<FeatureFlags> featureFlags) {
-        delegate = new DefaultClassNameVisitor(types, featureFlags);
+    public UndertowRequestBodyClassNameVisitor(ClassNameVisitor delegate) {
+        this.delegate = delegate;
     }
 
     @Override
@@ -55,7 +50,8 @@ public final class UndertowRequestBodyClassNameVisitor implements ClassNameVisit
 
     @Override
     public TypeName visitOptional(OptionalType optionalType) {
-        // TODO(ckozak): Support this? I don't know that jersey does.
+        // optional<binary> requests are not allowed, unlike responses there is no way to differentiate
+        // present 0-byte binary from empty optional.
         return delegate.visitOptional(optionalType);
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowTypeMappers.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowTypeMappers.java
@@ -1,0 +1,52 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.services;
+
+import com.palantir.conjure.java.types.TypeMapper;
+
+/** Wrapper around various {@link TypeMapper type mappers} used by conjure-undertow generation. */
+final class UndertowTypeMappers {
+
+    private final TypeMapper request;
+    private final TypeMapper handlerRequest;
+    private final TypeMapper params;
+    private final TypeMapper response;
+
+    UndertowTypeMappers(TypeMapper request, TypeMapper handlerRequest, TypeMapper params, TypeMapper response) {
+        this.request = request;
+        this.handlerRequest = handlerRequest;
+        this.params = params;
+        this.response = response;
+    }
+
+    TypeMapper request() {
+        return request;
+    }
+
+    // Handlers deserialize to immutable representations of the request body type.
+    TypeMapper handlerRequest() {
+        return handlerRequest;
+    }
+
+    TypeMapper params() {
+        return params;
+    }
+
+    TypeMapper response() {
+        return response;
+    }
+}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/GuavaImmutableClassNameVisitor.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/GuavaImmutableClassNameVisitor.java
@@ -1,0 +1,126 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.types;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.conjure.java.FeatureFlags;
+import com.palantir.conjure.spec.ExternalReference;
+import com.palantir.conjure.spec.ListType;
+import com.palantir.conjure.spec.MapType;
+import com.palantir.conjure.spec.OptionalType;
+import com.palantir.conjure.spec.PrimitiveType;
+import com.palantir.conjure.spec.SetType;
+import com.palantir.conjure.spec.TypeDefinition;
+import com.palantir.conjure.visitor.TypeVisitor;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.Set;
+
+/**
+ * Maps the conjure type into the 'standard' java type, applying guava immutable collections where possible.
+ * This is helpful as a deserialization target, but should not be used for exposed API.
+ */
+public final class GuavaImmutableClassNameVisitor implements ClassNameVisitor {
+
+    private final ClassNameVisitor defaultDelegate;
+
+    public GuavaImmutableClassNameVisitor(List<TypeDefinition> types, Set<FeatureFlags> featureFlags) {
+        this.defaultDelegate = new DefaultClassNameVisitor(types, featureFlags);
+    }
+
+    @Override
+    public TypeName visitList(ListType type) {
+        TypeName itemType = type.getItemType().accept(this).box();
+        return ParameterizedTypeName.get(ClassName.get(ImmutableList.class), itemType);
+    }
+
+    @Override
+    public TypeName visitMap(MapType type) {
+        return ParameterizedTypeName.get(ClassName.get(ImmutableMap.class),
+                type.getKeyType().accept(this).box(),
+                type.getValueType().accept(this).box());
+    }
+
+    @Override
+    @SuppressWarnings("CyclomaticComplexity")
+    public TypeName visitOptional(OptionalType type) {
+        if (type.getItemType().accept(TypeVisitor.IS_PRIMITIVE)) {
+            PrimitiveType primitiveType = type.getItemType().accept(TypeVisitor.PRIMITIVE);
+            // special handling for primitive optionals with Java 8
+            switch (primitiveType.get()) {
+                case UNKNOWN:
+                    throw new IllegalStateException("Unknown type " + primitiveType);
+                case DOUBLE:
+                    return ClassName.get(OptionalDouble.class);
+                case INTEGER:
+                    return ClassName.get(OptionalInt.class);
+                case BOOLEAN:
+                    // no OptionalBoolean type
+                case SAFELONG:
+                case STRING:
+                case RID:
+                case BEARERTOKEN:
+                case UUID:
+                case DATETIME:
+                case BINARY:
+                case ANY:
+                    // treat normally
+            }
+        }
+
+        TypeName itemType = type.getItemType().accept(this);
+        if (itemType.isPrimitive()) {
+            // Safe for primitives (e.g. Booleans with Java 8)
+            itemType = itemType.box();
+        }
+        return ParameterizedTypeName.get(ClassName.get(Optional.class), itemType);
+    }
+
+    @Override
+    @SuppressWarnings("checkstyle:cyclomaticcomplexity")
+    public TypeName visitPrimitive(PrimitiveType type) {
+        return defaultDelegate.visitPrimitive(type);
+    }
+
+    @Override
+    public TypeName visitReference(com.palantir.conjure.spec.TypeName type) {
+        return defaultDelegate.visitReference(type);
+    }
+
+    @Override
+    public TypeName visitExternal(ExternalReference externalType) {
+        return defaultDelegate.visitExternal(externalType);
+    }
+
+    @Override
+    public TypeName visitSet(SetType type) {
+        TypeName itemType = type.getItemType().accept(this).box();
+        return ParameterizedTypeName.get(ClassName.get(ImmutableSet.class), itemType);
+    }
+
+    @Override
+    public TypeName visitUnknown(String unknownType) {
+        return defaultDelegate.visitUnknown(unknownType);
+    }
+}

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/EteResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/EteResource.java
@@ -31,7 +31,9 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.StreamingOutput;
 
@@ -158,6 +160,12 @@ public class EteResource implements EteService {
     @Override
     public SimpleEnum enumHeader(AuthHeader authHeader, SimpleEnum headerParameter) {
         return headerParameter;
+    }
+
+    @Override
+    public Optional<Map<String, List<Set<String>>>> complexNestedWrappers(
+            AuthHeader authHeader, Optional<Map<String, List<Set<String>>>> body) {
+        return body;
     }
 
     interface Streaming extends StreamingOutput, BinaryResponseBody {}

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -71,7 +71,9 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
@@ -447,6 +449,14 @@ public final class UndertowServiceEteTest extends TestBase {
     @Test
     public void testEnumHeaderParameter() {
         assertThat(client.enumHeader(AuthHeader.valueOf("authHeader"), SimpleEnum.VALUE)).isEqualTo(SimpleEnum.VALUE);
+    }
+
+    @Test
+    public void testNestedComplexCastedTypes() {
+        Optional<Map<String, List<Set<String>>>> value = Optional.of(Collections.singletonMap("test",
+                Collections.singletonList(Collections.singleton("value"))));
+        assertThat(client.complexNestedWrappers(AuthHeader.valueOf("authHeader"), value))
+                .isEqualTo(value);
     }
 
     @BeforeClass

--- a/conjure-java-core/src/test/resources/ete-service.yml
+++ b/conjure-java-core/src/test/resources/ete-service.yml
@@ -169,3 +169,9 @@ services:
             param-id: Custom-Header
             type: SimpleEnum
         returns: SimpleEnum
+
+      complexNestedWrappers:
+        http: POST /wrappers/complex
+        args:
+          body: optional<map<string, list<set<string>>>>
+        returns: optional<map<string, list<set<string>>>>


### PR DESCRIPTION
No change to implemented interfaces, this simply prevents inputs
from being modified.

fix #272