### PR TITLE
[improvement] SafeLong is now Comparable

### DIFF
--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/SafeLong.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/SafeLong.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.lib;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
+import java.util.Comparable;
 import org.immutables.value.Value;
 
 /**
@@ -26,7 +27,7 @@ import org.immutables.value.Value;
  * without loss of precision.
  */
 @Value.Immutable
-public abstract class SafeLong {
+public abstract class SafeLong implements Comparable<SafeLong> {
 
     private static final long MIN_SAFE_VALUE = -(1L << 53) + 1;
     private static final long MAX_SAFE_VALUE = (1L << 53) - 1;
@@ -55,5 +56,9 @@ public abstract class SafeLong {
     public final String toString() {
         return Long.toString(longValue());
     }
-
+    
+    @Override
+    public final int compareTo(SafeLong other) {
+        return Long.compare(longValue(), other.longValue());
+    }
 }

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/SafeLong.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/SafeLong.java
@@ -55,7 +55,7 @@ public abstract class SafeLong implements Comparable<SafeLong> {
     public final String toString() {
         return Long.toString(longValue());
     }
-    
+
     @Override
     public final int compareTo(SafeLong other) {
         return Long.compare(longValue(), other.longValue());

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/SafeLong.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/SafeLong.java
@@ -19,7 +19,6 @@ package com.palantir.conjure.java.lib;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
-import java.util.Comparable;
 import org.immutables.value.Value;
 
 /**

--- a/conjure-lib/src/test/java/com/palantir/conjure/java/lib/SafeLongTests.java
+++ b/conjure-lib/src/test/java/com/palantir/conjure/java/lib/SafeLongTests.java
@@ -25,7 +25,9 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.Test;
 
 public final class SafeLongTests {
@@ -82,5 +84,13 @@ public final class SafeLongTests {
     public void testToString() {
         assertThat(SafeLong.of(maxValue).toString()).isEqualTo("9007199254740991");
         assertThat(SafeLong.of(minValue).toString()).isEqualTo("-9007199254740991");
+    }
+
+    @Test
+    public void testComparable() {
+        assertThat(Stream.of(SafeLong.of(1), SafeLong.of(3), SafeLong.of(2)).max(Comparator.naturalOrder()).get())
+                .isEqualTo(SafeLong.of(3));
+        assertThat(Stream.of(SafeLong.of(1), SafeLong.of(3), SafeLong.of(2)).min(Comparator.naturalOrder()).get())
+                .isEqualTo(SafeLong.of(1));
     }
 }


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

```java
         return Long.compare(left.get().longValue(), right.get().longValue());
```

is the sort of code that is pretty sad :)