### PR TITLE
Deserialize null fields as empty collections

### DIFF
--- a/changelog/@unreleased/pr-446.v2.yml
+++ b/changelog/@unreleased/pr-446.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Correctly coerce null fields into empty collections
+  links:
+  - https://github.com/palantir/conjure-java/pull/446

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
@@ -3,6 +3,7 @@ package com.palantir.binary;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
@@ -102,7 +103,7 @@ public final class OptionalExample {
             return this;
         }
 
-        @JsonSetter("item")
+        @JsonSetter(value = "item", nulls = Nulls.SKIP)
         public Builder item(Optional<ByteBuffer> item) {
             this.item = Preconditions.checkNotNull(item, "item cannot be null");
             return this;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
@@ -3,6 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
@@ -217,7 +218,7 @@ public final class AliasAsMapKeyExample {
             return this;
         }
 
-        @JsonSetter("strings")
+        @JsonSetter(value = "strings", nulls = Nulls.SKIP)
         public Builder strings(Map<StringAliasExample, ManyFieldExample> strings) {
             this.strings.clear();
             this.strings.putAll(Preconditions.checkNotNull(strings, "strings cannot be null"));
@@ -234,7 +235,7 @@ public final class AliasAsMapKeyExample {
             return this;
         }
 
-        @JsonSetter("rids")
+        @JsonSetter(value = "rids", nulls = Nulls.SKIP)
         public Builder rids(Map<RidAliasExample, ManyFieldExample> rids) {
             this.rids.clear();
             this.rids.putAll(Preconditions.checkNotNull(rids, "rids cannot be null"));
@@ -251,7 +252,7 @@ public final class AliasAsMapKeyExample {
             return this;
         }
 
-        @JsonSetter("bearertokens")
+        @JsonSetter(value = "bearertokens", nulls = Nulls.SKIP)
         public Builder bearertokens(Map<BearerTokenAliasExample, ManyFieldExample> bearertokens) {
             this.bearertokens.clear();
             this.bearertokens.putAll(
@@ -271,7 +272,7 @@ public final class AliasAsMapKeyExample {
             return this;
         }
 
-        @JsonSetter("integers")
+        @JsonSetter(value = "integers", nulls = Nulls.SKIP)
         public Builder integers(Map<IntegerAliasExample, ManyFieldExample> integers) {
             this.integers.clear();
             this.integers.putAll(Preconditions.checkNotNull(integers, "integers cannot be null"));
@@ -288,7 +289,7 @@ public final class AliasAsMapKeyExample {
             return this;
         }
 
-        @JsonSetter("safelongs")
+        @JsonSetter(value = "safelongs", nulls = Nulls.SKIP)
         public Builder safelongs(Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
             this.safelongs.clear();
             this.safelongs.putAll(
@@ -307,7 +308,7 @@ public final class AliasAsMapKeyExample {
             return this;
         }
 
-        @JsonSetter("datetimes")
+        @JsonSetter(value = "datetimes", nulls = Nulls.SKIP)
         public Builder datetimes(Map<DateTimeAliasExample, ManyFieldExample> datetimes) {
             this.datetimes.clear();
             this.datetimes.putAll(
@@ -326,7 +327,7 @@ public final class AliasAsMapKeyExample {
             return this;
         }
 
-        @JsonSetter("uuids")
+        @JsonSetter(value = "uuids", nulls = Nulls.SKIP)
         public Builder uuids(Map<UuidAliasExample, ManyFieldExample> uuids) {
             this.uuids.clear();
             this.uuids.putAll(Preconditions.checkNotNull(uuids, "uuids cannot be null"));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
@@ -3,6 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
@@ -102,7 +103,7 @@ public final class AnyMapExample {
             return this;
         }
 
-        @JsonSetter("items")
+        @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(Map<String, Object> items) {
             this.items.clear();
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
@@ -3,6 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.conjure.java.lib.internal.ConjureCollections;
 import com.palantir.logsafe.Preconditions;
@@ -121,7 +122,7 @@ public final class CovariantListExample {
             return this;
         }
 
-        @JsonSetter("items")
+        @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(Iterable<?> items) {
             this.items.clear();
             ConjureCollections.addAll(
@@ -140,7 +141,7 @@ public final class CovariantListExample {
             return this;
         }
 
-        @JsonSetter("externalItems")
+        @JsonSetter(value = "externalItems", nulls = Nulls.SKIP)
         public Builder externalItems(Iterable<? extends ExampleExternalReference> externalItems) {
             this.externalItems.clear();
             ConjureCollections.addAll(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
@@ -3,6 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
@@ -102,7 +103,7 @@ public final class CovariantOptionalExample {
             return this;
         }
 
-        @JsonSetter("item")
+        @JsonSetter(value = "item", nulls = Nulls.SKIP)
         public Builder item(Optional<?> item) {
             this.item = (Optional<Object>) Preconditions.checkNotNull(item, "item cannot be null");
             return this;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -3,6 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.conjure.java.lib.internal.ConjureCollections;
 import com.palantir.logsafe.Preconditions;
@@ -153,7 +154,7 @@ public final class ExternalLongExample {
             return this;
         }
 
-        @JsonSetter("optionalExternalLong")
+        @JsonSetter(value = "optionalExternalLong", nulls = Nulls.SKIP)
         public Builder optionalExternalLong(Optional<? extends Long> optionalExternalLong) {
             this.optionalExternalLong =
                     (Optional<Long>)
@@ -170,7 +171,7 @@ public final class ExternalLongExample {
             return this;
         }
 
-        @JsonSetter("listExternalLong")
+        @JsonSetter(value = "listExternalLong", nulls = Nulls.SKIP)
         public Builder listExternalLong(Iterable<? extends Long> listExternalLong) {
             this.listExternalLong.clear();
             ConjureCollections.addAll(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
@@ -3,6 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.conjure.java.lib.internal.ConjureCollections;
 import com.palantir.logsafe.Preconditions;
@@ -142,7 +143,7 @@ public final class ListExample {
             return this;
         }
 
-        @JsonSetter("items")
+        @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(Iterable<String> items) {
             this.items.clear();
             ConjureCollections.addAll(
@@ -161,7 +162,7 @@ public final class ListExample {
             return this;
         }
 
-        @JsonSetter("primitiveItems")
+        @JsonSetter(value = "primitiveItems", nulls = Nulls.SKIP)
         public Builder primitiveItems(Iterable<Integer> primitiveItems) {
             this.primitiveItems.clear();
             ConjureCollections.addAll(
@@ -182,7 +183,7 @@ public final class ListExample {
             return this;
         }
 
-        @JsonSetter("doubleItems")
+        @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP)
         public Builder doubleItems(Iterable<Double> doubleItems) {
             this.doubleItems.clear();
             ConjureCollections.addAll(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -3,6 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.conjure.java.lib.internal.ConjureCollections;
 import com.palantir.logsafe.Preconditions;
@@ -272,7 +273,7 @@ public final class ManyFieldExample {
         }
 
         /** docs for optionalItem field */
-        @JsonSetter("optionalItem")
+        @JsonSetter(value = "optionalItem", nulls = Nulls.SKIP)
         public Builder optionalItem(Optional<String> optionalItem) {
             this.optionalItem =
                     Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null");
@@ -289,7 +290,7 @@ public final class ManyFieldExample {
         }
 
         /** docs for items field */
-        @JsonSetter("items")
+        @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(Iterable<String> items) {
             this.items.clear();
             ConjureCollections.addAll(
@@ -311,7 +312,7 @@ public final class ManyFieldExample {
         }
 
         /** docs for set field */
-        @JsonSetter("set")
+        @JsonSetter(value = "set", nulls = Nulls.SKIP)
         public Builder set(Iterable<String> set) {
             this.set.clear();
             ConjureCollections.addAll(
@@ -333,7 +334,7 @@ public final class ManyFieldExample {
         }
 
         /** docs for map field */
-        @JsonSetter("map")
+        @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(Map<String, String> map) {
             this.map.clear();
             this.map.putAll(Preconditions.checkNotNull(map, "map cannot be null"));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
@@ -3,6 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
@@ -102,7 +103,7 @@ public final class MapExample {
             return this;
         }
 
-        @JsonSetter("items")
+        @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(Map<String, String> items) {
             this.items.clear();
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
@@ -3,6 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
@@ -101,7 +102,7 @@ public final class OptionalExample {
             return this;
         }
 
-        @JsonSetter("item")
+        @JsonSetter(value = "item", nulls = Nulls.SKIP)
         public Builder item(Optional<String> item) {
             this.item = Preconditions.checkNotNull(item, "item cannot be null");
             return this;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
@@ -3,6 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.logsafe.Preconditions;
@@ -220,7 +221,7 @@ public final class PrimitiveOptionalsExample {
             return this;
         }
 
-        @JsonSetter("num")
+        @JsonSetter(value = "num", nulls = Nulls.SKIP)
         public Builder num(OptionalDouble num) {
             this.num = Preconditions.checkNotNull(num, "num cannot be null");
             return this;
@@ -231,7 +232,7 @@ public final class PrimitiveOptionalsExample {
             return this;
         }
 
-        @JsonSetter("bool")
+        @JsonSetter(value = "bool", nulls = Nulls.SKIP)
         public Builder bool(Optional<Boolean> bool) {
             this.bool = Preconditions.checkNotNull(bool, "bool cannot be null");
             return this;
@@ -242,7 +243,7 @@ public final class PrimitiveOptionalsExample {
             return this;
         }
 
-        @JsonSetter("integer")
+        @JsonSetter(value = "integer", nulls = Nulls.SKIP)
         public Builder integer(OptionalInt integer) {
             this.integer = Preconditions.checkNotNull(integer, "integer cannot be null");
             return this;
@@ -253,7 +254,7 @@ public final class PrimitiveOptionalsExample {
             return this;
         }
 
-        @JsonSetter("safelong")
+        @JsonSetter(value = "safelong", nulls = Nulls.SKIP)
         public Builder safelong(Optional<SafeLong> safelong) {
             this.safelong = Preconditions.checkNotNull(safelong, "safelong cannot be null");
             return this;
@@ -265,7 +266,7 @@ public final class PrimitiveOptionalsExample {
             return this;
         }
 
-        @JsonSetter("rid")
+        @JsonSetter(value = "rid", nulls = Nulls.SKIP)
         public Builder rid(Optional<ResourceIdentifier> rid) {
             this.rid = Preconditions.checkNotNull(rid, "rid cannot be null");
             return this;
@@ -276,7 +277,7 @@ public final class PrimitiveOptionalsExample {
             return this;
         }
 
-        @JsonSetter("bearertoken")
+        @JsonSetter(value = "bearertoken", nulls = Nulls.SKIP)
         public Builder bearertoken(Optional<BearerToken> bearertoken) {
             this.bearertoken =
                     Preconditions.checkNotNull(bearertoken, "bearertoken cannot be null");
@@ -290,7 +291,7 @@ public final class PrimitiveOptionalsExample {
             return this;
         }
 
-        @JsonSetter("uuid")
+        @JsonSetter(value = "uuid", nulls = Nulls.SKIP)
         public Builder uuid(Optional<UUID> uuid) {
             this.uuid = Preconditions.checkNotNull(uuid, "uuid cannot be null");
             return this;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
@@ -3,6 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.conjure.java.lib.internal.ConjureCollections;
 import com.palantir.logsafe.Preconditions;
@@ -119,7 +120,7 @@ public final class SetExample {
             return this;
         }
 
-        @JsonSetter("items")
+        @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(Iterable<String> items) {
             this.items.clear();
             ConjureCollections.addAll(
@@ -138,7 +139,7 @@ public final class SetExample {
             return this;
         }
 
-        @JsonSetter("doubleItems")
+        @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP)
         public Builder doubleItems(Iterable<Double> doubleItems) {
             this.doubleItems.clear();
             ConjureCollections.addAll(

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/MissingFieldWireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/MissingFieldWireFormatTests.java
@@ -106,8 +106,11 @@ public class MissingFieldWireFormatTests {
     @Test
     public void missing_collection_fields_should_deserialize_as_empty() throws Exception {
         assertThat(mapper.readValue("{}", SetExample.class).getItems()).isEmpty();
+        assertThat(mapper.readValue("{\"items\":null}", SetExample.class).getItems()).isEmpty();
         assertThat(mapper.readValue("{}", ListExample.class).getItems()).isEmpty();
+        assertThat(mapper.readValue("{\"items\":null}", ListExample.class).getItems()).isEmpty();
         assertThat(mapper.readValue("{}", MapExample.class).getItems()).isEmpty();
+        assertThat(mapper.readValue("{\"items\":null}", MapExample.class).getItems()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
While the [Conjure wire spec](https://github.com/palantir/conjure/blob/master/docs/spec/wire.md#561-coercing-json-null--absent-to-conjure-types) specified that absent _or_ null JSON keys for collections (`list`, `set`, `map`, `optional`) should be coerced into their empty variants conjure-java implementation only correctly handled absent fields and would fail when attempting to coerce an explicit null.

This issue had not previously been encountered since conjure-java servers always respond with empty collections (`[]`, `{}`) or omit empty optionals. Recently, the issue surfaced since Golang server's serialize empty collections as null.

## After this PR
==COMMIT_MSG==
Correctly coerce null fields into empty collections
==COMMIT_MSG==

## Possible downsides?
It appears as if these cases had been explicitly omitted from the [verifier](https://github.com/palantir/conjure-verification/blob/develop/master-test-cases.yml#L179). I'm not sure why they were omitted so there may a downside I'm not aware of. 

We will want to clarify why the test cases were omitted and potentially re-introduce them
