### PR TITLE
[improvement] add a builder to Endpoint

### DIFF
--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureHandlerBuilderTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureHandlerBuilderTest.java
@@ -24,7 +24,6 @@ import com.palantir.conjure.java.undertow.lib.Endpoint;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.SafeLoggable;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
-import io.undertow.server.HttpHandler;
 import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import org.junit.Test;

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureHandlerBuilderTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureHandlerBuilderTest.java
@@ -55,31 +55,12 @@ public class ConjureHandlerBuilderTest {
     }
 
     private Endpoint buildEndpoint(HttpString method, String template, String serviceName, String name) {
-        return new Endpoint() {
-            @Override
-            public HttpString method() {
-                return method;
-            }
-
-            @Override
-            public String template() {
-                return template;
-            }
-
-            @Override
-            public HttpHandler handler() {
-                return null;
-            }
-
-            @Override
-            public String serviceName() {
-                return serviceName;
-            }
-
-            @Override
-            public String name() {
-                return name;
-            }
-        };
+        return Endpoint.builder()
+                .method(method)
+                .template(template)
+                .serviceName(serviceName)
+                .handler(exchange -> { })
+                .name(name)
+                .build();
     }
 }

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureHandlerTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureHandlerTest.java
@@ -60,32 +60,15 @@ public final class ConjureHandlerTest {
             }
         };
         HttpHandler handler = ConjureHandler.builder()
-                .endpoints(new Endpoint() {
-                    @Override
-                    public HttpString method() {
-                        return Methods.GET;
-                    }
-
-                    @Override
-                    public String template() {
-                        return "/test";
-                    }
-
-                    @Override
-                    public HttpHandler handler() {
-                        return httpHandler;
-                    }
-
-                    @Override
-                    public String serviceName() {
-                        return "TestService";
-                    }
-
-                    @Override
-                    public String name() {
-                        return "test";
-                    }
-                }).build();
+                .endpoints(Endpoint.builder()
+                        .method(Methods.GET)
+                        .template("/test")
+                        .handler(httpHandler)
+                        .serviceName("TestService")
+                        .name("test")
+                        .handler(httpHandler)
+                        .build())
+                .build();
         server = Undertow.builder()
                 .addHttpListener(12345, "localhost")
                 .setHandler(handler)

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureHandlerTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureHandlerTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.when;
 import com.palantir.conjure.java.undertow.lib.Endpoint;
 import io.undertow.Undertow;
 import io.undertow.server.HttpHandler;
-import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import java.io.IOException;
 import okhttp3.OkHttpClient;

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/Endpoint.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/Endpoint.java
@@ -16,6 +16,8 @@
 
 package com.palantir.conjure.java.undertow.lib;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.palantir.logsafe.Preconditions;
 import io.undertow.server.HttpHandler;
 import io.undertow.util.HttpString;
 
@@ -46,4 +48,92 @@ public interface Endpoint {
 
     /** Simple name of the endpoint method. This data may be used for metric instrumentation. */
     String name();
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    final class Builder {
+
+        private Builder() {}
+
+        private HttpString method;
+        private String template;
+        private HttpHandler handler;
+        private String serviceName;
+        private String name;
+
+        @CanIgnoreReturnValue
+        public Builder method(HttpString value) {
+            method = Preconditions.checkNotNull(value, "method is required");
+            return this;
+        }
+
+        @CanIgnoreReturnValue
+        public Builder template(String value) {
+            template = Preconditions.checkNotNull(value, "template is required");
+            return this;
+        }
+
+        @CanIgnoreReturnValue
+        public Builder handler(HttpHandler value) {
+            handler = Preconditions.checkNotNull(value, "handler is required");
+            return this;
+        }
+
+        @CanIgnoreReturnValue
+        public Builder serviceName(String value) {
+            serviceName = Preconditions.checkNotNull(value, "serviceName is required");
+            return this;
+        }
+
+        @CanIgnoreReturnValue
+        public Builder name(String value) {
+            name = Preconditions.checkNotNull(value, "name is required");
+            return this;
+        }
+
+        public Builder from(Endpoint endpoint) {
+            method = endpoint.method();
+            template = endpoint.template();
+            handler = endpoint.handler();
+            serviceName = endpoint.serviceName();
+            name = endpoint.name();
+            return this;
+        }
+
+        public Endpoint build() {
+            Preconditions.checkNotNull(method, "method is required");
+            Preconditions.checkNotNull(template, "template is required");
+            Preconditions.checkNotNull(handler, "handler is required");
+            Preconditions.checkNotNull(serviceName, "serviceName is required");
+            Preconditions.checkNotNull(name, "name is required");
+            return new Endpoint() {
+                @Override
+                public HttpString method() {
+                    return method;
+                }
+
+                @Override
+                public String template() {
+                    return template;
+                }
+
+                @Override
+                public HttpHandler handler() {
+                    return handler;
+                }
+
+                @Override
+                public String serviceName() {
+                    return serviceName;
+                }
+
+                @Override
+                public String name() {
+                    return name;
+                }
+            };
+        }
+    }
 }


### PR DESCRIPTION
## Before this PR

The `Endpoint`s can only be instantiated by implementing the `Endpoint` interface or through the anonymous constructor.

## After this PR
==COMMIT_MSG==
`Endpoint`s now have builders, and they implement the `from(Endpoint)` method.
==COMMIT_MSG==

## Possible downsides?
