### PR TITLE
[undertow][improvement] Generated undertow handlers use final variables

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceEndpoints.java
@@ -48,7 +48,7 @@ public final class EmptyPathServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            boolean result = delegate.emptyPath();
+            final boolean result = delegate.emptyPath();
             serializer.serialize(result, exchange);
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceEndpoints.java
@@ -54,9 +54,9 @@ public final class EteBinaryServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            InputStream body = runtime.bodySerDe().deserializeInputStream(exchange);
-            BinaryResponseBody result = delegate.postBinary(authHeader, body);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final InputStream body = runtime.bodySerDe().deserializeInputStream(exchange);
+            final BinaryResponseBody result = delegate.postBinary(authHeader, body);
             runtime.bodySerDe().serialize(result, exchange);
         }
 
@@ -99,8 +99,9 @@ public final class EteBinaryServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Optional<BinaryResponseBody> result = delegate.getOptionalBinaryPresent(authHeader);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Optional<BinaryResponseBody> result =
+                    delegate.getOptionalBinaryPresent(authHeader);
             if (result.isPresent()) {
                 runtime.bodySerDe().serialize(result.get(), exchange);
             } else {
@@ -146,8 +147,8 @@ public final class EteBinaryServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Optional<BinaryResponseBody> result = delegate.getOptionalBinaryEmpty(authHeader);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Optional<BinaryResponseBody> result = delegate.getOptionalBinaryEmpty(authHeader);
             if (result.isPresent()) {
                 runtime.bodySerDe().serialize(result.get(), exchange);
             } else {
@@ -193,10 +194,11 @@ public final class EteBinaryServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
-            int numBytes = runtime.plainSerDe().deserializeInteger(queryParams.get("numBytes"));
-            BinaryResponseBody result = delegate.getBinaryFailure(authHeader, numBytes);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            final int numBytes =
+                    runtime.plainSerDe().deserializeInteger(queryParams.get("numBytes"));
+            final BinaryResponseBody result = delegate.getBinaryFailure(authHeader, numBytes);
             runtime.bodySerDe().serialize(result, exchange);
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
@@ -85,8 +85,8 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            String result = delegate.string(authHeader);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final String result = delegate.string(authHeader);
             serializer.serialize(result, exchange);
         }
 
@@ -131,8 +131,8 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            int result = delegate.integer(authHeader);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final int result = delegate.integer(authHeader);
             serializer.serialize(result, exchange);
         }
 
@@ -177,8 +177,8 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            double result = delegate.double_(authHeader);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final double result = delegate.double_(authHeader);
             serializer.serialize(result, exchange);
         }
 
@@ -223,8 +223,8 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            boolean result = delegate.boolean_(authHeader);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final boolean result = delegate.boolean_(authHeader);
             serializer.serialize(result, exchange);
         }
 
@@ -269,8 +269,8 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            SafeLong result = delegate.safelong(authHeader);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final SafeLong result = delegate.safelong(authHeader);
             serializer.serialize(result, exchange);
         }
 
@@ -316,8 +316,8 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            ResourceIdentifier result = delegate.rid(authHeader);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final ResourceIdentifier result = delegate.rid(authHeader);
             serializer.serialize(result, exchange);
         }
 
@@ -362,8 +362,8 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            BearerToken result = delegate.bearertoken(authHeader);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final BearerToken result = delegate.bearertoken(authHeader);
             serializer.serialize(result, exchange);
         }
 
@@ -408,8 +408,8 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Optional<String> result = delegate.optionalString(authHeader);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Optional<String> result = delegate.optionalString(authHeader);
             if (result.isPresent()) {
                 serializer.serialize(result, exchange);
             } else {
@@ -458,8 +458,8 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Optional<String> result = delegate.optionalEmpty(authHeader);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Optional<String> result = delegate.optionalEmpty(authHeader);
             if (result.isPresent()) {
                 serializer.serialize(result, exchange);
             } else {
@@ -508,8 +508,8 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            OffsetDateTime result = delegate.datetime(authHeader);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final OffsetDateTime result = delegate.datetime(authHeader);
             serializer.serialize(result, exchange);
         }
 
@@ -551,8 +551,8 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            BinaryResponseBody result = delegate.binary(authHeader);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final BinaryResponseBody result = delegate.binary(authHeader);
             runtime.bodySerDe().serialize(result, exchange);
         }
 
@@ -597,11 +597,11 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, String> pathParams =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, String> pathParams =
                     exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
-            String param = runtime.plainSerDe().deserializeString(pathParams.get("param"));
-            String result = delegate.path(authHeader, param);
+            final String param = runtime.plainSerDe().deserializeString(pathParams.get("param"));
+            final String result = delegate.path(authHeader, param);
             serializer.serialize(result, exchange);
         }
 
@@ -651,9 +651,9 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            StringAliasExample notNullBody = deserializer.deserialize(exchange);
-            StringAliasExample result = delegate.notNullBody(authHeader, notNullBody);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final StringAliasExample notNullBody = deserializer.deserialize(exchange);
+            final StringAliasExample result = delegate.notNullBody(authHeader, notNullBody);
             serializer.serialize(result, exchange);
         }
 
@@ -699,12 +699,12 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
-            String queryParamNameRaw =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            final String queryParamNameRaw =
                     runtime.plainSerDe().deserializeString(queryParams.get("queryParamName"));
-            StringAliasExample queryParamName = StringAliasExample.of(queryParamNameRaw);
-            StringAliasExample result = delegate.aliasOne(authHeader, queryParamName);
+            final StringAliasExample queryParamName = StringAliasExample.of(queryParamNameRaw);
+            final StringAliasExample result = delegate.aliasOne(authHeader, queryParamName);
             serializer.serialize(result, exchange);
         }
 
@@ -750,17 +750,17 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
-            Optional<String> queryParamNameRaw =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            final Optional<String> queryParamNameRaw =
                     runtime.plainSerDe()
                             .deserializeOptionalString(queryParams.get("queryParamName"));
-            Optional<StringAliasExample> queryParamName =
+            final Optional<StringAliasExample> queryParamName =
                     Optional.ofNullable(
                             queryParamNameRaw.isPresent()
                                     ? StringAliasExample.of(queryParamNameRaw.get())
                                     : null);
-            StringAliasExample result = delegate.optionalAliasOne(authHeader, queryParamName);
+            final StringAliasExample result = delegate.optionalAliasOne(authHeader, queryParamName);
             serializer.serialize(result, exchange);
         }
 
@@ -806,13 +806,13 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
-            String queryParamNameRaw =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            final String queryParamNameRaw =
                     runtime.plainSerDe().deserializeString(queryParams.get("queryParamName"));
-            NestedStringAliasExample queryParamName =
+            final NestedStringAliasExample queryParamName =
                     NestedStringAliasExample.of(StringAliasExample.of(queryParamNameRaw));
-            NestedStringAliasExample result = delegate.aliasTwo(authHeader, queryParamName);
+            final NestedStringAliasExample result = delegate.aliasTwo(authHeader, queryParamName);
             serializer.serialize(result, exchange);
         }
 
@@ -862,9 +862,10 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            StringAliasExample notNullBody = deserializer.deserialize(exchange);
-            StringAliasExample result = delegate.notNullBodyExternalImport(authHeader, notNullBody);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final StringAliasExample notNullBody = deserializer.deserialize(exchange);
+            final StringAliasExample result =
+                    delegate.notNullBodyExternalImport(authHeader, notNullBody);
             serializer.serialize(result, exchange);
         }
 
@@ -916,9 +917,9 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Optional<StringAliasExample> body = deserializer.deserialize(exchange);
-            Optional<StringAliasExample> result =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Optional<StringAliasExample> body = deserializer.deserialize(exchange);
+            final Optional<StringAliasExample> result =
                     delegate.optionalBodyExternalImport(authHeader, body);
             if (result.isPresent()) {
                 serializer.serialize(result, exchange);
@@ -971,13 +972,13 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
-            Optional<StringAliasExample> query =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            final Optional<StringAliasExample> query =
                     runtime.plainSerDe()
                             .deserializeOptionalComplex(
                                     queryParams.get("query"), StringAliasExample::valueOf);
-            Optional<StringAliasExample> result =
+            final Optional<StringAliasExample> result =
                     delegate.optionalQueryExternalImport(authHeader, query);
             if (result.isPresent()) {
                 serializer.serialize(result, exchange);
@@ -1024,7 +1025,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
             delegate.noReturn(authHeader);
             exchange.setStatusCode(StatusCodes.NO_CONTENT);
         }
@@ -1070,13 +1071,13 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
-            SimpleEnum queryParamName =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            final SimpleEnum queryParamName =
                     runtime.plainSerDe()
                             .deserializeComplex(
                                     queryParams.get("queryParamName"), SimpleEnum::valueOf);
-            SimpleEnum result = delegate.enumQuery(authHeader, queryParamName);
+            final SimpleEnum result = delegate.enumQuery(authHeader, queryParamName);
             serializer.serialize(result, exchange);
         }
 
@@ -1121,13 +1122,13 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
-            List<SimpleEnum> queryParamName =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            final List<SimpleEnum> queryParamName =
                     runtime.plainSerDe()
                             .deserializeComplexList(
                                     queryParams.get("queryParamName"), SimpleEnum::valueOf);
-            List<SimpleEnum> result = delegate.enumListQuery(authHeader, queryParamName);
+            final List<SimpleEnum> result = delegate.enumListQuery(authHeader, queryParamName);
             serializer.serialize(result, exchange);
         }
 
@@ -1173,13 +1174,14 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
-            Optional<SimpleEnum> queryParamName =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            final Optional<SimpleEnum> queryParamName =
                     runtime.plainSerDe()
                             .deserializeOptionalComplex(
                                     queryParams.get("queryParamName"), SimpleEnum::valueOf);
-            Optional<SimpleEnum> result = delegate.optionalEnumQuery(authHeader, queryParamName);
+            final Optional<SimpleEnum> result =
+                    delegate.optionalEnumQuery(authHeader, queryParamName);
             if (result.isPresent()) {
                 serializer.serialize(result, exchange);
             } else {
@@ -1228,13 +1230,13 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            HeaderMap headerParams = exchange.getRequestHeaders();
-            SimpleEnum headerParameter =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final HeaderMap headerParams = exchange.getRequestHeaders();
+            final SimpleEnum headerParameter =
                     runtime.plainSerDe()
                             .deserializeComplex(
                                     headerParams.get("Custom-Header"), SimpleEnum::valueOf);
-            SimpleEnum result = delegate.enumHeader(authHeader, headerParameter);
+            final SimpleEnum result = delegate.enumHeader(authHeader, headerParameter);
             serializer.serialize(result, exchange);
         }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -292,10 +292,10 @@ final class UndertowServiceHandlerGenerator {
             String paramName = bodyParam.getArgName().get();
             if (bodyParam.getType().accept(TypeVisitor.IS_BINARY)) {
                 // TODO(ckozak): Support aliased and optional binary types
-                code.addStatement("$1T $2N = $3N.bodySerDe().deserializeInputStream($4N)",
+                code.addStatement("final $1T $2N = $3N.bodySerDe().deserializeInputStream($4N)",
                         InputStream.class, paramName, RUNTIME_VAR_NAME, EXCHANGE_VAR_NAME);
             } else {
-                code.addStatement("$1T $2N = $3N.deserialize($4N)",
+                code.addStatement("final $1T $2N = $3N.deserialize($4N)",
                         typeMapper.getClassName(bodyParam.getType()).box(),
                         paramName,
                         DESERIALIZER_VAR_NAME,
@@ -322,7 +322,7 @@ final class UndertowServiceHandlerGenerator {
         final String resultVarName = "result";
         if (endpointDefinition.getReturns().isPresent()) {
             Type returnType = endpointDefinition.getReturns().get();
-            code.addStatement("$1T $2N = $3N.$4L($5L)",
+            code.addStatement("final $1T $2N = $3N.$4L($5L)",
                     returnTypeMapper.getClassName(returnType),
                     resultVarName,
                     DELEGATE_VAR_NAME,
@@ -397,14 +397,14 @@ final class UndertowServiceHandlerGenerator {
             @Override
             public Optional<String> visitHeader(HeaderAuthType value) {
                 // header auth
-                code.addStatement("$1T $2N = $3N.auth().header($4N)",
+                code.addStatement("final $1T $2N = $3N.auth().header($4N)",
                         AuthHeader.class, AUTH_HEADER_VAR_NAME, RUNTIME_VAR_NAME, EXCHANGE_VAR_NAME);
                 return Optional.of(AUTH_HEADER_VAR_NAME);
             }
 
             @Override
             public Optional<String> visitCookie(CookieAuthType value) {
-                code.addStatement("$1T $2N = $3N.auth().cookie($4N, $5S)",
+                code.addStatement("final $1T $2N = $3N.auth().cookie($4N, $5S)",
                         BearerToken.class,
                         COOKIE_TOKEN_VAR_NAME,
                         RUNTIME_VAR_NAME,
@@ -426,7 +426,7 @@ final class UndertowServiceHandlerGenerator {
             List<TypeDefinition> typeDefinitions,
             TypeMapper typeMapper) {
         if (hasPathArgument(endpointDefinition.getArgs())) {
-            code.addStatement("$1T<$2T, $2T> $3N = $4N.getAttachment($5T.ATTACHMENT_KEY).getParameters()",
+            code.addStatement("final $1T<$2T, $2T> $3N = $4N.getAttachment($5T.ATTACHMENT_KEY).getParameters()",
                     Map.class, String.class, PATH_PARAMS_VAR_NAME, EXCHANGE_VAR_NAME,
                     io.undertow.util.PathTemplateMatch.class);
             code.add(
@@ -440,7 +440,7 @@ final class UndertowServiceHandlerGenerator {
             List<TypeDefinition> typeDefinitions,
             TypeMapper typeMapper) {
         if (hasHeaderArgument(endpointDefinition.getArgs())) {
-            code.addStatement("$1T $2N = $3N.getRequestHeaders()", io.undertow.util.HeaderMap.class,
+            code.addStatement("final $1T $2N = $3N.getRequestHeaders()", io.undertow.util.HeaderMap.class,
                     HEADER_PARAMS_VAR_NAME,
                     EXCHANGE_VAR_NAME);
             code.add(generateHeaderParameterCodeBlock(endpointDefinition.getArgs().stream(), typeDefinitions,
@@ -454,7 +454,7 @@ final class UndertowServiceHandlerGenerator {
             List<TypeDefinition> typeDefinitions,
             TypeMapper typeMapper) {
         if (hasQueryArgument(endpointDefinition.getArgs())) {
-            code.addStatement("$1T $2N = $3N.getQueryParameters()",
+            code.addStatement("final $1T $2N = $3N.getQueryParameters()",
                     ParameterizedTypeName.get(ClassName.get(Map.class), TypeName.get(String.class),
                             ParameterizedTypeName.get(Deque.class, String.class)), QUERY_PARAMS_VAR_NAME,
                     EXCHANGE_VAR_NAME);
@@ -534,7 +534,7 @@ final class UndertowServiceHandlerGenerator {
                                         paramsVarName,
                                         toParamId.apply(arg)),
                                 CodeBlocks.statement(
-                                        "$1T $2N = $3L",
+                                        "final $1T $2N = $3L",
                                         typeMapper.getClassName(arg.getType()),
                                         paramName,
                                         createConstructorForTypeWithReference(arg.getType(), rawVarName,
@@ -552,7 +552,7 @@ final class UndertowServiceHandlerGenerator {
             String paramsVarName, String paramId) {
         if (type.accept(MoreVisitors.IS_EXTERNAL)) {
             return CodeBlocks.statement(
-                    "$1T $2N = $3T.valueOf($4N.plainSerDe().deserializeString($5N.get($6S)))",
+                    "final $1T $2N = $3T.valueOf($4N.plainSerDe().deserializeString($5N.get($6S)))",
                     typeMapper.getClassName(type),
                     resultVarName,
                     typeMapper.getClassName(type),
@@ -567,7 +567,7 @@ final class UndertowServiceHandlerGenerator {
             return complexDeserializer.get();
         }
         return CodeBlocks.statement(
-                "$1T $2N = $3N.plainSerDe().$4L($5N.get($6S))",
+                "final $1T $2N = $3N.plainSerDe().$4L($5N.get($6S))",
                 typeMapper.getClassName(type),
                 resultVarName,
                 RUNTIME_VAR_NAME,
@@ -622,7 +622,7 @@ final class UndertowServiceHandlerGenerator {
                 return Optional.empty();
             }
         }).map(functionName -> CodeBlocks.statement(
-                "$1T $2N = $3N.plainSerDe().$4L($5N.get($6S), $7T::valueOf)",
+                "final $1T $2N = $3N.plainSerDe().$4L($5N.get($6S), $7T::valueOf)",
                 typeMapper.getClassName(type),
                 resultVarName,
                 RUNTIME_VAR_NAME,

--- a/conjure-java-core/src/test/resources/test/api/CookieServiceEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/CookieServiceEndpoints.java.undertow
@@ -45,7 +45,7 @@ public final class CookieServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            BearerToken cookieToken = runtime.auth().cookie(exchange, "PALANTIR_TOKEN");
+            final BearerToken cookieToken = runtime.auth().cookie(exchange, "PALANTIR_TOKEN");
             delegate.eatCookies(cookieToken);
             exchange.setStatusCode(StatusCodes.NO_CONTENT);
         }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
@@ -89,8 +89,8 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, BackingFileSystem> result = delegate.getFileSystems(authHeader);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, BackingFileSystem> result = delegate.getFileSystems(authHeader);
             serializer.serialize(result, exchange);
         }
 
@@ -139,14 +139,14 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            CreateDatasetRequest request = deserializer.deserialize(exchange);
-            HeaderMap headerParams = exchange.getRequestHeaders();
-            String testHeaderArg =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final CreateDatasetRequest request = deserializer.deserialize(exchange);
+            final HeaderMap headerParams = exchange.getRequestHeaders();
+            final String testHeaderArg =
                     runtime.plainSerDe().deserializeString(headerParams.get("Test-Header"));
             runtime.markers()
                     .param("com.palantir.redaction.Safe", "testHeaderArg", testHeaderArg, exchange);
-            Dataset result = delegate.createDataset(authHeader, testHeaderArg, request);
+            final Dataset result = delegate.createDataset(authHeader, testHeaderArg, request);
             serializer.serialize(result, exchange);
         }
 
@@ -192,14 +192,14 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, String> pathParams =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, String> pathParams =
                     exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
-            ResourceIdentifier datasetRid =
+            final ResourceIdentifier datasetRid =
                     runtime.plainSerDe().deserializeRid(pathParams.get("datasetRid"));
             runtime.markers()
                     .param("com.palantir.redaction.Safe", "datasetRid", datasetRid, exchange);
-            Optional<Dataset> result = delegate.getDataset(authHeader, datasetRid);
+            final Optional<Dataset> result = delegate.getDataset(authHeader, datasetRid);
             if (result.isPresent()) {
                 serializer.serialize(result, exchange);
             } else {
@@ -245,14 +245,14 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, String> pathParams =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, String> pathParams =
                     exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
-            ResourceIdentifier datasetRid =
+            final ResourceIdentifier datasetRid =
                     runtime.plainSerDe().deserializeRid(pathParams.get("datasetRid"));
             runtime.markers()
                     .param("com.palantir.redaction.Safe", "datasetRid", datasetRid, exchange);
-            BinaryResponseBody result = delegate.getRawData(authHeader, datasetRid);
+            final BinaryResponseBody result = delegate.getRawData(authHeader, datasetRid);
             runtime.bodySerDe().serialize(result, exchange);
         }
 
@@ -298,14 +298,14 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, String> pathParams =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, String> pathParams =
                     exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
-            ResourceIdentifier datasetRid =
+            final ResourceIdentifier datasetRid =
                     runtime.plainSerDe().deserializeRid(pathParams.get("datasetRid"));
             runtime.markers()
                     .param("com.palantir.redaction.Safe", "datasetRid", datasetRid, exchange);
-            NestedAliasedBinary result = delegate.getAliasedRawData(authHeader, datasetRid);
+            final NestedAliasedBinary result = delegate.getAliasedRawData(authHeader, datasetRid);
             serializer.serialize(result, exchange);
         }
 
@@ -347,15 +347,16 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, String> pathParams =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, String> pathParams =
                     exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
-            ResourceIdentifier datasetRid =
+            final ResourceIdentifier datasetRid =
                     runtime.plainSerDe().deserializeRid(pathParams.get("datasetRid"));
             runtime.markers()
                     .param("com.palantir.redaction.Safe", "datasetRid", datasetRid, exchange);
             runtime.markers().param("javax.annotation.Nonnull", "datasetRid", datasetRid, exchange);
-            Optional<BinaryResponseBody> result = delegate.maybeGetRawData(authHeader, datasetRid);
+            final Optional<BinaryResponseBody> result =
+                    delegate.maybeGetRawData(authHeader, datasetRid);
             if (result.isPresent()) {
                 runtime.bodySerDe().serialize(result.get(), exchange);
             } else {
@@ -404,14 +405,14 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, String> pathParams =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, String> pathParams =
                     exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
-            ResourceIdentifier datasetRid =
+            final ResourceIdentifier datasetRid =
                     runtime.plainSerDe().deserializeRid(pathParams.get("datasetRid"));
             runtime.markers()
                     .param("com.palantir.redaction.Safe", "datasetRid", datasetRid, exchange);
-            AliasedString result = delegate.getAliasedString(authHeader, datasetRid);
+            final AliasedString result = delegate.getAliasedString(authHeader, datasetRid);
             serializer.serialize(result, exchange);
         }
 
@@ -453,8 +454,8 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            InputStream input = runtime.bodySerDe().deserializeInputStream(exchange);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final InputStream input = runtime.bodySerDe().deserializeInputStream(exchange);
             runtime.markers().param("com.palantir.redaction.Safe", "input", input, exchange);
             delegate.uploadRawData(authHeader, input);
             exchange.setStatusCode(StatusCodes.NO_CONTENT);
@@ -502,8 +503,8 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            NestedAliasedBinary input = deserializer.deserialize(exchange);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final NestedAliasedBinary input = deserializer.deserialize(exchange);
             delegate.uploadAliasedRawData(authHeader, input);
             exchange.setStatusCode(StatusCodes.NO_CONTENT);
         }
@@ -549,14 +550,14 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, String> pathParams =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, String> pathParams =
                     exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
-            ResourceIdentifier datasetRid =
+            final ResourceIdentifier datasetRid =
                     runtime.plainSerDe().deserializeRid(pathParams.get("datasetRid"));
             runtime.markers()
                     .param("com.palantir.redaction.Safe", "datasetRid", datasetRid, exchange);
-            Set<String> result = delegate.getBranches(authHeader, datasetRid);
+            final Set<String> result = delegate.getBranches(authHeader, datasetRid);
             serializer.serialize(result, exchange);
         }
 
@@ -602,14 +603,14 @@ public final class TestServiceEndpoints implements UndertowService {
         @Override
         @SuppressWarnings("deprecation")
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, String> pathParams =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, String> pathParams =
                     exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
-            ResourceIdentifier datasetRid =
+            final ResourceIdentifier datasetRid =
                     runtime.plainSerDe().deserializeRid(pathParams.get("datasetRid"));
             runtime.markers()
                     .param("com.palantir.redaction.Safe", "datasetRid", datasetRid, exchange);
-            Set<String> result = delegate.getBranchesDeprecated(authHeader, datasetRid);
+            final Set<String> result = delegate.getBranchesDeprecated(authHeader, datasetRid);
             serializer.serialize(result, exchange);
         }
 
@@ -654,15 +655,15 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, String> pathParams =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, String> pathParams =
                     exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
-            ResourceIdentifier datasetRid =
+            final ResourceIdentifier datasetRid =
                     runtime.plainSerDe().deserializeRid(pathParams.get("datasetRid"));
             runtime.markers()
                     .param("com.palantir.redaction.Safe", "datasetRid", datasetRid, exchange);
-            String branch = runtime.plainSerDe().deserializeString(pathParams.get("branch"));
-            Optional<String> result = delegate.resolveBranch(authHeader, datasetRid, branch);
+            final String branch = runtime.plainSerDe().deserializeString(pathParams.get("branch"));
+            final Optional<String> result = delegate.resolveBranch(authHeader, datasetRid, branch);
             if (result.isPresent()) {
                 serializer.serialize(result, exchange);
             } else {
@@ -711,14 +712,14 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, String> pathParams =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, String> pathParams =
                     exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
-            ResourceIdentifier datasetRid =
+            final ResourceIdentifier datasetRid =
                     runtime.plainSerDe().deserializeRid(pathParams.get("datasetRid"));
             runtime.markers()
                     .param("com.palantir.redaction.Safe", "datasetRid", datasetRid, exchange);
-            Optional<String> result = delegate.testParam(authHeader, datasetRid);
+            final Optional<String> result = delegate.testParam(authHeader, datasetRid);
             if (result.isPresent()) {
                 serializer.serialize(result, exchange);
             } else {
@@ -770,22 +771,22 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            String query = deserializer.deserialize(exchange);
-            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
-            ResourceIdentifier something =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final String query = deserializer.deserialize(exchange);
+            final Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            final ResourceIdentifier something =
                     runtime.plainSerDe().deserializeRid(queryParams.get("different"));
             runtime.markers()
                     .param("com.palantir.redaction.Safe", "something", something, exchange);
-            Optional<ResourceIdentifier> optionalMiddle =
+            final Optional<ResourceIdentifier> optionalMiddle =
                     runtime.plainSerDe().deserializeOptionalRid(queryParams.get("optionalMiddle"));
-            ResourceIdentifier implicit =
+            final ResourceIdentifier implicit =
                     runtime.plainSerDe().deserializeRid(queryParams.get("implicit"));
-            Set<String> setEnd =
+            final Set<String> setEnd =
                     runtime.plainSerDe().deserializeStringSet(queryParams.get("setEnd"));
-            Optional<ResourceIdentifier> optionalEnd =
+            final Optional<ResourceIdentifier> optionalEnd =
                     runtime.plainSerDe().deserializeOptionalRid(queryParams.get("optionalEnd"));
-            int result =
+            final int result =
                     delegate.testQueryParams(
                             authHeader,
                             something,
@@ -838,18 +839,18 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            String query = deserializer.deserialize(exchange);
-            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
-            ResourceIdentifier something =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final String query = deserializer.deserialize(exchange);
+            final Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            final ResourceIdentifier something =
                     runtime.plainSerDe().deserializeRid(queryParams.get("different"));
-            Optional<ResourceIdentifier> optionalMiddle =
+            final Optional<ResourceIdentifier> optionalMiddle =
                     runtime.plainSerDe().deserializeOptionalRid(queryParams.get("optionalMiddle"));
-            ResourceIdentifier implicit =
+            final ResourceIdentifier implicit =
                     runtime.plainSerDe().deserializeRid(queryParams.get("implicit"));
-            Set<String> setEnd =
+            final Set<String> setEnd =
                     runtime.plainSerDe().deserializeStringSet(queryParams.get("setEnd"));
-            Optional<ResourceIdentifier> optionalEnd =
+            final Optional<ResourceIdentifier> optionalEnd =
                     runtime.plainSerDe().deserializeOptionalRid(queryParams.get("optionalEnd"));
             delegate.testNoResponseQueryParams(
                     authHeader, something, implicit, optionalMiddle, setEnd, optionalEnd, query);
@@ -897,8 +898,8 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            boolean result = delegate.testBoolean(authHeader);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final boolean result = delegate.testBoolean(authHeader);
             serializer.serialize(result, exchange);
         }
 
@@ -943,8 +944,8 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            double result = delegate.testDouble(authHeader);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final double result = delegate.testDouble(authHeader);
             serializer.serialize(result, exchange);
         }
 
@@ -989,8 +990,8 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            int result = delegate.testInteger(authHeader);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final int result = delegate.testInteger(authHeader);
             serializer.serialize(result, exchange);
         }
 
@@ -1039,9 +1040,9 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Optional<String> maybeString = deserializer.deserialize(exchange);
-            Optional<String> result = delegate.testPostOptional(authHeader, maybeString);
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Optional<String> maybeString = deserializer.deserialize(exchange);
+            final Optional<String> result = delegate.testPostOptional(authHeader, maybeString);
             if (result.isPresent()) {
                 serializer.serialize(result, exchange);
             } else {
@@ -1088,12 +1089,12 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            AuthHeader authHeader = runtime.auth().header(exchange);
-            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
-            OptionalInt maybeInteger =
+            final AuthHeader authHeader = runtime.auth().header(exchange);
+            final Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            final OptionalInt maybeInteger =
                     runtime.plainSerDe()
                             .deserializeOptionalInteger(queryParams.get("maybeInteger"));
-            OptionalDouble maybeDouble =
+            final OptionalDouble maybeDouble =
                     runtime.plainSerDe().deserializeOptionalDouble(queryParams.get("maybeDouble"));
             delegate.testOptionalIntegerAndDouble(authHeader, maybeInteger, maybeDouble);
             exchange.setStatusCode(StatusCodes.NO_CONTENT);

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.binary
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.binary
@@ -44,7 +44,7 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            BinaryResponseBody result = delegate.getBinary();
+            final BinaryResponseBody result = delegate.getBinary();
             runtime.bodySerDe().serialize(result, exchange);
         }
 


### PR DESCRIPTION
## After this PR
==COMMIT_MSG==
Generated undertow handlers use final variables
==COMMIT_MSG==

This provides additional compile-time safety ensuring that we don't
accidentally set the same variable twice.

## Possible downsides?
A couple more characters per line.