### PR TITLE
[improvement] Beans with no fields generate toString methods returning constant values

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyObjectExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyObjectExample.java
@@ -13,7 +13,7 @@ public final class EmptyObjectExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("EmptyObjectExample").append('{').append('}').toString();
+        return "EmptyObjectExample{}";
     }
 
     @JsonCreator

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/MethodSpecs.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/MethodSpecs.java
@@ -90,18 +90,20 @@ public final class MethodSpecs {
     }
 
     public static MethodSpec createToString(String thisClassName, Collection<FieldName> fieldNames) {
-        CodeBlock returnStatement = CodeBlock.builder()
-                .add("return new $T($S).append('{')\n", StringBuilder.class, thisClassName)
-                .indent()
-                .indent()
-                .add(CodeBlocks.of(fieldNames.stream()
-                        .map(MethodSpecs::createAppendStatement)
-                        .collect(joining(CodeBlock.of(".append(\", \")")))))
-                .unindent()
-                .add(".append('}')\n")
-                .addStatement(".toString()")
-                .unindent()
-                .build();
+        CodeBlock returnStatement = fieldNames.isEmpty()
+                ? CodeBlock.builder().addStatement("return $S", thisClassName + "{}").build()
+                : CodeBlock.builder()
+                        .add("return new $T($S).append('{')\n", StringBuilder.class, thisClassName)
+                        .indent()
+                        .indent()
+                        .add(CodeBlocks.of(fieldNames.stream()
+                                .map(MethodSpecs::createAppendStatement)
+                                .collect(joining(CodeBlock.of(".append(\", \")")))))
+                        .unindent()
+                        .add(".append('}')\n")
+                        .addStatement(".toString()")
+                        .unindent()
+                        .build();
 
         return MethodSpec.methodBuilder("toString")
                 .addAnnotation(Override.class)

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/NoFieldBeanTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/NoFieldBeanTests.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.product.EmptyObjectExample;
+import org.junit.Test;
+
+public class NoFieldBeanTests {
+
+    @Test
+    public void testSingletonInstance() {
+        assertThat(EmptyObjectExample.of()).isSameAs(EmptyObjectExample.of());
+    }
+
+    @Test
+    public void testConstantToString() {
+        EmptyObjectExample value = EmptyObjectExample.of();
+        assertThat(value.toString()).isSameAs(value.toString());
+    }
+}

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/NoFieldBeanTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/NoFieldBeanTests.java
@@ -18,10 +18,15 @@ package com.palantir.conjure.java.types;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.product.EmptyObjectExample;
+import java.io.IOException;
 import org.junit.Test;
 
 public class NoFieldBeanTests {
+
+    private final ObjectMapper mapper = ObjectMappers.newServerObjectMapper();
 
     @Test
     public void testSingletonInstance() {
@@ -29,8 +34,18 @@ public class NoFieldBeanTests {
     }
 
     @Test
+    public void testDeserializeUsesSingleton() throws IOException {
+        assertThat(mapper.readValue("{}", EmptyObjectExample.class)).isSameAs(EmptyObjectExample.of());
+    }
+
+    @Test
     public void testConstantToString() {
         EmptyObjectExample value = EmptyObjectExample.of();
         assertThat(value.toString()).isSameAs(value.toString());
+    }
+
+    @Test
+    public void testSerializedForm() throws IOException {
+        assertThat(mapper.writeValueAsString(EmptyObjectExample.of())).isEqualTo("{}");
     }
 }


### PR DESCRIPTION
## After this PR
==COMMIT_MSG==
Beans with no fields generate toString methods returning constant values
==COMMIT_MSG==
