### PR TITLE
[fix] Log error name in exception handler

### DIFF
--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptionHandler.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptionHandler.java
@@ -179,10 +179,14 @@ final class ConjureExceptionHandler implements HttpHandler {
     private static void log(ServiceException exception) {
         if (exception.getErrorType().httpErrorCode() / 100 == 4 /* client error */) {
             log.info("Error handling request",
-                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()), exception);
+                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()),
+                    SafeArg.of("errorName", exception.getErrorType().name()),
+                    exception);
         } else {
             log.error("Error handling request",
-                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()), exception);
+                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()),
+                    SafeArg.of("errorName", exception.getErrorType().name()),
+                    exception);
         }
     }
 


### PR DESCRIPTION
## Before this PR
Error names are not logged when handling errors from undertow endpoints.

## After this PR
Error names are logged when handling errors from undertow endpoints.

This was a small regression when switching to undertow endpoints. This behavior was added to the jersey exception mappers in https://github.com/palantir/conjure-java-runtime/pull/827.
