### PR TITLE
[feature] JAX-RS client Conjure generator

### DIFF
--- a/conjure-java-client-verifier/src/test/java/com/palantir/conjure/java/compliance/SingleParamServicesTest.java
+++ b/conjure-java-client-verifier/src/test/java/com/palantir/conjure/java/compliance/SingleParamServicesTest.java
@@ -44,10 +44,15 @@ public class SingleParamServicesTest {
 
     private static final Logger log = LoggerFactory.getLogger(SingleParamServicesTest.class);
     private static final ObjectMapper objectMapper = ObjectMappers.newClientObjectMapper();
-    private static ImmutableMap<String, Object> servicesMaps = ImmutableMap.of(
+    private static ImmutableMap<String, Object> jerseyServicesMaps = ImmutableMap.of(
             "singlePathParamService", VerificationClients.singlePathParamService(server),
             "singleHeaderService", VerificationClients.singleHeaderService(server),
             "singleQueryParamService", VerificationClients.singleQueryParamService(server));
+
+    private static ImmutableMap<String, Object> jaxRsServicesMaps = ImmutableMap.of(
+            "singlePathParamService", VerificationClients.singlePathParamServiceJaxRs(server),
+            "singleHeaderService", VerificationClients.singleHeaderServiceJaxRs(server),
+            "singleQueryParamService", VerificationClients.singleQueryParamServiceJaxRs(server));
 
     @Parameterized.Parameter(0)
     public String serviceName;
@@ -93,7 +98,16 @@ public class SingleParamServicesTest {
     }
 
     @Test
-    public void runTestCase() throws Exception {
+    public void runJerseyTestCase() throws Exception {
+        runTestCase(jerseyServicesMaps);
+    }
+
+    @Test
+    public void runJaxRsTestCase() throws Exception {
+        runTestCase(jaxRsServicesMaps);
+    }
+
+    private void runTestCase(ImmutableMap<String, Object> servicesMaps) throws Exception {
         Assume.assumeFalse(Cases.shouldIgnore(endpointName, jsonString));
 
         System.out.println(String.format("Invoking %s %s(%s)", serviceName, endpointName, jsonString));

--- a/conjure-java-client-verifier/src/test/java/com/palantir/conjure/java/compliance/VerificationClients.java
+++ b/conjure-java-client-verifier/src/test/java/com/palantir/conjure/java/compliance/VerificationClients.java
@@ -20,51 +20,61 @@ import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.client.jaxrs.JaxRsClient;
 import com.palantir.conjure.java.okhttp.HostMetricsRegistry;
 import com.palantir.conjure.verification.server.AutoDeserializeConfirmService;
+import com.palantir.conjure.verification.server.AutoDeserializeConfirmServiceJaxRsClient;
 import com.palantir.conjure.verification.server.AutoDeserializeService;
+import com.palantir.conjure.verification.server.AutoDeserializeServiceJaxRsClient;
 import com.palantir.conjure.verification.server.SingleHeaderService;
+import com.palantir.conjure.verification.server.SingleHeaderServiceJaxRsClient;
 import com.palantir.conjure.verification.server.SinglePathParamService;
+import com.palantir.conjure.verification.server.SinglePathParamServiceJaxRsClient;
 import com.palantir.conjure.verification.server.SingleQueryParamService;
+import com.palantir.conjure.verification.server.SingleQueryParamServiceJaxRsClient;
 
 public final class VerificationClients {
     private VerificationClients() {}
 
     public static AutoDeserializeService autoDeserializeService(VerificationServerRule server) {
-        return JaxRsClient.create(
-                AutoDeserializeService.class,
-                getUserAgent(),
-                new HostMetricsRegistry(),
-                server.getClientConfiguration());
+        return createJaxRsClient(server, AutoDeserializeService.class);
     }
 
     public static AutoDeserializeConfirmService confirmService(VerificationServerRule server) {
-        return JaxRsClient.create(
-                AutoDeserializeConfirmService.class,
-                getUserAgent(),
-                new HostMetricsRegistry(),
-                server.getClientConfiguration());
+        return createJaxRsClient(server, AutoDeserializeConfirmService.class);
+    }
+
+    public static AutoDeserializeServiceJaxRsClient autoDeserializeServiceJaxRsClient(VerificationServerRule server) {
+        return createJaxRsClient(server, AutoDeserializeServiceJaxRsClient.class);
+    }
+
+    public static AutoDeserializeConfirmServiceJaxRsClient confirmServiceJaxRsClient(VerificationServerRule server) {
+        return createJaxRsClient(server, AutoDeserializeConfirmServiceJaxRsClient.class);
     }
 
     public static SinglePathParamService singlePathParamService(VerificationServerRule server) {
-        return JaxRsClient.create(
-                SinglePathParamService.class,
-                getUserAgent(),
-                new HostMetricsRegistry(),
-                server.getClientConfiguration());
+        return createJaxRsClient(server, SinglePathParamService.class);
     }
 
     public static SingleHeaderService singleHeaderService(VerificationServerRule server) {
-        return JaxRsClient.create(
-                SingleHeaderService.class,
-                getUserAgent(),
-                new HostMetricsRegistry(),
-                server.getClientConfiguration());
+        return createJaxRsClient(server, SingleHeaderService.class);
     }
 
     public static SingleQueryParamService singleQueryParamService(VerificationServerRule server) {
-        return JaxRsClient.create(SingleQueryParamService.class,
-                getUserAgent(),
-                new HostMetricsRegistry(),
-                server.getClientConfiguration());
+        return createJaxRsClient(server, SingleQueryParamService.class);
+    }
+
+    public static SinglePathParamServiceJaxRsClient singlePathParamServiceJaxRs(VerificationServerRule server) {
+        return createJaxRsClient(server, SinglePathParamServiceJaxRsClient .class);
+    }
+
+    public static SingleHeaderServiceJaxRsClient  singleHeaderServiceJaxRs(VerificationServerRule server) {
+        return createJaxRsClient(server, SingleHeaderServiceJaxRsClient.class);
+    }
+
+    public static SingleQueryParamServiceJaxRsClient singleQueryParamServiceJaxRs(VerificationServerRule server) {
+        return createJaxRsClient(server, SingleQueryParamServiceJaxRsClient .class);
+    }
+
+    private static <T> T createJaxRsClient(VerificationServerRule server, Class<T> clazz) {
+        return JaxRsClient.create(clazz, getUserAgent(), new HostMetricsRegistry(), server.getClientConfiguration());
     }
 
     private static UserAgent getUserAgent() {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceJaxRsClient.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceJaxRsClient.java
@@ -1,4 +1,4 @@
-package test.api;
+package com.palantir.product;
 
 import javax.annotation.Generated;
 import javax.ws.rs.Consumes;
@@ -6,14 +6,12 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.StreamingOutput;
 
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 @Path("/")
-@Generated("com.palantir.conjure.java.services.JerseyServiceGenerator")
-public interface TestService {
+@Generated("com.palantir.conjure.java.services.JaxRsClientGenerator")
+public interface EmptyPathServiceJaxRsClient {
     @GET
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    StreamingOutput getBinary();
+    boolean emptyPath();
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceJaxRsClient.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceJaxRsClient.java
@@ -1,0 +1,46 @@
+package com.palantir.product;
+
+import com.palantir.tokens.auth.AuthHeader;
+import java.io.InputStream;
+import java.util.Optional;
+import javax.annotation.Generated;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/")
+@Generated("com.palantir.conjure.java.services.JaxRsClientGenerator")
+public interface EteBinaryServiceJaxRsClient {
+    @POST
+    @Path("binary")
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    @Consumes(MediaType.APPLICATION_OCTET_STREAM)
+    InputStream postBinary(@HeaderParam("Authorization") AuthHeader authHeader, InputStream body);
+
+    @GET
+    @Path("binary/optional/present")
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    Optional<InputStream> getOptionalBinaryPresent(
+            @HeaderParam("Authorization") AuthHeader authHeader);
+
+    @GET
+    @Path("binary/optional/empty")
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    Optional<InputStream> getOptionalBinaryEmpty(
+            @HeaderParam("Authorization") AuthHeader authHeader);
+
+    /** Throws an exception after partially writing a binary response. */
+    @GET
+    @Path("binary/failure")
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    InputStream getBinaryFailure(
+            @HeaderParam("Authorization") AuthHeader authHeader,
+            @QueryParam("numBytes") int numBytes);
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceJaxRsClient.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceJaxRsClient.java
@@ -1,0 +1,164 @@
+package com.palantir.product;
+
+import com.palantir.conjure.java.lib.SafeLong;
+import com.palantir.ri.ResourceIdentifier;
+import com.palantir.tokens.auth.AuthHeader;
+import com.palantir.tokens.auth.BearerToken;
+import java.io.InputStream;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Generated;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/")
+@Generated("com.palantir.conjure.java.services.JaxRsClientGenerator")
+public interface EteServiceJaxRsClient {
+    @GET
+    @Path("base/string")
+    String string(@HeaderParam("Authorization") AuthHeader authHeader);
+
+    @GET
+    @Path("base/integer")
+    int integer(@HeaderParam("Authorization") AuthHeader authHeader);
+
+    @GET
+    @Path("base/double")
+    double double_(@HeaderParam("Authorization") AuthHeader authHeader);
+
+    @GET
+    @Path("base/boolean")
+    boolean boolean_(@HeaderParam("Authorization") AuthHeader authHeader);
+
+    @GET
+    @Path("base/safelong")
+    SafeLong safelong(@HeaderParam("Authorization") AuthHeader authHeader);
+
+    @GET
+    @Path("base/rid")
+    ResourceIdentifier rid(@HeaderParam("Authorization") AuthHeader authHeader);
+
+    @GET
+    @Path("base/bearertoken")
+    BearerToken bearertoken(@HeaderParam("Authorization") AuthHeader authHeader);
+
+    @GET
+    @Path("base/optionalString")
+    Optional<String> optionalString(@HeaderParam("Authorization") AuthHeader authHeader);
+
+    @GET
+    @Path("base/optionalEmpty")
+    Optional<String> optionalEmpty(@HeaderParam("Authorization") AuthHeader authHeader);
+
+    @GET
+    @Path("base/datetime")
+    OffsetDateTime datetime(@HeaderParam("Authorization") AuthHeader authHeader);
+
+    @GET
+    @Path("base/binary")
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    InputStream binary(@HeaderParam("Authorization") AuthHeader authHeader);
+
+    @GET
+    @Path("base/path/{param}")
+    String path(
+            @HeaderParam("Authorization") AuthHeader authHeader, @PathParam("param") String param);
+
+    @POST
+    @Path("base/notNullBody")
+    StringAliasExample notNullBody(
+            @HeaderParam("Authorization") AuthHeader authHeader, StringAliasExample notNullBody);
+
+    @GET
+    @Path("base/aliasOne")
+    StringAliasExample aliasOne(
+            @HeaderParam("Authorization") AuthHeader authHeader,
+            @QueryParam("queryParamName") StringAliasExample queryParamName);
+
+    @GET
+    @Path("base/optionalAliasOne")
+    StringAliasExample optionalAliasOne(
+            @HeaderParam("Authorization") AuthHeader authHeader,
+            @QueryParam("queryParamName") Optional<StringAliasExample> queryParamName);
+
+    @GET
+    @Path("base/aliasTwo")
+    NestedStringAliasExample aliasTwo(
+            @HeaderParam("Authorization") AuthHeader authHeader,
+            @QueryParam("queryParamName") NestedStringAliasExample queryParamName);
+
+    @POST
+    @Path("base/external/notNullBody")
+    StringAliasExample notNullBodyExternalImport(
+            @HeaderParam("Authorization") AuthHeader authHeader, StringAliasExample notNullBody);
+
+    @POST
+    @Path("base/external/optional-body")
+    Optional<StringAliasExample> optionalBodyExternalImport(
+            @HeaderParam("Authorization") AuthHeader authHeader, Optional<StringAliasExample> body);
+
+    @POST
+    @Path("base/external/optional-query")
+    Optional<StringAliasExample> optionalQueryExternalImport(
+            @HeaderParam("Authorization") AuthHeader authHeader,
+            @QueryParam("query") Optional<StringAliasExample> query);
+
+    @POST
+    @Path("base/no-return")
+    void noReturn(@HeaderParam("Authorization") AuthHeader authHeader);
+
+    @GET
+    @Path("base/enum/query")
+    SimpleEnum enumQuery(
+            @HeaderParam("Authorization") AuthHeader authHeader,
+            @QueryParam("queryParamName") SimpleEnum queryParamName);
+
+    @GET
+    @Path("base/enum/list/query")
+    List<SimpleEnum> enumListQuery(
+            @HeaderParam("Authorization") AuthHeader authHeader,
+            @QueryParam("queryParamName") List<SimpleEnum> queryParamName);
+
+    @GET
+    @Path("base/enum/optional/query")
+    Optional<SimpleEnum> optionalEnumQuery(
+            @HeaderParam("Authorization") AuthHeader authHeader,
+            @QueryParam("queryParamName") Optional<SimpleEnum> queryParamName);
+
+    @GET
+    @Path("base/enum/header")
+    SimpleEnum enumHeader(
+            @HeaderParam("Authorization") AuthHeader authHeader,
+            @HeaderParam("Custom-Header") SimpleEnum headerParameter);
+
+    @Deprecated
+    default StringAliasExample optionalAliasOne(AuthHeader authHeader) {
+        return optionalAliasOne(authHeader, Optional.empty());
+    }
+
+    @Deprecated
+    default Optional<StringAliasExample> optionalQueryExternalImport(AuthHeader authHeader) {
+        return optionalQueryExternalImport(authHeader, Optional.empty());
+    }
+
+    @Deprecated
+    default List<SimpleEnum> enumListQuery(AuthHeader authHeader) {
+        return enumListQuery(authHeader, Collections.emptyList());
+    }
+
+    @Deprecated
+    default Optional<SimpleEnum> optionalEnumQuery(AuthHeader authHeader) {
+        return optionalEnumQuery(authHeader, Optional.empty());
+    }
+}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JaxRsClientGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JaxRsClientGenerator.java
@@ -1,0 +1,48 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.services;
+
+import com.palantir.conjure.java.FeatureFlags;
+import com.palantir.conjure.spec.ConjureDefinition;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.ParameterizedTypeName;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.Set;
+
+public final class JaxRsClientGenerator implements ServiceGenerator {
+
+    private final JaxRsServiceFactory delegate;
+
+    public JaxRsClientGenerator(Set<FeatureFlags> featureFlags) {
+        this.delegate = new JaxRsServiceFactory(
+                getClass(),
+                featureFlags,
+                serviceName -> serviceName + "JaxRsClient",
+                // Clients return InputStream and Optional<InputStream>
+                ClassName.get(InputStream.class),
+                ParameterizedTypeName.get(Optional.class, InputStream.class),
+                // Feign clients do not validate based on javax.validation.constraints
+                false);
+    }
+
+    @Override
+    public Set<JavaFile> generate(ConjureDefinition conjureDefinition) {
+        return delegate.generate(conjureDefinition);
+    }
+}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JaxRsServiceFactory.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JaxRsServiceFactory.java
@@ -1,0 +1,456 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.services;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.palantir.conjure.java.ConjureAnnotations;
+import com.palantir.conjure.java.FeatureFlags;
+import com.palantir.conjure.java.types.DefaultClassNameVisitor;
+import com.palantir.conjure.java.types.ReturnTypeClassNameVisitor;
+import com.palantir.conjure.java.types.SpecializeBinaryClassNameVisitor;
+import com.palantir.conjure.java.types.TypeMapper;
+import com.palantir.conjure.java.util.ParameterOrder;
+import com.palantir.conjure.java.visitor.DefaultTypeVisitor;
+import com.palantir.conjure.spec.ArgumentDefinition;
+import com.palantir.conjure.spec.AuthType;
+import com.palantir.conjure.spec.ConjureDefinition;
+import com.palantir.conjure.spec.EndpointDefinition;
+import com.palantir.conjure.spec.ListType;
+import com.palantir.conjure.spec.MapType;
+import com.palantir.conjure.spec.OptionalType;
+import com.palantir.conjure.spec.ParameterId;
+import com.palantir.conjure.spec.ParameterType;
+import com.palantir.conjure.spec.PrimitiveType;
+import com.palantir.conjure.spec.ServiceDefinition;
+import com.palantir.conjure.spec.SetType;
+import com.palantir.conjure.spec.Type;
+import com.palantir.conjure.visitor.AuthTypeVisitor;
+import com.palantir.conjure.visitor.ParameterTypeVisitor;
+import com.palantir.conjure.visitor.TypeVisitor;
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterSpec;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.lang.model.element.Modifier;
+import org.apache.commons.lang3.StringUtils;
+
+final class JaxRsServiceFactory {
+
+    private static final ClassName NOT_NULL = ClassName.get("javax.validation.constraints", "NotNull");
+
+    private static final ClassName BINARY_ARGUMENT_TYPE = ClassName.get(InputStream.class);
+
+    private final Class<? extends ServiceGenerator> generatorClass;
+    private final Set<FeatureFlags> featureFlags;
+    private final Function<String, String> serviceNameModifier;
+    private final boolean requireNotNullAuthAndBodyParams;
+    private final ClassName binaryReturnType;
+    private final TypeName optionalBinaryReturnType;
+
+    JaxRsServiceFactory(
+            Class<? extends ServiceGenerator> generatorClass,
+            Set<FeatureFlags> experimentalFeatures,
+            Function<String, String> serviceNameModifier,
+            ClassName binaryReturnType,
+            TypeName optionalBinaryReturnType,
+            boolean requireNotNullAuthAndBodyParams) {
+        this.featureFlags = ImmutableSet.copyOf(experimentalFeatures);
+        this.generatorClass = generatorClass;
+        this.serviceNameModifier = serviceNameModifier;
+        this.binaryReturnType = binaryReturnType;
+        this.optionalBinaryReturnType = optionalBinaryReturnType;
+        this.requireNotNullAuthAndBodyParams = requireNotNullAuthAndBodyParams;
+    }
+
+    Set<JavaFile> generate(ConjureDefinition conjureDefinition) {
+        TypeMapper returnTypeMapper = new TypeMapper(
+                conjureDefinition.getTypes(),
+                new ReturnTypeClassNameVisitor(
+                        conjureDefinition.getTypes(),
+                        binaryReturnType,
+                        optionalBinaryReturnType,
+                        featureFlags));
+
+        TypeMapper argumentTypeMapper = new TypeMapper(
+                conjureDefinition.getTypes(),
+                new SpecializeBinaryClassNameVisitor(
+                        new DefaultClassNameVisitor(conjureDefinition.getTypes(), featureFlags),
+                        BINARY_ARGUMENT_TYPE));
+
+        return conjureDefinition.getServices().stream()
+                .map(serviceDef -> generateService(serviceDef, returnTypeMapper, argumentTypeMapper))
+                .collect(Collectors.toSet());
+    }
+
+    private JavaFile generateService(ServiceDefinition serviceDefinition,
+            TypeMapper returnTypeMapper, TypeMapper argumentTypeMapper) {
+        String serviceName = serviceNameModifier.apply(serviceDefinition.getServiceName().getName());
+        TypeSpec.Builder serviceBuilder = TypeSpec.interfaceBuilder(serviceName)
+                .addModifiers(Modifier.PUBLIC)
+                .addAnnotation(AnnotationSpec.builder(ClassName.get("javax.ws.rs", "Consumes"))
+                        .addMember("value", "$T.APPLICATION_JSON", ClassName.get("javax.ws.rs.core", "MediaType"))
+                        .build())
+                .addAnnotation(AnnotationSpec.builder(ClassName.get("javax.ws.rs", "Produces"))
+                        .addMember("value", "$T.APPLICATION_JSON", ClassName.get("javax.ws.rs.core", "MediaType"))
+                        .build())
+                .addAnnotation(AnnotationSpec.builder(ClassName.get("javax.ws.rs", "Path"))
+                        .addMember("value", "$S", "/")
+                        .build())
+                .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(generatorClass));
+
+        serviceDefinition.getDocs().ifPresent(docs ->
+                serviceBuilder.addJavadoc("$L", StringUtils.appendIfMissing(docs.get(), "\n")));
+
+        serviceBuilder.addMethods(serviceDefinition.getEndpoints().stream()
+                .map(endpoint -> generateServiceMethod(endpoint, returnTypeMapper, argumentTypeMapper))
+                .collect(Collectors.toList()));
+
+        serviceBuilder.addMethods(serviceDefinition.getEndpoints().stream()
+                .map(endpoint -> generateCompatibilityBackfillServiceMethods(endpoint, returnTypeMapper,
+                        argumentTypeMapper))
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList()));
+
+        return JavaFile.builder(serviceDefinition.getServiceName().getPackage(), serviceBuilder.build())
+                .skipJavaLangImports(true)
+                .indent("    ")
+                .build();
+    }
+
+    private MethodSpec generateServiceMethod(
+            EndpointDefinition endpointDef,
+            TypeMapper returnTypeMapper,
+            TypeMapper argumentTypeMapper) {
+        TypeName returnType = endpointDef.getReturns()
+                .map(returnTypeMapper::getClassName)
+                .orElse(ClassName.VOID);
+
+        MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(endpointDef.getEndpointName().get())
+                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                .addAnnotations(createMarkers(argumentTypeMapper, endpointDef.getMarkers()))
+                .addAnnotation(httpMethodToClassName(endpointDef.getHttpMethod().get().name()))
+                .addParameters(createServiceMethodParameters(endpointDef, argumentTypeMapper, true))
+                .returns(returnType);
+
+        // @Path("") is invalid in Feign JaxRs and equivalent to absent on an endpoint method
+        String rawHttpPath = endpointDef.getHttpPath().get();
+        String httpPath = rawHttpPath.startsWith("/") ? rawHttpPath.substring(1) : rawHttpPath;
+        if (!httpPath.isEmpty()) {
+            methodBuilder.addAnnotation(AnnotationSpec.builder(ClassName.get("javax.ws.rs", "Path"))
+                        .addMember("value", "$S", httpPath)
+                        .build());
+        }
+
+        if (returnType.equals(binaryReturnType) || returnType.equals(optionalBinaryReturnType)) {
+            methodBuilder.addAnnotation(AnnotationSpec.builder(ClassName.get("javax.ws.rs", "Produces"))
+                    .addMember("value", "$T.APPLICATION_OCTET_STREAM", ClassName.get("javax.ws.rs.core", "MediaType"))
+                    .build());
+        }
+
+        boolean consumesTypeIsBinary = endpointDef.getArgs().stream()
+                .map(ArgumentDefinition::getType)
+                .map(argumentTypeMapper::getClassName)
+                .anyMatch(BINARY_ARGUMENT_TYPE::equals);
+
+        if (consumesTypeIsBinary) {
+            methodBuilder.addAnnotation(AnnotationSpec.builder(ClassName.get("javax.ws.rs", "Consumes"))
+                    .addMember("value", "$T.APPLICATION_OCTET_STREAM", ClassName.get("javax.ws.rs.core", "MediaType"))
+                    .build());
+        }
+
+        endpointDef.getDeprecated().ifPresent(deprecatedDocsValue -> methodBuilder.addAnnotation(
+                ClassName.get("java.lang", "Deprecated")));
+
+        ServiceGenerator.getJavaDoc(endpointDef).ifPresent(
+                content -> methodBuilder.addJavadoc("$L", content));
+
+        return methodBuilder.build();
+    }
+
+    /** Provides a linear expansion of optional query arguments to improve Java back-compat. */
+    private List<MethodSpec> generateCompatibilityBackfillServiceMethods(
+            EndpointDefinition endpointDef,
+            TypeMapper returnTypeMapper,
+            TypeMapper argumentTypeMapper) {
+
+        List<ArgumentDefinition> queryArgs = Lists.newArrayList();
+
+        for (ArgumentDefinition arg : endpointDef.getArgs()) {
+            if (arg.getParamType().accept(ParameterTypeVisitor.IS_QUERY)
+                    && arg.getType().accept(TYPE_DEFAULTABLE_PREDICATE)) {
+                queryArgs.add(arg);
+            }
+        }
+
+        List<MethodSpec> alternateMethods = Lists.newArrayList();
+        for (int i = 0; i < queryArgs.size(); i++) {
+            alternateMethods.add(createCompatibilityBackfillMethod(
+                    endpointDef,
+                    returnTypeMapper,
+                    argumentTypeMapper,
+                    queryArgs.subList(i, queryArgs.size())));
+        }
+
+        return alternateMethods;
+    }
+
+    private MethodSpec createCompatibilityBackfillMethod(
+            EndpointDefinition endpointDef,
+            TypeMapper returnTypeMapper,
+            TypeMapper argumentTypeMapper,
+            List<ArgumentDefinition> extraArgs) {
+        // ensure the correct ordering of parameters by creating the complete sorted parameter list
+        List<ParameterSpec> sortedParams = createServiceMethodParameters(endpointDef, argumentTypeMapper, false);
+        List<Optional<ArgumentDefinition>> sortedMaybeExtraArgs = sortedParams.stream().map(param ->
+                extraArgs.stream()
+                        .filter(arg -> arg.getArgName().get().equals(param.name))
+                        .findFirst())
+                .collect(Collectors.toList());
+
+        // omit extraArgs from the back fill method signature
+        MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(endpointDef.getEndpointName().get())
+                .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+                .addAnnotation(Deprecated.class)
+                .addParameters(IntStream.range(0, sortedParams.size())
+                        .filter(i -> !sortedMaybeExtraArgs.get(i).isPresent())
+                        .mapToObj(sortedParams::get)
+                        .collect(Collectors.toList()));
+
+        endpointDef.getReturns().ifPresent(type -> methodBuilder.returns(returnTypeMapper.getClassName(type)));
+
+        // replace extraArgs with default values when invoking the complete method
+        StringBuilder sb = new StringBuilder(endpointDef.getReturns().isPresent() ? "return $N(" : "$N(");
+        List<Object> values = IntStream.range(0, sortedParams.size()).mapToObj(i -> {
+            Optional<ArgumentDefinition> maybeArgDef = sortedMaybeExtraArgs.get(i);
+            if (maybeArgDef.isPresent()) {
+                sb.append("$L, ");
+                return maybeArgDef.get().getType().accept(TYPE_DEFAULT_VALUE);
+            } else {
+                sb.append("$N, ");
+                return sortedParams.get(i);
+            }
+        }).collect(Collectors.toList());
+        // trim the end
+        sb.setLength(sb.length() - 2);
+        sb.append(")");
+
+        ImmutableList<Object> methodCallArgs = ImmutableList.builder()
+                .add(endpointDef.getEndpointName().get())
+                .addAll(values)
+                .build();
+
+        methodBuilder.addStatement(sb.toString(), methodCallArgs.toArray(new Object[0]));
+
+        return methodBuilder.build();
+    }
+
+    private List<ParameterSpec> createServiceMethodParameters(
+            EndpointDefinition endpointDef,
+            TypeMapper typeMapper,
+            boolean withAnnotations) {
+        List<ParameterSpec> parameterSpecs = new ArrayList<>();
+
+        Optional<AuthType> auth = endpointDef.getAuth();
+        createAuthParameter(auth, withAnnotations).ifPresent(parameterSpecs::add);
+
+        ParameterOrder.sorted(endpointDef.getArgs()).forEach(def ->
+                parameterSpecs.add(createServiceMethodParameterArg(typeMapper, def, withAnnotations)));
+        return ImmutableList.copyOf(parameterSpecs);
+    }
+
+    private ParameterSpec createServiceMethodParameterArg(TypeMapper typeMapper, ArgumentDefinition def,
+            boolean withAnnotations) {
+        ParameterSpec.Builder param = ParameterSpec.builder(
+                typeMapper.getClassName(def.getType()), def.getArgName().get());
+        if (withAnnotations) {
+            getParamTypeAnnotation(def).ifPresent(param::addAnnotation);
+            param.addAnnotations(createMarkers(typeMapper, def.getMarkers()));
+        }
+        return param.build();
+    }
+
+    private Optional<ParameterSpec> createAuthParameter(Optional<AuthType> auth, boolean withAnnotations) {
+        if (!auth.isPresent()) {
+            return Optional.empty();
+        }
+
+        ClassName annotationClassName;
+        ClassName tokenClassName;
+        String paramName;
+        String tokenName;
+
+        if (auth.get().accept(AuthTypeVisitor.IS_HEADER)) {
+            annotationClassName = ClassName.get("javax.ws.rs", "HeaderParam");
+            tokenClassName = ClassName.get("com.palantir.tokens.auth", "AuthHeader");
+            paramName = "authHeader";
+            tokenName = "Authorization";
+        } else if (auth.get().accept(AuthTypeVisitor.IS_COOKIE)) {
+            annotationClassName = ClassName.get("javax.ws.rs", "CookieParam");
+            tokenClassName = ClassName.get("com.palantir.tokens.auth", "BearerToken");
+            paramName = "token";
+            tokenName = auth.get().accept(AuthTypeVisitor.COOKIE).getCookieName();
+        } else {
+            throw new IllegalStateException("Unrecognized auth type: " + auth.get());
+        }
+
+        ParameterSpec.Builder paramSpec = ParameterSpec.builder(tokenClassName, paramName);
+        if (withAnnotations) {
+            paramSpec.addAnnotation(AnnotationSpec.builder(annotationClassName)
+                    .addMember("value", "$S", tokenName).build());
+            if (requireNotNullAuthAndBodyParams) {
+                paramSpec.addAnnotation(AnnotationSpec.builder(NOT_NULL).build());
+            }
+        }
+        return Optional.of(paramSpec.build());
+    }
+
+    private Optional<AnnotationSpec> getParamTypeAnnotation(ArgumentDefinition def) {
+        AnnotationSpec.Builder annotationSpecBuilder;
+        ParameterType paramType = def.getParamType();
+        if (paramType.accept(ParameterTypeVisitor.IS_PATH)) {
+            annotationSpecBuilder = AnnotationSpec.builder(ClassName.get("javax.ws.rs", "PathParam"))
+                    .addMember("value", "$S", def.getArgName().get());
+        } else if (paramType.accept(ParameterTypeVisitor.IS_QUERY)) {
+            ParameterId paramId = paramType.accept(ParameterTypeVisitor.QUERY).getParamId();
+            annotationSpecBuilder = AnnotationSpec.builder(ClassName.get("javax.ws.rs", "QueryParam"))
+                    .addMember("value", "$S", paramId.get());
+        } else if (paramType.accept(ParameterTypeVisitor.IS_HEADER)) {
+            ParameterId paramId = paramType.accept(ParameterTypeVisitor.HEADER).getParamId();
+            annotationSpecBuilder = AnnotationSpec.builder(ClassName.get("javax.ws.rs", "HeaderParam"))
+                    .addMember("value", "$S", paramId.get());
+        } else if (paramType.accept(ParameterTypeVisitor.IS_BODY)) {
+            if (def.getType().accept(TypeVisitor.IS_OPTIONAL) || !requireNotNullAuthAndBodyParams) {
+                return Optional.empty();
+            }
+            annotationSpecBuilder = AnnotationSpec
+                    .builder(NOT_NULL);
+        } else {
+            throw new IllegalStateException("Unrecognized argument type: " + def.getParamType());
+        }
+
+        return Optional.of(annotationSpecBuilder.build());
+    }
+
+    private static Set<AnnotationSpec> createMarkers(TypeMapper typeMapper, List<Type> markers) {
+        checkArgument(markers.stream().allMatch(type -> type.accept(TypeVisitor.IS_REFERENCE)),
+                "Markers must refer to reference types.");
+        return markers.stream()
+                .map(typeMapper::getClassName)
+                .map(ClassName.class::cast)
+                .map(AnnotationSpec::builder)
+                .map(AnnotationSpec.Builder::build)
+                .collect(Collectors.toSet());
+    }
+
+    private static ClassName httpMethodToClassName(String method) {
+        switch (method) {
+            case "DELETE":
+                return ClassName.get("javax.ws.rs", "DELETE");
+            case "GET":
+                return ClassName.get("javax.ws.rs", "GET");
+            case "PUT":
+                return ClassName.get("javax.ws.rs", "PUT");
+            case "POST":
+                return ClassName.get("javax.ws.rs", "POST");
+        }
+        throw new IllegalArgumentException("Unrecognized HTTP method: " + method);
+    }
+
+    /** Indicates whether a particular type has a defaultable value. */
+    private static final Type.Visitor<Boolean> TYPE_DEFAULTABLE_PREDICATE = new DefaultTypeVisitor<Boolean>() {
+        @Override
+        public Boolean visitOptional(OptionalType value) {
+            return true;
+        }
+
+        @Override
+        public Boolean visitList(ListType value) {
+            return true;
+        }
+
+        @Override
+        public Boolean visitSet(SetType value) {
+            return true;
+        }
+
+        @Override
+        public Boolean visitMap(MapType value) {
+            return true;
+        }
+
+        @Override
+        public Boolean visitDefault() {
+            return false;
+        }
+    };
+
+    private static final Type.Visitor<CodeBlock> TYPE_DEFAULT_VALUE = new DefaultTypeVisitor<CodeBlock>() {
+        @Override
+        public CodeBlock visitOptional(OptionalType value) {
+            if (value.getItemType().accept(TypeVisitor.IS_PRIMITIVE)) {
+                PrimitiveType primitiveType = value.getItemType().accept(TypeVisitor.PRIMITIVE);
+                // special handling for primitive optionals with Java 8
+                if (primitiveType.equals(PrimitiveType.DOUBLE)) {
+                    return CodeBlock.of("$T.empty()", OptionalDouble.class);
+                } else if (primitiveType.equals(PrimitiveType.INTEGER)) {
+                    return CodeBlock.of("$T.empty()", OptionalInt.class);
+                }
+            }
+            return CodeBlock.of("$T.empty()", Optional.class);
+        }
+
+        @Override
+        public CodeBlock visitList(ListType value) {
+            return CodeBlock.of("$T.emptyList()", Collections.class);
+        }
+
+        @Override
+        public CodeBlock visitSet(SetType value) {
+            return CodeBlock.of("$T.emptySet()", Collections.class);
+        }
+
+        @Override
+        public CodeBlock visitMap(MapType value) {
+            return CodeBlock.of("$T.emptyMap()", Collections.class);
+        }
+
+        @Override
+        public CodeBlock visitDefault() {
+            throw new IllegalArgumentException("Cannot backfill non-defaultable parameter type.");
+        }
+    };
+}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
@@ -16,443 +16,49 @@
 
 package com.palantir.conjure.java.services;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import com.palantir.conjure.java.ConjureAnnotations;
 import com.palantir.conjure.java.FeatureFlags;
-import com.palantir.conjure.java.types.DefaultClassNameVisitor;
-import com.palantir.conjure.java.types.ReturnTypeClassNameVisitor;
-import com.palantir.conjure.java.types.SpecializeBinaryClassNameVisitor;
-import com.palantir.conjure.java.types.TypeMapper;
-import com.palantir.conjure.java.util.ParameterOrder;
-import com.palantir.conjure.java.visitor.DefaultTypeVisitor;
-import com.palantir.conjure.spec.ArgumentDefinition;
-import com.palantir.conjure.spec.AuthType;
 import com.palantir.conjure.spec.ConjureDefinition;
-import com.palantir.conjure.spec.EndpointDefinition;
-import com.palantir.conjure.spec.ListType;
-import com.palantir.conjure.spec.MapType;
-import com.palantir.conjure.spec.OptionalType;
-import com.palantir.conjure.spec.ParameterId;
-import com.palantir.conjure.spec.ParameterType;
-import com.palantir.conjure.spec.PrimitiveType;
-import com.palantir.conjure.spec.ServiceDefinition;
-import com.palantir.conjure.spec.SetType;
-import com.palantir.conjure.spec.Type;
-import com.palantir.conjure.visitor.AuthTypeVisitor;
-import com.palantir.conjure.visitor.ParameterTypeVisitor;
-import com.palantir.conjure.visitor.TypeVisitor;
-import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
-import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.JavaFile;
-import com.squareup.javapoet.MethodSpec;
-import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
-import com.squareup.javapoet.TypeSpec;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
-import java.util.OptionalDouble;
-import java.util.OptionalInt;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import javax.lang.model.element.Modifier;
+import java.util.function.Function;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
-import org.apache.commons.lang3.StringUtils;
 
 public final class JerseyServiceGenerator implements ServiceGenerator {
 
-    private static final ClassName NOT_NULL = ClassName.get("javax.validation.constraints", "NotNull");
-
-    private static final ClassName BINARY_ARGUMENT_TYPE = ClassName.get(InputStream.class);
     private static final ClassName BINARY_RETURN_TYPE_RESPONSE = ClassName.get(Response.class);
     private static final ClassName BINARY_RETURN_TYPE_OUTPUT = ClassName.get(StreamingOutput.class);
     private static final TypeName OPTIONAL_BINARY_RETURN_TYPE =
             ParameterizedTypeName.get(ClassName.get(Optional.class), BINARY_RETURN_TYPE_OUTPUT);
 
-    private final Set<FeatureFlags> featureFlags;
+    private final JaxRsServiceFactory delegate;
 
     public JerseyServiceGenerator() {
         this(ImmutableSet.of());
     }
 
-    public JerseyServiceGenerator(Set<FeatureFlags> experimentalFeatures) {
-        this.featureFlags = ImmutableSet.copyOf(experimentalFeatures);
+    public JerseyServiceGenerator(Set<FeatureFlags> featureFlags) {
+        ClassName binaryReturnType = featureFlags.contains(FeatureFlags.JerseyBinaryAsResponse)
+                ? BINARY_RETURN_TYPE_RESPONSE : BINARY_RETURN_TYPE_OUTPUT;
+        TypeName optionalBinaryReturnType = featureFlags.contains(FeatureFlags.JerseyBinaryAsResponse)
+                ? BINARY_RETURN_TYPE_RESPONSE : OPTIONAL_BINARY_RETURN_TYPE;
+        boolean requireNotNullAuthAndBodyParams = featureFlags.contains(FeatureFlags.RequireNotNullAuthAndBodyParams);
+        this.delegate = new JaxRsServiceFactory(
+                getClass(),
+                featureFlags,
+                Function.identity(),
+                binaryReturnType,
+                optionalBinaryReturnType,
+                requireNotNullAuthAndBodyParams);
     }
 
     @Override
     public Set<JavaFile> generate(ConjureDefinition conjureDefinition) {
-        ClassName binaryReturnType = featureFlags.contains(FeatureFlags.JerseyBinaryAsResponse)
-                ? BINARY_RETURN_TYPE_RESPONSE
-                : BINARY_RETURN_TYPE_OUTPUT;
-
-        TypeName optionalBinaryReturnType = featureFlags.contains(FeatureFlags.JerseyBinaryAsResponse)
-                ? BINARY_RETURN_TYPE_RESPONSE : OPTIONAL_BINARY_RETURN_TYPE;
-
-        TypeMapper returnTypeMapper = new TypeMapper(
-                conjureDefinition.getTypes(),
-                new ReturnTypeClassNameVisitor(
-                        conjureDefinition.getTypes(),
-                        binaryReturnType,
-                        optionalBinaryReturnType,
-                        featureFlags));
-
-        TypeMapper argumentTypeMapper = new TypeMapper(
-                conjureDefinition.getTypes(),
-                new SpecializeBinaryClassNameVisitor(
-                        new DefaultClassNameVisitor(conjureDefinition.getTypes(), featureFlags),
-                        BINARY_ARGUMENT_TYPE));
-
-        return conjureDefinition.getServices().stream()
-                .map(serviceDef -> generateService(serviceDef, returnTypeMapper, argumentTypeMapper))
-                .collect(Collectors.toSet());
+        return delegate.generate(conjureDefinition);
     }
-
-    private JavaFile generateService(ServiceDefinition serviceDefinition,
-            TypeMapper returnTypeMapper, TypeMapper argumentTypeMapper) {
-        TypeSpec.Builder serviceBuilder = TypeSpec.interfaceBuilder(serviceDefinition.getServiceName().getName())
-                .addModifiers(Modifier.PUBLIC)
-                .addAnnotation(AnnotationSpec.builder(ClassName.get("javax.ws.rs", "Consumes"))
-                        .addMember("value", "$T.APPLICATION_JSON", ClassName.get("javax.ws.rs.core", "MediaType"))
-                        .build())
-                .addAnnotation(AnnotationSpec.builder(ClassName.get("javax.ws.rs", "Produces"))
-                        .addMember("value", "$T.APPLICATION_JSON", ClassName.get("javax.ws.rs.core", "MediaType"))
-                        .build())
-                .addAnnotation(AnnotationSpec.builder(ClassName.get("javax.ws.rs", "Path"))
-                        .addMember("value", "$S", "/")
-                        .build())
-                .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(JerseyServiceGenerator.class));
-
-        serviceDefinition.getDocs().ifPresent(docs ->
-                serviceBuilder.addJavadoc("$L", StringUtils.appendIfMissing(docs.get(), "\n")));
-
-        serviceBuilder.addMethods(serviceDefinition.getEndpoints().stream()
-                .map(endpoint -> generateServiceMethod(endpoint, returnTypeMapper, argumentTypeMapper))
-                .collect(Collectors.toList()));
-
-        serviceBuilder.addMethods(serviceDefinition.getEndpoints().stream()
-                .map(endpoint -> generateCompatibilityBackfillServiceMethods(endpoint, returnTypeMapper,
-                        argumentTypeMapper))
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList()));
-
-        return JavaFile.builder(serviceDefinition.getServiceName().getPackage(), serviceBuilder.build())
-                .skipJavaLangImports(true)
-                .indent("    ")
-                .build();
-    }
-
-    private MethodSpec generateServiceMethod(
-            EndpointDefinition endpointDef,
-            TypeMapper returnTypeMapper,
-            TypeMapper argumentTypeMapper) {
-        TypeName returnType = endpointDef.getReturns()
-                .map(returnTypeMapper::getClassName)
-                .orElse(ClassName.VOID);
-
-        MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(endpointDef.getEndpointName().get())
-                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-                .addAnnotation(httpMethodToClassName(endpointDef.getHttpMethod().get().name()))
-                .addParameters(createServiceMethodParameters(endpointDef, argumentTypeMapper, true))
-                .returns(returnType);
-
-        // @Path("") is invalid in Feign JaxRs and equivalent to absent on an endpoint method
-        String rawHttpPath = endpointDef.getHttpPath().get();
-        String httpPath = rawHttpPath.startsWith("/") ? rawHttpPath.substring(1) : rawHttpPath;
-        if (!httpPath.isEmpty()) {
-            methodBuilder.addAnnotation(AnnotationSpec.builder(ClassName.get("javax.ws.rs", "Path"))
-                        .addMember("value", "$S", httpPath)
-                        .build());
-        }
-
-        if (returnType.equals(BINARY_RETURN_TYPE_OUTPUT) || returnType.equals(BINARY_RETURN_TYPE_RESPONSE)
-                || returnType.equals(OPTIONAL_BINARY_RETURN_TYPE)) {
-            methodBuilder.addAnnotation(AnnotationSpec.builder(ClassName.get("javax.ws.rs", "Produces"))
-                    .addMember("value", "$T.APPLICATION_OCTET_STREAM", ClassName.get("javax.ws.rs.core", "MediaType"))
-                    .build());
-        }
-
-        boolean consumesTypeIsBinary = endpointDef.getArgs().stream()
-                .map(ArgumentDefinition::getType)
-                .map(argumentTypeMapper::getClassName)
-                .anyMatch(BINARY_ARGUMENT_TYPE::equals);
-
-        if (consumesTypeIsBinary) {
-            methodBuilder.addAnnotation(AnnotationSpec.builder(ClassName.get("javax.ws.rs", "Consumes"))
-                    .addMember("value", "$T.APPLICATION_OCTET_STREAM", ClassName.get("javax.ws.rs.core", "MediaType"))
-                    .build());
-        }
-
-        endpointDef.getDeprecated().ifPresent(deprecatedDocsValue -> methodBuilder.addAnnotation(
-                ClassName.get("java.lang", "Deprecated")));
-
-        ServiceGenerator.getJavaDoc(endpointDef).ifPresent(
-                content -> methodBuilder.addJavadoc("$L", content));
-
-        return methodBuilder.build();
-    }
-
-    /** Provides a linear expansion of optional query arguments to improve Java back-compat. */
-    private List<MethodSpec> generateCompatibilityBackfillServiceMethods(
-            EndpointDefinition endpointDef,
-            TypeMapper returnTypeMapper,
-            TypeMapper argumentTypeMapper) {
-
-        List<ArgumentDefinition> queryArgs = Lists.newArrayList();
-
-        for (ArgumentDefinition arg : endpointDef.getArgs()) {
-            if (arg.getParamType().accept(ParameterTypeVisitor.IS_QUERY)
-                    && arg.getType().accept(TYPE_DEFAULTABLE_PREDICATE)) {
-                queryArgs.add(arg);
-            }
-        }
-
-        List<MethodSpec> alternateMethods = Lists.newArrayList();
-        for (int i = 0; i < queryArgs.size(); i++) {
-            alternateMethods.add(createCompatibilityBackfillMethod(
-                    endpointDef,
-                    returnTypeMapper,
-                    argumentTypeMapper,
-                    queryArgs.subList(i, queryArgs.size())));
-        }
-
-        return alternateMethods;
-    }
-
-    private MethodSpec createCompatibilityBackfillMethod(
-            EndpointDefinition endpointDef,
-            TypeMapper returnTypeMapper,
-            TypeMapper argumentTypeMapper,
-            List<ArgumentDefinition> extraArgs) {
-        // ensure the correct ordering of parameters by creating the complete sorted parameter list
-        List<ParameterSpec> sortedParams = createServiceMethodParameters(endpointDef, argumentTypeMapper, false);
-        List<Optional<ArgumentDefinition>> sortedMaybeExtraArgs = sortedParams.stream().map(param ->
-                extraArgs.stream()
-                        .filter(arg -> arg.getArgName().get().equals(param.name))
-                        .findFirst())
-                .collect(Collectors.toList());
-
-        // omit extraArgs from the back fill method signature
-        MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(endpointDef.getEndpointName().get())
-                .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
-                .addAnnotation(Deprecated.class)
-                .addParameters(IntStream.range(0, sortedParams.size())
-                        .filter(i -> !sortedMaybeExtraArgs.get(i).isPresent())
-                        .mapToObj(sortedParams::get)
-                        .collect(Collectors.toList()));
-
-        endpointDef.getReturns().ifPresent(type -> methodBuilder.returns(returnTypeMapper.getClassName(type)));
-
-        // replace extraArgs with default values when invoking the complete method
-        StringBuilder sb = new StringBuilder(endpointDef.getReturns().isPresent() ? "return $N(" : "$N(");
-        List<Object> values = IntStream.range(0, sortedParams.size()).mapToObj(i -> {
-            Optional<ArgumentDefinition> maybeArgDef = sortedMaybeExtraArgs.get(i);
-            if (maybeArgDef.isPresent()) {
-                sb.append("$L, ");
-                return maybeArgDef.get().getType().accept(TYPE_DEFAULT_VALUE);
-            } else {
-                sb.append("$N, ");
-                return sortedParams.get(i);
-            }
-        }).collect(Collectors.toList());
-        // trim the end
-        sb.setLength(sb.length() - 2);
-        sb.append(")");
-
-        ImmutableList<Object> methodCallArgs = ImmutableList.builder()
-                .add(endpointDef.getEndpointName().get())
-                .addAll(values)
-                .build();
-
-        methodBuilder.addStatement(sb.toString(), methodCallArgs.toArray(new Object[0]));
-
-        return methodBuilder.build();
-    }
-
-    private List<ParameterSpec> createServiceMethodParameters(
-            EndpointDefinition endpointDef,
-            TypeMapper typeMapper,
-            boolean withAnnotations) {
-        List<ParameterSpec> parameterSpecs = new ArrayList<>();
-
-        Optional<AuthType> auth = endpointDef.getAuth();
-        createAuthParameter(auth, withAnnotations).ifPresent(parameterSpecs::add);
-
-        ParameterOrder.sorted(endpointDef.getArgs()).forEach(def ->
-                parameterSpecs.add(createServiceMethodParameterArg(typeMapper, def, withAnnotations)));
-        return ImmutableList.copyOf(parameterSpecs);
-    }
-
-    private ParameterSpec createServiceMethodParameterArg(TypeMapper typeMapper, ArgumentDefinition def,
-            boolean withAnnotations) {
-        ParameterSpec.Builder param = ParameterSpec.builder(
-                typeMapper.getClassName(def.getType()), def.getArgName().get());
-        if (withAnnotations) {
-            getParamTypeAnnotation(def).ifPresent(param::addAnnotation);
-            param.addAnnotations(createMarkers(typeMapper, def.getMarkers()));
-        }
-        return param.build();
-    }
-
-    private Optional<ParameterSpec> createAuthParameter(Optional<AuthType> auth, boolean withAnnotations) {
-        if (!auth.isPresent()) {
-            return Optional.empty();
-        }
-
-        ClassName annotationClassName;
-        ClassName tokenClassName;
-        String paramName;
-        String tokenName;
-
-        if (auth.get().accept(AuthTypeVisitor.IS_HEADER)) {
-            annotationClassName = ClassName.get("javax.ws.rs", "HeaderParam");
-            tokenClassName = ClassName.get("com.palantir.tokens.auth", "AuthHeader");
-            paramName = "authHeader";
-            tokenName = "Authorization";
-        } else if (auth.get().accept(AuthTypeVisitor.IS_COOKIE)) {
-            annotationClassName = ClassName.get("javax.ws.rs", "CookieParam");
-            tokenClassName = ClassName.get("com.palantir.tokens.auth", "BearerToken");
-            paramName = "token";
-            tokenName = auth.get().accept(AuthTypeVisitor.COOKIE).getCookieName();
-        } else {
-            throw new IllegalStateException("Unrecognized auth type: " + auth.get());
-        }
-
-        ParameterSpec.Builder paramSpec = ParameterSpec.builder(tokenClassName, paramName);
-        if (withAnnotations) {
-            paramSpec.addAnnotation(AnnotationSpec.builder(annotationClassName)
-                    .addMember("value", "$S", tokenName).build());
-            if (featureFlags.contains(FeatureFlags.RequireNotNullAuthAndBodyParams)) {
-                paramSpec.addAnnotation(AnnotationSpec.builder(NOT_NULL).build());
-            }
-        }
-        return Optional.of(paramSpec.build());
-    }
-
-    private Optional<AnnotationSpec> getParamTypeAnnotation(ArgumentDefinition def) {
-        AnnotationSpec.Builder annotationSpecBuilder;
-        ParameterType paramType = def.getParamType();
-        if (paramType.accept(ParameterTypeVisitor.IS_PATH)) {
-            annotationSpecBuilder = AnnotationSpec.builder(ClassName.get("javax.ws.rs", "PathParam"))
-                    .addMember("value", "$S", def.getArgName().get());
-        } else if (paramType.accept(ParameterTypeVisitor.IS_QUERY)) {
-            ParameterId paramId = paramType.accept(ParameterTypeVisitor.QUERY).getParamId();
-            annotationSpecBuilder = AnnotationSpec.builder(ClassName.get("javax.ws.rs", "QueryParam"))
-                    .addMember("value", "$S", paramId.get());
-        } else if (paramType.accept(ParameterTypeVisitor.IS_HEADER)) {
-            ParameterId paramId = paramType.accept(ParameterTypeVisitor.HEADER).getParamId();
-            annotationSpecBuilder = AnnotationSpec.builder(ClassName.get("javax.ws.rs", "HeaderParam"))
-                    .addMember("value", "$S", paramId.get());
-        } else if (paramType.accept(ParameterTypeVisitor.IS_BODY)) {
-            if (def.getType().accept(TypeVisitor.IS_OPTIONAL)
-                    || !featureFlags.contains(FeatureFlags.RequireNotNullAuthAndBodyParams)) {
-                return Optional.empty();
-            }
-            annotationSpecBuilder = AnnotationSpec
-                    .builder(NOT_NULL);
-        } else {
-            throw new IllegalStateException("Unrecognized argument type: " + def.getParamType());
-        }
-
-        return Optional.of(annotationSpecBuilder.build());
-    }
-
-    private static Set<AnnotationSpec> createMarkers(TypeMapper typeMapper, List<Type> markers) {
-        checkArgument(markers.stream().allMatch(type -> type.accept(TypeVisitor.IS_REFERENCE)),
-                "Markers must refer to reference types.");
-        return markers.stream()
-                .map(typeMapper::getClassName)
-                .map(ClassName.class::cast)
-                .map(AnnotationSpec::builder)
-                .map(AnnotationSpec.Builder::build)
-                .collect(Collectors.toSet());
-    }
-
-    private static ClassName httpMethodToClassName(String method) {
-        switch (method) {
-            case "DELETE":
-                return ClassName.get("javax.ws.rs", "DELETE");
-            case "GET":
-                return ClassName.get("javax.ws.rs", "GET");
-            case "PUT":
-                return ClassName.get("javax.ws.rs", "PUT");
-            case "POST":
-                return ClassName.get("javax.ws.rs", "POST");
-        }
-        throw new IllegalArgumentException("Unrecognized HTTP method: " + method);
-    }
-
-    /** Indicates whether a particular type has a defaultable value. */
-    private static final Type.Visitor<Boolean> TYPE_DEFAULTABLE_PREDICATE = new DefaultTypeVisitor<Boolean>() {
-        @Override
-        public Boolean visitOptional(OptionalType value) {
-            return true;
-        }
-
-        @Override
-        public Boolean visitList(ListType value) {
-            return true;
-        }
-
-        @Override
-        public Boolean visitSet(SetType value) {
-            return true;
-        }
-
-        @Override
-        public Boolean visitMap(MapType value) {
-            return true;
-        }
-
-        @Override
-        public Boolean visitDefault() {
-            return false;
-        }
-    };
-
-    private static final Type.Visitor<CodeBlock> TYPE_DEFAULT_VALUE = new DefaultTypeVisitor<CodeBlock>() {
-        @Override
-        public CodeBlock visitOptional(OptionalType value) {
-            if (value.getItemType().accept(TypeVisitor.IS_PRIMITIVE)) {
-                PrimitiveType primitiveType = value.getItemType().accept(TypeVisitor.PRIMITIVE);
-                // special handling for primitive optionals with Java 8
-                if (primitiveType.equals(PrimitiveType.DOUBLE)) {
-                    return CodeBlock.of("$T.empty()", OptionalDouble.class);
-                } else if (primitiveType.equals(PrimitiveType.INTEGER)) {
-                    return CodeBlock.of("$T.empty()", OptionalInt.class);
-                }
-            }
-            return CodeBlock.of("$T.empty()", Optional.class);
-        }
-
-        @Override
-        public CodeBlock visitList(ListType value) {
-            return CodeBlock.of("$T.emptyList()", Collections.class);
-        }
-
-        @Override
-        public CodeBlock visitSet(SetType value) {
-            return CodeBlock.of("$T.emptySet()", Collections.class);
-        }
-
-        @Override
-        public CodeBlock visitMap(MapType value) {
-            return CodeBlock.of("$T.emptyMap()", Collections.class);
-        }
-
-        @Override
-        public CodeBlock visitDefault() {
-            throw new IllegalArgumentException("Cannot backfill non-defaultable parameter type.");
-        }
-    };
 }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/JaxRsClientGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/JaxRsClientGeneratorTests.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,12 @@
 
 package com.palantir.conjure.java;
 
-import static com.palantir.conjure.java.FeatureFlags.RequireNotNullAuthAndBodyParams;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.conjure.defs.Conjure;
-import com.palantir.conjure.java.services.JerseyServiceGenerator;
+import com.palantir.conjure.java.services.JaxRsClientGenerator;
 import com.palantir.conjure.spec.ConjureDefinition;
 import java.io.File;
 import java.io.IOException;
@@ -36,7 +35,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public final class JerseyServiceGeneratorTests extends TestBase {
+public final class JaxRsClientGeneratorTests extends TestBase {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
@@ -55,15 +54,6 @@ public final class JerseyServiceGeneratorTests extends TestBase {
     }
 
     @Test
-    public void testServiceGeneration_exampleService_requireNotNullAuthHeadersAndRequestBodies() throws IOException {
-        ConjureDefinition def = Conjure.parse(
-                ImmutableList.of(new File("src/test/resources/example-service.yml")));
-        List<Path> files = new JerseyServiceGenerator(
-                ImmutableSet.of(RequireNotNullAuthAndBodyParams)).emit(def, folder.getRoot());
-        validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".jersey_require_not_null");
-    }
-
-    @Test
     public void testConjureImports() throws IOException {
         ConjureDefinition conjure = Conjure.parse(ImmutableList.of(
                 new File("src/test/resources/example-binary.yml"),
@@ -71,29 +61,19 @@ public final class JerseyServiceGeneratorTests extends TestBase {
                 new File("src/test/resources/example-types.yml"),
                 new File("src/test/resources/example-service.yml")));
         File src = folder.newFolder("src");
-        JerseyServiceGenerator generator = new JerseyServiceGenerator(Collections.emptySet());
+        JaxRsClientGenerator generator = new JaxRsClientGenerator(Collections.emptySet());
         generator.emit(conjure, src);
 
         // Generated files contain imports
-        assertThat(compiledFileContent(src, "test/api/with/imports/ImportService.java"))
+        assertThat(compiledFileContent(src, "test/api/with/imports/ImportServiceJaxRsClient.java"))
                 .contains("import com.palantir.product.StringExample;");
     }
 
-    @Test
-    public void testBinaryReturnResponse() throws IOException {
-        ConjureDefinition def = Conjure.parse(
-                ImmutableList.of(new File("src/test/resources/example-binary.yml")));
-        List<Path> files = new JerseyServiceGenerator(ImmutableSet.of(FeatureFlags.JerseyBinaryAsResponse))
-                .emit(def, folder.getRoot());
-        validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".jersey.binary_as_response");
-    }
-
     private void testServiceGeneration(String conjureFile) throws IOException {
-        ConjureDefinition def = Conjure.parse(
-                ImmutableList.of(new File("src/test/resources/" + conjureFile + ".yml")));
-        List<Path> files = new JerseyServiceGenerator(ImmutableSet.of(RequireNotNullAuthAndBodyParams)).emit(def,
-                folder.getRoot());
-        validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".jersey");
+        ConjureDefinition def = Conjure.parse(ImmutableList.of(
+                new File("src/test/resources/" + conjureFile + ".yml")));
+        List<Path> files = new JaxRsClientGenerator(ImmutableSet.of()).emit(def, folder.getRoot());
+        validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".jaxrs");
     }
 
 }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/TestBase.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/TestBase.java
@@ -53,7 +53,12 @@ public abstract class TestBase {
         for (Path file : files) {
             Path output = outputDir.resolve(file.getFileName() + suffix);
             if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
-                Files.delete(output);
+                if (Files.exists(output)) {
+                    Files.delete(output);
+                }
+                if (!Files.isDirectory(output.getParent())) {
+                    Files.createDirectories(output.getParent());
+                }
                 Files.copy(file, output);
             }
             assertThat(readFromFile(file)).isEqualTo(readFromFile(output));

--- a/conjure-java-core/src/test/resources/example-binary.yml
+++ b/conjure-java-core/src/test/resources/example-binary.yml
@@ -1,5 +1,5 @@
 services:
-  TestService:
+  BinaryTestService:
     default-auth: none
     base-path: /
     package: test.api

--- a/conjure-java-core/src/test/resources/test/api/BinaryTestService.java.jersey.binary_as_response
+++ b/conjure-java-core/src/test/resources/test/api/BinaryTestService.java.jersey.binary_as_response
@@ -1,0 +1,19 @@
+package test.api;
+
+import javax.annotation.Generated;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/")
+@Generated("com.palantir.conjure.java.services.JerseyServiceGenerator")
+public interface BinaryTestService {
+    @GET
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    Response getBinary();
+}

--- a/conjure-java-core/src/test/resources/test/api/BinaryTestService.java.undertow.binary
+++ b/conjure-java-core/src/test/resources/test/api/BinaryTestService.java.undertow.binary
@@ -4,6 +4,6 @@ import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
-public interface TestService {
+public interface BinaryTestService {
     BinaryResponseBody getBinary();
 }

--- a/conjure-java-core/src/test/resources/test/api/BinaryTestServiceEndpoints.java.undertow.binary
+++ b/conjure-java-core/src/test/resources/test/api/BinaryTestServiceEndpoints.java.undertow.binary
@@ -15,15 +15,15 @@ import java.util.List;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceHandlerGenerator")
-public final class TestServiceEndpoints implements UndertowService {
-    private final TestService delegate;
+public final class BinaryTestServiceEndpoints implements UndertowService {
+    private final BinaryTestService delegate;
 
-    private TestServiceEndpoints(TestService delegate) {
+    private BinaryTestServiceEndpoints(BinaryTestService delegate) {
         this.delegate = delegate;
     }
 
-    public static UndertowService of(TestService delegate) {
-        return new TestServiceEndpoints(delegate);
+    public static UndertowService of(BinaryTestService delegate) {
+        return new BinaryTestServiceEndpoints(delegate);
     }
 
     @Override
@@ -35,9 +35,9 @@ public final class TestServiceEndpoints implements UndertowService {
     private static final class GetBinaryEndpoint implements HttpHandler, Endpoint {
         private final UndertowRuntime runtime;
 
-        private final TestService delegate;
+        private final BinaryTestService delegate;
 
-        GetBinaryEndpoint(UndertowRuntime runtime, TestService delegate) {
+        GetBinaryEndpoint(UndertowRuntime runtime, BinaryTestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
         }
@@ -60,7 +60,7 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "TestService";
+            return "BinaryTestService";
         }
 
         @Override

--- a/conjure-java-core/src/test/resources/test/api/CookieServiceJaxRsClient.java.jaxrs
+++ b/conjure-java-core/src/test/resources/test/api/CookieServiceJaxRsClient.java.jaxrs
@@ -1,19 +1,20 @@
 package test.api;
 
+import com.palantir.tokens.auth.BearerToken;
 import javax.annotation.Generated;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.CookieParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 @Path("/")
-@Generated("com.palantir.conjure.java.services.JerseyServiceGenerator")
-public interface TestService {
+@Generated("com.palantir.conjure.java.services.JaxRsClientGenerator")
+public interface CookieServiceJaxRsClient {
     @GET
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    Response getBinary();
+    @Path("cookies")
+    void eatCookies(@CookieParam("PALANTIR_TOKEN") BearerToken token);
 }

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
@@ -16,6 +16,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.Set;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -35,6 +36,7 @@ import javax.ws.rs.core.StreamingOutput;
 @Generated("com.palantir.conjure.java.services.JerseyServiceGenerator")
 public interface TestService {
     /** Returns a mapping from file system id to backing file system configuration. */
+    @Nonnull
     @GET
     @Path("catalog/fileSystems")
     Map<String, BackingFileSystem> getFileSystems(

--- a/conjure-java-core/src/test/resources/test/api/TestServiceJaxRsClient.java.jaxrs
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceJaxRsClient.java.jaxrs
@@ -17,7 +17,6 @@ import java.util.OptionalInt;
 import java.util.Set;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
-import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -27,78 +26,74 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.StreamingOutput;
 
 /** A Markdown description of the service. */
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 @Path("/")
-@Generated("com.palantir.conjure.java.services.JerseyServiceGenerator")
-public interface TestService {
+@Generated("com.palantir.conjure.java.services.JaxRsClientGenerator")
+public interface TestServiceJaxRsClient {
     /** Returns a mapping from file system id to backing file system configuration. */
     @Nonnull
     @GET
     @Path("catalog/fileSystems")
     Map<String, BackingFileSystem> getFileSystems(
-            @HeaderParam("Authorization") @NotNull AuthHeader authHeader);
+            @HeaderParam("Authorization") AuthHeader authHeader);
 
     @POST
     @Path("catalog/datasets")
     Dataset createDataset(
-            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @HeaderParam("Authorization") AuthHeader authHeader,
             @HeaderParam("Test-Header") String testHeaderArg,
-            @NotNull CreateDatasetRequest request);
+            CreateDatasetRequest request);
 
     @GET
     @Path("catalog/datasets/{datasetRid}")
     Optional<Dataset> getDataset(
-            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @HeaderParam("Authorization") AuthHeader authHeader,
             @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/raw")
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    StreamingOutput getRawData(
-            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+    InputStream getRawData(
+            @HeaderParam("Authorization") AuthHeader authHeader,
             @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/raw-aliased")
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    StreamingOutput getAliasedRawData(
-            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+    InputStream getAliasedRawData(
+            @HeaderParam("Authorization") AuthHeader authHeader,
             @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/raw-maybe")
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    Optional<StreamingOutput> maybeGetRawData(
-            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+    Optional<InputStream> maybeGetRawData(
+            @HeaderParam("Authorization") AuthHeader authHeader,
             @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/string-aliased")
     AliasedString getAliasedString(
-            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @HeaderParam("Authorization") AuthHeader authHeader,
             @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
 
     @POST
     @Path("catalog/datasets/upload-raw")
     @Consumes(MediaType.APPLICATION_OCTET_STREAM)
-    void uploadRawData(
-            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @NotNull InputStream input);
+    void uploadRawData(@HeaderParam("Authorization") AuthHeader authHeader, InputStream input);
 
     @POST
     @Path("catalog/datasets/upload-raw-aliased")
     void uploadAliasedRawData(
-            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @NotNull NestedAliasedBinary input);
+            @HeaderParam("Authorization") AuthHeader authHeader, NestedAliasedBinary input);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/branches")
     Set<String> getBranches(
-            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @HeaderParam("Authorization") AuthHeader authHeader,
             @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
 
     /**
@@ -110,66 +105,65 @@ public interface TestService {
     @Path("catalog/datasets/{datasetRid}/branchesDeprecated")
     @Deprecated
     Set<String> getBranchesDeprecated(
-            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @HeaderParam("Authorization") AuthHeader authHeader,
             @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
     Optional<String> resolveBranch(
-            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @HeaderParam("Authorization") AuthHeader authHeader,
             @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid,
             @PathParam("branch") String branch);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/testParam")
     Optional<String> testParam(
-            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @HeaderParam("Authorization") AuthHeader authHeader,
             @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @POST
     @Path("catalog/test-query-params")
     int testQueryParams(
-            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @HeaderParam("Authorization") AuthHeader authHeader,
             @QueryParam("different") ResourceIdentifier something,
             @QueryParam("implicit") ResourceIdentifier implicit,
             @QueryParam("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @QueryParam("setEnd") Set<String> setEnd,
             @QueryParam("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
-            @NotNull String query);
+            String query);
 
     @POST
     @Path("catalog/test-no-response-query-params")
     void testNoResponseQueryParams(
-            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @HeaderParam("Authorization") AuthHeader authHeader,
             @QueryParam("different") ResourceIdentifier something,
             @QueryParam("implicit") ResourceIdentifier implicit,
             @QueryParam("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @QueryParam("setEnd") Set<String> setEnd,
             @QueryParam("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
-            @NotNull String query);
+            String query);
 
     @GET
     @Path("catalog/boolean")
-    boolean testBoolean(@HeaderParam("Authorization") @NotNull AuthHeader authHeader);
+    boolean testBoolean(@HeaderParam("Authorization") AuthHeader authHeader);
 
     @GET
     @Path("catalog/double")
-    double testDouble(@HeaderParam("Authorization") @NotNull AuthHeader authHeader);
+    double testDouble(@HeaderParam("Authorization") AuthHeader authHeader);
 
     @GET
     @Path("catalog/integer")
-    int testInteger(@HeaderParam("Authorization") @NotNull AuthHeader authHeader);
+    int testInteger(@HeaderParam("Authorization") AuthHeader authHeader);
 
     @POST
     @Path("catalog/optional")
     Optional<String> testPostOptional(
-            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            Optional<String> maybeString);
+            @HeaderParam("Authorization") AuthHeader authHeader, Optional<String> maybeString);
 
     @GET
     @Path("catalog/optional-integer-double")
     void testOptionalIntegerAndDouble(
-            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @HeaderParam("Authorization") AuthHeader authHeader,
             @QueryParam("maybeInteger") OptionalInt maybeInteger,
             @QueryParam("maybeDouble") OptionalDouble maybeDouble);
 

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/CliConfiguration.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/CliConfiguration.java
@@ -37,6 +37,12 @@ public abstract class CliConfiguration {
 
     @Value.Default
     @SuppressWarnings("checkstyle:designforextension")
+    boolean generateJaxRsClient() {
+        return false;
+    }
+
+    @Value.Default
+    @SuppressWarnings("checkstyle:designforextension")
     boolean generateJersey() {
         return false;
     }
@@ -64,7 +70,8 @@ public abstract class CliConfiguration {
     final void check() {
         Preconditions.checkArgument(input().isFile(), "Target must exist and be a file");
         Preconditions.checkArgument(outputDirectory().isDirectory(), "Output must exist and be a directory");
-        Preconditions.checkArgument(generateObjects() ^ generateJersey() ^ generateRetrofit() ^ generateUndertow(),
+        Preconditions.checkArgument(generateObjects() ^ generateJaxRsClient()
+                        ^ generateJersey() ^ generateRetrofit() ^ generateUndertow(),
                 "Must specify exactly one project to generate");
     }
 

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -27,7 +27,6 @@ import com.palantir.conjure.java.services.Retrofit2ServiceGenerator;
 import com.palantir.conjure.java.services.UndertowServiceGenerator;
 import com.palantir.conjure.java.types.ObjectGenerator;
 import com.palantir.conjure.spec.ConjureDefinition;
-import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -157,7 +156,7 @@ public final class ConjureJavaCli implements Runnable {
                             .emit(conjureDefinition, config.outputDirectory());
                 }
             } catch (IOException e) {
-                throw new SafeRuntimeException("Error parsing definition", e);
+                throw new RuntimeException("Error parsing definition", e);
             }
         }
 

--- a/gradle/verifier.gradle
+++ b/gradle/verifier.gradle
@@ -75,6 +75,16 @@ task conjureJavaObjects(type: JavaExec) {
     doFirst { delete "src/generatedObjects/java/*" }
 }
 
+task conjureJavaJaxRsClient(type: JavaExec) {
+    main = "com.palantir.conjure.java.cli.ConjureJavaCli"
+    classpath = project(':conjure-java').sourceSets.main.runtimeClasspath
+    args 'generate',  "${-> configurations.verificationApi.singleFile}", 'src/generatedJersey/java', '--jaxRsClient'
+
+    inputs.file "${-> configurations.verificationApi.singleFile}"
+    outputs.dir "src/generatedJersey/java"
+    doFirst { delete "src/generatedJersey/java/*" }
+}
+
 task conjureJavaJersey(type: JavaExec) {
     main = "com.palantir.conjure.java.cli.ConjureJavaCli"
     classpath = project(':conjure-java').sourceSets.main.runtimeClasspath
@@ -97,6 +107,7 @@ task conjureJavaUndertow(type: JavaExec) {
 }
 
 compileGeneratedObjectsJava.dependsOn conjureJavaObjects
+compileGeneratedObjectsJava.dependsOn conjureJavaJaxRsClient
 compileGeneratedObjectsJava.dependsOn conjureJavaJersey
 compileGeneratedObjectsJava.dependsOn conjureJavaUndertow
 

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,10 @@ The recommended way to use conjure-java is via a build tool like [gradle-conjure
 
     Options:
         --objects    Generate POJOs for Conjure type definitions
-        --jersey     Generate jax-rs annotated interfaces for client or server-usage
+        --jaxRsClient
+                     Generate jax-rs annotated interfaces for client usage
+        --jersey     Generate jax-rs annotated interfaces server-usage. These may produce functional clients in many
+                     cases, however the '--jaxRsClient' option is preferred for client usage
         --undertow   Generate undertow handlers and interfaces for server-usage
         --retrofit   Generate retrofit interfaces for streaming/async clients
         --requireNotNullAuthAndBodyParams


### PR DESCRIPTION
**Why**
Many use cases are better suited for blocking clients. There is no
doubt that asynchronous clients can be more powerful, however
they're often both unnecessary and dangerous. Threads are hard,
and it's best to avoid thinking about them until we need to.

The existing Jersey generator is sufficient in many cases,
but it's entirely broken for streaming binary data. Because
the Jersey generator outputs code for both clients and servers,
it must be a jack of all trades and master of none. For example,
there's no reason for server interfaces to scramble argument
order or provide default methods, but they do so because it's
helpful when the interface is reused by clients. There's also
no reason for client interfaces to return a server-side
`StreamingOutput` from binary methods because the type is
unhelpful to clients. By decoupling client and server
interfaces we allow ourselves to generate more accurate
code for both.

**What**
This change adds a `--jaxRsClient` flag to the CLI to generate
client-specific interfaces. Our JaxRsClient interfaces differ
in a few ways:
1. Generated interfaces names are suffixed with `JaxRsClient`
   to differentiate them from Jersey services and avoid classpath
   conflicts.
2. `returns: binary` results in methods which return InputStream
3. `returns: optional<binary>` results in methods which return
   `Optional<InputStream>`
4. The generator ignores `--requireNotNullAuthAndBodyParams`
   because feign doesn't use doesn't use
   `javax.validation.constraints`

**Future Work**
I plan to update `conjure-java-runtime` JaxRsClients to avoid fully
buffering binary request and response bodies on heap. This is not
a blocker for the generator because we have decided that buffering
binary request bodies is acceptable, so we can temporarily allow
the same behavior for responses.

==COMMIT_MSG==
[feature] JAX-RS client Conjure generator
==COMMIT_MSG==
