### PR TITLE
[improvement] The conjure-undertow runtime deserializes immutable collections

### DIFF
--- a/conjure-java-server-verifier/src/test/resources/ignored-test-cases.yml
+++ b/conjure-java-server-verifier/src/test/resources/ignored-test-cases.yml
@@ -27,3 +27,7 @@ server:
       - 'null'
     getOptionalAnyAliasExample:
       - 'null'
+    getListAnyAliasExample:
+      - '[null, 0, "content", true, [1,2,3], {"key":3}]'
+    getSetAnyAliasExample:
+      - '[null, 0, "content", true, [1,2,3], {"key":3}]'

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encodings.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encodings.java
@@ -124,7 +124,10 @@ public final class Encodings {
         // See documentation on Encoding.Serializer#serialize: Implementations must not close the stream.
         return mapper.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET)
                 // Avoid flushing, allowing us to set content-length if the length is below the buffer size.
-                .disable(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM);
+                .disable(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM)
+                // Deserialize List, Map, and Set to guava ImmutableList, ImmutableMap, and ImmutableSet
+                // in order to match semantics of our generated bean objects.
+                .registerModule(new ImmutableCollectionsModule());
     }
 
     /**

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ImmutableCollectionsModule.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ImmutableCollectionsModule.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Values deserialized into {@link List}, {@link Set}, and {@link Map}, use Guava implementations of
+ * {@link ImmutableList}, {@link ImmutableSet}, and {@link ImmutableMap} respectively.
+ */
+final class ImmutableCollectionsModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
+
+    ImmutableCollectionsModule() {
+        super(ImmutableCollectionsModule.class.getCanonicalName());
+        addAbstractTypeMapping(List.class, ImmutableList.class);
+        addAbstractTypeMapping(Map.class, ImmutableMap.class);
+        addAbstractTypeMapping(Set.class, ImmutableSet.class);
+    }
+}

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/EncodingsTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/EncodingsTest.java
@@ -22,6 +22,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.palantir.conjure.java.undertow.lib.TypeMarker;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.exceptions.SafeNullPointerException;
@@ -31,7 +34,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.Test;
 
 public final class EncodingsTest {
@@ -67,6 +73,24 @@ public final class EncodingsTest {
         OutputStream outputStream = mock(OutputStream.class);
         serialize("test", outputStream);
         verify(outputStream, never()).close();
+    }
+
+    @Test
+    public void json_deserialize_list_immutable() throws IOException {
+        assertThat(deserialize(asStream("[1,2,3]"), new TypeMarker<List<Integer>>() {}))
+                .isInstanceOf(ImmutableList.class);
+    }
+
+    @Test
+    public void json_deserialize_set_immutable() throws IOException {
+        assertThat(deserialize(asStream("[1,2,3]"), new TypeMarker<Set<Integer>>() {}))
+                .isInstanceOf(ImmutableSet.class);
+    }
+
+    @Test
+    public void json_deserialize_map_immutable() throws IOException {
+        assertThat(deserialize(asStream("{\"0\":\"1\"}"), new TypeMarker<Map<String, String>>() {}))
+                .isInstanceOf(ImmutableMap.class);
     }
 
     private static InputStream asStream(String data) {


### PR DESCRIPTION
conjure-undertow endpoints which expect List, Map, and Set types (including nested
in optional, and nested in alias types) receive guava immutable
implementations.

For context, see https://github.com/palantir/conjure-java-runtime/pull/973