### PR TITLE
[improvement] ConjureAsyncRequestProcessing invokes 'nextListener.proceed()' in finally

### DIFF
--- a/changelog/@unreleased/pr-444.v2.yml
+++ b/changelog/@unreleased/pr-444.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: ConjureAsyncRequestProcessing invokes 'nextListener.proceed()' in a
+    finally block for safety. No known issues with the previous implementation.
+  links:
+  - https://github.com/palantir/conjure-java/pull/444

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureAsyncRequestProcessing.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureAsyncRequestProcessing.java
@@ -70,11 +70,14 @@ final class ConjureAsyncRequestProcessing implements AsyncRequestProcessing {
     // If the request is ended before the future has completed, cancel the future to signal that work
     // should be stopped. This occurs when clients cancel requests or connections are closed.
     private static final ExchangeCompletionListener COMPLETION_LISTENER = (exchange, nextListener) -> {
-        ListenableFuture<?> future = exchange.getAttachment(FUTURE);
-        if (future != null) {
-            future.cancel(INTERRUPT_ON_CANCEL);
+        try {
+            ListenableFuture<?> future = exchange.getAttachment(FUTURE);
+            if (future != null) {
+                future.cancel(INTERRUPT_ON_CANCEL);
+            }
+        } finally {
+            nextListener.proceed();
         }
-        nextListener.proceed();
     };
 
     private final Serializer<SerializableError> exceptionSerializer = ConjureExceptions.serializer();


### PR DESCRIPTION
No known issues, updating for safety.

## After this PR
==COMMIT_MSG==
ConjureAsyncRequestProcessing invokes 'nextListener.proceed()' in a finally block for safety. No known issues with the previous implementation.
==COMMIT_MSG==

## Possible downsides?
none