### PR TITLE
[improvement] Simpler alias valueOf implementation

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryAliasExample.java
@@ -2,8 +2,8 @@ package com.palantir.binary;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
 import java.nio.ByteBuffer;
-import java.util.Objects;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -11,8 +11,7 @@ public final class BinaryAliasExample {
     private final ByteBuffer value;
 
     private BinaryAliasExample(ByteBuffer value) {
-        Objects.requireNonNull(value, "value cannot be null");
-        this.value = value;
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
     @JsonValue

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenAliasExample.java
@@ -2,8 +2,8 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
 import com.palantir.tokens.auth.BearerToken;
-import java.util.Objects;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -11,8 +11,7 @@ public final class BearerTokenAliasExample {
     private final BearerToken value;
 
     private BearerTokenAliasExample(BearerToken value) {
-        Objects.requireNonNull(value, "value cannot be null");
-        this.value = value;
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
     @JsonValue
@@ -38,7 +37,7 @@ public final class BearerTokenAliasExample {
     }
 
     public static BearerTokenAliasExample valueOf(String value) {
-        return new BearerTokenAliasExample(BearerToken.valueOf(value));
+        return of(BearerToken.valueOf(value));
     }
 
     @JsonCreator

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasExample.java
@@ -3,7 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.Bytes;
-import java.util.Objects;
+import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -11,8 +11,7 @@ public final class BinaryAliasExample {
     private final Bytes value;
 
     private BinaryAliasExample(Bytes value) {
-        Objects.requireNonNull(value, "value cannot be null");
-        this.value = value;
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
     @JsonValue

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasOne.java
@@ -3,7 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.Bytes;
-import java.util.Objects;
+import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -11,8 +11,7 @@ public final class BinaryAliasOne {
     private final Bytes value;
 
     private BinaryAliasOne(Bytes value) {
-        Objects.requireNonNull(value, "value cannot be null");
-        this.value = value;
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
     @JsonValue

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeAliasExample.java
@@ -2,8 +2,8 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
 import java.time.OffsetDateTime;
-import java.util.Objects;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -11,8 +11,7 @@ public final class DateTimeAliasExample {
     private final OffsetDateTime value;
 
     private DateTimeAliasExample(OffsetDateTime value) {
-        Objects.requireNonNull(value, "value cannot be null");
-        this.value = value;
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
     @JsonValue
@@ -38,7 +37,7 @@ public final class DateTimeAliasExample {
     }
 
     public static DateTimeAliasExample valueOf(String value) {
-        return new DateTimeAliasExample(OffsetDateTime.parse(value));
+        return of(OffsetDateTime.parse(value));
     }
 
     @JsonCreator

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
@@ -35,7 +35,7 @@ public final class DoubleAliasExample {
     }
 
     public static DoubleAliasExample valueOf(String value) {
-        return new DoubleAliasExample(Double.parseDouble(value));
+        return of(Double.parseDouble(value));
     }
 
     @JsonCreator

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasExample.java
@@ -34,6 +34,10 @@ public final class ExternalLongAliasExample {
         return Long.hashCode(value);
     }
 
+    public static ExternalLongAliasExample valueOf(String value) {
+        return of(Long.valueOf(value));
+    }
+
     @JsonCreator
     public static ExternalLongAliasExample of(long value) {
         return new ExternalLongAliasExample(value);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasOne.java
@@ -5,15 +5,15 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
-public final class BooleanAliasExample {
-    private final boolean value;
+public final class ExternalLongAliasOne {
+    private final long value;
 
-    private BooleanAliasExample(boolean value) {
+    private ExternalLongAliasOne(long value) {
         this.value = value;
     }
 
     @JsonValue
-    public boolean get() {
+    public long get() {
         return value;
     }
 
@@ -25,21 +25,21 @@ public final class BooleanAliasExample {
     @Override
     public boolean equals(Object other) {
         return this == other
-                || (other instanceof BooleanAliasExample
-                        && this.value == ((BooleanAliasExample) other).value);
+                || (other instanceof ExternalLongAliasOne
+                        && this.value == ((ExternalLongAliasOne) other).value);
     }
 
     @Override
     public int hashCode() {
-        return Boolean.hashCode(value);
+        return Long.hashCode(value);
     }
 
-    public static BooleanAliasExample valueOf(String value) {
-        return of(Boolean.parseBoolean(value));
+    public static ExternalLongAliasOne valueOf(String value) {
+        return of(Long.valueOf(value));
     }
 
     @JsonCreator
-    public static BooleanAliasExample of(boolean value) {
-        return new BooleanAliasExample(value);
+    public static ExternalLongAliasOne of(long value) {
+        return new ExternalLongAliasOne(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasTwo.java
@@ -6,15 +6,15 @@ import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
-public final class BinaryAliasTwo {
-    private final BinaryAliasOne value;
+public final class ExternalLongAliasTwo {
+    private final ExternalLongAliasOne value;
 
-    private BinaryAliasTwo(BinaryAliasOne value) {
+    private ExternalLongAliasTwo(ExternalLongAliasOne value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
     @JsonValue
-    public BinaryAliasOne get() {
+    public ExternalLongAliasOne get() {
         return value;
     }
 
@@ -26,8 +26,8 @@ public final class BinaryAliasTwo {
     @Override
     public boolean equals(Object other) {
         return this == other
-                || (other instanceof BinaryAliasTwo
-                        && this.value.equals(((BinaryAliasTwo) other).value));
+                || (other instanceof ExternalLongAliasTwo
+                        && this.value.equals(((ExternalLongAliasTwo) other).value));
     }
 
     @Override
@@ -35,8 +35,12 @@ public final class BinaryAliasTwo {
         return value.hashCode();
     }
 
+    public static ExternalLongAliasTwo valueOf(String value) {
+        return of(ExternalLongAliasOne.valueOf(value));
+    }
+
     @JsonCreator
-    public static BinaryAliasTwo of(BinaryAliasOne value) {
-        return new BinaryAliasTwo(value);
+    public static ExternalLongAliasTwo of(ExternalLongAliasOne value) {
+        return new ExternalLongAliasTwo(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerAliasExample.java
@@ -35,7 +35,7 @@ public final class IntegerAliasExample {
     }
 
     public static IntegerAliasExample valueOf(String value) {
-        return new IntegerAliasExample(Integer.parseInt(value));
+        return of(Integer.parseInt(value));
     }
 
     @JsonCreator

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapAliasExample.java
@@ -2,8 +2,8 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
 import java.util.Map;
-import java.util.Objects;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -11,8 +11,7 @@ public final class MapAliasExample {
     private final Map<String, Object> value;
 
     private MapAliasExample(Map<String, Object> value) {
-        Objects.requireNonNull(value, "value cannot be null");
-        this.value = value;
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
     @JsonValue

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/NestedStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/NestedStringAliasExample.java
@@ -2,7 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.util.Objects;
+import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -10,8 +10,7 @@ public final class NestedStringAliasExample {
     private final StringAliasExample value;
 
     private NestedStringAliasExample(StringAliasExample value) {
-        Objects.requireNonNull(value, "value cannot be null");
-        this.value = value;
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
     @JsonValue
@@ -37,7 +36,7 @@ public final class NestedStringAliasExample {
     }
 
     public static NestedStringAliasExample valueOf(String value) {
-        return new NestedStringAliasExample(StringAliasExample.valueOf(value));
+        return of(StringAliasExample.valueOf(value));
     }
 
     @JsonCreator

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReferenceAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReferenceAliasExample.java
@@ -2,7 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.util.Objects;
+import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -10,8 +10,7 @@ public final class ReferenceAliasExample {
     private final AnyExample value;
 
     private ReferenceAliasExample(AnyExample value) {
-        Objects.requireNonNull(value, "value cannot be null");
-        this.value = value;
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
     @JsonValue

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RidAliasExample.java
@@ -2,8 +2,8 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
 import com.palantir.ri.ResourceIdentifier;
-import java.util.Objects;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -11,8 +11,7 @@ public final class RidAliasExample {
     private final ResourceIdentifier value;
 
     private RidAliasExample(ResourceIdentifier value) {
-        Objects.requireNonNull(value, "value cannot be null");
-        this.value = value;
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
     @JsonValue
@@ -38,7 +37,7 @@ public final class RidAliasExample {
     }
 
     public static RidAliasExample valueOf(String value) {
-        return new RidAliasExample(ResourceIdentifier.valueOf(value));
+        return of(ResourceIdentifier.valueOf(value));
     }
 
     @JsonCreator

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongAliasExample.java
@@ -3,7 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.SafeLong;
-import java.util.Objects;
+import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -11,8 +11,7 @@ public final class SafeLongAliasExample {
     private final SafeLong value;
 
     private SafeLongAliasExample(SafeLong value) {
-        Objects.requireNonNull(value, "value cannot be null");
-        this.value = value;
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
     @JsonValue
@@ -38,7 +37,7 @@ public final class SafeLongAliasExample {
     }
 
     public static SafeLongAliasExample valueOf(String value) {
-        return new SafeLongAliasExample(SafeLong.valueOf(value));
+        return of(SafeLong.valueOf(value));
     }
 
     @JsonCreator

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasExample.java
@@ -2,7 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.util.Objects;
+import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -10,8 +10,7 @@ public final class StringAliasExample {
     private final String value;
 
     private StringAliasExample(String value) {
-        Objects.requireNonNull(value, "value cannot be null");
-        this.value = value;
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
     @JsonValue
@@ -37,7 +36,7 @@ public final class StringAliasExample {
     }
 
     public static StringAliasExample valueOf(String value) {
-        return new StringAliasExample(value);
+        return of(value);
     }
 
     @JsonCreator

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasOne.java
@@ -2,7 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.util.Objects;
+import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -10,8 +10,7 @@ public final class StringAliasOne {
     private final String value;
 
     private StringAliasOne(String value) {
-        Objects.requireNonNull(value, "value cannot be null");
-        this.value = value;
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
     @JsonValue
@@ -37,7 +36,7 @@ public final class StringAliasOne {
     }
 
     public static StringAliasOne valueOf(String value) {
-        return new StringAliasOne(value);
+        return of(value);
     }
 
     @JsonCreator

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasThree.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasThree.java
@@ -2,7 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.util.Objects;
+import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -10,8 +10,7 @@ public final class StringAliasThree {
     private final StringAliasTwo value;
 
     private StringAliasThree(StringAliasTwo value) {
-        Objects.requireNonNull(value, "value cannot be null");
-        this.value = value;
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
     @JsonValue

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasTwo.java
@@ -2,7 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.util.Objects;
+import com.palantir.logsafe.Preconditions;
 import java.util.Optional;
 import javax.annotation.Generated;
 
@@ -11,8 +11,7 @@ public final class StringAliasTwo {
     private final Optional<StringAliasOne> value;
 
     private StringAliasTwo(Optional<StringAliasOne> value) {
-        Objects.requireNonNull(value, "value cannot be null");
-        this.value = value;
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
     @JsonValue

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidAliasExample.java
@@ -2,7 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.util.Objects;
+import com.palantir.logsafe.Preconditions;
 import java.util.UUID;
 import javax.annotation.Generated;
 
@@ -11,8 +11,7 @@ public final class UuidAliasExample {
     private final UUID value;
 
     private UuidAliasExample(UUID value) {
-        Objects.requireNonNull(value, "value cannot be null");
-        this.value = value;
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
     @JsonValue
@@ -38,7 +37,7 @@ public final class UuidAliasExample {
     }
 
     public static UuidAliasExample valueOf(String value) {
-        return new UuidAliasExample(UUID.fromString(value));
+        return of(UUID.fromString(value));
     }
 
     @JsonCreator

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -169,7 +169,8 @@ public final class AliasGenerator {
             return typeMapper.getType(conjureType.accept(TypeVisitor.REFERENCE))
                     .filter(type -> type.accept(TypeDefinitionVisitor.IS_ALIAS))
                     .map(type -> type.accept(TypeDefinitionVisitor.ALIAS))
-                    .flatMap(type -> valueOfFactoryMethod(type.getAlias(), aliasTypeName, typeMapper)
+                    .flatMap(type -> valueOfFactoryMethod(
+                            type.getAlias(), typeMapper.getClassName(type.getAlias()), typeMapper)
                             .map(ignored -> {
                                 ClassName className = ClassName.get(
                                         type.getTypeName().getPackage(), type.getTypeName().getName());
@@ -179,8 +180,9 @@ public final class AliasGenerator {
         } else if (conjureType.accept(MoreVisitors.IS_EXTERNAL)) {
             ExternalReference reference = conjureType.accept(MoreVisitors.EXTERNAL);
             // Only generate valueOf methods for external type imports if the fallback type is valid
-            if (valueOfFactoryMethod(reference.getFallback(), aliasTypeName, typeMapper).isPresent()
-                    && hasValueOfFactory(reference.getExternalReference())) {
+            if (valueOfFactoryMethod(reference.getFallback(),
+                    typeMapper.getClassName(reference.getFallback()), typeMapper).isPresent()
+                    && hasValueOfFactory(reference.getExternalReference()) && aliasTypeName.isPrimitive()) {
                 return Optional.of(CodeBlock.builder()
                         .addStatement("return of($T.valueOf(value))", aliasTypeName.box())
                         .build());

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/visitor/MoreVisitors.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/visitor/MoreVisitors.java
@@ -17,12 +17,20 @@ public final class MoreVisitors {
     private MoreVisitors() {}
 
     public static final IsExternalType IS_EXTERNAL = new IsExternalType();
+    public static final ExternalType EXTERNAL = new ExternalType();
     public static final IsInternalReference IS_INTERNAL_REFERENCE = new IsInternalReference();
 
     private static class IsExternalType extends IsTypeVisitor {
         @Override
         public Boolean visitExternal(ExternalReference value) {
             return true;
+        }
+    }
+
+    private static class ExternalType extends DefaultTypeVisitor<ExternalReference> {
+        @Override
+        public ExternalReference visitExternal(ExternalReference value) {
+            return value;
         }
     }
 

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/AliasTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/AliasTests.java
@@ -1,0 +1,46 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.palantir.logsafe.exceptions.SafeNullPointerException;
+import com.palantir.product.ExternalLongAliasOne;
+import com.palantir.product.ExternalLongAliasTwo;
+import com.palantir.product.UuidAliasExample;
+import org.junit.Test;
+
+public class AliasTests {
+
+    @Test
+    public void testNullValueSafeLoggable() {
+        assertThatThrownBy(() -> UuidAliasExample.of(null))
+                .isInstanceOf(SafeNullPointerException.class)
+                .hasMessage("value cannot be null");
+    }
+
+    @Test
+    public void testValueOf_external() {
+        assertThat(ExternalLongAliasOne.valueOf("123")).isEqualTo(ExternalLongAliasOne.of(123L));
+    }
+
+    @Test
+    public void testValueOf_externalNested() {
+        assertThat(ExternalLongAliasTwo.valueOf("3")).isEqualTo(ExternalLongAliasTwo.of(ExternalLongAliasOne.of(3L)));
+    }
+}

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -206,3 +206,7 @@ types:
         alias: binary
       BinaryAliasTwo:
         alias: BinaryAliasOne
+      ExternalLongAliasOne:
+        alias: ExternalLong
+      ExternalLongAliasTwo:
+        alias: ExternalLongAliasOne


### PR DESCRIPTION
We no longer duplicate code between `of` and `valueOf`. `valueOf` simply
parses a string and passes the result to `of`.
Alias.of(null) results in a safe-logging npe rather than using
`Objects.requireNonNull`. Slightly simplified constructors to use
the result of the null check.
Add a `valueOf` function to alias of external type imports which both
declare a base type allowed to have a valueOf, and have a
`public static valueOf` function on the imported type (only applies
to types known by the generator).

## After this PR
==COMMIT_MSG==
Simpler alias valueOf implementation
==COMMIT_MSG==
