### PR TITLE
[improvement] conjure-undertow endpoints provide tracing spans around body serde

### DIFF
--- a/changelog/@unreleased/pr-425.v2.yml
+++ b/changelog/@unreleased/pr-425.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: conjure-undertow endpoints provide tracing spans around body serde.
+  links:
+  - https://github.com/palantir/conjure-java/pull/425

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
@@ -129,7 +129,7 @@ final class ConjureBodySerDe implements BodySerDe {
 
         EncodingSerializerContainer(Encoding encoding, TypeMarker<T> token) {
             this.encoding = encoding;
-            this.serializer = encoding.serializer(token);
+            this.serializer = TracedEncoding.wrap(encoding).serializer(token);
         }
     }
 
@@ -209,7 +209,7 @@ final class ConjureBodySerDe implements BodySerDe {
 
         EncodingDeserializerContainer(Encoding encoding, TypeMarker<T> token) {
             this.encoding = encoding;
-            this.deserializer = encoding.deserializer(token);
+            this.deserializer = TracedEncoding.wrap(encoding).deserializer(token);
         }
     }
 }

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
@@ -25,6 +25,7 @@ import com.palantir.conjure.java.undertow.lib.TypeMarker;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.tracing.Tracer;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderValues;
 import io.undertow.util.Headers;
@@ -65,7 +66,12 @@ final class ConjureBodySerDe implements BodySerDe {
     public void serialize(BinaryResponseBody value, HttpServerExchange exchange) throws IOException {
         Preconditions.checkNotNull(value, "A BinaryResponseBody value is required");
         exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, BINARY_CONTENT_TYPE);
-        value.write(exchange.getOutputStream());
+        Tracer.fastStartSpan("Undertow: serialize binary");
+        try {
+            value.write(exchange.getOutputStream());
+        } finally {
+            Tracer.fastCompleteSpan();
+        }
     }
 
     @Override

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/TracedEncoding.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/TracedEncoding.java
@@ -1,0 +1,114 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.tracing.Tracer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Type;
+
+/** Encoding implementation which wraps serialization and deserialization with tracing spans. */
+final class TracedEncoding implements Encoding {
+
+    private final Encoding encoding;
+
+    private TracedEncoding(Encoding encoding) {
+        this.encoding = encoding;
+    }
+
+    static Encoding wrap(Encoding encoding) {
+        return new TracedEncoding(encoding);
+    }
+
+    @Override
+    public <T> Serializer<T> serializer(TypeMarker<T> type) {
+        String operation = "Undertow: serialize " + toString(type) + " to " + getContentType();
+        return new TracedSerializer<>(encoding.serializer(type), operation);
+    }
+
+    @Override
+    public <T> Deserializer<T> deserializer(TypeMarker<T> type) {
+        String operation = "Undertow: deserialize " + toString(type) + " from " + getContentType();
+        return new TracedDeserializer<>(encoding.deserializer(type), operation);
+    }
+
+    /**
+     * Builds a human readable type string. Class types use the classes simple name, however complex types
+     * do not have this optimization because it is more complex than it's worth for now.
+     */
+    static String toString(TypeMarker<?> typeMarker) {
+        Type type = typeMarker.getType();
+        if (type instanceof Class) {
+            return ((Class<?>) type).getSimpleName();
+        }
+        return type.toString();
+    }
+
+    @Override
+    public String getContentType() {
+        return encoding.getContentType();
+    }
+
+    @Override
+    public boolean supportsContentType(String contentType) {
+        return encoding.supportsContentType(contentType);
+    }
+
+    private static final class TracedSerializer<T> implements Serializer<T> {
+
+        private final Serializer<T> delegate;
+        private final String operation;
+
+        TracedSerializer(Serializer<T> delegate, String operation) {
+            this.delegate = delegate;
+            this.operation = operation;
+        }
+
+        @Override
+        public void serialize(T value, OutputStream output) throws IOException {
+            Tracer.fastStartSpan(operation);
+            try {
+                delegate.serialize(value, output);
+            } finally {
+                Tracer.fastCompleteSpan();
+            }
+        }
+    }
+
+    private static final class TracedDeserializer<T> implements Deserializer<T> {
+
+        private final Deserializer<T> delegate;
+        private final String operation;
+
+        TracedDeserializer(Deserializer<T> delegate, String operation) {
+            this.delegate = delegate;
+            this.operation = operation;
+        }
+
+        @Override
+        public T deserialize(InputStream input) throws IOException {
+            Tracer.fastStartSpan(operation);
+            try {
+                return delegate.deserialize(input);
+            } finally {
+                Tracer.fastCompleteSpan();
+            }
+        }
+    }
+}

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/TracedEncodingTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/TracedEncodingTest.java
@@ -1,0 +1,110 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.io.ByteStreams;
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.tracing.AlwaysSampler;
+import com.palantir.tracing.Tracer;
+import com.palantir.tracing.api.Span;
+import com.palantir.tracing.api.SpanObserver;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.List;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class TracedEncodingTest {
+
+    @Test
+    public void testTypeString_string() {
+        // non-generic types use the simple name
+        assertThat(TracedEncoding.toString(new TypeMarker<String>() {})).isEqualTo("String");
+    }
+
+    @Test
+    public void testTypeString_stringList() {
+        // It's more complicated to generate 'List<String>' from Type, that can be done later if necessary
+        assertThat(TracedEncoding.toString(new TypeMarker<List<String>>() {}))
+                .isEqualTo("java.util.List<java.lang.String>");
+    }
+
+    @Test
+    public void testSerializerOperationName() throws IOException {
+        Tracer.setSampler(AlwaysSampler.INSTANCE);
+        Tracer.getAndClearTrace();
+        Encoding.Serializer<String> serializer = TracedEncoding.wrap(new StubEncoding())
+                .serializer(new TypeMarker<String>() {});
+        SpanObserver mockObserver = mock(SpanObserver.class);
+        Tracer.subscribe("test", mockObserver);
+        try {
+            serializer.serialize("value", ByteStreams.nullOutputStream());
+        } finally {
+            Tracer.unsubscribe("test");
+        }
+        ArgumentCaptor<Span> captor = ArgumentCaptor.forClass(Span.class);
+        verify(mockObserver).consume(captor.capture());
+        Span span = captor.getValue();
+        assertThat(span.getOperation()).isEqualTo("Undertow: serialize String to application/stub");
+    }
+
+    @Test
+    public void testDeserializerOperationName() throws IOException {
+        Tracer.setSampler(AlwaysSampler.INSTANCE);
+        Tracer.getAndClearTrace();
+        Encoding.Deserializer<String> deserializer = TracedEncoding.wrap(new StubEncoding())
+                .deserializer(new TypeMarker<String>() {});
+        SpanObserver mockObserver = mock(SpanObserver.class);
+        Tracer.subscribe("test", mockObserver);
+        try {
+            deserializer.deserialize(new ByteArrayInputStream(new byte[0]));
+        } finally {
+            Tracer.unsubscribe("test");
+        }
+        ArgumentCaptor<Span> captor = ArgumentCaptor.forClass(Span.class);
+        verify(mockObserver).consume(captor.capture());
+        Span span = captor.getValue();
+        assertThat(span.getOperation()).isEqualTo("Undertow: deserialize String from application/stub");
+    }
+
+    private static final class StubEncoding implements Encoding {
+
+        @Override
+        public <T> Serializer<T> serializer(TypeMarker<T> type) {
+            return (value, output) -> { };
+        }
+
+        @Override
+        public <T> Deserializer<T> deserializer(TypeMarker<T> type) {
+            return input -> null;
+        }
+
+        @Override
+        public String getContentType() {
+            return "application/stub";
+        }
+
+        @Override
+        public boolean supportsContentType(String contentType) {
+            return true;
+        }
+    }
+}

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/TracedEncodingTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/TracedEncodingTest.java
@@ -29,7 +29,7 @@ import com.palantir.tracing.api.SpanObserver;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 public class TracedEncodingTest {


### PR DESCRIPTION
## Before this PR
No differentiation between resource execution, and I/O + serde 

## After this PR
==COMMIT_MSG==
conjure-undertow endpoints provide tracing spans around body serde
==COMMIT_MSG==

## Possible downsides?
Up to 2 additional spans for every sampled call (only if request/response body is sent)
