### PR TITLE
[improvement] Add a feature flag to disable parameter sorting in service method generation

### DIFF
--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/FeatureFlags.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/FeatureFlags.java
@@ -59,4 +59,10 @@ public enum FeatureFlags {
      * Use the conjure immutable "Bytes" class over ByteBuffer.
      */
     UseImmutableBytes,
+
+    /**
+     * Instructs the {@link com.palantir.conjure.java.services.ServiceGenerator} implementation to not sort parameters
+     * for generated service methods. See {@link com.palantir.conjure.java.util.ParameterOrder} for sort implementation.
+     */
+    DisableParameterSorting,
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -315,8 +315,10 @@ final class UndertowServiceHandlerGenerator {
 
         List<String> methodArgs = new ArrayList<>();
         authVarName.ifPresent(methodArgs::add);
+
+        boolean disableParameterSorting = experimentalFeatures.contains(FeatureFlags.DisableParameterSorting);
         methodArgs.addAll(ParameterOrder.sorted(
-                endpointDefinition.getArgs()).stream().map(
+                endpointDefinition.getArgs(), disableParameterSorting).stream().map(
                     arg -> arg.getArgName().get()).collect(Collectors.toList()));
 
         final String resultVarName = "result";

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceInterfaceGenerator.java
@@ -109,7 +109,9 @@ final class UndertowServiceInterfaceGenerator {
                         throw new IllegalStateException("unknown auth type: " + unknownType);
                     }
                 })));
-        List<ArgumentDefinition> sortedArgList = ParameterOrder.sorted(endpointDef.getArgs());
+
+        boolean disableParameterSorting = experimentalFeatures.contains(FeatureFlags.DisableParameterSorting);
+        List<ArgumentDefinition> sortedArgList = ParameterOrder.sorted(endpointDef.getArgs(), disableParameterSorting);
         sortedArgList.forEach(def -> parameterSpecs.add(createServiceMethodParameterArg(typeMapper, def)));
 
         return ImmutableList.copyOf(parameterSpecs);

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/ParameterOrder.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/ParameterOrder.java
@@ -96,7 +96,10 @@ public final class ParameterOrder {
     private static final Comparator<ArgumentDefinition> COMPARATOR = Comparator.comparing(o ->
             o.getParamType().accept(PARAM_SORT_ORDER) + o.getType().accept(TYPE_SORT_ORDER));
 
-    public static List<ArgumentDefinition> sorted(List<ArgumentDefinition> input) {
+    public static List<ArgumentDefinition> sorted(List<ArgumentDefinition> input, boolean disableParameterSorting) {
+        if (disableParameterSorting) {
+            return ImmutableList.copyOf(input);
+        }
         return input.stream()
                 .sorted(COMPARATOR)
                 .collect(ImmutableList.toImmutableList());

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceGeneratorTests.java
@@ -97,6 +97,25 @@ public final class JerseyServiceGeneratorTests extends TestBase {
         validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".jersey.binary_as_response");
     }
 
+    @Test
+    public void testSortedMethodParameters() throws IOException {
+        ConjureDefinition def = Conjure.parse(
+                ImmutableList.of(new File("src/test/resources/example-param-sorting.yml")));
+        List<Path> files = new JerseyServiceGenerator(Collections.emptySet())
+                .emit(def, folder.getRoot());
+        validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".jersey.sorted_params");
+    }
+
+    @Test
+    public void testUnsortedMethodParameters() throws IOException {
+        ConjureDefinition def = Conjure.parse(
+                ImmutableList.of(new File("src/test/resources/example-param-sorting.yml")));
+        List<Path> files =
+                new JerseyServiceGenerator(ImmutableSet.of(FeatureFlags.DisableParameterSorting))
+                        .emit(def, folder.getRoot());
+        validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".jersey.unsorted_params");
+    }
+
     private void testServiceGeneration(String conjureFile) throws IOException {
         ConjureDefinition def = Conjure.parse(
                 ImmutableList.of(new File("src/test/resources/" + conjureFile + ".yml")));

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceGeneratorTests.java
@@ -79,6 +79,25 @@ public final class UndertowServiceGeneratorTests extends TestBase {
         validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".undertow.binary");
     }
 
+    @Test
+    public void testSortedMethodParameters() throws IOException {
+        ConjureDefinition def = Conjure.parse(
+                ImmutableList.of(new File("src/test/resources/example-param-sorting.yml")));
+        List<Path> files = new UndertowServiceGenerator(Collections.emptySet())
+                .emit(def, folder.getRoot());
+        validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".undertow.sorted_params");
+    }
+
+    @Test
+    public void testUnsortedMethodParameters() throws IOException {
+        ConjureDefinition def = Conjure.parse(
+                ImmutableList.of(new File("src/test/resources/example-param-sorting.yml")));
+        List<Path> files =
+                new UndertowServiceGenerator(ImmutableSet.of(FeatureFlags.DisableParameterSorting))
+                        .emit(def, folder.getRoot());
+        validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".undertow.unsorted_params");
+    }
+
     private void testServiceGeneration(String conjureFile) throws IOException {
         ConjureDefinition def = Conjure.parse(
                 ImmutableList.of(new File("src/test/resources/" + conjureFile + ".yml")));

--- a/conjure-java-core/src/test/resources/example-param-sorting.yml
+++ b/conjure-java-core/src/test/resources/example-param-sorting.yml
@@ -1,0 +1,41 @@
+services:
+  TestService:
+    default-auth: none
+    base-path: /
+    package: test.api
+    name: Test Interface
+    endpoints:
+      getMethodParams:
+        http: PUT /{testPathStringArg}/{testPathIntegerArg}
+        args:
+          testBodySetArg:
+            param-type: body
+            type: set<string>
+          testQueryBooleanArg:
+            param-id: testQueryBoolean
+            param-type: query
+            type: boolean
+          # Put an optional query param before non-optional to trigger backcompat method generation for Jersey
+          testQueryOptionalArg:
+            param-id: testQueryOptional
+            param-type: query
+            type: optional<string>
+          testQueryUuidArg:
+            param-id: testQueryUuid
+            param-type: query
+            type: uuid
+          testPathIntegerArg:
+            param-type: path
+            type: integer
+          testPathStringArg:
+            param-type: path
+            type: string
+          testHeaderOptionalArg:
+            param-id: TestHeaderDateTime
+            param-type: header
+            type: optional<datetime>
+          testHeaderBearerTokenArg:
+            param-id: TestHeaderBearerToken
+            param-type: header
+            type: bearertoken
+        returns: string

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.sorted_params
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.sorted_params
@@ -1,0 +1,54 @@
+package test.api;
+
+import com.palantir.tokens.auth.BearerToken;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import javax.annotation.Generated;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/")
+@Generated("com.palantir.conjure.java.services.JerseyServiceGenerator")
+public interface TestService {
+    @PUT
+    @Path("{testPathStringArg}/{testPathIntegerArg}")
+    String getMethodParams(
+            @HeaderParam("TestHeaderBearerToken") BearerToken testHeaderBearerTokenArg,
+            @HeaderParam("TestHeaderDateTime") Optional<OffsetDateTime> testHeaderOptionalArg,
+            @PathParam("testPathIntegerArg") int testPathIntegerArg,
+            @PathParam("testPathStringArg") String testPathStringArg,
+            @QueryParam("testQueryBoolean") boolean testQueryBooleanArg,
+            @QueryParam("testQueryUuid") UUID testQueryUuidArg,
+            @QueryParam("testQueryOptional") Optional<String> testQueryOptionalArg,
+            Set<String> testBodySetArg);
+
+    @Deprecated
+    default String getMethodParams(
+            BearerToken testHeaderBearerTokenArg,
+            Optional<OffsetDateTime> testHeaderOptionalArg,
+            int testPathIntegerArg,
+            String testPathStringArg,
+            boolean testQueryBooleanArg,
+            UUID testQueryUuidArg,
+            Set<String> testBodySetArg) {
+        return getMethodParams(
+                testHeaderBearerTokenArg,
+                testHeaderOptionalArg,
+                testPathIntegerArg,
+                testPathStringArg,
+                testQueryBooleanArg,
+                testQueryUuidArg,
+                Optional.empty(),
+                testBodySetArg);
+    }
+}

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.unsorted_params
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.unsorted_params
@@ -1,0 +1,34 @@
+package test.api;
+
+import com.palantir.tokens.auth.BearerToken;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import javax.annotation.Generated;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/")
+@Generated("com.palantir.conjure.java.services.JerseyServiceGenerator")
+public interface TestService {
+    @PUT
+    @Path("{testPathStringArg}/{testPathIntegerArg}")
+    String getMethodParams(
+            Set<String> testBodySetArg,
+            @QueryParam("testQueryBoolean") boolean testQueryBooleanArg,
+            @QueryParam("testQueryOptional") Optional<String> testQueryOptionalArg,
+            @QueryParam("testQueryUuid") UUID testQueryUuidArg,
+            @PathParam("testPathIntegerArg") int testPathIntegerArg,
+            @PathParam("testPathStringArg") String testPathStringArg,
+            @HeaderParam("TestHeaderDateTime") Optional<OffsetDateTime> testHeaderOptionalArg,
+            @HeaderParam("TestHeaderBearerToken") BearerToken testHeaderBearerTokenArg);
+}

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.sorted_params
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.sorted_params
@@ -1,0 +1,21 @@
+package test.api;
+
+import com.palantir.tokens.auth.BearerToken;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
+public interface TestService {
+    String getMethodParams(
+            BearerToken testHeaderBearerTokenArg,
+            Optional<OffsetDateTime> testHeaderOptionalArg,
+            int testPathIntegerArg,
+            String testPathStringArg,
+            boolean testQueryBooleanArg,
+            UUID testQueryUuidArg,
+            Optional<String> testQueryOptionalArg,
+            Set<String> testBodySetArg);
+}

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.unsorted_params
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.unsorted_params
@@ -1,0 +1,21 @@
+package test.api;
+
+import com.palantir.tokens.auth.BearerToken;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
+public interface TestService {
+    String getMethodParams(
+            Set<String> testBodySetArg,
+            boolean testQueryBooleanArg,
+            Optional<String> testQueryOptionalArg,
+            UUID testQueryUuidArg,
+            int testPathIntegerArg,
+            String testPathStringArg,
+            Optional<OffsetDateTime> testHeaderOptionalArg,
+            BearerToken testHeaderBearerTokenArg);
+}

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.sorted_params
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.sorted_params
@@ -1,0 +1,124 @@
+package test.api;
+
+import com.palantir.conjure.java.undertow.lib.Deserializer;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.Serializer;
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import com.palantir.tokens.auth.BearerToken;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderMap;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import io.undertow.util.PathTemplateMatch;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.services.UndertowServiceHandlerGenerator")
+public final class TestServiceEndpoints implements UndertowService {
+    private final TestService delegate;
+
+    private TestServiceEndpoints(TestService delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(TestService delegate) {
+        return new TestServiceEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return Collections.unmodifiableList(
+                Arrays.asList(new GetMethodParamsEndpoint(runtime, delegate)));
+    }
+
+    private static final class GetMethodParamsEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final TestService delegate;
+
+        private final Deserializer<Set<String>> deserializer;
+
+        private final Serializer<String> serializer;
+
+        GetMethodParamsEndpoint(UndertowRuntime runtime, TestService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Set<String>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            Set<String> testBodySetArg = deserializer.deserialize(exchange);
+            Map<String, String> pathParams =
+                    exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
+            int testPathIntegerArg =
+                    runtime.plainSerDe().deserializeInteger(pathParams.get("testPathIntegerArg"));
+            String testPathStringArg =
+                    runtime.plainSerDe().deserializeString(pathParams.get("testPathStringArg"));
+            HeaderMap headerParams = exchange.getRequestHeaders();
+            Optional<OffsetDateTime> testHeaderOptionalArg =
+                    runtime.plainSerDe()
+                            .deserializeOptionalDateTime(headerParams.get("TestHeaderDateTime"));
+            BearerToken testHeaderBearerTokenArg =
+                    runtime.plainSerDe()
+                            .deserializeBearerToken(headerParams.get("TestHeaderBearerToken"));
+            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            boolean testQueryBooleanArg =
+                    runtime.plainSerDe().deserializeBoolean(queryParams.get("testQueryBoolean"));
+            Optional<String> testQueryOptionalArg =
+                    runtime.plainSerDe()
+                            .deserializeOptionalString(queryParams.get("testQueryOptional"));
+            UUID testQueryUuidArg =
+                    runtime.plainSerDe().deserializeUuid(queryParams.get("testQueryUuid"));
+            String result =
+                    delegate.getMethodParams(
+                            testHeaderBearerTokenArg,
+                            testHeaderOptionalArg,
+                            testPathIntegerArg,
+                            testPathStringArg,
+                            testQueryBooleanArg,
+                            testQueryUuidArg,
+                            testQueryOptionalArg,
+                            testBodySetArg);
+            serializer.serialize(result, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.PUT;
+        }
+
+        @Override
+        public String template() {
+            return "/{testPathStringArg}/{testPathIntegerArg}";
+        }
+
+        @Override
+        public String serviceName() {
+            return "TestService";
+        }
+
+        @Override
+        public String name() {
+            return "getMethodParams";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.unsorted_params
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.unsorted_params
@@ -1,0 +1,124 @@
+package test.api;
+
+import com.palantir.conjure.java.undertow.lib.Deserializer;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.Serializer;
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import com.palantir.tokens.auth.BearerToken;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderMap;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import io.undertow.util.PathTemplateMatch;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.services.UndertowServiceHandlerGenerator")
+public final class TestServiceEndpoints implements UndertowService {
+    private final TestService delegate;
+
+    private TestServiceEndpoints(TestService delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(TestService delegate) {
+        return new TestServiceEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return Collections.unmodifiableList(
+                Arrays.asList(new GetMethodParamsEndpoint(runtime, delegate)));
+    }
+
+    private static final class GetMethodParamsEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final TestService delegate;
+
+        private final Deserializer<Set<String>> deserializer;
+
+        private final Serializer<String> serializer;
+
+        GetMethodParamsEndpoint(UndertowRuntime runtime, TestService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Set<String>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            Set<String> testBodySetArg = deserializer.deserialize(exchange);
+            Map<String, String> pathParams =
+                    exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
+            int testPathIntegerArg =
+                    runtime.plainSerDe().deserializeInteger(pathParams.get("testPathIntegerArg"));
+            String testPathStringArg =
+                    runtime.plainSerDe().deserializeString(pathParams.get("testPathStringArg"));
+            HeaderMap headerParams = exchange.getRequestHeaders();
+            Optional<OffsetDateTime> testHeaderOptionalArg =
+                    runtime.plainSerDe()
+                            .deserializeOptionalDateTime(headerParams.get("TestHeaderDateTime"));
+            BearerToken testHeaderBearerTokenArg =
+                    runtime.plainSerDe()
+                            .deserializeBearerToken(headerParams.get("TestHeaderBearerToken"));
+            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            boolean testQueryBooleanArg =
+                    runtime.plainSerDe().deserializeBoolean(queryParams.get("testQueryBoolean"));
+            Optional<String> testQueryOptionalArg =
+                    runtime.plainSerDe()
+                            .deserializeOptionalString(queryParams.get("testQueryOptional"));
+            UUID testQueryUuidArg =
+                    runtime.plainSerDe().deserializeUuid(queryParams.get("testQueryUuid"));
+            String result =
+                    delegate.getMethodParams(
+                            testBodySetArg,
+                            testQueryBooleanArg,
+                            testQueryOptionalArg,
+                            testQueryUuidArg,
+                            testPathIntegerArg,
+                            testPathStringArg,
+                            testHeaderOptionalArg,
+                            testHeaderBearerTokenArg);
+            serializer.serialize(result, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.PUT;
+        }
+
+        @Override
+        public String template() {
+            return "/{testPathStringArg}/{testPathIntegerArg}";
+        }
+
+        @Override
+        public String serviceName() {
+            return "TestService";
+        }
+
+        @Override
+        public String name() {
+            return "getMethodParams";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/CliConfiguration.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/CliConfiguration.java
@@ -96,5 +96,9 @@ public abstract class CliConfiguration {
         Builder useImmutableBytes(boolean flag) {
             return flag ? addFeatureFlags(FeatureFlags.UseImmutableBytes) : this;
         }
+
+        Builder disableParameterSorting(boolean flag) {
+            return flag ? addFeatureFlags(FeatureFlags.DisableParameterSorting) : this;
+        }
     }
 }

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -119,6 +119,11 @@ public final class ConjureJavaCli implements Runnable {
                 description = "Generate binary fields using the immutable 'Bytes' type instead of 'ByteBuffer'")
         private boolean useImmutableBytes;
 
+        @CommandLine.Option(names = "--disableParameterSorting",
+                defaultValue = "false",
+                description = "Generate jersey interfaces without sorted method parameters.")
+        private boolean disableParameterSorting;
+
         @SuppressWarnings("unused")
         @CommandLine.Unmatched
         private List<String> unmatchedOptions;
@@ -170,6 +175,7 @@ public final class ConjureJavaCli implements Runnable {
                     .notNullAuthAndBody(notNullAuthAndBody)
                     .undertowServicePrefix(undertowServicePrefix)
                     .useImmutableBytes(useImmutableBytes)
+                    .disableParameterSorting(disableParameterSorting)
                     .build();
         }
 

--- a/conjure-java/src/test/java/com/palantir/conjure/java/cli/ConjureJavaCliTest.java
+++ b/conjure-java/src/test/java/com/palantir/conjure/java/cli/ConjureJavaCliTest.java
@@ -72,7 +72,8 @@ public final class ConjureJavaCliTest {
                 "--retrofitCompletableFutures",
                 "--jerseyBinaryAsResponse",
                 "--requireNotNullAuthAndBodyParams",
-                "--useImmutableBytes"
+                "--useImmutableBytes",
+                "--disableParameterSorting"
         };
         CliConfiguration expectedConfiguration = CliConfiguration.builder()
                 .input(targetFile)
@@ -82,7 +83,8 @@ public final class ConjureJavaCliTest {
                         FeatureFlags.RetrofitCompletableFutures,
                         FeatureFlags.JerseyBinaryAsResponse,
                         FeatureFlags.RequireNotNullAuthAndBodyParams,
-                        FeatureFlags.UseImmutableBytes))
+                        FeatureFlags.UseImmutableBytes,
+                        FeatureFlags.DisableParameterSorting))
                 .build();
         ConjureJavaCli.GenerateCommand cmd = new CommandLine(new ConjureJavaCli()).parse(args).get(1).getCommand();
         assertThat(cmd.getConfiguration()).isEqualTo(expectedConfiguration);

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,8 @@ The recommended way to use conjure-java is via a build tool like [gradle-conjure
                      Generate service interfaces for Undertow with class names prefixed 'Undertow'
         --useImmutableBytes
                      Generate binary fields using the immutable 'Bytes' type instead of 'ByteBuffer'
+        --disableParameterSorting
+                     Generate service interfaces that respect the order of method parameters in the conjure definition
 
 ### Feature Flags
 


### PR DESCRIPTION
## Before this PR
Service methods from the service method generators will always sort parameters to help with backwards compatibility. However, this can make it very difficult for applications upgrading from older versions of conjure-java as parameter sorting has the potential to change the signature of all service methods.

## After this PR
There is now a new feature flag which allows parameter sorting for service methods to be skipped and instead just follow the order as specified in the conjure definition. The flag will allow developers to more easily upgrade versions and continue to use conjure-java generators by providing a consistent ordering of method parameters.
