### PR TITLE
Don't warn about immutable bytes unless objects are generated

### DIFF
--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -126,7 +126,7 @@ public final class ConjureJavaCli implements Runnable {
         @SuppressWarnings("BanSystemErr")
         public void run() {
             CliConfiguration config = getConfiguration();
-            if (!config.featureFlags().contains(FeatureFlags.UseImmutableBytes)) {
+            if (config.generateObjects() && !config.featureFlags().contains(FeatureFlags.UseImmutableBytes)) {
                 System.err.println("[WARNING] Using deprecated ByteBuffer codegen, please enable the "
                         + "--useImmutableBytes feature flag to opt into the preferred implementation");
             }

--- a/conjure-java/src/test/java/com/palantir/conjure/java/cli/ConjureJavaCliTest.java
+++ b/conjure-java/src/test/java/com/palantir/conjure/java/cli/ConjureJavaCliTest.java
@@ -180,4 +180,17 @@ public final class ConjureJavaCliTest {
         CommandLine.run(new ConjureJavaCli(), args);
         assertThat(systemErr.getLog()).contains("[WARNING] Using deprecated ByteBuffer");
     }
+
+    @Test
+    public void doesNotWriteWarningWhenObjectsAreNotGenerated() throws IOException {
+        File outputDirectory = folder.newFolder();
+        String[] args = {
+                "generate",
+                "src/test/resources/conjure-api.json",
+                outputDirectory.getAbsolutePath(),
+                "--jersey"
+        };
+        CommandLine.run(new ConjureJavaCli(), args);
+        assertThat(systemErr.getLog()).doesNotContain("[WARNING] Using deprecated ByteBuffer");
+    }
 }


### PR DESCRIPTION
The binary type is not allowed in headers/query/path parameters,
and streaming types are used for the request and response
bodies. The flag only modifies output of object generation.