### PR TITLE
[fix] Fix deserialization for aliases of external type imports

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasExample.java
@@ -1,5 +1,6 @@
 package com.palantir.product;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import javax.annotation.Generated;
 
@@ -33,10 +34,12 @@ public final class ExternalLongAliasExample {
         return Long.hashCode(value);
     }
 
+    @JsonCreator
     public static ExternalLongAliasExample valueOf(String value) {
         return of(Long.valueOf(value));
     }
 
+    @JsonCreator
     public static ExternalLongAliasExample of(long value) {
         return new ExternalLongAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import javax.annotation.Generated;
 
@@ -38,7 +37,6 @@ public final class ExternalLongAliasExample {
         return of(Long.valueOf(value));
     }
 
-    @JsonCreator
     public static ExternalLongAliasExample of(long value) {
         return new ExternalLongAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasOne.java
@@ -1,5 +1,6 @@
 package com.palantir.product;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import javax.annotation.Generated;
 
@@ -33,10 +34,12 @@ public final class ExternalLongAliasOne {
         return Long.hashCode(value);
     }
 
+    @JsonCreator
     public static ExternalLongAliasOne valueOf(String value) {
         return of(Long.valueOf(value));
     }
 
+    @JsonCreator
     public static ExternalLongAliasOne of(long value) {
         return new ExternalLongAliasOne(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasOne.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import javax.annotation.Generated;
 
@@ -38,7 +37,6 @@ public final class ExternalLongAliasOne {
         return of(Long.valueOf(value));
     }
 
-    @JsonCreator
     public static ExternalLongAliasOne of(long value) {
         return new ExternalLongAliasOne(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalStringAliasExample.java
@@ -1,0 +1,42 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class ExternalStringAliasExample {
+    private final String value;
+
+    private ExternalStringAliasExample(String value) {
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
+    }
+
+    @JsonValue
+    public String get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof ExternalStringAliasExample
+                        && this.value.equals(((ExternalStringAliasExample) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @JsonCreator
+    public static ExternalStringAliasExample of(String value) {
+        return new ExternalStringAliasExample(value);
+    }
+}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -92,18 +92,18 @@ public final class AliasGenerator {
                     .addParameter(String.class, "value")
                     .returns(thisClass)
                     .addCode(maybeValueOfFactoryMethod.get())
+                    .addAnnotations(typeDef.getAlias().accept(MoreVisitors.IS_EXTERNAL)
+                            // JsonCreator behaves in unexpected ways:
+                            // https://github.com/FasterXML/jackson-databind/issues/2318
+                            // allow jackson to try all possible approaches to deserialize external type imports.
+                            ? Collections.singleton(AnnotationSpec.builder(JsonCreator.class).build())
+                            : Collections.emptySet())
                     .build());
         }
 
         spec.addMethod(MethodSpec.methodBuilder("of")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .addAnnotations(maybeValueOfFactoryMethod.isPresent()
-                        && typeDef.getAlias().accept(MoreVisitors.IS_EXTERNAL)
-                        // JsonCreator behaves in unexpected ways:
-                        // https://github.com/FasterXML/jackson-databind/issues/2318
-                        // allow jackson to try all possible approaches to deserialize external type imports.
-                        ? Collections.emptySet()
-                        : Collections.singleton(AnnotationSpec.builder(JsonCreator.class).build()))
+                .addAnnotation(JsonCreator.class)
                 .addParameter(aliasTypeName, "value")
                 .returns(thisClass)
                 .addStatement("return new $T(value)", thisClass)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -98,12 +98,12 @@ public final class AliasGenerator {
         spec.addMethod(MethodSpec.methodBuilder("of")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .addAnnotations(maybeValueOfFactoryMethod.isPresent()
-                        && typeDef.getAlias().accept(MoreVisitors.IS_EXTERNAL) ?
+                        && typeDef.getAlias().accept(MoreVisitors.IS_EXTERNAL)
                         // JsonCreator behaves in unexpected ways:
                         // https://github.com/FasterXML/jackson-databind/issues/2318
                         // allow jackson to try all possible approaches to deserialize external type imports.
-                        Collections.emptySet() :
-                        Collections.singleton(AnnotationSpec.builder(JsonCreator.class).build()))
+                        ? Collections.emptySet()
+                        : Collections.singleton(AnnotationSpec.builder(JsonCreator.class).build()))
                 .addParameter(aliasTypeName, "value")
                 .returns(thisClass)
                 .addStatement("return new $T(value)", thisClass)

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -18,6 +18,7 @@ import com.palantir.product.DoubleAliasExample;
 import com.palantir.product.DoubleExample;
 import com.palantir.product.EmptyObjectExample;
 import com.palantir.product.EnumExample;
+import com.palantir.product.ExternalLongAliasExample;
 import com.palantir.product.IntegerAliasExample;
 import com.palantir.product.ListExample;
 import com.palantir.product.MapExample;
@@ -369,6 +370,18 @@ public final class WireFormatTests {
 
         assertThat(mapper.writeValueAsString(deserialized)).isEqualTo(serialized);
         assertThat(mapper.readValue(serialized, UuidExample.class)).isEqualTo(deserialized);
+    }
+
+    @Test
+    public void test_long_alias_numeric() throws IOException {
+        assertThat(mapper.readValue("123", ExternalLongAliasExample.class))
+                .isEqualTo(ExternalLongAliasExample.of(123L));
+    }
+
+    @Test
+    public void test_long_alias_string() throws IOException {
+        assertThat(mapper.readValue("\"123\"", ExternalLongAliasExample.class))
+                .isEqualTo(ExternalLongAliasExample.of(123L));
     }
 
     @Test

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -19,6 +19,7 @@ import com.palantir.product.DoubleExample;
 import com.palantir.product.EmptyObjectExample;
 import com.palantir.product.EnumExample;
 import com.palantir.product.ExternalLongAliasExample;
+import com.palantir.product.ExternalStringAliasExample;
 import com.palantir.product.IntegerAliasExample;
 import com.palantir.product.ListExample;
 import com.palantir.product.MapExample;
@@ -382,6 +383,12 @@ public final class WireFormatTests {
     public void test_long_alias_string() throws IOException {
         assertThat(mapper.readValue("\"123\"", ExternalLongAliasExample.class))
                 .isEqualTo(ExternalLongAliasExample.of(123L));
+    }
+
+    @Test
+    public void test_external_string_alias() throws IOException {
+        assertThat(mapper.readValue("\"Hello, World!\"", ExternalStringAliasExample.class))
+                .isEqualTo(ExternalStringAliasExample.of("Hello, World!"));
     }
 
     @Test

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -9,6 +9,10 @@ types:
       base-type: safelong
       external:
         java: java.lang.Long
+    ExternalString:
+      base-type: string
+      external:
+        java: java.lang.String
   definitions:
     default-package: com.palantir.product
     objects:
@@ -118,6 +122,8 @@ types:
           uuid: optional<uuid>
       ExternalLongAliasExample:
         alias: ExternalLong
+      ExternalStringAliasExample:
+        alias: ExternalString
       ExternalLongExample:
         fields:
           externalLong: ExternalLong


### PR DESCRIPTION
Regression introduced between 1.10.3 and 3.5.

JsonCreator factory methods are handled as 'native' deserializers,
bypassing all ObjectMapper configuration and deserializers.
https://github.com/FasterXML/jackson-databind/issues/2318

In cases when both a `valueOf` and `of` method exist for an
external type import, we do not apply the `JsonCreator`
annotation, allowing jackson to choose the most accurate
deserializer function (either `of` or `valueOf` depending
on the input node type).

## After this PR
==COMMIT_MSG==
Fix deserialization for aliases of external type imports
==COMMIT_MSG==
