### PR TITLE
[improvement] conjure-undertow binary deserialization exception matches json

### DIFF
--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
@@ -75,7 +75,7 @@ final class ConjureBodySerDe implements BodySerDe {
             throw new SafeIllegalArgumentException("Request is missing Content-Type header");
         }
         if (!contentType.startsWith(BINARY_CONTENT_TYPE)) {
-            throw new SafeIllegalArgumentException("Unsupported Content-Type",
+            throw FrameworkException.unsupportedMediaType("Unsupported Content-Type",
                     SafeArg.of("Content-Type", contentType));
         }
         return exchange.getInputStream();

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDeTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDeTest.java
@@ -66,6 +66,16 @@ public class ConjureBodySerDeTest {
     }
 
     @Test
+    public void testUnsupportedBinaryRequestContentType() {
+        HttpServerExchange exchange = HttpServerExchanges.createStub();
+        exchange.getRequestHeaders().put(Headers.CONTENT_TYPE, "application/unknown");
+        BodySerDe serializers = new ConjureBodySerDe(ImmutableList.of(new StubEncoding("application/json")));
+        assertThatThrownBy(() -> serializers.deserializeInputStream(exchange))
+                .isInstanceOf(FrameworkException.class)
+                .hasMessageContaining("Unsupported Content-Type");
+    }
+
+    @Test
     public void testResponseContentType() throws IOException  {
         Encoding json = new StubEncoding("application/json");
         Encoding plain = new StubEncoding("text/plain");


### PR DESCRIPTION
Previously a standard exception was used rather than a
FrameworkException. Now both produce the correct 415 status code.

## After this PR
==COMMIT_MSG==
conjure-undertow binary deserialization exception matches json
==COMMIT_MSG==

## Possible downsides?
none