### PR TITLE
[fix] Box external type before calling valueOf in UndertowServiceHandlerGenerator

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
@@ -79,7 +79,7 @@ public interface EteService {
 
     @GET
     @Path("base/externalLong/{param}")
-    String externalLongPath(
+    long externalLongPath(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @PathParam("param") long param);
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
@@ -77,6 +77,12 @@ public interface EteService {
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @PathParam("param") String param);
 
+    @GET
+    @Path("base/externalLong/{param}")
+    String externalLongPath(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @PathParam("param") long param);
+
     @POST
     @Path("base/notNullBody")
     StringAliasExample notNullBody(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
@@ -637,12 +637,12 @@ public final class EteServiceEndpoints implements UndertowService {
 
         private final UndertowEteService delegate;
 
-        private final Serializer<String> serializer;
+        private final Serializer<Long> serializer;
 
         ExternalLongPathEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Long>() {});
         }
 
         @Override
@@ -652,7 +652,7 @@ public final class EteServiceEndpoints implements UndertowService {
                     exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
             long param =
                     Long.valueOf(runtime.plainSerDe().deserializeString(pathParams.get("param")));
-            String result = delegate.externalLongPath(authHeader, param);
+            long result = delegate.externalLongPath(authHeader, param);
             serializer.serialize(result, exchange);
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
@@ -72,7 +72,7 @@ public interface EteServiceRetrofit {
 
     @GET("./base/externalLong/{param}")
     @Headers({"hr-path-template: /base/externalLong/{param}", "Accept: application/json"})
-    Call<String> externalLongPath(
+    Call<Long> externalLongPath(
             @Header("Authorization") AuthHeader authHeader, @Path("param") long param);
 
     @POST("./base/notNullBody")

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
@@ -70,6 +70,11 @@ public interface EteServiceRetrofit {
     @Headers({"hr-path-template: /base/path/{param}", "Accept: application/json"})
     Call<String> path(@Header("Authorization") AuthHeader authHeader, @Path("param") String param);
 
+    @GET("./base/externalLong/{param}")
+    @Headers({"hr-path-template: /base/externalLong/{param}", "Accept: application/json"})
+    Call<String> externalLongPath(
+            @Header("Authorization") AuthHeader authHeader, @Path("param") long param);
+
     @POST("./base/notNullBody")
     @Headers({"hr-path-template: /base/notNullBody", "Accept: application/json"})
     Call<StringAliasExample> notNullBody(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
@@ -36,7 +36,7 @@ public interface UndertowEteService {
 
     String path(AuthHeader authHeader, String param);
 
-    String externalLongPath(AuthHeader authHeader, long param);
+    long externalLongPath(AuthHeader authHeader, long param);
 
     StringAliasExample notNullBody(AuthHeader authHeader, StringAliasExample notNullBody);
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
@@ -36,6 +36,8 @@ public interface UndertowEteService {
 
     String path(AuthHeader authHeader, String param);
 
+    String externalLongPath(AuthHeader authHeader, long param);
+
     StringAliasExample notNullBody(AuthHeader authHeader, StringAliasExample notNullBody);
 
     StringAliasExample aliasOne(AuthHeader authHeader, StringAliasExample queryParamName);

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -603,7 +603,7 @@ final class UndertowServiceHandlerGenerator {
                     "$1T $2N = $3T.valueOf($4N.plainSerDe().deserializeString($5N.get($6S)))",
                     typeMapper.getClassName(type),
                     resultVarName,
-                    typeMapper.getClassName(type),
+                    typeMapper.getClassName(type).box(),
                     RUNTIME_VAR_NAME,
                     paramsVarName,
                     paramId

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/EteResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/EteResource.java
@@ -98,6 +98,11 @@ public class EteResource implements EteService {
     }
 
     @Override
+    public long externalLongPath(AuthHeader authHeader, long param) {
+        return param;
+    }
+
+    @Override
     public StringAliasExample notNullBody(AuthHeader authHeader, StringAliasExample notNullBody) {
         return notNullBody;
     }

--- a/conjure-java-core/src/test/resources/ete-service.yml
+++ b/conjure-java-core/src/test/resources/ete-service.yml
@@ -92,7 +92,7 @@ services:
         http: GET /externalLong/{param}
         args:
           param: Long
-        returns: string
+        returns: Long
 
       notNullBody:
         http: POST /notNullBody

--- a/conjure-java-core/src/test/resources/ete-service.yml
+++ b/conjure-java-core/src/test/resources/ete-service.yml
@@ -4,6 +4,10 @@ types:
       base-type: string
       external:
         java: com.palantir.product.StringAliasExample
+    Long:
+      base-type: string
+      external:
+        java: java.lang.Long
   definitions:
     default-package: com.palantir.product
     objects:
@@ -82,6 +86,12 @@ services:
         http: GET /path/{param}
         args:
           param: string
+        returns: string
+
+      externalLongPath:
+        http: GET /externalLong/{param}
+        args:
+          param: Long
         returns: string
 
       notNullBody:


### PR DESCRIPTION
## Before this PR
Use of external imports that have primitive types would cause parameter code blocks generated by the UndertowServiceHandlerGenerator to not compile by calling valueOf on the primitive type.

## After this PR
==COMMIT_MSG==
Parameter code generated by the UndertowServiceHandlerGenerator now correctly boxes external types.
==COMMIT_MSG==
