### PR TITLE
[improvement] SafeLong bounds check throws a safe exception on failure

### DIFF
--- a/conjure-lib/build.gradle
+++ b/conjure-lib/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testCompile 'junit:junit'
     testCompile 'org.assertj:assertj-core'
     testCompile 'org.mockito:mockito-core'
+    testCompile 'com.palantir.safe-logging:preconditions-assertj'
 
     annotationProcessor 'org.immutables:value'
     compileOnly 'org.immutables:value::annotations'

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/SafeLong.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/SafeLong.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.java.lib;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
 import org.immutables.value.Value;
 
 /**
@@ -36,11 +37,9 @@ public abstract class SafeLong {
 
     @Value.Check
     protected final void check() {
-        if (!(MIN_SAFE_VALUE <= longValue() && longValue() <= MAX_SAFE_VALUE)) {
-            throw new IllegalArgumentException(String.format(
-                    "number must be safely representable in javascript i.e. lie between %s and %s",
-                    MIN_SAFE_VALUE, MAX_SAFE_VALUE));
-        }
+        Preconditions.checkArgument(MIN_SAFE_VALUE <= longValue() && longValue() <= MAX_SAFE_VALUE,
+                "number must be safely representable in javascript i.e. "
+                        + "lie between -9007199254740991 and 9007199254740991");
     }
 
     public static SafeLong valueOf(String value) {


### PR DESCRIPTION
## Before this PR
Previously we threw a standard IllegalArgumentException, which
provides very little informatino in some environments.


## After this PR
==COMMIT_MSG==
SafeLong bounds check throws a safe exception on failure
==COMMIT_MSG==
