### PR TITLE
[fix] Box external types before calling valueOf when used in optionals in UndertowServiceHandlerGenerator

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
@@ -83,6 +83,12 @@ public interface EteService {
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @PathParam("param") long param);
 
+    @GET
+    @Path("base/optionalExternalLong")
+    Optional<Long> optionalExternalLongQuery(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @QueryParam("param") Optional<Long> param);
+
     @POST
     @Path("base/notNullBody")
     StringAliasExample notNullBody(
@@ -152,6 +158,11 @@ public interface EteService {
     SimpleEnum enumHeader(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @HeaderParam("Custom-Header") SimpleEnum headerParameter);
+
+    @Deprecated
+    default Optional<Long> optionalExternalLongQuery(AuthHeader authHeader) {
+        return optionalExternalLongQuery(authHeader, Optional.empty());
+    }
 
     @Deprecated
     default StringAliasExample optionalAliasOne(AuthHeader authHeader) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
@@ -75,6 +75,11 @@ public interface EteServiceRetrofit {
     Call<Long> externalLongPath(
             @Header("Authorization") AuthHeader authHeader, @Path("param") long param);
 
+    @GET("./base/optionalExternalLong")
+    @Headers({"hr-path-template: /base/optionalExternalLong", "Accept: application/json"})
+    Call<Optional<Long>> optionalExternalLongQuery(
+            @Header("Authorization") AuthHeader authHeader, @Query("param") Optional<Long> param);
+
     @POST("./base/notNullBody")
     @Headers({"hr-path-template: /base/notNullBody", "Accept: application/json"})
     Call<StringAliasExample> notNullBody(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
@@ -38,6 +38,8 @@ public interface UndertowEteService {
 
     long externalLongPath(AuthHeader authHeader, long param);
 
+    Optional<Long> optionalExternalLongQuery(AuthHeader authHeader, Optional<Long> param);
+
     StringAliasExample notNullBody(AuthHeader authHeader, StringAliasExample notNullBody);
 
     StringAliasExample aliasOne(AuthHeader authHeader, StringAliasExample queryParamName);

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -678,7 +678,7 @@ final class UndertowServiceHandlerGenerator {
                 functionName,
                 paramsVarName,
                 paramId,
-                typeMapper.getClassName(getComplexType(type))));
+                typeMapper.getClassName(getComplexType(type)).box()));
     }
 
     /**

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/EteResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/EteResource.java
@@ -103,6 +103,11 @@ public class EteResource implements EteService {
     }
 
     @Override
+    public Optional<Long> optionalExternalLongQuery(AuthHeader authHeader, Optional<Long> param) {
+        return param;
+    }
+
+    @Override
     public StringAliasExample notNullBody(AuthHeader authHeader, StringAliasExample notNullBody) {
         return notNullBody;
     }

--- a/conjure-java-core/src/test/resources/ete-service.yml
+++ b/conjure-java-core/src/test/resources/ete-service.yml
@@ -94,6 +94,14 @@ services:
           param: Long
         returns: Long
 
+      optionalExternalLongQuery:
+        http: GET /optionalExternalLong
+        args:
+          param:
+            param-type: query
+            type: optional<Long>
+        returns: optional<Long>
+
       notNullBody:
         http: POST /notNullBody
         args:


### PR DESCRIPTION
## Before this PR
Use of external imports that have primitive types that are used in optionals would cause parameter code blocks generated by the UndertowServiceHandlerGenerator to not compile by calling valueOf on the primitive type.

## After this PR
==COMMIT_MSG==
Parameter code generated by the UndertowServiceHandlerGenerator now correctly boxes external types used in optionals.
==COMMIT_MSG==

