### PR TITLE
[fix] Alias 'valueOf' generation validates nested aliases recursively

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasOne.java
@@ -1,0 +1,44 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.conjure.java.lib.Bytes;
+import java.util.Objects;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class BinaryAliasOne {
+    private final Bytes value;
+
+    private BinaryAliasOne(Bytes value) {
+        Objects.requireNonNull(value, "value cannot be null");
+        this.value = value;
+    }
+
+    @JsonValue
+    public Bytes get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof BinaryAliasOne
+                        && this.value.equals(((BinaryAliasOne) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @JsonCreator
+    public static BinaryAliasOne of(Bytes value) {
+        return new BinaryAliasOne(value);
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasTwo.java
@@ -1,0 +1,43 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Objects;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class BinaryAliasTwo {
+    private final BinaryAliasOne value;
+
+    private BinaryAliasTwo(BinaryAliasOne value) {
+        Objects.requireNonNull(value, "value cannot be null");
+        this.value = value;
+    }
+
+    @JsonValue
+    public BinaryAliasOne get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof BinaryAliasTwo
+                        && this.value.equals(((BinaryAliasTwo) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @JsonCreator
+    public static BinaryAliasTwo of(BinaryAliasOne value) {
+        return new BinaryAliasTwo(value);
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasOne.java
@@ -1,0 +1,47 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Objects;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class StringAliasOne {
+    private final String value;
+
+    private StringAliasOne(String value) {
+        Objects.requireNonNull(value, "value cannot be null");
+        this.value = value;
+    }
+
+    @JsonValue
+    public String get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof StringAliasOne
+                        && this.value.equals(((StringAliasOne) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    public static StringAliasOne valueOf(String value) {
+        return new StringAliasOne(value);
+    }
+
+    @JsonCreator
+    public static StringAliasOne of(String value) {
+        return new StringAliasOne(value);
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasThree.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasThree.java
@@ -1,0 +1,43 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Objects;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class StringAliasThree {
+    private final StringAliasTwo value;
+
+    private StringAliasThree(StringAliasTwo value) {
+        Objects.requireNonNull(value, "value cannot be null");
+        this.value = value;
+    }
+
+    @JsonValue
+    public StringAliasTwo get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof StringAliasThree
+                        && this.value.equals(((StringAliasThree) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @JsonCreator
+    public static StringAliasThree of(StringAliasTwo value) {
+        return new StringAliasThree(value);
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasTwo.java
@@ -1,0 +1,44 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class StringAliasTwo {
+    private final Optional<StringAliasOne> value;
+
+    private StringAliasTwo(Optional<StringAliasOne> value) {
+        Objects.requireNonNull(value, "value cannot be null");
+        this.value = value;
+    }
+
+    @JsonValue
+    public Optional<StringAliasOne> get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof StringAliasTwo
+                        && this.value.equals(((StringAliasTwo) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @JsonCreator
+    public static StringAliasTwo of(Optional<StringAliasOne> value) {
+        return new StringAliasTwo(value);
+    }
+}

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -196,3 +196,13 @@ types:
       SimpleEnum:
         values:
           - VALUE
+      StringAliasOne:
+        alias: string
+      StringAliasTwo:
+        alias: optional<StringAliasOne>
+      StringAliasThree:
+        alias: StringAliasTwo
+      BinaryAliasOne:
+        alias: binary
+      BinaryAliasTwo:
+        alias: BinaryAliasOne


### PR DESCRIPTION
## Before this PR
Both examples added to `example-types.yml` failed to compile.

## After this PR
==COMMIT_MSG==
Certain nested aliases no longer result in Java which cannot compile.
==COMMIT_MSG==


closes #130