### PR TITLE
[improvement] Javadoc html is rendered from conjure docs markdown

### DIFF
--- a/conjure-java-core/build.gradle
+++ b/conjure-java-core/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     compile 'javax.validation:validation-api'
     compile 'org.apache.commons:commons-lang3'
     compile 'org.slf4j:slf4j-api'
+    compile 'com.atlassian.commonmark:commonmark'
 
     testCompile('com.palantir.conjure:conjure-core') {
         exclude group: 'com.palantir.conjure.java', module: 'conjure-lib'

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
@@ -84,6 +84,11 @@ public interface EteService {
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
     StreamingOutput binary(@HeaderParam("Authorization") @NotNull AuthHeader authHeader);
 
+    /**
+     * Path endpoint.
+     *
+     * @param param Documentation for <code>param</code>
+     */
     @GET
     @Path("base/path/{param}")
     String path(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
@@ -26,10 +26,23 @@ import javax.ws.rs.core.StreamingOutput;
 @Path("/")
 @Generated("com.palantir.conjure.java.services.JerseyServiceGenerator")
 public interface EteService {
+    /**
+     * foo bar baz.
+     *
+     * <h2>Very Important Documentation</h2>
+     *
+     * This documentation provides a <em>list</em>:
+     *
+     * <ul>
+     *   <li>Docs rule
+     *   <li>Lists are wonderful
+     * </ul>
+     */
     @GET
     @Path("base/string")
     String string(@HeaderParam("Authorization") @NotNull AuthHeader authHeader);
 
+    /** one <em>two</em> three. */
     @GET
     @Path("base/integer")
     int integer(@HeaderParam("Authorization") @NotNull AuthHeader authHeader);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
@@ -31,7 +31,7 @@ public interface EteService {
      *
      * <h2>Very Important Documentation</h2>
      *
-     * This documentation provides a <em>list</em>:
+     * <p>This documentation provides a <em>list</em>:
      *
      * <ul>
      *   <li>Docs rule

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
@@ -21,10 +21,23 @@ import retrofit2.http.Streaming;
 
 @Generated("com.palantir.conjure.java.services.Retrofit2ServiceGenerator")
 public interface EteServiceRetrofit {
+    /**
+     * foo bar baz.
+     *
+     * <h2>Very Important Documentation</h2>
+     *
+     * This documentation provides a <em>list</em>:
+     *
+     * <ul>
+     *   <li>Docs rule
+     *   <li>Lists are wonderful
+     * </ul>
+     */
     @GET("./base/string")
     @Headers({"hr-path-template: /base/string", "Accept: application/json"})
     Call<String> string(@Header("Authorization") AuthHeader authHeader);
 
+    /** one <em>two</em> three. */
     @GET("./base/integer")
     @Headers({"hr-path-template: /base/integer", "Accept: application/json"})
     Call<Integer> integer(@Header("Authorization") AuthHeader authHeader);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
@@ -26,7 +26,7 @@ public interface EteServiceRetrofit {
      *
      * <h2>Very Important Documentation</h2>
      *
-     * This documentation provides a <em>list</em>:
+     * <p>This documentation provides a <em>list</em>:
      *
      * <ul>
      *   <li>Docs rule

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
@@ -79,6 +79,11 @@ public interface EteServiceRetrofit {
     @Streaming
     Call<ResponseBody> binary(@Header("Authorization") AuthHeader authHeader);
 
+    /**
+     * Path endpoint.
+     *
+     * @param param Documentation for <code>param</code>
+     */
     @GET("./base/path/{param}")
     @Headers({"hr-path-template: /base/path/{param}", "Accept: application/json"})
     Call<String> path(@Header("Authorization") AuthHeader authHeader, @Path("param") String param);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
@@ -47,6 +47,11 @@ public interface UndertowEteService {
 
     BinaryResponseBody binary(AuthHeader authHeader);
 
+    /**
+     * Path endpoint.
+     *
+     * @param param Documentation for <code>param</code>
+     */
     String path(AuthHeader authHeader, String param);
 
     long externalLongPath(AuthHeader authHeader, long param);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
@@ -12,8 +12,21 @@ import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
 public interface UndertowEteService {
+    /**
+     * foo bar baz.
+     *
+     * <h2>Very Important Documentation</h2>
+     *
+     * This documentation provides a <em>list</em>:
+     *
+     * <ul>
+     *   <li>Docs rule
+     *   <li>Lists are wonderful
+     * </ul>
+     */
     String string(AuthHeader authHeader);
 
+    /** one <em>two</em> three. */
     int integer(AuthHeader authHeader);
 
     double double_(AuthHeader authHeader);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
@@ -17,7 +17,7 @@ public interface UndertowEteService {
      *
      * <h2>Very Important Documentation</h2>
      *
-     * This documentation provides a <em>list</em>:
+     * <p>This documentation provides a <em>list</em>:
      *
      * <ul>
      *   <li>Docs rule

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
@@ -27,6 +27,7 @@ import com.palantir.conjure.java.types.DefaultClassNameVisitor;
 import com.palantir.conjure.java.types.ReturnTypeClassNameVisitor;
 import com.palantir.conjure.java.types.SpecializeBinaryClassNameVisitor;
 import com.palantir.conjure.java.types.TypeMapper;
+import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.java.util.ParameterOrder;
 import com.palantir.conjure.java.visitor.DefaultTypeVisitor;
 import com.palantir.conjure.spec.ArgumentDefinition;
@@ -68,7 +69,6 @@ import java.util.stream.IntStream;
 import javax.lang.model.element.Modifier;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
-import org.apache.commons.lang3.StringUtils;
 
 public final class JerseyServiceGenerator implements ServiceGenerator {
 
@@ -133,8 +133,7 @@ public final class JerseyServiceGenerator implements ServiceGenerator {
                         .build())
                 .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(JerseyServiceGenerator.class));
 
-        serviceDefinition.getDocs().ifPresent(docs ->
-                serviceBuilder.addJavadoc("$L", StringUtils.appendIfMissing(docs.get(), "\n")));
+        serviceDefinition.getDocs().ifPresent(docs -> serviceBuilder.addJavadoc("$L", Javadoc.render(docs)));
 
         serviceBuilder.addMethods(serviceDefinition.getEndpoints().stream()
                 .map(endpoint -> generateServiceMethod(endpoint, returnTypeMapper, argumentTypeMapper))

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
@@ -27,6 +27,7 @@ import com.palantir.conjure.java.types.DefaultClassNameVisitor;
 import com.palantir.conjure.java.types.ReturnTypeClassNameVisitor;
 import com.palantir.conjure.java.types.SpecializeBinaryClassNameVisitor;
 import com.palantir.conjure.java.types.TypeMapper;
+import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.spec.ArgumentDefinition;
 import com.palantir.conjure.spec.ArgumentName;
 import com.palantir.conjure.spec.AuthType;
@@ -56,7 +57,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
 import javax.ws.rs.core.MediaType;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,9 +108,7 @@ public final class Retrofit2ServiceGenerator implements ServiceGenerator {
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(Retrofit2ServiceGenerator.class));
 
-        serviceDefinition.getDocs().ifPresent(docs -> {
-            serviceBuilder.addJavadoc("$L", StringUtils.appendIfMissing(docs.get(), "\n"));
-        });
+        serviceDefinition.getDocs().ifPresent(docs -> serviceBuilder.addJavadoc("$L", Javadoc.render(docs)));
 
         serviceBuilder.addMethods(serviceDefinition.getEndpoints().stream()
                 .map(endpoint -> generateServiceMethod(endpoint, returnTypeMapper, argumentTypeMapper))

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/ServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/ServiceGenerator.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.services;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.palantir.conjure.java.util.Goethe;
 import com.palantir.conjure.java.util.Javadoc;
@@ -27,6 +28,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 public interface ServiceGenerator {
@@ -53,8 +55,14 @@ public interface ServiceGenerator {
 
         Optional<String> docs = endpointDef.getDocs().map(Javadoc::render);
 
+        Optional<String> params = Optional.ofNullable(Strings.emptyToNull(endpointDef.getArgs().stream()
+                .filter(argument -> argument.getDocs().isPresent())
+                .map(argument -> Javadoc.getParameterJavadoc(argument, endpointDef))
+                .collect(Collectors.joining("\n"))));
+
         StringBuilder sb = new StringBuilder();
         docs.ifPresent(sb::append);
+        params.ifPresent(sb::append);
         depr.ifPresent(sb::append);
         return sb.length() > 0 ? Optional.of(sb.toString()) : Optional.empty();
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/ServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/ServiceGenerator.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.java.services;
 
 import com.google.common.collect.Lists;
 import com.palantir.conjure.java.util.Goethe;
+import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.spec.ConjureDefinition;
 import com.palantir.conjure.spec.EndpointDefinition;
 import com.squareup.javapoet.JavaFile;
@@ -50,8 +51,7 @@ public interface ServiceGenerator {
         Optional<String> depr = endpointDef.getDeprecated()
                 .map(v -> StringUtils.appendIfMissing("@deprecated " + v, "\n"));
 
-        Optional<String> docs = endpointDef.getDocs()
-                .map(v -> StringUtils.appendIfMissing(v.get(), "\n"));
+        Optional<String> docs = endpointDef.getDocs().map(Javadoc::render);
 
         StringBuilder sb = new StringBuilder();
         docs.ifPresent(sb::append);

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/ServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/ServiceGenerator.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.java.services;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Streams;
 import com.palantir.conjure.java.util.Goethe;
 import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.spec.ConjureDefinition;
@@ -56,8 +57,7 @@ public interface ServiceGenerator {
         Optional<String> docs = endpointDef.getDocs().map(Javadoc::render);
 
         Optional<String> params = Optional.ofNullable(Strings.emptyToNull(endpointDef.getArgs().stream()
-                .filter(argument -> argument.getDocs().isPresent())
-                .map(argument -> Javadoc.getParameterJavadoc(argument, endpointDef))
+                .flatMap(argument -> Streams.stream(Javadoc.getParameterJavadoc(argument, endpointDef)))
                 .collect(Collectors.joining("\n"))));
 
         StringBuilder sb = new StringBuilder();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceInterfaceGenerator.java
@@ -21,6 +21,7 @@ import com.palantir.conjure.java.ConjureAnnotations;
 import com.palantir.conjure.java.FeatureFlags;
 import com.palantir.conjure.java.types.TypeMapper;
 import com.palantir.conjure.java.util.JavaNameSanitizer;
+import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.java.util.ParameterOrder;
 import com.palantir.conjure.spec.ArgumentDefinition;
 import com.palantir.conjure.spec.AuthType;
@@ -40,7 +41,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
-import org.apache.commons.lang3.StringUtils;
 
 final class UndertowServiceInterfaceGenerator {
 
@@ -59,8 +59,7 @@ final class UndertowServiceInterfaceGenerator {
                 .addAnnotation(
                         ConjureAnnotations.getConjureGeneratedAnnotation(UndertowServiceInterfaceGenerator.class));
 
-        serviceDefinition.getDocs().ifPresent(docs ->
-                serviceBuilder.addJavadoc("$L", StringUtils.appendIfMissing(docs.get(), "\n")));
+        serviceDefinition.getDocs().ifPresent(docs -> serviceBuilder.addJavadoc("$L", Javadoc.render(docs)));
 
         serviceBuilder.addMethods(serviceDefinition.getEndpoints().stream()
                 .map(endpoint -> generateServiceInterfaceMethod(endpoint, typeMapper, returnTypeMapper))

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.types;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.ConjureAnnotations;
+import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.java.visitor.MoreVisitors;
 import com.palantir.conjure.spec.AliasDefinition;
 import com.palantir.conjure.spec.ExternalReference;
@@ -38,7 +39,6 @@ import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Optional;
 import javax.lang.model.element.Modifier;
-import org.apache.commons.lang3.StringUtils;
 
 public final class AliasGenerator {
 
@@ -155,7 +155,7 @@ public final class AliasGenerator {
                     .build());
         }
 
-        typeDef.getDocs().ifPresent(docs -> spec.addJavadoc("$L", StringUtils.appendIfMissing(docs.get(), "\n")));
+        typeDef.getDocs().ifPresent(docs -> spec.addJavadoc("$L", Javadoc.render(docs)));
 
         return JavaFile.builder(typePackage, spec.build())
                 .skipJavaLangImports(true)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -26,8 +26,8 @@ import com.palantir.conjure.java.FeatureFlags;
 import com.palantir.conjure.java.lib.internal.ConjureCollections;
 import com.palantir.conjure.java.types.BeanGenerator.EnrichedField;
 import com.palantir.conjure.java.util.JavaNameSanitizer;
+import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.java.visitor.DefaultTypeVisitor;
-import com.palantir.conjure.spec.Documentation;
 import com.palantir.conjure.spec.FieldDefinition;
 import com.palantir.conjure.spec.FieldName;
 import com.palantir.conjure.spec.MapType;
@@ -265,7 +265,7 @@ public final class BeanBuilderGenerator {
         Type type = enriched.conjureDef().getType();
         boolean shouldClearFirst = false;
         return MethodSpec.methodBuilder(prefix + StringUtils.capitalize(field.name))
-                .addJavadoc(enriched.conjureDef().getDocs().map(Documentation::get).orElse(""))
+                .addJavadoc(enriched.conjureDef().getDocs().map(Javadoc::render).orElse(""))
                 .addModifiers(Modifier.PUBLIC)
                 .returns(builderClass)
                 .addParameter(widenParameterIfPossible(field.type, type), field.name)
@@ -470,7 +470,7 @@ public final class BeanBuilderGenerator {
 
     private MethodSpec.Builder publicSetter(EnrichedField enriched) {
         return MethodSpec.methodBuilder(enriched.poetSpec().name)
-                .addJavadoc(enriched.conjureDef().getDocs().map(Documentation::get).orElse(""))
+                .addJavadoc(enriched.conjureDef().getDocs().map(Javadoc::render).orElse(""))
                 .addModifiers(Modifier.PUBLIC)
                 .returns(builderClass);
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -25,6 +25,7 @@ import com.palantir.conjure.CaseConverter;
 import com.palantir.conjure.java.ConjureAnnotations;
 import com.palantir.conjure.java.FeatureFlags;
 import com.palantir.conjure.java.util.JavaNameSanitizer;
+import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.spec.FieldDefinition;
 import com.palantir.conjure.spec.FieldName;
 import com.palantir.conjure.spec.ObjectDefinition;
@@ -116,8 +117,7 @@ public final class BeanGenerator {
 
         typeBuilder.addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(BeanGenerator.class));
 
-        typeDef.getDocs().ifPresent(docs ->
-                typeBuilder.addJavadoc("$L", StringUtils.appendIfMissing(docs.get(), "\n")));
+        typeDef.getDocs().ifPresent(docs -> typeBuilder.addJavadoc("$L", Javadoc.render(docs)));
 
         return JavaFile.builder(typePackage, typeBuilder.build())
                 .skipJavaLangImports(true)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -22,6 +22,7 @@ import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.palantir.conjure.java.ConjureAnnotations;
+import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.spec.EnumDefinition;
 import com.palantir.conjure.spec.EnumValueDefinition;
 import com.squareup.javapoet.ClassName;
@@ -89,8 +90,7 @@ public final class EnumGenerator {
                 .addMethod(createValueOf(thisClass, typeDef.getValues()))
                 .addMethod(generateAcceptVisitMethod(visitorClass, typeDef.getValues()));
 
-        typeDef.getDocs().ifPresent(
-                docs -> wrapper.addJavadoc("$L<p>\n", StringUtils.appendIfMissing(docs.get(), "\n")));
+        typeDef.getDocs().ifPresent(docs -> wrapper.addJavadoc("$L<p>\n", Javadoc.render(docs)));
 
         wrapper.addJavadoc(
                 "This class is used instead of a native enum to support unknown values.\n"
@@ -129,8 +129,7 @@ public final class EnumGenerator {
                 .addModifiers(Modifier.PUBLIC);
         for (EnumValueDefinition value : values) {
             TypeSpec.Builder anonymousClassBuilder = TypeSpec.anonymousClassBuilder("");
-            value.getDocs().ifPresent(docs ->
-                    anonymousClassBuilder.addJavadoc("$L", StringUtils.appendIfMissing(docs.get(), "\n")));
+            value.getDocs().ifPresent(docs -> anonymousClassBuilder.addJavadoc("$L", Javadoc.render(docs)));
             enumBuilder.addEnumConstant(value.getValue(), anonymousClassBuilder.build());
         }
         if (withUnknown) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ErrorGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ErrorGenerator.java
@@ -22,7 +22,7 @@ import com.google.common.collect.Streams;
 import com.palantir.conjure.java.ConjureAnnotations;
 import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.ServiceException;
-import com.palantir.conjure.spec.Documentation;
+import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.spec.ErrorDefinition;
 import com.palantir.conjure.spec.ErrorNamespace;
 import com.palantir.conjure.spec.FieldDefinition;
@@ -140,7 +140,7 @@ public final class ErrorGenerator {
                         methodBuilder.addParameter(typeMapper.getClassName(arg.getType()), arg.getFieldName().get());
                         methodBuilder.addJavadoc("@param $L $L", arg.getFieldName().get(),
                                         StringUtils.appendIfMissing(
-                                                arg.getDocs().map(Documentation::get).orElse(""), "\n"));
+                                                arg.getDocs().map(Javadoc::render).orElse(""), "\n"));
                     });
 
             methodBuilder.addCode("if ($L) {", shouldThrowVar);
@@ -203,7 +203,7 @@ public final class ErrorGenerator {
         Class<?> clazz = isSafe ? SafeArg.class : UnsafeArg.class;
         methodBuilder.addCode(",\n    $T.of($S, $L)", clazz, argName, argName);
         argDefinition.getDocs().ifPresent(docs ->
-                methodBuilder.addJavadoc("@param $L $L", argName, StringUtils.appendIfMissing(docs.get(), "\n")));
+                methodBuilder.addJavadoc("@param $L $L", argName, Javadoc.render(docs)));
     }
 
     private static ClassName errorTypesClassName(String conjurePackage, ErrorNamespace namespace) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.ConjureAnnotations;
 import com.palantir.conjure.java.util.JavaNameSanitizer;
+import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.java.util.StableCollectors;
 import com.palantir.conjure.spec.FieldDefinition;
 import com.palantir.conjure.spec.FieldName;
@@ -92,8 +93,7 @@ public final class UnionGenerator {
                                 fieldSpec -> FieldName.of(fieldSpec.name))
                                 .collect(Collectors.toList())));
 
-        typeDef.getDocs().ifPresent(docs ->
-                typeBuilder.addJavadoc("$L", StringUtils.appendIfMissing(docs.get(), "\n")));
+        typeDef.getDocs().ifPresent(docs -> typeBuilder.addJavadoc("$L", Javadoc.render(docs)));
 
         return JavaFile.builder(typePackage, typeBuilder.build())
                 .skipJavaLangImports(true)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/Javadoc.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/Javadoc.java
@@ -34,15 +34,24 @@ public final class Javadoc {
             // Disable paragraph tags, prefer raw text instead. Otherwise
             // all javadoc will be wrapped in paragraphs.
             .nodeRendererFactory(context -> new CoreHtmlNodeRenderer(context) {
+
+                private boolean firstParagraph = true;
+
                 @Override
                 public void visit(Paragraph paragraph) {
-                    visitChildren(paragraph);
+                    // Exclude the first set of paragraph tags for javadoc style.
+                    if (firstParagraph) {
+                        firstParagraph = false;
+                        visitChildren(paragraph);
+                    } else {
+                        super.visit(paragraph);
+                    }
                 }
             })
             .build();
 
     public static String render(Documentation documentation) {
-        String rawDocumentation = documentation.get();
+        String rawDocumentation = StringUtils.stripToEmpty(documentation.get());
         if (StringUtils.isBlank(rawDocumentation)) {
             return "";
         }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/Javadoc.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/Javadoc.java
@@ -16,7 +16,10 @@
 
 package com.palantir.conjure.java.util;
 
+import com.google.common.base.Preconditions;
+import com.palantir.conjure.spec.ArgumentDefinition;
 import com.palantir.conjure.spec.Documentation;
+import com.palantir.conjure.spec.EndpointDefinition;
 import org.apache.commons.lang3.StringUtils;
 import org.commonmark.node.Paragraph;
 import org.commonmark.parser.Parser;
@@ -57,6 +60,12 @@ public final class Javadoc {
         }
         String renderedHtml = renderer.render(parser.parse(rawDocumentation));
         return StringUtils.appendIfMissing(renderedHtml, "\n");
+    }
+
+    public static String getParameterJavadoc(ArgumentDefinition argument, EndpointDefinition endpoint) {
+        Preconditions.checkArgument(argument.getDocs().isPresent(), "Argument documentation is required");
+        String argumentName = JavaNameSanitizer.sanitizeParameterName(argument.getArgName().get(), endpoint);
+        return "@param " + argumentName + " " +  Javadoc.render(argument.getDocs().get());
     }
 
     private Javadoc() {}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/Javadoc.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/Javadoc.java
@@ -16,10 +16,10 @@
 
 package com.palantir.conjure.java.util;
 
-import com.google.common.base.Preconditions;
 import com.palantir.conjure.spec.ArgumentDefinition;
 import com.palantir.conjure.spec.Documentation;
 import com.palantir.conjure.spec.EndpointDefinition;
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.commonmark.node.Paragraph;
 import org.commonmark.parser.Parser;
@@ -62,10 +62,10 @@ public final class Javadoc {
         return StringUtils.appendIfMissing(renderedHtml, "\n");
     }
 
-    public static String getParameterJavadoc(ArgumentDefinition argument, EndpointDefinition endpoint) {
-        Preconditions.checkArgument(argument.getDocs().isPresent(), "Argument documentation is required");
-        String argumentName = JavaNameSanitizer.sanitizeParameterName(argument.getArgName().get(), endpoint);
-        return "@param " + argumentName + " " +  Javadoc.render(argument.getDocs().get());
+    public static Optional<String> getParameterJavadoc(ArgumentDefinition argument, EndpointDefinition endpoint) {
+        return argument.getDocs().map(docs -> "@param "
+                + JavaNameSanitizer.sanitizeParameterName(argument.getArgName().get(), endpoint) + " "
+                + Javadoc.render(argument.getDocs().get()));
     }
 
     private Javadoc() {}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/Javadoc.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/Javadoc.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.util;
+
+import com.palantir.conjure.spec.Documentation;
+import org.apache.commons.lang3.StringUtils;
+
+/** Provides utility functionality for rendering javadoc. */
+public final class Javadoc {
+
+    public static String render(Documentation documentation) {
+        return StringUtils.isBlank(documentation.get())
+                ? "" : StringUtils.appendIfMissing(documentation.get(), "\n");
+    }
+
+    private Javadoc() {}
+}

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/util/JavadocTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/util/JavadocTest.java
@@ -30,16 +30,33 @@ public class JavadocTest {
 
     @Test
     public void testBlankString() {
-        assertThat(Javadoc.render(Documentation.of(" "))).isEmpty();
+        assertThat(Javadoc.render(Documentation.of(" \n "))).isEmpty();
     }
 
     @Test
-    public void testAddsTrailingSlash() {
+    public void testAddsTrailingNewline() {
         assertThat(Javadoc.render(Documentation.of("Returns a Foo."))).isEqualTo("Returns a Foo.\n");
+    }
+
+    @Test
+    public void testRetainsTrailingNewline() {
+        assertThat(Javadoc.render(Documentation.of("Returns a Foo.\n"))).isEqualTo("Returns a Foo.\n");
     }
 
     @Test
     public void testRendersMarkdown() {
         assertThat(Javadoc.render(Documentation.of("Docs in _markdown_?"))).isEqualTo("Docs in <em>markdown</em>?\n");
+    }
+
+    @Test
+    public void testNewlines() {
+        assertThat(Javadoc.render(Documentation.of("Line one.\n\nLine two.")))
+                .isEqualTo("Line one.\n<p>Line two.</p>\n");
+    }
+
+    @Test
+    public void testExistingHtmlTags() {
+        assertThat(Javadoc.render(Documentation.of("Line includes <em>existing</em> html.")))
+                .isEqualTo("Line includes <em>existing</em> html.\n");
     }
 }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/util/JavadocTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/util/JavadocTest.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.conjure.spec.Documentation;
+import org.junit.Test;
+
+public class JavadocTest {
+
+    @Test
+    public void testEmptyString() {
+        assertThat(Javadoc.render(Documentation.of(""))).isEmpty();
+    }
+
+    @Test
+    public void testBlankString() {
+        assertThat(Javadoc.render(Documentation.of(" "))).isEmpty();
+    }
+
+    @Test
+    public void testAddsTrailingSlash() {
+        assertThat(Javadoc.render(Documentation.of("Returns a Foo."))).isEqualTo("Returns a Foo.\n");
+    }
+}

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/util/JavadocTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/util/JavadocTest.java
@@ -37,4 +37,9 @@ public class JavadocTest {
     public void testAddsTrailingSlash() {
         assertThat(Javadoc.render(Documentation.of("Returns a Foo."))).isEqualTo("Returns a Foo.\n");
     }
+
+    @Test
+    public void testRendersMarkdown() {
+        assertThat(Javadoc.render(Documentation.of("Docs in _markdown_?"))).isEqualTo("Docs in <em>markdown</em>?\n");
+    }
 }

--- a/conjure-java-core/src/test/resources/ete-service.yml
+++ b/conjure-java-core/src/test/resources/ete-service.yml
@@ -93,8 +93,11 @@ services:
       path:
         http: GET /path/{param}
         args:
-          param: string
+          param:
+            type: string
+            docs: Documentation for `param`
         returns: string
+        docs: Path endpoint.
 
       externalLongPath:
         http: GET /externalLong/{param}

--- a/conjure-java-core/src/test/resources/ete-service.yml
+++ b/conjure-java-core/src/test/resources/ete-service.yml
@@ -41,10 +41,18 @@ services:
       string:
         http: GET /string
         returns: string
+        docs: |
+          foo bar baz.
 
+          ## Very Important Documentation
+
+          This documentation provides a _list_:
+          * Docs rule
+          * Lists are wonderful
       integer:
         http: GET /integer
         returns: integer
+        docs: one *two* three.
 
       double_:
         http: GET /double

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
@@ -94,6 +94,7 @@ public interface TestService {
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @NotNull NestedAliasedBinary input);
 
+    /** @param datasetRid A valid dataset resource identifier. */
     @GET
     @Path("catalog/datasets/{datasetRid}/branches")
     Set<String> getBranches(
@@ -103,6 +104,7 @@ public interface TestService {
     /**
      * Gets all branches of this dataset.
      *
+     * @param datasetRid A valid dataset resource identifier.
      * @deprecated use getBranches instead
      */
     @GET

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
@@ -94,6 +94,7 @@ public interface TestService {
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @NotNull NestedAliasedBinary input);
 
+    /** @param datasetRid A valid dataset resource identifier. */
     @GET
     @Path("catalog/datasets/{datasetRid}/branches")
     Set<String> getBranches(
@@ -103,6 +104,7 @@ public interface TestService {
     /**
      * Gets all branches of this dataset.
      *
+     * @param datasetRid A valid dataset resource identifier.
      * @deprecated use getBranches instead
      */
     @GET

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
@@ -40,11 +40,13 @@ public interface TestService {
 
     void uploadAliasedRawData(AuthHeader authHeader, NestedAliasedBinary input);
 
+    /** @param datasetRid A valid dataset resource identifier. */
     Set<String> getBranches(AuthHeader authHeader, ResourceIdentifier datasetRid);
 
     /**
      * Gets all branches of this dataset.
      *
+     * @param datasetRid A valid dataset resource identifier.
      * @deprecated use getBranches instead
      */
     @Deprecated

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
@@ -96,6 +96,7 @@ public interface TestServiceRetrofit {
     Call<Void> uploadAliasedRawData(
             @Header("Authorization") AuthHeader authHeader, @Body NestedAliasedBinary input);
 
+    /** @param datasetRid A valid dataset resource identifier. */
     @GET("./catalog/datasets/{datasetRid}/branches")
     @Headers({
         "hr-path-template: /catalog/datasets/{datasetRid}/branches",
@@ -108,6 +109,7 @@ public interface TestServiceRetrofit {
     /**
      * Gets all branches of this dataset.
      *
+     * @param datasetRid A valid dataset resource identifier.
      * @deprecated use getBranches instead
      */
     @GET("./catalog/datasets/{datasetRid}/branchesDeprecated")

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
@@ -96,6 +96,7 @@ public interface TestServiceRetrofit {
     CompletableFuture<Void> uploadAliasedRawData(
             @Header("Authorization") AuthHeader authHeader, @Body NestedAliasedBinary input);
 
+    /** @param datasetRid A valid dataset resource identifier. */
     @GET("./catalog/datasets/{datasetRid}/branches")
     @Headers({
         "hr-path-template: /catalog/datasets/{datasetRid}/branches",
@@ -108,6 +109,7 @@ public interface TestServiceRetrofit {
     /**
      * Gets all branches of this dataset.
      *
+     * @param datasetRid A valid dataset resource identifier.
      * @deprecated use getBranches instead
      */
     @GET("./catalog/datasets/{datasetRid}/branchesDeprecated")

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_listenable_future
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_listenable_future
@@ -96,6 +96,7 @@ public interface TestServiceRetrofit {
     ListenableFuture<Void> uploadAliasedRawData(
             @Header("Authorization") AuthHeader authHeader, @Body NestedAliasedBinary input);
 
+    /** @param datasetRid A valid dataset resource identifier. */
     @GET("./catalog/datasets/{datasetRid}/branches")
     @Headers({
         "hr-path-template: /catalog/datasets/{datasetRid}/branches",
@@ -108,6 +109,7 @@ public interface TestServiceRetrofit {
     /**
      * Gets all branches of this dataset.
      *
+     * @param datasetRid A valid dataset resource identifier.
      * @deprecated use getBranches instead
      */
     @GET("./catalog/datasets/{datasetRid}/branchesDeprecated")

--- a/versions.lock
+++ b/versions.lock
@@ -1,4 +1,5 @@
 # Run ./gradlew --write-locks to regenerate this file
+com.atlassian.commonmark:commonmark:0.12.1 (1 constraints: 36052a3b)
 com.fasterxml.jackson.core:jackson-annotations:2.9.9 (6 constraints: ca659407)
 com.fasterxml.jackson.core:jackson-core:2.9.9 (8 constraints: 4fa88978)
 com.fasterxml.jackson.core:jackson-databind:2.9.9 (11 constraints: eec45d47)

--- a/versions.props
+++ b/versions.props
@@ -1,4 +1,5 @@
 ch.qos.logback:* = 1.2.3
+com.atlassian.commonmark:* = 0.12.1
 com.fasterxml.jackson.*:jackson-* = 2.9.9
 com.github.stefanbirkner:system-rules = 1.19.0
 com.google.code.findbugs:jsr305 = 3.0.2


### PR DESCRIPTION
## Before this PR
Javadoc fields were populated with the string value from conjure definitions, resulting in issues described in #399.

## After this PR
==COMMIT_MSG==
[improvement] Javadoc html is rendered from conjure docs markdown
[fix] Generate `@param` javadoc based on ArgumentDefinition docs 
==COMMIT_MSG==

## Possible downsides?
It's possible that existing docs may be parsed into HTML in unexpected ways.