### PR TITLE
[proposal][wip] conjure-undertow async request processing (Callback)

### DIFF
--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureAsyncRequestProcessing.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureAsyncRequestProcessing.java
@@ -1,0 +1,144 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
+import com.palantir.conjure.java.api.errors.SerializableError;
+import com.palantir.conjure.java.undertow.lib.AsyncContext;
+import com.palantir.conjure.java.undertow.lib.AsyncRequestProcessing;
+import com.palantir.conjure.java.undertow.lib.ReturnValueWriter;
+import com.palantir.conjure.java.undertow.lib.Serializer;
+import com.palantir.logsafe.Preconditions;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xnio.XnioExecutor;
+
+final class ConjureAsyncRequestProcessing implements AsyncRequestProcessing {
+
+    private static final Logger log = LoggerFactory.getLogger(ConjureAsyncRequestProcessing.class);
+
+    private final Serializer<SerializableError> exceptionSerializer = ConjureExceptions.serializer();
+
+    private final Duration timeout;
+
+    ConjureAsyncRequestProcessing(Duration timeout) {
+        this.timeout = Preconditions.checkNotNull(timeout, "Timeout is required");
+    }
+
+    @Override
+    public <T> AsyncContext<T> context(ReturnValueWriter<T> returnValueWriter, HttpServerExchange exchange) {
+        DefaultAsyncContext<T> context = new DefaultAsyncContext<>(returnValueWriter, exchange);
+        context.register();
+        return context;
+    }
+
+    final class DefaultAsyncContext<T> implements AsyncContext<T>, FutureCallback<T> {
+
+        private final ReturnValueWriter<T> returnValueWriter;
+        private final HttpServerExchange exchange;
+        private final SettableFuture<T> future = SettableFuture.create();
+
+        private final List<Runnable> onTimeout = Lists.newCopyOnWriteArrayList();
+        private volatile XnioExecutor.Key timeoutKey;
+        private volatile boolean registered;
+
+        DefaultAsyncContext(ReturnValueWriter<T> returnValueWriter, HttpServerExchange exchange) {
+            this.returnValueWriter = returnValueWriter;
+            this.exchange = exchange;
+        }
+
+        @Override
+        public boolean complete(T value) {
+            return future.set(value);
+        }
+
+        @Override
+        public boolean completeExceptionally(Throwable throwable) {
+            return future.setException(throwable);
+        }
+
+        @Override
+        public void onTimeout(Runnable onTimeoutCallback) {
+            Preconditions.checkState(!registered,
+                    "Timeout callbacks must me registered on the initial request thread");
+            onTimeout.add(onTimeoutCallback);
+        }
+
+        void timeout() {
+            // Only execute cancellation if the request has not already been completed normally
+            // TODO(ckozak): Consider 'if (completeExceptionally(<specific exception>))' for clarity
+            if (future.cancel(false)
+                    // Bypass if there is no timeout listener
+                    && !onTimeout.isEmpty()) {
+                // Always execute timeouts from the task pool
+                exchange.dispatch(serverExchange -> onTimeout.forEach(runnable -> {
+                    try {
+                        runnable.run();
+                    } catch (RuntimeException e) {
+                        log.error("Timeout callback failed", e);
+                    }
+                }));
+            }
+        }
+
+        void register() {
+            exchange.dispatch(() -> {
+                registered = true;
+                // TODO(ckozak): potential optimization: avoid scheduling a timeout if the future is already complete.
+                // Timeout scheduling MUST occur prior to adding the future callback, otherwise quick completion
+                // will fail to remove scheduled tasks.
+                this.timeoutKey = exchange.getIoThread()
+                        .executeAfter(this::timeout, timeout.toMillis(), TimeUnit.MILLISECONDS);
+                Futures.addCallback(future, this, MoreExecutors.directExecutor());
+            });
+        }
+
+        // Guava FutureCallback
+
+        @Override
+        public void onSuccess(T result) {
+            completeCallback(serverExchange -> returnValueWriter.write(result, exchange));
+        }
+
+        @Override
+        public void onFailure(Throwable throwable) {
+            completeCallback(serverExchange ->
+                    ConjureExceptions.handle(serverExchange, exceptionSerializer, throwable));
+        }
+
+        private void completeCallback(HttpHandler completionHandler) {
+            removeTimeout();
+            exchange.dispatch(new ConjureExceptionHandler(completionHandler, exceptionSerializer));
+        }
+
+        private void removeTimeout() {
+            XnioExecutor.Key key = this.timeoutKey;
+            if (key != null) {
+                key.remove();
+            }
+        }
+    }
+}

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptionHandler.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptionHandler.java
@@ -16,27 +16,10 @@
 
 package com.palantir.conjure.java.undertow.runtime;
 
-import com.palantir.conjure.java.api.errors.ErrorType;
-import com.palantir.conjure.java.api.errors.QosException;
-import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.SerializableError;
-import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.conjure.java.undertow.lib.Serializer;
-import com.palantir.conjure.java.undertow.lib.TypeMarker;
-import com.palantir.logsafe.SafeArg;
-import io.undertow.io.UndertowOutputStream;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
-import io.undertow.util.Headers;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.time.temporal.ChronoUnit;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.function.Consumer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.xnio.IoUtils;
 
 /**
  * Delegates to the given {@link HttpHandler}, and catches&forwards all {@link Throwable}s. Any exception thrown in
@@ -45,16 +28,17 @@ import org.xnio.IoUtils;
  */
 final class ConjureExceptionHandler implements HttpHandler {
 
-    private static final Logger log = LoggerFactory.getLogger(ConjureExceptionHandler.class);
-
-    // Exceptions should always be serialized using JSON
-    private final Serializer<SerializableError> serializer =
-            new ConjureBodySerDe(Collections.singletonList(Encodings.json()))
-            .serializer(new TypeMarker<SerializableError>() {});
+    private final Serializer<SerializableError> serializer;
     private final HttpHandler delegate;
 
     ConjureExceptionHandler(HttpHandler delegate) {
+        this(delegate, ConjureExceptions.serializer());
+    }
+
+    // Constructor allows new exception handlers to be created without creating new serializer instances.
+    ConjureExceptionHandler(HttpHandler delegate, Serializer<SerializableError> serializer) {
         this.delegate = delegate;
+        this.serializer = serializer;
     }
 
     @Override
@@ -62,172 +46,7 @@ final class ConjureExceptionHandler implements HttpHandler {
         try {
             delegate.handleRequest(exchange);
         } catch (Throwable throwable) {
-            if (throwable instanceof ServiceException) {
-                serviceException(exchange, (ServiceException) throwable);
-            } else if (throwable instanceof QosException) {
-                qosException(exchange, (QosException) throwable);
-            } else if (throwable instanceof RemoteException) {
-                remoteException(exchange, (RemoteException) throwable);
-            } else if (throwable instanceof IllegalArgumentException) {
-                illegalArgumentException(exchange, throwable);
-            } else if (throwable instanceof FrameworkException) {
-                frameworkException(exchange, (FrameworkException) throwable);
-            } else if (throwable instanceof Error) {
-                throw (Error) throwable;
-            } else {
-                ServiceException exception = new ServiceException(ErrorType.INTERNAL, throwable);
-                log(exception);
-                writeResponse(
-                        exchange,
-                        Optional.of(SerializableError.forException(exception)),
-                        exception.getErrorType().httpErrorCode());
-            }
+            ConjureExceptions.handle(exchange, serializer, throwable);
         }
     }
-
-    private void serviceException(HttpServerExchange exchange, ServiceException exception) {
-        log(exception);
-        writeResponse(
-                exchange,
-                Optional.of(SerializableError.forException(exception)),
-                exception.getErrorType().httpErrorCode());
-    }
-
-    private void qosException(HttpServerExchange exchange, QosException exception) {
-        exception.accept(QOS_EXCEPTION_HEADERS).accept(exchange);
-        log.debug("Possible quality-of-service intervention", exception);
-        writeResponse(
-                exchange,
-                Optional.empty(),
-                exception.accept(QOS_EXCEPTION_STATUS_CODE));
-    }
-
-    // RemoteExceptions are thrown by Conjure clients to indicate a remote/service-side problem.
-    // We forward these exceptions, but change the ErrorType to INTERNAL, i.e., the problem is now
-    // considered internal to *this* service rather than the originating service. This means in particular
-    // that Conjure errors are defined only local to a given service and these error types don't
-    // propagate through other services.
-    private void remoteException(HttpServerExchange exchange, RemoteException exception) {
-        // log at WARN instead of ERROR because although this indicates an issue in a remote server
-        log.warn("Encountered a remote exception. Mapping to an internal error before propagating",
-                SafeArg.of("errorInstanceId", exception.getError().errorInstanceId()),
-                SafeArg.of("errorName", exception.getError().errorName()),
-                SafeArg.of("statusCode", exception.getStatus()),
-                exception);
-
-        ErrorType errorType = ErrorType.INTERNAL;
-        writeResponse(exchange,
-                Optional.of(SerializableError.builder()
-                        .errorName(errorType.name())
-                        .errorCode(errorType.code().toString())
-                        .errorInstanceId(exception.getError().errorInstanceId())
-                        .build()),
-                errorType.httpErrorCode());
-    }
-
-    private void illegalArgumentException(HttpServerExchange exchange, Throwable throwable) {
-        ServiceException exception = new ServiceException(ErrorType.INVALID_ARGUMENT, throwable);
-        log(exception);
-        writeResponse(
-                exchange,
-                Optional.of(SerializableError.forException(exception)),
-                exception.getErrorType().httpErrorCode());
-    }
-
-    private void frameworkException(HttpServerExchange exchange, FrameworkException frameworkException) {
-        int statusCode = frameworkException.getStatusCode();
-        ErrorType errorType = statusCode / 100 == 4 ? ErrorType.INVALID_ARGUMENT : ErrorType.INTERNAL;
-        ServiceException exception = new ServiceException(errorType, frameworkException);
-        log(exception);
-        writeResponse(exchange, Optional.of(SerializableError.forException(exception)), statusCode);
-    }
-
-    private void writeResponse(HttpServerExchange exchange, Optional<SerializableError> maybeBody, int statusCode) {
-        // Do not attempt to write the failure if data has already been written
-        if (!isResponseStarted(exchange)) {
-            exchange.setStatusCode(statusCode);
-            try {
-                if (maybeBody.isPresent()) {
-                    serializer.serialize(maybeBody.get(), exchange);
-                }
-            } catch (IOException | RuntimeException e) {
-                log.info("Failed to write error response", e);
-            }
-        } else {
-            // This prevents the server from sending the final null chunk, alerting
-            // clients that the response was terminated prior to receiving full contents.
-            // Note that in the case of http/2 this does not close a connection, which
-            // would break other active requests, only resets the stream.
-            log.warn("Closing the connection to alert the client of an error");
-            IoUtils.safeClose(exchange.getConnection());
-        }
-    }
-
-    private static boolean isResponseStarted(HttpServerExchange exchange) {
-        if (exchange.isResponseStarted()) {
-            return true;
-        }
-        // The blocking exchange output stream may have un-committed data buffered.
-        // In this case we can clear the buffer allowing us to send a serializable error.
-        OutputStream outputStream = exchange.getOutputStream();
-        if (outputStream instanceof UndertowOutputStream) {
-            ((UndertowOutputStream) outputStream).resetBuffer();
-        }
-        return false;
-    }
-
-    private static void log(ServiceException exception) {
-        if (exception.getErrorType().httpErrorCode() / 100 == 4 /* client error */) {
-            log.info("Error handling request",
-                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()),
-                    SafeArg.of("errorName", exception.getErrorType().name()),
-                    exception);
-        } else {
-            log.error("Error handling request",
-                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()),
-                    SafeArg.of("errorName", exception.getErrorType().name()),
-                    exception);
-        }
-    }
-
-    private static final QosException.Visitor<Integer> QOS_EXCEPTION_STATUS_CODE = new QosException.Visitor<Integer>() {
-        @Override
-        public Integer visit(QosException.Throttle exception) {
-            return 429;
-        }
-
-        @Override
-        public Integer visit(QosException.RetryOther exception) {
-            return 308;
-        }
-
-        @Override
-        public Integer visit(QosException.Unavailable exception) {
-            return 503;
-        }
-    };
-
-    private static final QosException.Visitor<Consumer<HttpServerExchange>>
-            QOS_EXCEPTION_HEADERS = new QosException.Visitor<Consumer<HttpServerExchange>>() {
-                @Override
-                public Consumer<HttpServerExchange> visit(QosException.Throttle exception) {
-                    return exchange -> exception.getRetryAfter().ifPresent(duration -> {
-                        exchange.getResponseHeaders()
-                                .put(Headers.RETRY_AFTER, Long.toString(duration.get(ChronoUnit.SECONDS)));
-                    });
-                }
-
-                @Override
-                public Consumer<HttpServerExchange> visit(QosException.RetryOther exception) {
-                    return exchange -> exchange.getResponseHeaders()
-                            .put(Headers.LOCATION, exception.getRedirectTo().toString());
-                }
-
-                @Override
-                public Consumer<HttpServerExchange> visit(QosException.Unavailable exception) {
-                    return exchange -> {
-
-                    };
-                }
-            };
 }

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
@@ -1,0 +1,240 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.QosException;
+import com.palantir.conjure.java.api.errors.RemoteException;
+import com.palantir.conjure.java.api.errors.SerializableError;
+import com.palantir.conjure.java.api.errors.ServiceException;
+import com.palantir.conjure.java.undertow.lib.Serializer;
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.logsafe.SafeArg;
+import io.undertow.io.UndertowOutputStream;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xnio.IoUtils;
+
+/**
+ * Maps caught {@link Throwable} instances into HTTP responses. The result is written into the
+ * {@link HttpServerExchange exchange's} response, and an appropriate HTTP status code is set.
+ */
+final class ConjureExceptions {
+
+    private static final Logger log = LoggerFactory.getLogger(ConjureExceptions.class);
+
+    private ConjureExceptions() { }
+
+    static Serializer<SerializableError> serializer() {
+        // Exceptions should always be serialized using JSON
+        return new ConjureBodySerDe(Collections.singletonList(Encodings.json()))
+                .serializer(new TypeMarker<SerializableError>() {});
+    }
+
+    static void handle(HttpServerExchange exchange, Serializer<SerializableError> serializer, Throwable throwable) {
+        if (throwable instanceof ServiceException) {
+            serviceException(exchange, serializer, (ServiceException) throwable);
+        } else if (throwable instanceof QosException) {
+            qosException(exchange, serializer, (QosException) throwable);
+        } else if (throwable instanceof RemoteException) {
+            remoteException(exchange, serializer, (RemoteException) throwable);
+        } else if (throwable instanceof IllegalArgumentException) {
+            illegalArgumentException(exchange, serializer, throwable);
+        } else if (throwable instanceof FrameworkException) {
+            frameworkException(exchange, serializer, (FrameworkException) throwable);
+        } else if (throwable instanceof Error) {
+            throw (Error) throwable;
+        } else {
+            ServiceException exception = new ServiceException(ErrorType.INTERNAL, throwable);
+            log(exception);
+            writeResponse(
+                    exchange,
+                    Optional.of(SerializableError.forException(exception)),
+                    exception.getErrorType().httpErrorCode(),
+                    serializer);
+        }
+    }
+
+    private static void serviceException(
+            HttpServerExchange exchange, Serializer<SerializableError> serializer, ServiceException exception) {
+        log(exception);
+        writeResponse(
+                exchange,
+                Optional.of(SerializableError.forException(exception)),
+                exception.getErrorType().httpErrorCode(),
+                serializer);
+    }
+
+    private static void qosException(
+            HttpServerExchange exchange, Serializer<SerializableError> serializer, QosException exception) {
+        exception.accept(QOS_EXCEPTION_HEADERS).accept(exchange);
+        log.debug("Possible quality-of-service intervention", exception);
+        writeResponse(
+                exchange,
+                Optional.empty(),
+                exception.accept(QOS_EXCEPTION_STATUS_CODE),
+                serializer);
+    }
+
+    // RemoteExceptions are thrown by Conjure clients to indicate a remote/service-side problem.
+    // We forward these exceptions, but change the ErrorType to INTERNAL, i.e., the problem is now
+    // considered internal to *this* service rather than the originating service. This means in particular
+    // that Conjure errors are defined only local to a given service and these error types don't
+    // propagate through other services.
+    private static void remoteException(
+            HttpServerExchange exchange, Serializer<SerializableError> serializer, RemoteException exception) {
+        // log at WARN instead of ERROR because although this indicates an issue in a remote server
+        log.warn("Encountered a remote exception. Mapping to an internal error before propagating",
+                SafeArg.of("errorInstanceId", exception.getError().errorInstanceId()),
+                SafeArg.of("errorName", exception.getError().errorName()),
+                SafeArg.of("statusCode", exception.getStatus()),
+                exception);
+
+        ErrorType errorType = ErrorType.INTERNAL;
+        writeResponse(exchange,
+                Optional.of(SerializableError.builder()
+                        .errorName(errorType.name())
+                        .errorCode(errorType.code().toString())
+                        .errorInstanceId(exception.getError().errorInstanceId())
+                        .build()),
+                errorType.httpErrorCode(),
+                serializer);
+    }
+
+    private static void illegalArgumentException(
+            HttpServerExchange exchange, Serializer<SerializableError> serializer, Throwable throwable) {
+        ServiceException exception = new ServiceException(ErrorType.INVALID_ARGUMENT, throwable);
+        log(exception);
+        writeResponse(
+                exchange,
+                Optional.of(SerializableError.forException(exception)),
+                exception.getErrorType().httpErrorCode(),
+                serializer);
+    }
+
+    private static void frameworkException(
+            HttpServerExchange exchange,
+            Serializer<SerializableError> serializer,
+            FrameworkException frameworkException) {
+        int statusCode = frameworkException.getStatusCode();
+        ErrorType errorType = statusCode / 100 == 4 ? ErrorType.INVALID_ARGUMENT : ErrorType.INTERNAL;
+        ServiceException exception = new ServiceException(errorType, frameworkException);
+        log(exception);
+        writeResponse(exchange, Optional.of(SerializableError.forException(exception)), statusCode, serializer);
+    }
+
+    private static void writeResponse(
+            HttpServerExchange exchange,
+            Optional<SerializableError> maybeBody,
+            int statusCode,
+            Serializer<SerializableError> serializer) {
+        // Do not attempt to write the failure if data has already been written
+        if (!isResponseStarted(exchange)) {
+            exchange.setStatusCode(statusCode);
+            try {
+                if (maybeBody.isPresent()) {
+                    serializer.serialize(maybeBody.get(), exchange);
+                }
+            } catch (IOException | RuntimeException e) {
+                log.info("Failed to write error response", e);
+            }
+        } else {
+            // This prevents the server from sending the final null chunk, alerting
+            // clients that the response was terminated prior to receiving full contents.
+            // Note that in the case of http/2 this does not close a connection, which
+            // would break other active requests, only resets the stream.
+            log.warn("Closing the connection to alert the client of an error");
+            IoUtils.safeClose(exchange.getConnection());
+        }
+    }
+
+    private static boolean isResponseStarted(HttpServerExchange exchange) {
+        if (exchange.isResponseStarted()) {
+            return true;
+        }
+        // The blocking exchange output stream may have un-committed data buffered.
+        // In this case we can clear the buffer allowing us to send a serializable error.
+        OutputStream outputStream = exchange.getOutputStream();
+        if (outputStream instanceof UndertowOutputStream) {
+            ((UndertowOutputStream) outputStream).resetBuffer();
+        }
+        return false;
+    }
+
+    private static void log(ServiceException exception) {
+        if (exception.getErrorType().httpErrorCode() / 100 == 4 /* client error */) {
+            log.info("Error handling request",
+                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()),
+                    SafeArg.of("errorName", exception.getErrorType().name()),
+                    exception);
+        } else {
+            log.error("Error handling request",
+                    SafeArg.of("errorInstanceId", exception.getErrorInstanceId()),
+                    SafeArg.of("errorName", exception.getErrorType().name()),
+                    exception);
+        }
+    }
+
+    private static final QosException.Visitor<Integer> QOS_EXCEPTION_STATUS_CODE = new QosException.Visitor<Integer>() {
+        @Override
+        public Integer visit(QosException.Throttle exception) {
+            return 429;
+        }
+
+        @Override
+        public Integer visit(QosException.RetryOther exception) {
+            return 308;
+        }
+
+        @Override
+        public Integer visit(QosException.Unavailable exception) {
+            return 503;
+        }
+    };
+
+    private static final QosException.Visitor<Consumer<HttpServerExchange>>
+            QOS_EXCEPTION_HEADERS = new QosException.Visitor<Consumer<HttpServerExchange>>() {
+                @Override
+                public Consumer<HttpServerExchange> visit(QosException.Throttle exception) {
+                    return exchange -> exception.getRetryAfter().ifPresent(duration -> {
+                        exchange.getResponseHeaders()
+                                .put(Headers.RETRY_AFTER, Long.toString(duration.get(ChronoUnit.SECONDS)));
+                    });
+                }
+
+                @Override
+                public Consumer<HttpServerExchange> visit(QosException.RetryOther exception) {
+                    return exchange -> exchange.getResponseHeaders()
+                            .put(Headers.LOCATION, exception.getRedirectTo().toString());
+                }
+
+                @Override
+                public Consumer<HttpServerExchange> visit(QosException.Unavailable exception) {
+                    return exchange -> {
+
+                    };
+                }
+            };
+}

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/AsyncRequestProcessingTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/AsyncRequestProcessingTest.java
@@ -1,0 +1,194 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.conjure.java.api.errors.SerializableError;
+import com.palantir.conjure.java.serialization.ObjectMappers;
+import com.palantir.conjure.java.undertow.lib.AsyncContext;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.ReturnValueWriter;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import io.undertow.Undertow;
+import io.undertow.server.HttpHandler;
+import io.undertow.util.Headers;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.OptionalInt;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public final class AsyncRequestProcessingTest {
+
+    private static final ObjectMapper clientMapper = ObjectMappers.newClientObjectMapper();
+
+    private Undertow server;
+    private ListeningScheduledExecutorService scheduler;
+
+    @Before
+    public void before() {
+        this.scheduler = MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor());
+        UndertowRuntime runtime = ConjureUndertowRuntime.builder()
+                // Use a 1 second timeout so we can wait for the timeout to be hit without tests running too long.
+                .asyncTimeout(Duration.ofSeconds(1))
+                .build();
+        ReturnValueWriter<String> writer = (returnValue, exchange) -> {
+            exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/plain");
+            exchange.getResponseSender().send(returnValue);
+        };
+        HttpHandler httpHandler = exchange -> {
+            AsyncContext<String> async = runtime.async().context(writer, exchange);
+            OptionalInt maybeDelay = runtime.plainSerDe()
+                    .deserializeOptionalInteger(exchange.getQueryParameters().get("delay"));
+            if (maybeDelay.isPresent()) {
+                int delay = maybeDelay.getAsInt();
+                Future<?> key = scheduler.schedule(() -> {
+                    async.complete("Completed after " + delay + "ms");
+                }, delay, TimeUnit.MILLISECONDS);
+                // Cancel the scheduled task on timeout
+                async.onTimeout(() -> key.cancel(false));
+            } else {
+                async.complete("Completed immediately");
+            }
+        };
+        HttpHandler handler = ConjureHandler.builder()
+                .endpoints(new Endpoint() {
+                    @Override
+                    public HttpString method() {
+                        return Methods.GET;
+                    }
+
+                    @Override
+                    public String template() {
+                        return "/test";
+                    }
+
+                    @Override
+                    public HttpHandler handler() {
+                        return httpHandler;
+                    }
+
+                    @Override
+                    public String serviceName() {
+                        return "TestService";
+                    }
+
+                    @Override
+                    public String name() {
+                        return "test";
+                    }
+                }).build();
+        server = Undertow.builder()
+                .addHttpListener(12345, "localhost")
+                .setHandler(handler)
+                .build();
+        server.start();
+    }
+
+    @After
+    public void after() throws InterruptedException {
+        if (server != null) {
+            server.stop();
+        }
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+            assertThat(scheduler.awaitTermination(1, TimeUnit.MINUTES))
+                    .describedAs("Executor failed to shut down")
+                    .isTrue();
+        }
+    }
+
+    @Test
+    public void testNoDelay() throws IOException {
+        try (Response response = execute(OptionalInt.empty())) {
+            assertThat(response).matches(Response::isSuccessful);
+            assertThat(response.body().string()).isEqualTo("Completed immediately");
+        }
+    }
+
+    @Test
+    public void testTinyDelay() throws IOException {
+        try (Response response = execute(OptionalInt.of(0))) {
+            assertThat(response).matches(Response::isSuccessful);
+            assertThat(response.body().string()).isEqualTo("Completed after 0ms");
+        }
+    }
+
+    @Test
+    public void testSmallDelay() throws IOException {
+        try (Response response = execute(OptionalInt.of(100))) {
+            assertThat(response).matches(Response::isSuccessful);
+            assertThat(response.body().string()).isEqualTo("Completed after 100ms");
+        }
+    }
+
+    @Test
+    public void testTimeout() throws IOException {
+        try (Response response = execute(OptionalInt.of(2000))) {
+            assertThat(response).matches(resp -> resp.code() == 500);
+            SerializableError error = clientMapper.readValue(response.body().byteStream(), SerializableError.class);
+            assertThat(error.errorCode()).isEqualTo("INTERNAL");
+        }
+    }
+
+    @Test
+    public void testAddTimeoutCallbackAsynchronously() {
+        // TODO(ckozak): test that onTimeout(Runnable) fails unless it's run on the initial thread.
+    }
+
+    @Test
+    public void testMultipleTimeoutCallbacksAreInvoked() {
+        // TODO(ckozak): All callbacks registered using onTimeout(Runnable) should be executed.
+    }
+
+    @Test
+    public void testTimeoutCallbacksDoNotRunOnIoThreads() {
+        // TODO(ckozak): Accidental blocking on I/O threads is dangerous, there's no reason to execute there.
+    }
+
+    private static Response execute(OptionalInt delay) {
+        Request request = new Request.Builder()
+                .get()
+                .url("http://localhost:12345/test" + (delay.isPresent() ? "?delay=" + delay.getAsInt() : ""))
+                .build();
+        try {
+            return client().newCall(request).execute();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static OkHttpClient client() {
+        return new OkHttpClient.Builder()
+                .retryOnConnectionFailure(false)
+                .cache(null)
+                .build();
+    }
+}

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/AsyncRequestProcessingTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/AsyncRequestProcessingTest.java
@@ -173,6 +173,11 @@ public final class AsyncRequestProcessingTest {
         // TODO(ckozak): Accidental blocking on I/O threads is dangerous, there's no reason to execute there.
     }
 
+    @Test
+    public void testExceptionThrownInHandlerMethod() {
+        // TODO(ckozak): Exceptions thrown in the service method should be handled the same way as blocking services.
+    }
+
     private static Response execute(OptionalInt delay) {
         Request request = new Request.Builder()
                 .get()

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/AsyncContext.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/AsyncContext.java
@@ -1,0 +1,39 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.lib;
+
+public interface AsyncContext<T> {
+
+    /**
+     * Sets the value to be returned if the request has not already been completed. Returns true if the request has
+     * not already completed.
+     */
+    boolean complete(T value);
+
+    /**
+     * Completes this request exceptionally if it has not already been completed. Returns true if the request has not
+     * already completed.
+     */
+    boolean completeExceptionally(Throwable throwable);
+
+    /**
+     * Registers a callback to execute if the asynchronous request timeout is reached before this context is completed.
+     * Cancellation should never be used for control flow, and represents an upper limit.
+     * Timeout callbacks must be registered when a request is received and cannot be added asynchronously.
+     */
+    void onTimeout(Runnable onTimeoutCallback);
+}

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/AsyncRequestProcessing.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/AsyncRequestProcessing.java
@@ -1,0 +1,30 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.lib;
+
+import io.undertow.server.HttpServerExchange;
+
+/**
+ * Provides functionality to process requests asynchronously. This decouples the lifecycle of a request
+ * from the execution of the handler method.
+ */
+public interface AsyncRequestProcessing {
+
+    /** Creates a new {@link AsyncContext} for the provided {@link HttpServerExchange request}. */
+    <T> AsyncContext<T> context(ReturnValueWriter<T> returnValueWriter, HttpServerExchange exchange);
+
+}

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/ReturnValueWriter.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/ReturnValueWriter.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.lib;
+
+import io.undertow.server.HttpServerExchange;
+import java.io.IOException;
+
+/**
+ * Writes a typed return value to the HTTP response.
+ */
+public interface ReturnValueWriter<T> {
+
+    void write(T returnValue, HttpServerExchange exchange) throws IOException;
+
+}

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/UndertowRuntime.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/UndertowRuntime.java
@@ -32,4 +32,7 @@ public interface UndertowRuntime {
 
     /** Provides the {@link AuthorizationExtractor} used to read auth tokens from request headers. */
     AuthorizationExtractor auth();
+
+    /** Provides the {@link AsyncRequestProcessing} used to detach execution from the request thread. */
+    AsyncRequestProcessing async();
 }


### PR DESCRIPTION
Target generated interface:

```java
interface MyService {
  void getFoo(AuthHeader authHeader, AsyncContext<Foo> context);
}
```

impl:

```java
class MyResource {
  @Override
  void getFoo(AuthHeader authHeader, AsyncContext<Foo> context) {
    context.complete(Foo.builder().build());
  }
}
```

Where the blocking implementation would take the form:

```java
interface MyService {
  Foo getFoo(AuthHeader authHeader);
}
```