### PR TITLE
Document the 'undertowServicePrefixes' flag, remove experimental markers

### DIFF
--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -80,7 +80,7 @@ public final class ConjureJavaCli implements Runnable {
         @CommandLine.Option(names = "--undertow",
                 defaultValue = "false",
                 description =
-                        "Experimental: Generate undertow service interfaces and endpoint wrappers for server usage")
+                        "Generate undertow service interfaces and endpoint wrappers for server usage")
         private boolean generateUndertow;
 
         @CommandLine.Option(names = "--retrofit",
@@ -111,7 +111,7 @@ public final class ConjureJavaCli implements Runnable {
         @CommandLine.Option(names = "--undertowServicePrefixes",
                 defaultValue = "false",
                 description =
-                        "Experimental: Generate service interfaces for Undertow with class names prefixed 'Undertow'")
+                        "Generate service interfaces for Undertow with class names prefixed 'Undertow'")
         private boolean undertowServicePrefix;
 
         @CommandLine.Option(names = "--useImmutableBytes",

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,8 @@ The recommended way to use conjure-java is via a build tool like [gradle-conjure
                      Generate retrofit services which return Java8 CompletableFuture instead of OkHttp Call (deprecated)
         --retrofitListenableFutures
                      Generate retrofit services which return Guava ListenableFuture instead of OkHttp Call
+        --undertowServicePrefixes
+                     Generate service interfaces for Undertow with class names prefixed 'Undertow'
         --useImmutableBytes
                      Generate binary fields using the immutable 'Bytes' type instead of 'ByteBuffer'
 
@@ -188,8 +190,6 @@ Call<List<Recipe>> asyncResults = recipes.getRecipes();
 ```
 
 ## Undertow
-
-_This feature is experimental and subject to change._
 
 In the undertow setting, for a `ServiceName` conjure defined service, conjure will generate an interface: `ServiceName` to be extended by your resource and a [Service](https://github.com/palantir/conjure-java/blob/develop/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/Service.java) named `ServiceNameEndpoints`
 


### PR DESCRIPTION
conjure-undertow is stable. The runtime library will move to
conjure-java-runtime in the future, but the generator and
supporting library will not be broken.

## After this PR
==COMMIT_MSG==
Document the 'undertowServicePrefixes' flag, remove experimental markers.

conjure-undertow is stable. 
==COMMIT_MSG==
