### PR TITLE
[break] Consistently unbox external type imports for boxed primitives 

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasExample.java
@@ -1,0 +1,41 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class ExternalLongAliasExample {
+    private final long value;
+
+    private ExternalLongAliasExample(long value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public long get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof ExternalLongAliasExample
+                        && this.value == ((ExternalLongAliasExample) other).value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(value);
+    }
+
+    @JsonCreator
+    public static ExternalLongAliasExample of(long value) {
+        return new ExternalLongAliasExample(value);
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.palantir.conjure.java.lib.internal.ConjureCollections;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -20,12 +22,16 @@ public final class ExternalLongExample {
 
     private final Optional<Long> optionalExternalLong;
 
+    private final List<Long> listExternalLong;
+
     private volatile int memoizedHashCode;
 
-    private ExternalLongExample(long externalLong, Optional<Long> optionalExternalLong) {
-        validateFields(optionalExternalLong);
+    private ExternalLongExample(
+            long externalLong, Optional<Long> optionalExternalLong, List<Long> listExternalLong) {
+        validateFields(optionalExternalLong, listExternalLong);
         this.externalLong = externalLong;
         this.optionalExternalLong = optionalExternalLong;
+        this.listExternalLong = Collections.unmodifiableList(listExternalLong);
     }
 
     @JsonProperty("externalLong")
@@ -38,6 +44,11 @@ public final class ExternalLongExample {
         return this.optionalExternalLong;
     }
 
+    @JsonProperty("listExternalLong")
+    public List<Long> getListExternalLong() {
+        return this.listExternalLong;
+    }
+
     @Override
     public boolean equals(Object other) {
         return this == other
@@ -46,13 +57,14 @@ public final class ExternalLongExample {
 
     private boolean equalTo(ExternalLongExample other) {
         return this.externalLong == other.externalLong
-                && this.optionalExternalLong.equals(other.optionalExternalLong);
+                && this.optionalExternalLong.equals(other.optionalExternalLong)
+                && this.listExternalLong.equals(other.listExternalLong);
     }
 
     @Override
     public int hashCode() {
         if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(externalLong, optionalExternalLong);
+            memoizedHashCode = Objects.hash(externalLong, optionalExternalLong, listExternalLong);
         }
         return memoizedHashCode;
     }
@@ -68,21 +80,29 @@ public final class ExternalLongExample {
                 .append("optionalExternalLong")
                 .append(": ")
                 .append(optionalExternalLong)
+                .append(", ")
+                .append("listExternalLong")
+                .append(": ")
+                .append(listExternalLong)
                 .append('}')
                 .toString();
     }
 
-    public static ExternalLongExample of(long externalLong, Long optionalExternalLong) {
+    public static ExternalLongExample of(
+            long externalLong, Long optionalExternalLong, List<Long> listExternalLong) {
         return builder()
                 .externalLong(externalLong)
                 .optionalExternalLong(Optional.of(optionalExternalLong))
+                .listExternalLong(listExternalLong)
                 .build();
     }
 
-    private static void validateFields(Optional<Long> optionalExternalLong) {
+    private static void validateFields(
+            Optional<Long> optionalExternalLong, List<Long> listExternalLong) {
         List<String> missingFields = null;
         missingFields =
                 addFieldIfMissing(missingFields, optionalExternalLong, "optionalExternalLong");
+        missingFields = addFieldIfMissing(missingFields, listExternalLong, "listExternalLong");
         if (missingFields != null) {
             throw new SafeIllegalArgumentException(
                     "Some required fields have not been set",
@@ -95,7 +115,7 @@ public final class ExternalLongExample {
         List<String> missingFields = prev;
         if (fieldValue == null) {
             if (missingFields == null) {
-                missingFields = new ArrayList<>(1);
+                missingFields = new ArrayList<>(2);
             }
             missingFields.add(fieldName);
         }
@@ -113,6 +133,8 @@ public final class ExternalLongExample {
 
         private Optional<Long> optionalExternalLong = Optional.empty();
 
+        private List<Long> listExternalLong = new ArrayList<>();
+
         private boolean _externalLongInitialized = false;
 
         private Builder() {}
@@ -120,6 +142,7 @@ public final class ExternalLongExample {
         public Builder from(ExternalLongExample other) {
             externalLong(other.getExternalLong());
             optionalExternalLong(other.getOptionalExternalLong());
+            listExternalLong(other.getListExternalLong());
             return this;
         }
 
@@ -144,6 +167,29 @@ public final class ExternalLongExample {
                     Optional.of(
                             Preconditions.checkNotNull(
                                     optionalExternalLong, "optionalExternalLong cannot be null"));
+            return this;
+        }
+
+        @JsonSetter("listExternalLong")
+        public Builder listExternalLong(Iterable<? extends Long> listExternalLong) {
+            this.listExternalLong.clear();
+            ConjureCollections.addAll(
+                    this.listExternalLong,
+                    Preconditions.checkNotNull(
+                            listExternalLong, "listExternalLong cannot be null"));
+            return this;
+        }
+
+        public Builder addAllListExternalLong(Iterable<? extends Long> listExternalLong) {
+            ConjureCollections.addAll(
+                    this.listExternalLong,
+                    Preconditions.checkNotNull(
+                            listExternalLong, "listExternalLong cannot be null"));
+            return this;
+        }
+
+        public Builder listExternalLong(long listExternalLong) {
+            this.listExternalLong.add(listExternalLong);
             return this;
         }
 
@@ -172,7 +218,7 @@ public final class ExternalLongExample {
 
         public ExternalLongExample build() {
             validatePrimitiveFieldsHaveBeenInitialized();
-            return new ExternalLongExample(externalLong, optionalExternalLong);
+            return new ExternalLongExample(externalLong, optionalExternalLong, listExternalLong);
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -1,0 +1,178 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Generated;
+
+@JsonDeserialize(builder = ExternalLongExample.Builder.class)
+@Generated("com.palantir.conjure.java.types.BeanGenerator")
+public final class ExternalLongExample {
+    private final long externalLong;
+
+    private final Optional<Long> optionalExternalLong;
+
+    private volatile int memoizedHashCode;
+
+    private ExternalLongExample(long externalLong, Optional<Long> optionalExternalLong) {
+        validateFields(optionalExternalLong);
+        this.externalLong = externalLong;
+        this.optionalExternalLong = optionalExternalLong;
+    }
+
+    @JsonProperty("externalLong")
+    public long getExternalLong() {
+        return this.externalLong;
+    }
+
+    @JsonProperty("optionalExternalLong")
+    public Optional<Long> getOptionalExternalLong() {
+        return this.optionalExternalLong;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof ExternalLongExample && equalTo((ExternalLongExample) other));
+    }
+
+    private boolean equalTo(ExternalLongExample other) {
+        return this.externalLong == other.externalLong
+                && this.optionalExternalLong.equals(other.optionalExternalLong);
+    }
+
+    @Override
+    public int hashCode() {
+        if (memoizedHashCode == 0) {
+            memoizedHashCode = Objects.hash(externalLong, optionalExternalLong);
+        }
+        return memoizedHashCode;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder("ExternalLongExample")
+                .append('{')
+                .append("externalLong")
+                .append(": ")
+                .append(externalLong)
+                .append(", ")
+                .append("optionalExternalLong")
+                .append(": ")
+                .append(optionalExternalLong)
+                .append('}')
+                .toString();
+    }
+
+    public static ExternalLongExample of(long externalLong, Long optionalExternalLong) {
+        return builder()
+                .externalLong(externalLong)
+                .optionalExternalLong(Optional.of(optionalExternalLong))
+                .build();
+    }
+
+    private static void validateFields(Optional<Long> optionalExternalLong) {
+        List<String> missingFields = null;
+        missingFields =
+                addFieldIfMissing(missingFields, optionalExternalLong, "optionalExternalLong");
+        if (missingFields != null) {
+            throw new SafeIllegalArgumentException(
+                    "Some required fields have not been set",
+                    SafeArg.of("missingFields", missingFields));
+        }
+    }
+
+    private static List<String> addFieldIfMissing(
+            List<String> prev, Object fieldValue, String fieldName) {
+        List<String> missingFields = prev;
+        if (fieldValue == null) {
+            if (missingFields == null) {
+                missingFields = new ArrayList<>(1);
+            }
+            missingFields.add(fieldName);
+        }
+        return missingFields;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder {
+        private long externalLong;
+
+        private Optional<Long> optionalExternalLong = Optional.empty();
+
+        private boolean _externalLongInitialized = false;
+
+        private Builder() {}
+
+        public Builder from(ExternalLongExample other) {
+            externalLong(other.getExternalLong());
+            optionalExternalLong(other.getOptionalExternalLong());
+            return this;
+        }
+
+        @JsonSetter("externalLong")
+        public Builder externalLong(long externalLong) {
+            this.externalLong = externalLong;
+            this._externalLongInitialized = true;
+            return this;
+        }
+
+        @JsonSetter("optionalExternalLong")
+        public Builder optionalExternalLong(Optional<? extends Long> optionalExternalLong) {
+            this.optionalExternalLong =
+                    (Optional<Long>)
+                            Preconditions.checkNotNull(
+                                    optionalExternalLong, "optionalExternalLong cannot be null");
+            return this;
+        }
+
+        public Builder optionalExternalLong(long optionalExternalLong) {
+            this.optionalExternalLong =
+                    Optional.of(
+                            Preconditions.checkNotNull(
+                                    optionalExternalLong, "optionalExternalLong cannot be null"));
+            return this;
+        }
+
+        private void validatePrimitiveFieldsHaveBeenInitialized() {
+            List<String> missingFields = null;
+            missingFields =
+                    addFieldIfMissing(missingFields, _externalLongInitialized, "externalLong");
+            if (missingFields != null) {
+                throw new SafeIllegalArgumentException(
+                        "Some required fields have not been set",
+                        SafeArg.of("missingFields", missingFields));
+            }
+        }
+
+        private static List<String> addFieldIfMissing(
+                List<String> prev, boolean initialized, String fieldName) {
+            List<String> missingFields = prev;
+            if (!initialized) {
+                if (missingFields == null) {
+                    missingFields = new ArrayList<>(1);
+                }
+                missingFields.add(fieldName);
+            }
+            return missingFields;
+        }
+
+        public ExternalLongExample build() {
+            validatePrimitiveFieldsHaveBeenInitialized();
+            return new ExternalLongExample(externalLong, optionalExternalLong);
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -37,11 +37,17 @@ public final class Union {
         return new Union(new BarWrapper(value));
     }
 
+    public static Union baz(long value) {
+        return new Union(new BazWrapper(value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         if (value instanceof FooWrapper) {
             return visitor.visitFoo(((FooWrapper) value).value);
         } else if (value instanceof BarWrapper) {
             return visitor.visitBar(((BarWrapper) value).value);
+        } else if (value instanceof BazWrapper) {
+            return visitor.visitBaz(((BazWrapper) value).value);
         } else if (value instanceof UnknownWrapper) {
             return visitor.visitUnknown(((UnknownWrapper) value).getType());
         }
@@ -79,6 +85,8 @@ public final class Union {
 
         T visitBar(int value);
 
+        T visitBaz(long value);
+
         T visitUnknown(String unknownType);
     }
 
@@ -87,7 +95,11 @@ public final class Union {
             property = "type",
             visible = true,
             defaultImpl = UnknownWrapper.class)
-    @JsonSubTypes({@JsonSubTypes.Type(FooWrapper.class), @JsonSubTypes.Type(BarWrapper.class)})
+    @JsonSubTypes({
+        @JsonSubTypes.Type(FooWrapper.class),
+        @JsonSubTypes.Type(BarWrapper.class),
+        @JsonSubTypes.Type(BazWrapper.class)
+    })
     @JsonIgnoreProperties(ignoreUnknown = true)
     private interface Base {}
 
@@ -164,6 +176,47 @@ public final class Union {
         @Override
         public String toString() {
             return new StringBuilder("BarWrapper")
+                    .append('{')
+                    .append("value")
+                    .append(": ")
+                    .append(value)
+                    .append('}')
+                    .toString();
+        }
+    }
+
+    @JsonTypeName("baz")
+    private static class BazWrapper implements Base {
+        private final long value;
+
+        @JsonCreator
+        private BazWrapper(@JsonProperty("baz") long value) {
+            Preconditions.checkNotNull(value, "baz cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty("baz")
+        private long getValue() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof BazWrapper && equalTo((BazWrapper) other));
+        }
+
+        private boolean equalTo(BazWrapper other) {
+            return this.value == other.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value);
+        }
+
+        @Override
+        public String toString() {
+            return new StringBuilder("BazWrapper")
                     .append('{')
                     .append("value")
                     .append(": ")

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceInterfaceGenerator.java
@@ -83,8 +83,7 @@ final class UndertowServiceInterfaceGenerator {
 
         ServiceGenerator.getJavaDoc(endpointDef).ifPresent(content -> methodBuilder.addJavadoc("$L", content));
 
-        endpointDef.getReturns().ifPresent(type -> methodBuilder.returns(
-                UndertowTypeFunctions.unbox(returnTypeMapper.getClassName(type))));
+        endpointDef.getReturns().ifPresent(type -> methodBuilder.returns(returnTypeMapper.getClassName(type)));
 
         return methodBuilder.build();
     }
@@ -123,8 +122,6 @@ final class UndertowServiceInterfaceGenerator {
     }
 
     private ParameterSpec createServiceMethodParameterArg(TypeMapper typeMapper, ArgumentDefinition def) {
-        ParameterSpec.Builder param = ParameterSpec.builder(
-                UndertowTypeFunctions.unbox(typeMapper.getClassName(def.getType())), def.getArgName().get());
-        return param.build();
+        return ParameterSpec.builder(typeMapper.getClassName(def.getType()), def.getArgName().get()).build();
     }
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowTypeFunctions.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowTypeFunctions.java
@@ -30,7 +30,6 @@ import com.palantir.conjure.spec.Type;
 import com.palantir.conjure.spec.TypeDefinition;
 import com.palantir.conjure.visitor.TypeDefinitionVisitor;
 import com.palantir.conjure.visitor.TypeVisitor;
-import com.squareup.javapoet.TypeName;
 import java.util.List;
 import java.util.Optional;
 
@@ -258,13 +257,6 @@ final class UndertowTypeFunctions {
         public Boolean visitUnknown(String unknownType) {
             return false;
         }
-    }
-
-    static TypeName unbox(TypeName input) {
-        if (input.isBoxedPrimitive()) {
-            return input.unbox();
-        }
-        return input;
     }
 
     private UndertowTypeFunctions() {}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -340,7 +340,7 @@ public final class BeanBuilderGenerator {
                 Type innerType = optionalType.getItemType();
                 return CodeBlock.builder()
                         .addStatement("this.$1N = ($3T<$4T>) $2L",
-                                spec.name, nullCheckedValue, Optional.class, typeMapper.getClassName(innerType))
+                                spec.name, nullCheckedValue, Optional.class, typeMapper.getClassName(innerType).box())
                         .build();
             } else {
                 return CodeBlocks.statement("this.$1L = $2L", spec.name, nullCheckedValue);

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/DefaultClassNameVisitor.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/DefaultClassNameVisitor.java
@@ -153,7 +153,8 @@ public final class DefaultClassNameVisitor implements ClassNameVisitor {
     @Override
     public TypeName visitExternal(ExternalReference externalType) {
         String conjurePackage = externalType.getExternalReference().getPackage();
-        return ClassName.get(conjurePackage, externalType.getExternalReference().getName());
+        ClassName typeName = ClassName.get(conjurePackage, externalType.getExternalReference().getName());
+        return typeName.isBoxedPrimitive() ? typeName.unbox() : typeName;
     }
 
     @Override

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -5,6 +5,10 @@ types:
       base-type: string
       external:
         java: test.api.ExampleExternalReference
+    ExternalLong:
+      base-type: safelong
+      external:
+        java: java.lang.Long
   definitions:
     default-package: com.palantir.product
     objects:
@@ -112,6 +116,12 @@ types:
           rid: optional<rid>
           bearertoken: optional<bearertoken>
           uuid: optional<uuid>
+      ExternalLongAliasExample:
+        alias: ExternalLong
+      ExternalLongExample:
+        fields:
+          externalLong: ExternalLong
+          optionalExternalLong: optional<ExternalLong>
       ManyFieldExample:
         fields:
           string:
@@ -178,6 +188,7 @@ types:
         union:
           foo: string
           bar: integer
+          baz: ExternalLong
       SingleUnion:
         union:
           foo: string

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -122,6 +122,7 @@ types:
         fields:
           externalLong: ExternalLong
           optionalExternalLong: optional<ExternalLong>
+          listExternalLong: list<ExternalLong>
       ManyFieldExample:
         fields:
           string:


### PR DESCRIPTION
Note: We do not recommend using external type imports, they bring
significant risk. However while they are supported we should avoid
generating code that would not pass a code review.

## Before this PR
Java primitive external type imports were previously handled
sporadically.

## After this PR
Now the type DefaultClassNameVisitor handles
unboxing consistently across the project.

==COMMIT_MSG==
External type imports for boxed java primitives are unboxed in generated code.
==COMMIT_MSG==
