### PR TITLE
[fix] Undertow generator properly handles query params of optional of alias of external

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
@@ -177,6 +177,12 @@ public interface EteService {
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @HeaderParam("Custom-Header") SimpleEnum headerParameter);
 
+    @GET
+    @Path("base/alias-long")
+    Optional<LongAlias> aliasLongEndpoint(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @QueryParam("input") Optional<LongAlias> input);
+
     @Deprecated
     default Optional<Long> optionalExternalLongQuery(AuthHeader authHeader) {
         return optionalExternalLongQuery(authHeader, Optional.empty());
@@ -200,5 +206,10 @@ public interface EteService {
     @Deprecated
     default Optional<SimpleEnum> optionalEnumQuery(AuthHeader authHeader) {
         return optionalEnumQuery(authHeader, Optional.empty());
+    }
+
+    @Deprecated
+    default Optional<LongAlias> aliasLongEndpoint(AuthHeader authHeader) {
+        return aliasLongEndpoint(authHeader, Optional.empty());
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
@@ -165,4 +165,10 @@ public interface EteServiceRetrofit {
     Call<SimpleEnum> enumHeader(
             @Header("Authorization") AuthHeader authHeader,
             @Header("Custom-Header") SimpleEnum headerParameter);
+
+    @GET("./base/alias-long")
+    @Headers({"hr-path-template: /base/alias-long", "Accept: application/json"})
+    Call<Optional<LongAlias>> aliasLongEndpoint(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("input") Optional<LongAlias> input);
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/LongAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/LongAlias.java
@@ -1,0 +1,45 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class LongAlias {
+    private final long value;
+
+    private LongAlias(long value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public long get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof LongAlias && this.value == ((LongAlias) other).value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(value);
+    }
+
+    @JsonCreator
+    public static LongAlias valueOf(String value) {
+        return of(Long.valueOf(value));
+    }
+
+    @JsonCreator
+    public static LongAlias of(long value) {
+        return new LongAlias(value);
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
@@ -87,4 +87,6 @@ public interface UndertowEteService {
             AuthHeader authHeader, Optional<SimpleEnum> queryParamName);
 
     SimpleEnum enumHeader(AuthHeader authHeader, SimpleEnum headerParameter);
+
+    Optional<LongAlias> aliasLongEndpoint(AuthHeader authHeader, Optional<LongAlias> input);
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -772,7 +772,7 @@ final class UndertowServiceHandlerGenerator {
             //   * optional<alias that resolves to a primitive>
             //   * alias that follows one of these rules (recursive definition)
             Type aliasedType = UndertowTypeFunctions.getAliasedType(inType, typeDefinitions);
-            if (aliasedType.accept(TypeVisitor.IS_PRIMITIVE)) {
+            if (aliasedType.accept(TypeVisitor.IS_PRIMITIVE) || aliasedType.accept(MoreVisitors.IS_EXTERNAL)) {
                 // primitive
                 ofContent = CodeBlock.of("$1N", decodedVarName);
             } else if (aliasedType.accept(TypeVisitor.IS_OPTIONAL)) {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/EteResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/EteResource.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java;
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.product.EteService;
+import com.palantir.product.LongAlias;
 import com.palantir.product.NestedStringAliasExample;
 import com.palantir.product.SimpleEnum;
 import com.palantir.product.StringAliasExample;
@@ -168,6 +169,12 @@ public class EteResource implements EteService {
     @Override
     public SimpleEnum enumHeader(AuthHeader authHeader, SimpleEnum headerParameter) {
         return headerParameter;
+    }
+
+    @Override
+    public Optional<LongAlias> aliasLongEndpoint(
+            AuthHeader authHeader, Optional<LongAlias> input) {
+        return input;
     }
 
     interface Streaming extends StreamingOutput, BinaryResponseBody {}

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -35,6 +35,7 @@ import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.conjure.java.okhttp.HostMetricsRegistry;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.conjure.java.services.UndertowServiceGenerator;
+import com.palantir.conjure.java.types.ObjectGenerator;
 import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
 import com.palantir.conjure.java.undertow.runtime.ConjureHandler;
 import com.palantir.conjure.java.undertow.runtime.ConjureUndertowRuntime;
@@ -479,8 +480,12 @@ public final class UndertowServiceEteTest extends TestBase {
         ConjureDefinition def = Conjure.parse(ImmutableList.of(
                 new File("src/test/resources/ete-service.yml"),
                 new File("src/test/resources/ete-binary.yml")));
-        List<Path> files = new UndertowServiceGenerator(ImmutableSet.of(FeatureFlags.UndertowServicePrefix))
-                .emit(def, folder.getRoot());
+        List<Path> files = ImmutableList.<Path>builder()
+                .addAll(new UndertowServiceGenerator(ImmutableSet.of(FeatureFlags.UndertowServicePrefix))
+                        .emit(def, folder.getRoot()))
+                .addAll(new ObjectGenerator(ImmutableSet.of(FeatureFlags.UndertowServicePrefix))
+                        .emit(def, folder.getRoot()))
+                .build();
         validateGeneratorOutput(files, Paths.get("src/integrationInput/java/com/palantir/product"));
     }
 

--- a/conjure-java-core/src/test/resources/ete-service.yml
+++ b/conjure-java-core/src/test/resources/ete-service.yml
@@ -18,6 +18,8 @@ types:
       SimpleEnum:
         values:
           - VALUE
+      LongAlias:
+        alias: Long
 
 services:
   EmptyPathService:
@@ -198,3 +200,11 @@ services:
             param-id: Custom-Header
             type: SimpleEnum
         returns: SimpleEnum
+
+      aliasLongEndpoint:
+        http: GET /alias-long
+        args:
+          input:
+            type: optional<LongAlias>
+            param-type: query
+        returns: optional<LongAlias>


### PR DESCRIPTION
## Before this PR
Previously the generator would throw because it expected a Type to
be an alias when it was an external reference.


## After this PR
==COMMIT_MSG==
Undertow generator properly handles query params of optional of alias of external
==COMMIT_MSG==
