### PR TITLE
[fix] Fixing formatting violation to comply with baseline rules.

### DIFF
--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/Javadoc.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/Javadoc.java
@@ -37,7 +37,6 @@ public final class Javadoc {
             // Disable paragraph tags, prefer raw text instead. Otherwise
             // all javadoc will be wrapped in paragraphs.
             .nodeRendererFactory(context -> new CoreHtmlNodeRenderer(context) {
-
                 private boolean firstParagraph = true;
 
                 @Override


### PR DESCRIPTION
## Before this PR
There is a compile-time break caused by a formatting issues enforced by an updated version of baseline.

## After this PR
Formatting is fixed and library can compile.
