### PR TITLE
[fix] conjure-undertow supports empty request body empty optionals

### DIFF
--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -343,6 +343,25 @@ public final class UndertowServiceEteTest extends TestBase {
     }
 
     @Test
+    public void testExternalImportOptionalEmptyBodyZeroLength_noContentType() throws IOException {
+        URL url = new URL("http://0.0.0.0:8080/test-example/api/base/external/optional-body");
+        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        con.setRequestMethod("POST");
+        con.setRequestProperty(HttpHeaders.AUTHORIZATION, AuthHeader.valueOf("authHeader").toString());
+        assertThat(con.getResponseCode()).isEqualTo(204);
+    }
+
+    @Test
+    public void testExternalImportOptionalEmptyBodyZeroLength_withContentType() throws IOException {
+        URL url = new URL("http://0.0.0.0:8080/test-example/api/base/external/optional-body");
+        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        con.setRequestMethod("POST");
+        con.setRequestProperty(HttpHeaders.CONTENT_TYPE, "application/json");
+        con.setRequestProperty(HttpHeaders.AUTHORIZATION, AuthHeader.valueOf("authHeader").toString());
+        assertThat(con.getResponseCode()).isEqualTo(204);
+    }
+
+    @Test
     public void testUnknownContentType() {
         assertThatThrownBy(() -> binaryClient.postBinary(AuthHeader.valueOf("authHeader"),
                 RequestBody.create(MediaType.parse("application/unsupported"), new byte[] {1, 2, 3})).execute())

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
@@ -149,11 +149,10 @@ final class ConjureBodySerDe implements BodySerDe {
 
         @Override
         public T deserialize(HttpServerExchange exchange) throws IOException {
-            InputStream requestStream = exchange.getInputStream();
             if (optionalType && maybeEmptyBody(exchange)) {
                 return deserializeOptional(exchange);
             }
-            return deserializeInternal(exchange, requestStream);
+            return deserializeInternal(exchange, exchange.getInputStream());
         }
 
         private T deserializeOptional(HttpServerExchange exchange) throws IOException {

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
@@ -30,6 +30,7 @@ import io.undertow.util.HeaderValues;
 import io.undertow.util.Headers;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PushbackInputStream;
 import java.util.List;
 
 /** Package private internal API. */
@@ -135,17 +136,45 @@ final class ConjureBodySerDe implements BodySerDe {
     private static final class EncodingDeserializerRegistry<T> implements Deserializer<T> {
 
         private final List<EncodingDeserializerContainer<T>> encodings;
+        private final boolean optionalType;
+        private final TypeMarker<T> marker;
 
         EncodingDeserializerRegistry(List<Encoding> encodings, TypeMarker<T> token) {
             this.encodings = encodings.stream()
                     .map(encoding -> new EncodingDeserializerContainer<>(encoding, token))
                     .collect(ImmutableList.toImmutableList());
+            this.optionalType = TypeMarkers.isOptional(token);
+            this.marker = token;
         }
 
         @Override
         public T deserialize(HttpServerExchange exchange) throws IOException {
+            InputStream requestStream = exchange.getInputStream();
+            if (optionalType && maybeEmptyBody(exchange)) {
+                return deserializeOptional(exchange);
+            }
+            return deserializeInternal(exchange, requestStream);
+        }
+
+        private T deserializeOptional(HttpServerExchange exchange) throws IOException {
+            PushbackInputStream requestStream = new PushbackInputStream(exchange.getInputStream(), 1);
+            int read = requestStream.read();
+            if (read == -1) {
+                return TypeMarkers.getEmptyOptional(marker);
+            }
+            requestStream.unread(read);
+            return deserializeInternal(exchange, requestStream);
+        }
+
+        private T deserializeInternal(HttpServerExchange exchange, InputStream requestStream) throws IOException {
             EncodingDeserializerContainer<T> container = getRequestDeserializer(exchange);
-            return container.deserializer.deserialize(exchange.getInputStream());
+            return container.deserializer.deserialize(requestStream);
+        }
+
+        private static boolean maybeEmptyBody(HttpServerExchange exchange) {
+            // Content-Length maybe null if "Transfer-Encoding: chunked" is sent with a full body.
+            String contentLength = exchange.getRequestHeaders().getFirst(Headers.CONTENT_LENGTH);
+            return contentLength == null || "0".equals(contentLength);
         }
 
         /** Returns the {@link EncodingDeserializerContainer} to use to deserialize the request body. */

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encodings.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encodings.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.java.undertow.runtime;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -56,9 +57,11 @@ public final class Encodings {
 
         @Override
         public <T> Deserializer<T> deserializer(TypeMarker<T> type) {
-            ObjectReader reader = mapper.readerFor(mapper.constructType(type.getType()));
+            JavaType javaType = mapper.constructType(type.getType());
+            ObjectReader reader = mapper.readerFor(javaType);
             return input -> {
                 try {
+                    mapper.convertValue(null, javaType);
                     T value = reader.readValue(input);
                     // Bad input should result in a 4XX response status, throw IAE rather than NPE.
                     Preconditions.checkArgument(value != null, "cannot deserialize a JSON null value");

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encodings.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encodings.java
@@ -17,7 +17,6 @@
 package com.palantir.conjure.java.undertow.runtime;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -57,11 +56,9 @@ public final class Encodings {
 
         @Override
         public <T> Deserializer<T> deserializer(TypeMarker<T> type) {
-            JavaType javaType = mapper.constructType(type.getType());
-            ObjectReader reader = mapper.readerFor(javaType);
+            ObjectReader reader = mapper.readerFor(mapper.constructType(type.getType()));
             return input -> {
                 try {
-                    mapper.convertValue(null, javaType);
                     T value = reader.readValue(input);
                     // Bad input should result in a 4XX response status, throw IAE rather than NPE.
                     Preconditions.checkArgument(value != null, "cannot deserialize a JSON null value");

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/TypeMarkers.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/TypeMarkers.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+
+final class TypeMarkers {
+
+    static boolean isOptional(TypeMarker<?> marker) {
+        Type type = marker.getType();
+        if (OptionalDouble.class.equals(type) || OptionalInt.class.equals(type) || OptionalLong.class.equals(type)) {
+            return true;
+        }
+        if (type instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType) type;
+            return Optional.class.equals(parameterizedType.getRawType());
+        }
+        return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> T getEmptyOptional(TypeMarker<T> marker) {
+        Type type = marker.getType();
+        if (type instanceof ParameterizedType && Optional.class.equals(((ParameterizedType) type).getRawType())) {
+            return (T) Optional.empty();
+        } else if (OptionalDouble.class.equals(type)) {
+            return (T) OptionalDouble.empty();
+        } else if (OptionalInt.class.equals(type)) {
+            return (T) OptionalInt.empty();
+        } else if (OptionalLong.class.equals(type)) {
+            return (T) OptionalLong.empty();
+        }
+        throw new SafeIllegalArgumentException("Expected a TypeMarker representing an optional type",
+                SafeArg.of("marker", marker));
+    }
+
+    private TypeMarkers() {}
+}

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/TypeMarkersTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/TypeMarkersTest.java
@@ -1,0 +1,89 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import org.junit.Test;
+
+public class TypeMarkersTest {
+
+    @Test
+    public void testIsOptional_optional() {
+        assertThat(TypeMarkers.isOptional(new TypeMarker<Optional<String>>() {})).isTrue();
+    }
+
+    @Test
+    public void testIsOptional_optionalDouble() {
+        assertThat(TypeMarkers.isOptional(new TypeMarker<OptionalDouble>() {})).isTrue();
+    }
+
+    @Test
+    public void testIsOptional_optionalLong() {
+        assertThat(TypeMarkers.isOptional(new TypeMarker<OptionalLong>() {})).isTrue();
+    }
+
+    @Test
+    public void testIsOptional_optionalInt() {
+        assertThat(TypeMarkers.isOptional(new TypeMarker<OptionalInt>() {})).isTrue();
+    }
+
+    @Test
+    public void testIsOptional_object() {
+        assertThat(TypeMarkers.isOptional(new TypeMarker<Object>() {})).isFalse();
+    }
+
+    @Test
+    public void testIsOptional_listOptional() {
+        assertThat(TypeMarkers.isOptional(new TypeMarker<List<Optional<String>>>() {})).isFalse();
+    }
+
+    @Test
+    public void testGetEmptyOptional_optional() {
+        assertThat(TypeMarkers.getEmptyOptional(new TypeMarker<Optional<String>>() {})).isEmpty();
+    }
+
+    @Test
+    public void testGetEmptyOptional_optionalDouble() {
+        assertThat(TypeMarkers.getEmptyOptional(new TypeMarker<OptionalDouble>() {})).isEmpty();
+    }
+
+    @Test
+    public void testGetEmptyOptional_optionalLong() {
+        assertThat(TypeMarkers.getEmptyOptional(new TypeMarker<OptionalLong>() {})).isEmpty();
+    }
+
+    @Test
+    public void testGetEmptyOptional_optionalInt() {
+        assertThat(TypeMarkers.getEmptyOptional(new TypeMarker<OptionalInt>() {})).isEmpty();
+    }
+
+    @Test
+    public void testGetEmptyOptional_notOptionalType() {
+        assertThatLoggableExceptionThrownBy(() -> TypeMarkers.getEmptyOptional(new TypeMarker<String>() {}))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasLogMessage("Expected a TypeMarker representing an optional type");
+    }
+}


### PR DESCRIPTION
## Before this PR
Requests with optional body types would only be parsed if JSON `null` was provided, not if the body was not included.

## After this PR
==COMMIT_MSG==
conjure-undertow supports empty request body empty optional values
==COMMIT_MSG==

Fix #317
