### PR TITLE
[fix] JDK 8 binary compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,11 @@ subprojects {
     tasks.withType(JavaCompile) {
         options.errorprone.errorproneArgs += ['-Xep:PreferSafeLoggingPreconditions:OFF', '-Xep:PreferSafeLoggableExceptions:OFF']
         options.compilerArgs += ['-Werror']
+        if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
+            // Link against JDK 8 APIs per https://openjdk.java.net/jeps/247
+            // see also gradle `releaseCompatibility` RFC https://github.com/gradle/gradle/issues/2510
+            options.compilerArgs += ['--release', '8']
+        }
     }
 
     // Run `./gradlew test -Drecreate=true` to recreate all the expected

--- a/build.gradle
+++ b/build.gradle
@@ -70,9 +70,9 @@ subprojects {
     tasks.withType(JavaCompile) {
         options.errorprone.errorproneArgs += ['-Xep:PreferSafeLoggingPreconditions:OFF', '-Xep:PreferSafeLoggableExceptions:OFF']
         options.compilerArgs += ['-Werror']
+        
+        // necessary until https://github.com/palantir/gradle-baseline/pull/582
         if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
-            // Link against JDK 8 APIs per https://openjdk.java.net/jeps/247
-            // see also gradle `releaseCompatibility` RFC https://github.com/gradle/gradle/issues/2510
             options.compilerArgs += ['--release', '8']
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryExample.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -104,7 +105,7 @@ public final class BinaryExample {
         public Builder binary(ByteBuffer binary) {
             Preconditions.checkNotNull(binary, "binary cannot be null");
             this.binary = ByteBuffer.allocate(binary.remaining()).put(binary.duplicate());
-            this.binary.rewind();
+            ((Buffer) this.binary).rewind();
             return this;
         }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -48,6 +48,7 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.WildcardTypeName;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -328,7 +329,7 @@ public final class BeanBuilderGenerator {
                     .addStatement("this.$1N = $2T.allocate($1N.remaining()).put($1N.duplicate())",
                             spec.name,
                             ByteBuffer.class)
-                    .addStatement("this.$1N.rewind()", spec.name)
+                    .addStatement("(($1T)this.$2N).rewind()", Buffer.class, spec.name)
                     .build();
         } else if (type.accept(TypeVisitor.IS_OPTIONAL)) {
             OptionalType optionalType = type.accept(TypeVisitor.OPTIONAL);


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
`NoSuchMethodError` when `conjure-java` is built on JDK 9+ and run on JDK 8, for example:

```
java.lang.NoSuchMethodError: java.nio.ByteBuffer.rewind()Ljava/nio/ByteBuffer;
	at com.palantir.foo.bar.Key$Builder.encodedKey(Key.java:155)
```

## After this PR
==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
Generate JDK 8 compatible binary types

JDK 9 added covariant return types to ByteBuffer (and other *Buffer)
classes for methods including flip, rewind, clear, mark, limit, reset,
position. Unfortunately, building against JDK 9+ with a target of JDK 8 can lead to `java.lang.NoSuchMethodError: java.nio.ByteBuffer.rewind()Ljava/nio/ByteBuffer;`

See [lucene-dev thread on this issue](https://mail-archives.apache.org/mod_mbox/lucene-dev/201503.mbox/%3CCAOdYfZWTWzBq9=kc-ECvi9_jLQDuS7_k7wcX+Uem2=y9VvRFKw@mail.gmail.com%3E)

This workaround avoids such problems by explicitly casting to the base `Buffer` type before rewinding.

Use [JEP 247](https://openjdk.java.net/jeps/247) to specify JDK target release on JDK 9+ in gradle compiler arguments.

See also [gradle `releaseCompatibility` RFC](https://github.com/gradle/gradle/issues/2510) 

==COMMIT_MSG==

## Possible downsides?
