### PR TITLE
[fix][undertow] sanitize bad argument names

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceEndpoints.java
@@ -64,7 +64,7 @@ public final class EmptyPathServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEmptyPathService";
+            return "EmptyPathService";
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceEndpoints.java
@@ -72,7 +72,7 @@ public final class EteBinaryServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteBinaryService";
+            return "EteBinaryService";
         }
 
         @Override
@@ -120,7 +120,7 @@ public final class EteBinaryServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteBinaryService";
+            return "EteBinaryService";
         }
 
         @Override
@@ -167,7 +167,7 @@ public final class EteBinaryServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteBinaryService";
+            return "EteBinaryService";
         }
 
         @Override
@@ -212,7 +212,7 @@ public final class EteBinaryServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteBinaryService";
+            return "EteBinaryService";
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
@@ -102,7 +102,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -148,7 +148,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -194,7 +194,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -240,7 +240,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -286,7 +286,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -333,7 +333,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -379,7 +379,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -429,7 +429,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -479,7 +479,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -525,7 +525,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -568,7 +568,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -617,7 +617,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -669,7 +669,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -720,7 +720,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -776,7 +776,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -828,7 +828,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -880,7 +880,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -939,7 +939,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -998,7 +998,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -1041,7 +1041,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -1092,7 +1092,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -1143,7 +1143,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -1199,7 +1199,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override
@@ -1250,7 +1250,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowEteService";
+            return "EteService";
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/NameCollisionServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/NameCollisionServiceEndpoints.java
@@ -105,7 +105,7 @@ public final class NameCollisionServiceEndpoints implements UndertowService {
 
         @Override
         public String serviceName() {
-            return "UndertowNameCollisionService";
+            return "NameCollisionService";
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/NameCollisionServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/NameCollisionServiceEndpoints.java
@@ -1,0 +1,103 @@
+package com.palantir.product;
+
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.Serializer;
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import com.palantir.tokens.auth.AuthHeader;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.services.UndertowServiceHandlerGenerator")
+public final class NameCollisionServiceEndpoints implements UndertowService {
+    private final UndertowNameCollisionService delegate;
+
+    private NameCollisionServiceEndpoints(UndertowNameCollisionService delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(UndertowNameCollisionService delegate) {
+        return new NameCollisionServiceEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return Collections.unmodifiableList(Arrays.asList(new IntEndpoint(runtime, delegate)));
+    }
+
+    private static final class IntEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final UndertowNameCollisionService delegate;
+
+        private final Serializer<String> serializer;
+
+        IntEndpoint(UndertowRuntime runtime, UndertowNameCollisionService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            String authHeader_ =
+                    runtime.plainSerDe().deserializeString(queryParams.get("authHeader"));
+            String long_ = runtime.plainSerDe().deserializeString(queryParams.get("long"));
+            String runtime_ = runtime.plainSerDe().deserializeString(queryParams.get("runtime"));
+            String serializer_ =
+                    runtime.plainSerDe().deserializeString(queryParams.get("serializer"));
+            String deserializer_ =
+                    runtime.plainSerDe().deserializeString(queryParams.get("deserializer"));
+            String delegate_ = runtime.plainSerDe().deserializeString(queryParams.get("delegate"));
+            String result_ = runtime.plainSerDe().deserializeString(queryParams.get("result"));
+            String result =
+                    delegate.int_(
+                            authHeader,
+                            authHeader_,
+                            long_,
+                            runtime_,
+                            serializer_,
+                            deserializer_,
+                            delegate_,
+                            result_);
+            serializer.serialize(result, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/";
+        }
+
+        @Override
+        public String serviceName() {
+            return "UndertowNameCollisionService";
+        }
+
+        @Override
+        public String name() {
+            return "int";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/NameCollisionServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/NameCollisionServiceEndpoints.java
@@ -58,18 +58,28 @@ public final class NameCollisionServiceEndpoints implements UndertowService {
         public void handleRequest(HttpServerExchange exchange) throws IOException {
             AuthHeader authHeader = runtime.auth().header(exchange);
             String deserializer_ = deserializer.deserialize(exchange);
+            runtime.markers()
+                    .param("com.palantir.redaction.Safe", "deserializer", deserializer_, exchange);
             Map<String, String> pathParams =
                     exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
             String runtime_ = runtime.plainSerDe().deserializeString(pathParams.get("runtime"));
+            runtime.markers().param("com.palantir.redaction.Safe", "runtime", runtime_, exchange);
             HeaderMap headerParams = exchange.getRequestHeaders();
             String serializer_ =
                     runtime.plainSerDe().deserializeString(headerParams.get("Serializer"));
+            runtime.markers()
+                    .param("com.palantir.redaction.Safe", "serializer", serializer_, exchange);
             Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
             String authHeader_ =
                     runtime.plainSerDe().deserializeString(queryParams.get("authHeader"));
+            runtime.markers()
+                    .param("com.palantir.redaction.Safe", "authHeader", authHeader_, exchange);
             String long_ = runtime.plainSerDe().deserializeString(queryParams.get("long"));
+            runtime.markers().param("com.palantir.redaction.Safe", "long", long_, exchange);
             String delegate_ = runtime.plainSerDe().deserializeString(queryParams.get("delegate"));
+            runtime.markers().param("com.palantir.redaction.Safe", "delegate", delegate_, exchange);
             String result_ = runtime.plainSerDe().deserializeString(queryParams.get("result"));
+            runtime.markers().param("com.palantir.redaction.Safe", "result", result_, exchange);
             String result =
                     delegate.int_(
                             authHeader,

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowNameCollisionService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowNameCollisionService.java
@@ -1,0 +1,17 @@
+package com.palantir.product;
+
+import com.palantir.tokens.auth.AuthHeader;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
+public interface UndertowNameCollisionService {
+    String int_(
+            AuthHeader authHeader,
+            String authHeader_,
+            String long_,
+            String runtime,
+            String serializer,
+            String deserializer,
+            String delegate,
+            String result);
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowNameCollisionService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowNameCollisionService.java
@@ -7,11 +7,11 @@ import javax.annotation.Generated;
 public interface UndertowNameCollisionService {
     String int_(
             AuthHeader authHeader,
+            String serializer,
+            String runtime,
             String authHeader_,
             String long_,
-            String runtime,
-            String serializer,
-            String deserializer,
             String delegate,
-            String result);
+            String result,
+            String deserializer);
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -293,7 +293,7 @@ final class UndertowServiceHandlerGenerator {
 
         // body parameter
         getBodyParamTypeArgument(endpointDefinition.getArgs()).ifPresent(bodyParam -> {
-            String paramName = bodyParam.getArgName().get();
+            String paramName = sanitizeVarName(bodyParam.getArgName().get(), endpointDefinition);
             if (bodyParam.getType().accept(TypeVisitor.IS_BINARY)) {
                 // TODO(ckozak): Support aliased and optional binary types
                 code.addStatement("$1T $2N = $3N.bodySerDe().deserializeInputStream($4N)",

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -162,7 +162,8 @@ final class UndertowServiceHandlerGenerator {
                                 Collections.class, Arrays.class, endpointBlock)
                         .build())
                 .addTypes(Iterables.transform(serviceDefinition.getEndpoints(),
-                        e -> generateEndpointHandler(e, serviceClass, typeDefinitions, typeMapper, returnTypeMapper)))
+                        e -> generateEndpointHandler(e, serviceDefinition, serviceClass, typeDefinitions, typeMapper,
+                                returnTypeMapper)))
                 .build();
 
         return JavaFile.builder(serviceDefinition.getServiceName().getPackage(), endpoints)
@@ -182,6 +183,7 @@ final class UndertowServiceHandlerGenerator {
 
     private TypeSpec generateEndpointHandler(
             EndpointDefinition endpointDefinition,
+            ServiceDefinition serviceDefinition,
             ClassName serviceClass,
             List<TypeDefinition> typeDefinitions,
             TypeMapper typeMapper,
@@ -262,7 +264,7 @@ final class UndertowServiceHandlerGenerator {
                         // Note that this is the service name as defined in conjure, not the potentially modified
                         // name of the generated service interface. We may generate "UndertowFooService", but we
                         // should still return "FooService" here.
-                        .addStatement("return $1S", serviceClass.simpleName())
+                        .addStatement("return $1S", serviceDefinition.getServiceName().getName())
                         .build())
                 .addMethod(MethodSpec.methodBuilder("name")
                         .addModifiers(Modifier.PUBLIC)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -305,7 +305,7 @@ final class UndertowServiceHandlerGenerator {
                         DESERIALIZER_VAR_NAME,
                         EXCHANGE_VAR_NAME);
             }
-            code.add(generateParamMarkers(bodyParam.getMarkers(), paramName, typeMapper));
+            code.add(generateParamMarkers(bodyParam.getMarkers(), bodyParam.getArgName().get(), paramName, typeMapper));
         });
 
         // path parameters
@@ -378,12 +378,15 @@ final class UndertowServiceHandlerGenerator {
     private CodeBlock generateParamMarkers(
             List<Type> markers,
             String paramName,
+            // Variable may be sanitized
+            String variableName,
             TypeMapper typeMapper) {
         return CodeBlocks.of(markers.stream().map(marker ->
                 CodeBlock.of("$1N.markers().param($2S, $3S, $4N, $5N);",
                         RUNTIME_VAR_NAME,
-                        typeMapper.getClassName(marker).box(), paramName,
+                        typeMapper.getClassName(marker).box(),
                         paramName,
+                        variableName,
                         EXCHANGE_VAR_NAME))
                 .collect(Collectors.toList()));
     }
@@ -550,7 +553,7 @@ final class UndertowServiceHandlerGenerator {
                     }
                     return CodeBlocks.of(
                             retrieveParam,
-                            generateParamMarkers(arg.getMarkers(), paramName, typeMapper));
+                            generateParamMarkers(arg.getMarkers(), arg.getArgName().get(), paramName, typeMapper));
                 }).collect(Collectors.toList()));
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/JavaNameSanitizer.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/JavaNameSanitizer.java
@@ -18,7 +18,14 @@ package com.palantir.conjure.java.util;
 
 import com.google.common.collect.ImmutableSet;
 import com.palantir.conjure.CaseConverter;
+import com.palantir.conjure.spec.AuthType;
+import com.palantir.conjure.spec.CookieAuthType;
+import com.palantir.conjure.spec.EndpointDefinition;
 import com.palantir.conjure.spec.FieldName;
+import com.palantir.conjure.spec.HeaderAuthType;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Optional;
 import javax.lang.model.SourceVersion;
 
 public final class JavaNameSanitizer {
@@ -30,11 +37,48 @@ public final class JavaNameSanitizer {
      */
     public static String sanitize(FieldName fieldName) {
         String identifier = CaseConverter.toCase(fieldName.get(), CaseConverter.Case.LOWER_CAMEL_CASE);
-        return sanitize(identifier);
+        return sanitizeFieldName(identifier);
     }
 
-    private static String sanitize(String name) {
-        return SourceVersion.isName(name) && !RESERVED_FIELD_NAMES.contains(name) ? name : name + "_";
+    /** Returns a valid java name based on the input. */
+    public static String sanitize(String name) {
+        return SourceVersion.isName(name) ? name : escape(name);
+    }
+
+    /** Sanitizes parameter names taking into account default auth type parameter names. */
+    public static String sanitizeParameterName(String input, EndpointDefinition endpoint) {
+        String value = sanitize(input);
+        Optional<String> maybeAuthParamName = endpoint.getAuth()
+                .map(authType -> authType.accept(new AuthType.Visitor<String>() {
+                    @Override
+                    public String visitHeader(HeaderAuthType header) {
+                        return "authHeader";
+                    }
+
+                    @Override
+                    public String visitCookie(CookieAuthType cookie) {
+                        return "cookieToken";
+                    }
+
+                    @Override
+                    public String visitUnknown(String unknownType) {
+                        throw new SafeIllegalArgumentException(
+                                "Unknown auth type",
+                                SafeArg.of("authType", unknownType));
+                    }
+                }));
+        if (maybeAuthParamName.isPresent() && maybeAuthParamName.get().equals(value)) {
+            return sanitizeParameterName(escape(value), endpoint);
+        }
+        return value;
+    }
+
+    private static String sanitizeFieldName(String name) {
+        return SourceVersion.isName(name) && !RESERVED_FIELD_NAMES.contains(name) ? name : escape(name);
+    }
+
+    private static String escape(String input) {
+        return input + '_';
     }
 
     private JavaNameSanitizer() {}

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceGeneratorTests.java
@@ -79,6 +79,17 @@ public final class UndertowServiceGeneratorTests extends TestBase {
         validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".undertow.binary");
     }
 
+    @Test
+    public void testEndpointWithNameCollisions() throws IOException {
+        ConjureDefinition conjure = Conjure.parse(ImmutableList.of(
+                new File("src/test/resources/dangerous-name-service.yml")));
+        File src = folder.newFolder("src");
+        ServiceGenerator generator = new UndertowServiceGenerator(
+                Collections.singleton(FeatureFlags.UndertowServicePrefix));
+        List<Path> files = generator.emit(conjure, src);
+        validateGeneratorOutput(files, Paths.get("src/integrationInput/java/com/palantir/product"));
+    }
+
     private void testServiceGeneration(String conjureFile) throws IOException {
         ConjureDefinition def = Conjure.parse(
                 ImmutableList.of(new File("src/test/resources/" + conjureFile + ".yml")));

--- a/conjure-java-core/src/test/resources/dangerous-name-service.yml
+++ b/conjure-java-core/src/test/resources/dangerous-name-service.yml
@@ -6,7 +6,7 @@ services:
 
     endpoints:
       int:
-        http: GET /
+        http: POST /{runtime}
         auth: header
         args:
           authHeader:
@@ -16,13 +16,14 @@ services:
             param-type: query
             type: string
           runtime:
-            param-type: query
+            param-type: path
             type: string
           serializer:
-            param-type: query
+            param-type: header
+            param-id: Serializer
             type: string
           deserializer:
-            param-type: query
+            param-type: body
             type: string
           delegate:
             param-type: query

--- a/conjure-java-core/src/test/resources/dangerous-name-service.yml
+++ b/conjure-java-core/src/test/resources/dangerous-name-service.yml
@@ -1,3 +1,9 @@
+types:
+  imports:
+    Safe:
+      external:
+        java: com.palantir.redaction.Safe
+
 services:
   NameCollisionService:
     name: Naming Collision Service
@@ -12,23 +18,37 @@ services:
           authHeader:
             param-type: query
             type: string
+            markers:
+              - Safe
           long:
             param-type: query
             type: string
+            markers:
+              - Safe
           runtime:
             param-type: path
             type: string
+            markers:
+              - Safe
           serializer:
             param-type: header
             param-id: Serializer
             type: string
+            markers:
+              - Safe
           deserializer:
             param-type: body
             type: string
+            markers:
+              - Safe
           delegate:
             param-type: query
             type: string
+            markers:
+              - Safe
           result:
             param-type: query
             type: string
+            markers:
+              - Safe
         returns: string

--- a/conjure-java-core/src/test/resources/dangerous-name-service.yml
+++ b/conjure-java-core/src/test/resources/dangerous-name-service.yml
@@ -1,0 +1,33 @@
+services:
+  NameCollisionService:
+    name: Naming Collision Service
+    package: com.palantir.product
+    base-path: /
+
+    endpoints:
+      int:
+        http: GET /
+        auth: header
+        args:
+          authHeader:
+            param-type: query
+            type: string
+          long:
+            param-type: query
+            type: string
+          runtime:
+            param-type: query
+            type: string
+          serializer:
+            param-type: query
+            type: string
+          deserializer:
+            param-type: query
+            type: string
+          delegate:
+            param-type: query
+            type: string
+          result:
+            param-type: query
+            type: string
+        returns: string


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
Previously some parameter names resulted in undertow handlers which failed to compile.

## After this PR
We sanitize variable names.

==COMMIT_MSG==
The Undertow generator no longer produces code that cannot compile when given certain inputs.
==COMMIT_MSG==
