### PR TITLE
[improvement] Adds a visitor builder for union type visitors

### DIFF
--- a/changelog/@unreleased/pr-465.v2.yml
+++ b/changelog/@unreleased/pr-465.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Adds a visitor builder for union type visitors.
+  links:
+  - https://github.com/palantir/conjure-java/pull/465

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -13,6 +13,7 @@ import com.palantir.logsafe.Preconditions;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
@@ -72,6 +73,40 @@ public final class SingleUnion {
         T visitFoo(String value);
 
         T visitUnknown(String unknownType);
+
+        static <T> FooStageVisitorBuilder<T> builder() {
+            return new VisitorBuilder<T>();
+        }
+    }
+
+    private static class VisitorBuilder<T>
+            implements FooStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T> {
+        private Function<String, T> fooVisitor;
+
+        public UnknownStageVisitorBuilder<T> foo(Function<String, T> fooVisitor) {
+            this.fooVisitor = fooVisitor;
+            return this;
+        }
+
+        public Visitor<T> unknown(Function<String, T> unknownVisitor) {
+            return new Visitor<T>() {
+                public T visitFoo(String value) {
+                    return fooVisitor.apply(value);
+                }
+
+                public T visitUnknown(String value) {
+                    return unknownVisitor.apply(value);
+                }
+            };
+        }
+    }
+
+    public interface FooStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> foo(Function<String, T> fooVisitor);
+    }
+
+    public interface UnknownStageVisitorBuilder<T> {
+        Visitor<T> unknown(Function<String, T> unknownVisitor);
     }
 
     @JsonTypeInfo(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
-import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class SingleUnion {
@@ -88,14 +87,13 @@ public final class SingleUnion {
 
         private Function<String, T> unknownVisitor;
 
-        public UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor) {
+        public UnknownStageVisitorBuilder<T> foo(Function<String, T> fooVisitor) {
             Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
             this.fooVisitor = fooVisitor;
             return this;
         }
 
-        public CompletedStageVisitorBuilder<T> unknown(
-                @Nonnull Function<String, T> unknownVisitor) {
+        public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -115,11 +113,11 @@ public final class SingleUnion {
     }
 
     public interface FooStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor);
+        UnknownStageVisitorBuilder<T> foo(Function<String, T> fooVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+        CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor);
     }
 
     public interface CompletedStageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -80,15 +80,26 @@ public final class SingleUnion {
     }
 
     private static class VisitorBuilder<T>
-            implements FooStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T> {
+            implements FooStageVisitorBuilder<T>,
+                    UnknownStageVisitorBuilder<T>,
+                    CompletedStageVisitorBuilder<T> {
         private Function<String, T> fooVisitor;
 
+        private Function<String, T> unknownVisitor;
+
         public UnknownStageVisitorBuilder<T> foo(Function<String, T> fooVisitor) {
+            Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
             this.fooVisitor = fooVisitor;
             return this;
         }
 
-        public Visitor<T> unknown(Function<String, T> unknownVisitor) {
+        public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
+            Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
+            this.unknownVisitor = unknownVisitor;
+            return this;
+        }
+
+        public Visitor<T> build() {
             return new Visitor<T>() {
                 public T visitFoo(String value) {
                     return fooVisitor.apply(value);
@@ -106,7 +117,11 @@ public final class SingleUnion {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        Visitor<T> unknown(Function<String, T> unknownVisitor);
+        CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor);
+    }
+
+    public interface CompletedStageVisitorBuilder<T> {
+        Visitor<T> build();
     }
 
     @JsonTypeInfo(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class SingleUnion {
@@ -87,13 +88,14 @@ public final class SingleUnion {
 
         private Function<String, T> unknownVisitor;
 
-        public UnknownStageVisitorBuilder<T> foo(Function<String, T> fooVisitor) {
+        public UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor) {
             Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
             this.fooVisitor = fooVisitor;
             return this;
         }
 
-        public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
+        public CompletedStageVisitorBuilder<T> unknown(
+                @Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -113,11 +115,11 @@ public final class SingleUnion {
     }
 
     public interface FooStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> foo(Function<String, T> fooVisitor);
+        UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor);
+        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
     }
 
     public interface CompletedStageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -14,7 +14,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.IntFunction;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class Union {
@@ -103,31 +105,32 @@ public final class Union {
                     CompletedStageVisitorBuilder<T> {
         private Function<String, T> fooVisitor;
 
-        private Function<Integer, T> barVisitor;
+        private IntFunction<T> barVisitor;
 
         private Function<Long, T> bazVisitor;
 
         private Function<String, T> unknownVisitor;
 
-        public BarStageVisitorBuilder<T> foo(Function<String, T> fooVisitor) {
+        public BarStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor) {
             Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
             this.fooVisitor = fooVisitor;
             return this;
         }
 
-        public BazStageVisitorBuilder<T> bar(Function<Integer, T> barVisitor) {
+        public BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor) {
             Preconditions.checkNotNull(barVisitor, "barVisitor cannot be null");
             this.barVisitor = barVisitor;
             return this;
         }
 
-        public UnknownStageVisitorBuilder<T> baz(Function<Long, T> bazVisitor) {
+        public UnknownStageVisitorBuilder<T> baz(@Nonnull Function<Long, T> bazVisitor) {
             Preconditions.checkNotNull(bazVisitor, "bazVisitor cannot be null");
             this.bazVisitor = bazVisitor;
             return this;
         }
 
-        public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
+        public CompletedStageVisitorBuilder<T> unknown(
+                @Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -155,19 +158,19 @@ public final class Union {
     }
 
     public interface FooStageVisitorBuilder<T> {
-        BarStageVisitorBuilder<T> foo(Function<String, T> fooVisitor);
+        BarStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor);
     }
 
     public interface BarStageVisitorBuilder<T> {
-        BazStageVisitorBuilder<T> bar(Function<Integer, T> barVisitor);
+        BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor);
     }
 
     public interface BazStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> baz(Function<Long, T> bazVisitor);
+        UnknownStageVisitorBuilder<T> baz(@Nonnull Function<Long, T> bazVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor);
+        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
     }
 
     public interface CompletedStageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -91,15 +91,15 @@ public final class Union {
 
         T visitUnknown(String unknownType);
 
-        static <T> FooStageVisitorBuilder<T> builder() {
+        static <T> BarStageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
         }
     }
 
     private static class VisitorBuilder<T>
-            implements FooStageVisitorBuilder<T>,
-                    BarStageVisitorBuilder<T>,
+            implements BarStageVisitorBuilder<T>,
                     BazStageVisitorBuilder<T>,
+                    FooStageVisitorBuilder<T>,
                     UnknownStageVisitorBuilder<T>,
                     CompletedStageVisitorBuilder<T> {
         private Function<String, T> fooVisitor;
@@ -110,21 +110,21 @@ public final class Union {
 
         private Function<String, T> unknownVisitor;
 
-        public BarStageVisitorBuilder<T> foo(Function<String, T> fooVisitor) {
-            Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
-            this.fooVisitor = fooVisitor;
-            return this;
-        }
-
         public BazStageVisitorBuilder<T> bar(IntFunction<T> barVisitor) {
             Preconditions.checkNotNull(barVisitor, "barVisitor cannot be null");
             this.barVisitor = barVisitor;
             return this;
         }
 
-        public UnknownStageVisitorBuilder<T> baz(Function<Long, T> bazVisitor) {
+        public FooStageVisitorBuilder<T> baz(Function<Long, T> bazVisitor) {
             Preconditions.checkNotNull(bazVisitor, "bazVisitor cannot be null");
             this.bazVisitor = bazVisitor;
+            return this;
+        }
+
+        public UnknownStageVisitorBuilder<T> foo(Function<String, T> fooVisitor) {
+            Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
+            this.fooVisitor = fooVisitor;
             return this;
         }
 
@@ -155,16 +155,16 @@ public final class Union {
         }
     }
 
-    public interface FooStageVisitorBuilder<T> {
-        BarStageVisitorBuilder<T> foo(Function<String, T> fooVisitor);
-    }
-
     public interface BarStageVisitorBuilder<T> {
         BazStageVisitorBuilder<T> bar(IntFunction<T> barVisitor);
     }
 
     public interface BazStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> baz(Function<Long, T> bazVisitor);
+        FooStageVisitorBuilder<T> baz(Function<Long, T> bazVisitor);
+    }
+
+    public interface FooStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> foo(Function<String, T> fooVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -13,6 +13,7 @@ import com.palantir.logsafe.Preconditions;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
@@ -88,6 +89,73 @@ public final class Union {
         T visitBaz(long value);
 
         T visitUnknown(String unknownType);
+
+        static <T> FooStageVisitorBuilder<T> builder() {
+            return new VisitorBuilder<T>();
+        }
+    }
+
+    private static class VisitorBuilder<T>
+            implements FooStageVisitorBuilder<T>,
+                    BarStageVisitorBuilder<T>,
+                    BazStageVisitorBuilder<T>,
+                    UnknownStageVisitorBuilder<T> {
+        private Function<String, T> fooVisitor;
+
+        private Function<Integer, T> barVisitor;
+
+        private Function<Long, T> bazVisitor;
+
+        public BarStageVisitorBuilder<T> foo(Function<String, T> fooVisitor) {
+            this.fooVisitor = fooVisitor;
+            return this;
+        }
+
+        public BazStageVisitorBuilder<T> bar(Function<Integer, T> barVisitor) {
+            this.barVisitor = barVisitor;
+            return this;
+        }
+
+        public UnknownStageVisitorBuilder<T> baz(Function<Long, T> bazVisitor) {
+            this.bazVisitor = bazVisitor;
+            return this;
+        }
+
+        public Visitor<T> unknown(Function<String, T> unknownVisitor) {
+            return new Visitor<T>() {
+                public T visitFoo(String value) {
+                    return fooVisitor.apply(value);
+                }
+
+                public T visitBar(int value) {
+                    return barVisitor.apply(value);
+                }
+
+                public T visitBaz(long value) {
+                    return bazVisitor.apply(value);
+                }
+
+                public T visitUnknown(String value) {
+                    return unknownVisitor.apply(value);
+                }
+            };
+        }
+    }
+
+    public interface FooStageVisitorBuilder<T> {
+        BarStageVisitorBuilder<T> foo(Function<String, T> fooVisitor);
+    }
+
+    public interface BarStageVisitorBuilder<T> {
+        BazStageVisitorBuilder<T> bar(Function<Integer, T> barVisitor);
+    }
+
+    public interface BazStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> baz(Function<Long, T> bazVisitor);
+    }
+
+    public interface UnknownStageVisitorBuilder<T> {
+        Visitor<T> unknown(Function<String, T> unknownVisitor);
     }
 
     @JsonTypeInfo(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -16,7 +16,6 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import javax.annotation.Generated;
-import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class Union {
@@ -111,26 +110,25 @@ public final class Union {
 
         private Function<String, T> unknownVisitor;
 
-        public BarStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor) {
+        public BarStageVisitorBuilder<T> foo(Function<String, T> fooVisitor) {
             Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
             this.fooVisitor = fooVisitor;
             return this;
         }
 
-        public BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor) {
+        public BazStageVisitorBuilder<T> bar(IntFunction<T> barVisitor) {
             Preconditions.checkNotNull(barVisitor, "barVisitor cannot be null");
             this.barVisitor = barVisitor;
             return this;
         }
 
-        public UnknownStageVisitorBuilder<T> baz(@Nonnull Function<Long, T> bazVisitor) {
+        public UnknownStageVisitorBuilder<T> baz(Function<Long, T> bazVisitor) {
             Preconditions.checkNotNull(bazVisitor, "bazVisitor cannot be null");
             this.bazVisitor = bazVisitor;
             return this;
         }
 
-        public CompletedStageVisitorBuilder<T> unknown(
-                @Nonnull Function<String, T> unknownVisitor) {
+        public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -158,19 +156,19 @@ public final class Union {
     }
 
     public interface FooStageVisitorBuilder<T> {
-        BarStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor);
+        BarStageVisitorBuilder<T> foo(Function<String, T> fooVisitor);
     }
 
     public interface BarStageVisitorBuilder<T> {
-        BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor);
+        BazStageVisitorBuilder<T> bar(IntFunction<T> barVisitor);
     }
 
     public interface BazStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> baz(@Nonnull Function<Long, T> bazVisitor);
+        UnknownStageVisitorBuilder<T> baz(Function<Long, T> bazVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+        CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor);
     }
 
     public interface CompletedStageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -99,29 +99,41 @@ public final class Union {
             implements FooStageVisitorBuilder<T>,
                     BarStageVisitorBuilder<T>,
                     BazStageVisitorBuilder<T>,
-                    UnknownStageVisitorBuilder<T> {
+                    UnknownStageVisitorBuilder<T>,
+                    CompletedStageVisitorBuilder<T> {
         private Function<String, T> fooVisitor;
 
         private Function<Integer, T> barVisitor;
 
         private Function<Long, T> bazVisitor;
 
+        private Function<String, T> unknownVisitor;
+
         public BarStageVisitorBuilder<T> foo(Function<String, T> fooVisitor) {
+            Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
             this.fooVisitor = fooVisitor;
             return this;
         }
 
         public BazStageVisitorBuilder<T> bar(Function<Integer, T> barVisitor) {
+            Preconditions.checkNotNull(barVisitor, "barVisitor cannot be null");
             this.barVisitor = barVisitor;
             return this;
         }
 
         public UnknownStageVisitorBuilder<T> baz(Function<Long, T> bazVisitor) {
+            Preconditions.checkNotNull(bazVisitor, "bazVisitor cannot be null");
             this.bazVisitor = bazVisitor;
             return this;
         }
 
-        public Visitor<T> unknown(Function<String, T> unknownVisitor) {
+        public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
+            Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
+            this.unknownVisitor = unknownVisitor;
+            return this;
+        }
+
+        public Visitor<T> build() {
             return new Visitor<T>() {
                 public T visitFoo(String value) {
                     return fooVisitor.apply(value);
@@ -155,7 +167,11 @@ public final class Union {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        Visitor<T> unknown(Function<String, T> unknownVisitor);
+        CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor);
+    }
+
+    public interface CompletedStageVisitorBuilder<T> {
+        Visitor<T> build();
     }
 
     @JsonTypeInfo(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -139,7 +139,8 @@ public final class UnionTypeExample {
                     IfStageVisitorBuilder<T>,
                     NewStageVisitorBuilder<T>,
                     InterfaceStageVisitorBuilder<T>,
-                    UnknownStageVisitorBuilder<T> {
+                    UnknownStageVisitorBuilder<T>,
+                    CompletedStageVisitorBuilder<T> {
         private Function<StringExample, T> stringExampleVisitor;
 
         private Function<Set<String>, T> setVisitor;
@@ -154,44 +155,60 @@ public final class UnionTypeExample {
 
         private Function<Integer, T> interfaceVisitor;
 
+        private Function<String, T> unknownVisitor;
+
         public SetStageVisitorBuilder<T> stringExample(
                 Function<StringExample, T> stringExampleVisitor) {
+            Preconditions.checkNotNull(stringExampleVisitor, "stringExampleVisitor cannot be null");
             this.stringExampleVisitor = stringExampleVisitor;
             return this;
         }
 
         public ThisFieldIsAnIntegerStageVisitorBuilder<T> set(Function<Set<String>, T> setVisitor) {
+            Preconditions.checkNotNull(setVisitor, "setVisitor cannot be null");
             this.setVisitor = setVisitor;
             return this;
         }
 
         public AlsoAnIntegerStageVisitorBuilder<T> thisFieldIsAnInteger(
                 Function<Integer, T> thisFieldIsAnIntegerVisitor) {
+            Preconditions.checkNotNull(
+                    thisFieldIsAnIntegerVisitor, "thisFieldIsAnIntegerVisitor cannot be null");
             this.thisFieldIsAnIntegerVisitor = thisFieldIsAnIntegerVisitor;
             return this;
         }
 
         public IfStageVisitorBuilder<T> alsoAnInteger(Function<Integer, T> alsoAnIntegerVisitor) {
+            Preconditions.checkNotNull(alsoAnIntegerVisitor, "alsoAnIntegerVisitor cannot be null");
             this.alsoAnIntegerVisitor = alsoAnIntegerVisitor;
             return this;
         }
 
         public NewStageVisitorBuilder<T> if_(Function<Integer, T> ifVisitor) {
+            Preconditions.checkNotNull(ifVisitor, "ifVisitor cannot be null");
             this.ifVisitor = ifVisitor;
             return this;
         }
 
         public InterfaceStageVisitorBuilder<T> new_(Function<Integer, T> newVisitor) {
+            Preconditions.checkNotNull(newVisitor, "newVisitor cannot be null");
             this.newVisitor = newVisitor;
             return this;
         }
 
         public UnknownStageVisitorBuilder<T> interface_(Function<Integer, T> interfaceVisitor) {
+            Preconditions.checkNotNull(interfaceVisitor, "interfaceVisitor cannot be null");
             this.interfaceVisitor = interfaceVisitor;
             return this;
         }
 
-        public Visitor<T> unknown(Function<String, T> unknownVisitor) {
+        public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
+            Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
+            this.unknownVisitor = unknownVisitor;
+            return this;
+        }
+
+        public Visitor<T> build() {
             return new Visitor<T>() {
                 public T visitStringExample(StringExample value) {
                     return stringExampleVisitor.apply(value);
@@ -258,7 +275,11 @@ public final class UnionTypeExample {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        Visitor<T> unknown(Function<String, T> unknownVisitor);
+        CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor);
+    }
+
+    public interface CompletedStageVisitorBuilder<T> {
+        Visitor<T> build();
     }
 
     @JsonTypeInfo(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import javax.annotation.Generated;
 
 /** A type which can either be a StringExample, a set of strings, or an integer. */
@@ -124,6 +125,140 @@ public final class UnionTypeExample {
         T visitInterface(int value);
 
         T visitUnknown(String unknownType);
+
+        static <T> StringExampleStageVisitorBuilder<T> builder() {
+            return new VisitorBuilder<T>();
+        }
+    }
+
+    private static class VisitorBuilder<T>
+            implements StringExampleStageVisitorBuilder<T>,
+                    SetStageVisitorBuilder<T>,
+                    ThisFieldIsAnIntegerStageVisitorBuilder<T>,
+                    AlsoAnIntegerStageVisitorBuilder<T>,
+                    IfStageVisitorBuilder<T>,
+                    NewStageVisitorBuilder<T>,
+                    InterfaceStageVisitorBuilder<T>,
+                    UnknownStageVisitorBuilder<T> {
+        private Function<StringExample, T> stringExampleVisitor;
+
+        private Function<Set<String>, T> setVisitor;
+
+        private Function<Integer, T> thisFieldIsAnIntegerVisitor;
+
+        private Function<Integer, T> alsoAnIntegerVisitor;
+
+        private Function<Integer, T> ifVisitor;
+
+        private Function<Integer, T> newVisitor;
+
+        private Function<Integer, T> interfaceVisitor;
+
+        public SetStageVisitorBuilder<T> stringExample(
+                Function<StringExample, T> stringExampleVisitor) {
+            this.stringExampleVisitor = stringExampleVisitor;
+            return this;
+        }
+
+        public ThisFieldIsAnIntegerStageVisitorBuilder<T> set(Function<Set<String>, T> setVisitor) {
+            this.setVisitor = setVisitor;
+            return this;
+        }
+
+        public AlsoAnIntegerStageVisitorBuilder<T> thisFieldIsAnInteger(
+                Function<Integer, T> thisFieldIsAnIntegerVisitor) {
+            this.thisFieldIsAnIntegerVisitor = thisFieldIsAnIntegerVisitor;
+            return this;
+        }
+
+        public IfStageVisitorBuilder<T> alsoAnInteger(Function<Integer, T> alsoAnIntegerVisitor) {
+            this.alsoAnIntegerVisitor = alsoAnIntegerVisitor;
+            return this;
+        }
+
+        public NewStageVisitorBuilder<T> if_(Function<Integer, T> ifVisitor) {
+            this.ifVisitor = ifVisitor;
+            return this;
+        }
+
+        public InterfaceStageVisitorBuilder<T> new_(Function<Integer, T> newVisitor) {
+            this.newVisitor = newVisitor;
+            return this;
+        }
+
+        public UnknownStageVisitorBuilder<T> interface_(Function<Integer, T> interfaceVisitor) {
+            this.interfaceVisitor = interfaceVisitor;
+            return this;
+        }
+
+        public Visitor<T> unknown(Function<String, T> unknownVisitor) {
+            return new Visitor<T>() {
+                public T visitStringExample(StringExample value) {
+                    return stringExampleVisitor.apply(value);
+                }
+
+                public T visitSet(Set<String> value) {
+                    return setVisitor.apply(value);
+                }
+
+                public T visitThisFieldIsAnInteger(int value) {
+                    return thisFieldIsAnIntegerVisitor.apply(value);
+                }
+
+                public T visitAlsoAnInteger(int value) {
+                    return alsoAnIntegerVisitor.apply(value);
+                }
+
+                public T visitIf(int value) {
+                    return ifVisitor.apply(value);
+                }
+
+                public T visitNew(int value) {
+                    return newVisitor.apply(value);
+                }
+
+                public T visitInterface(int value) {
+                    return interfaceVisitor.apply(value);
+                }
+
+                public T visitUnknown(String value) {
+                    return unknownVisitor.apply(value);
+                }
+            };
+        }
+    }
+
+    public interface StringExampleStageVisitorBuilder<T> {
+        SetStageVisitorBuilder<T> stringExample(Function<StringExample, T> stringExampleVisitor);
+    }
+
+    public interface SetStageVisitorBuilder<T> {
+        ThisFieldIsAnIntegerStageVisitorBuilder<T> set(Function<Set<String>, T> setVisitor);
+    }
+
+    public interface ThisFieldIsAnIntegerStageVisitorBuilder<T> {
+        AlsoAnIntegerStageVisitorBuilder<T> thisFieldIsAnInteger(
+                Function<Integer, T> thisFieldIsAnIntegerVisitor);
+    }
+
+    public interface AlsoAnIntegerStageVisitorBuilder<T> {
+        IfStageVisitorBuilder<T> alsoAnInteger(Function<Integer, T> alsoAnIntegerVisitor);
+    }
+
+    public interface IfStageVisitorBuilder<T> {
+        NewStageVisitorBuilder<T> if_(Function<Integer, T> ifVisitor);
+    }
+
+    public interface NewStageVisitorBuilder<T> {
+        InterfaceStageVisitorBuilder<T> new_(Function<Integer, T> newVisitor);
+    }
+
+    public interface InterfaceStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> interface_(Function<Integer, T> interfaceVisitor);
+    }
+
+    public interface UnknownStageVisitorBuilder<T> {
+        Visitor<T> unknown(Function<String, T> unknownVisitor);
     }
 
     @JsonTypeInfo(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -17,7 +17,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import javax.annotation.Generated;
-import javax.annotation.Nonnull;
 
 /** A type which can either be a StringExample, a set of strings, or an integer. */
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
@@ -160,54 +159,51 @@ public final class UnionTypeExample {
         private Function<String, T> unknownVisitor;
 
         public SetStageVisitorBuilder<T> stringExample(
-                @Nonnull Function<StringExample, T> stringExampleVisitor) {
+                Function<StringExample, T> stringExampleVisitor) {
             Preconditions.checkNotNull(stringExampleVisitor, "stringExampleVisitor cannot be null");
             this.stringExampleVisitor = stringExampleVisitor;
             return this;
         }
 
-        public ThisFieldIsAnIntegerStageVisitorBuilder<T> set(
-                @Nonnull Function<Set<String>, T> setVisitor) {
+        public ThisFieldIsAnIntegerStageVisitorBuilder<T> set(Function<Set<String>, T> setVisitor) {
             Preconditions.checkNotNull(setVisitor, "setVisitor cannot be null");
             this.setVisitor = setVisitor;
             return this;
         }
 
         public AlsoAnIntegerStageVisitorBuilder<T> thisFieldIsAnInteger(
-                @Nonnull IntFunction<T> thisFieldIsAnIntegerVisitor) {
+                IntFunction<T> thisFieldIsAnIntegerVisitor) {
             Preconditions.checkNotNull(
                     thisFieldIsAnIntegerVisitor, "thisFieldIsAnIntegerVisitor cannot be null");
             this.thisFieldIsAnIntegerVisitor = thisFieldIsAnIntegerVisitor;
             return this;
         }
 
-        public IfStageVisitorBuilder<T> alsoAnInteger(
-                @Nonnull IntFunction<T> alsoAnIntegerVisitor) {
+        public IfStageVisitorBuilder<T> alsoAnInteger(IntFunction<T> alsoAnIntegerVisitor) {
             Preconditions.checkNotNull(alsoAnIntegerVisitor, "alsoAnIntegerVisitor cannot be null");
             this.alsoAnIntegerVisitor = alsoAnIntegerVisitor;
             return this;
         }
 
-        public NewStageVisitorBuilder<T> if_(@Nonnull IntFunction<T> ifVisitor) {
+        public NewStageVisitorBuilder<T> if_(IntFunction<T> ifVisitor) {
             Preconditions.checkNotNull(ifVisitor, "ifVisitor cannot be null");
             this.ifVisitor = ifVisitor;
             return this;
         }
 
-        public InterfaceStageVisitorBuilder<T> new_(@Nonnull IntFunction<T> newVisitor) {
+        public InterfaceStageVisitorBuilder<T> new_(IntFunction<T> newVisitor) {
             Preconditions.checkNotNull(newVisitor, "newVisitor cannot be null");
             this.newVisitor = newVisitor;
             return this;
         }
 
-        public UnknownStageVisitorBuilder<T> interface_(@Nonnull IntFunction<T> interfaceVisitor) {
+        public UnknownStageVisitorBuilder<T> interface_(IntFunction<T> interfaceVisitor) {
             Preconditions.checkNotNull(interfaceVisitor, "interfaceVisitor cannot be null");
             this.interfaceVisitor = interfaceVisitor;
             return this;
         }
 
-        public CompletedStageVisitorBuilder<T> unknown(
-                @Nonnull Function<String, T> unknownVisitor) {
+        public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -251,38 +247,36 @@ public final class UnionTypeExample {
     }
 
     public interface StringExampleStageVisitorBuilder<T> {
-        SetStageVisitorBuilder<T> stringExample(
-                @Nonnull Function<StringExample, T> stringExampleVisitor);
+        SetStageVisitorBuilder<T> stringExample(Function<StringExample, T> stringExampleVisitor);
     }
 
     public interface SetStageVisitorBuilder<T> {
-        ThisFieldIsAnIntegerStageVisitorBuilder<T> set(
-                @Nonnull Function<Set<String>, T> setVisitor);
+        ThisFieldIsAnIntegerStageVisitorBuilder<T> set(Function<Set<String>, T> setVisitor);
     }
 
     public interface ThisFieldIsAnIntegerStageVisitorBuilder<T> {
         AlsoAnIntegerStageVisitorBuilder<T> thisFieldIsAnInteger(
-                @Nonnull IntFunction<T> thisFieldIsAnIntegerVisitor);
+                IntFunction<T> thisFieldIsAnIntegerVisitor);
     }
 
     public interface AlsoAnIntegerStageVisitorBuilder<T> {
-        IfStageVisitorBuilder<T> alsoAnInteger(@Nonnull IntFunction<T> alsoAnIntegerVisitor);
+        IfStageVisitorBuilder<T> alsoAnInteger(IntFunction<T> alsoAnIntegerVisitor);
     }
 
     public interface IfStageVisitorBuilder<T> {
-        NewStageVisitorBuilder<T> if_(@Nonnull IntFunction<T> ifVisitor);
+        NewStageVisitorBuilder<T> if_(IntFunction<T> ifVisitor);
     }
 
     public interface NewStageVisitorBuilder<T> {
-        InterfaceStageVisitorBuilder<T> new_(@Nonnull IntFunction<T> newVisitor);
+        InterfaceStageVisitorBuilder<T> new_(IntFunction<T> newVisitor);
     }
 
     public interface InterfaceStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> interface_(@Nonnull IntFunction<T> interfaceVisitor);
+        UnknownStageVisitorBuilder<T> interface_(IntFunction<T> interfaceVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+        CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor);
     }
 
     public interface CompletedStageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -15,7 +15,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.IntFunction;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 /** A type which can either be a StringExample, a set of strings, or an integer. */
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
@@ -145,64 +147,67 @@ public final class UnionTypeExample {
 
         private Function<Set<String>, T> setVisitor;
 
-        private Function<Integer, T> thisFieldIsAnIntegerVisitor;
+        private IntFunction<T> thisFieldIsAnIntegerVisitor;
 
-        private Function<Integer, T> alsoAnIntegerVisitor;
+        private IntFunction<T> alsoAnIntegerVisitor;
 
-        private Function<Integer, T> ifVisitor;
+        private IntFunction<T> ifVisitor;
 
-        private Function<Integer, T> newVisitor;
+        private IntFunction<T> newVisitor;
 
-        private Function<Integer, T> interfaceVisitor;
+        private IntFunction<T> interfaceVisitor;
 
         private Function<String, T> unknownVisitor;
 
         public SetStageVisitorBuilder<T> stringExample(
-                Function<StringExample, T> stringExampleVisitor) {
+                @Nonnull Function<StringExample, T> stringExampleVisitor) {
             Preconditions.checkNotNull(stringExampleVisitor, "stringExampleVisitor cannot be null");
             this.stringExampleVisitor = stringExampleVisitor;
             return this;
         }
 
-        public ThisFieldIsAnIntegerStageVisitorBuilder<T> set(Function<Set<String>, T> setVisitor) {
+        public ThisFieldIsAnIntegerStageVisitorBuilder<T> set(
+                @Nonnull Function<Set<String>, T> setVisitor) {
             Preconditions.checkNotNull(setVisitor, "setVisitor cannot be null");
             this.setVisitor = setVisitor;
             return this;
         }
 
         public AlsoAnIntegerStageVisitorBuilder<T> thisFieldIsAnInteger(
-                Function<Integer, T> thisFieldIsAnIntegerVisitor) {
+                @Nonnull IntFunction<T> thisFieldIsAnIntegerVisitor) {
             Preconditions.checkNotNull(
                     thisFieldIsAnIntegerVisitor, "thisFieldIsAnIntegerVisitor cannot be null");
             this.thisFieldIsAnIntegerVisitor = thisFieldIsAnIntegerVisitor;
             return this;
         }
 
-        public IfStageVisitorBuilder<T> alsoAnInteger(Function<Integer, T> alsoAnIntegerVisitor) {
+        public IfStageVisitorBuilder<T> alsoAnInteger(
+                @Nonnull IntFunction<T> alsoAnIntegerVisitor) {
             Preconditions.checkNotNull(alsoAnIntegerVisitor, "alsoAnIntegerVisitor cannot be null");
             this.alsoAnIntegerVisitor = alsoAnIntegerVisitor;
             return this;
         }
 
-        public NewStageVisitorBuilder<T> if_(Function<Integer, T> ifVisitor) {
+        public NewStageVisitorBuilder<T> if_(@Nonnull IntFunction<T> ifVisitor) {
             Preconditions.checkNotNull(ifVisitor, "ifVisitor cannot be null");
             this.ifVisitor = ifVisitor;
             return this;
         }
 
-        public InterfaceStageVisitorBuilder<T> new_(Function<Integer, T> newVisitor) {
+        public InterfaceStageVisitorBuilder<T> new_(@Nonnull IntFunction<T> newVisitor) {
             Preconditions.checkNotNull(newVisitor, "newVisitor cannot be null");
             this.newVisitor = newVisitor;
             return this;
         }
 
-        public UnknownStageVisitorBuilder<T> interface_(Function<Integer, T> interfaceVisitor) {
+        public UnknownStageVisitorBuilder<T> interface_(@Nonnull IntFunction<T> interfaceVisitor) {
             Preconditions.checkNotNull(interfaceVisitor, "interfaceVisitor cannot be null");
             this.interfaceVisitor = interfaceVisitor;
             return this;
         }
 
-        public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
+        public CompletedStageVisitorBuilder<T> unknown(
+                @Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -246,36 +251,38 @@ public final class UnionTypeExample {
     }
 
     public interface StringExampleStageVisitorBuilder<T> {
-        SetStageVisitorBuilder<T> stringExample(Function<StringExample, T> stringExampleVisitor);
+        SetStageVisitorBuilder<T> stringExample(
+                @Nonnull Function<StringExample, T> stringExampleVisitor);
     }
 
     public interface SetStageVisitorBuilder<T> {
-        ThisFieldIsAnIntegerStageVisitorBuilder<T> set(Function<Set<String>, T> setVisitor);
+        ThisFieldIsAnIntegerStageVisitorBuilder<T> set(
+                @Nonnull Function<Set<String>, T> setVisitor);
     }
 
     public interface ThisFieldIsAnIntegerStageVisitorBuilder<T> {
         AlsoAnIntegerStageVisitorBuilder<T> thisFieldIsAnInteger(
-                Function<Integer, T> thisFieldIsAnIntegerVisitor);
+                @Nonnull IntFunction<T> thisFieldIsAnIntegerVisitor);
     }
 
     public interface AlsoAnIntegerStageVisitorBuilder<T> {
-        IfStageVisitorBuilder<T> alsoAnInteger(Function<Integer, T> alsoAnIntegerVisitor);
+        IfStageVisitorBuilder<T> alsoAnInteger(@Nonnull IntFunction<T> alsoAnIntegerVisitor);
     }
 
     public interface IfStageVisitorBuilder<T> {
-        NewStageVisitorBuilder<T> if_(Function<Integer, T> ifVisitor);
+        NewStageVisitorBuilder<T> if_(@Nonnull IntFunction<T> ifVisitor);
     }
 
     public interface NewStageVisitorBuilder<T> {
-        InterfaceStageVisitorBuilder<T> new_(Function<Integer, T> newVisitor);
+        InterfaceStageVisitorBuilder<T> new_(@Nonnull IntFunction<T> newVisitor);
     }
 
     public interface InterfaceStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> interface_(Function<Integer, T> interfaceVisitor);
+        UnknownStageVisitorBuilder<T> interface_(@Nonnull IntFunction<T> interfaceVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor);
+        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
     }
 
     public interface CompletedStageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -127,19 +127,19 @@ public final class UnionTypeExample {
 
         T visitUnknown(String unknownType);
 
-        static <T> StringExampleStageVisitorBuilder<T> builder() {
+        static <T> AlsoAnIntegerStageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
         }
     }
 
     private static class VisitorBuilder<T>
-            implements StringExampleStageVisitorBuilder<T>,
-                    SetStageVisitorBuilder<T>,
-                    ThisFieldIsAnIntegerStageVisitorBuilder<T>,
-                    AlsoAnIntegerStageVisitorBuilder<T>,
+            implements AlsoAnIntegerStageVisitorBuilder<T>,
                     IfStageVisitorBuilder<T>,
-                    NewStageVisitorBuilder<T>,
                     InterfaceStageVisitorBuilder<T>,
+                    NewStageVisitorBuilder<T>,
+                    SetStageVisitorBuilder<T>,
+                    StringExampleStageVisitorBuilder<T>,
+                    ThisFieldIsAnIntegerStageVisitorBuilder<T>,
                     UnknownStageVisitorBuilder<T>,
                     CompletedStageVisitorBuilder<T> {
         private Function<StringExample, T> stringExampleVisitor;
@@ -158,48 +158,48 @@ public final class UnionTypeExample {
 
         private Function<String, T> unknownVisitor;
 
-        public SetStageVisitorBuilder<T> stringExample(
-                Function<StringExample, T> stringExampleVisitor) {
-            Preconditions.checkNotNull(stringExampleVisitor, "stringExampleVisitor cannot be null");
-            this.stringExampleVisitor = stringExampleVisitor;
-            return this;
-        }
-
-        public ThisFieldIsAnIntegerStageVisitorBuilder<T> set(Function<Set<String>, T> setVisitor) {
-            Preconditions.checkNotNull(setVisitor, "setVisitor cannot be null");
-            this.setVisitor = setVisitor;
-            return this;
-        }
-
-        public AlsoAnIntegerStageVisitorBuilder<T> thisFieldIsAnInteger(
-                IntFunction<T> thisFieldIsAnIntegerVisitor) {
-            Preconditions.checkNotNull(
-                    thisFieldIsAnIntegerVisitor, "thisFieldIsAnIntegerVisitor cannot be null");
-            this.thisFieldIsAnIntegerVisitor = thisFieldIsAnIntegerVisitor;
-            return this;
-        }
-
         public IfStageVisitorBuilder<T> alsoAnInteger(IntFunction<T> alsoAnIntegerVisitor) {
             Preconditions.checkNotNull(alsoAnIntegerVisitor, "alsoAnIntegerVisitor cannot be null");
             this.alsoAnIntegerVisitor = alsoAnIntegerVisitor;
             return this;
         }
 
-        public NewStageVisitorBuilder<T> if_(IntFunction<T> ifVisitor) {
+        public InterfaceStageVisitorBuilder<T> if_(IntFunction<T> ifVisitor) {
             Preconditions.checkNotNull(ifVisitor, "ifVisitor cannot be null");
             this.ifVisitor = ifVisitor;
             return this;
         }
 
-        public InterfaceStageVisitorBuilder<T> new_(IntFunction<T> newVisitor) {
+        public NewStageVisitorBuilder<T> interface_(IntFunction<T> interfaceVisitor) {
+            Preconditions.checkNotNull(interfaceVisitor, "interfaceVisitor cannot be null");
+            this.interfaceVisitor = interfaceVisitor;
+            return this;
+        }
+
+        public SetStageVisitorBuilder<T> new_(IntFunction<T> newVisitor) {
             Preconditions.checkNotNull(newVisitor, "newVisitor cannot be null");
             this.newVisitor = newVisitor;
             return this;
         }
 
-        public UnknownStageVisitorBuilder<T> interface_(IntFunction<T> interfaceVisitor) {
-            Preconditions.checkNotNull(interfaceVisitor, "interfaceVisitor cannot be null");
-            this.interfaceVisitor = interfaceVisitor;
+        public StringExampleStageVisitorBuilder<T> set(Function<Set<String>, T> setVisitor) {
+            Preconditions.checkNotNull(setVisitor, "setVisitor cannot be null");
+            this.setVisitor = setVisitor;
+            return this;
+        }
+
+        public ThisFieldIsAnIntegerStageVisitorBuilder<T> stringExample(
+                Function<StringExample, T> stringExampleVisitor) {
+            Preconditions.checkNotNull(stringExampleVisitor, "stringExampleVisitor cannot be null");
+            this.stringExampleVisitor = stringExampleVisitor;
+            return this;
+        }
+
+        public UnknownStageVisitorBuilder<T> thisFieldIsAnInteger(
+                IntFunction<T> thisFieldIsAnIntegerVisitor) {
+            Preconditions.checkNotNull(
+                    thisFieldIsAnIntegerVisitor, "thisFieldIsAnIntegerVisitor cannot be null");
+            this.thisFieldIsAnIntegerVisitor = thisFieldIsAnIntegerVisitor;
             return this;
         }
 
@@ -246,33 +246,34 @@ public final class UnionTypeExample {
         }
     }
 
-    public interface StringExampleStageVisitorBuilder<T> {
-        SetStageVisitorBuilder<T> stringExample(Function<StringExample, T> stringExampleVisitor);
-    }
-
-    public interface SetStageVisitorBuilder<T> {
-        ThisFieldIsAnIntegerStageVisitorBuilder<T> set(Function<Set<String>, T> setVisitor);
-    }
-
-    public interface ThisFieldIsAnIntegerStageVisitorBuilder<T> {
-        AlsoAnIntegerStageVisitorBuilder<T> thisFieldIsAnInteger(
-                IntFunction<T> thisFieldIsAnIntegerVisitor);
-    }
-
     public interface AlsoAnIntegerStageVisitorBuilder<T> {
         IfStageVisitorBuilder<T> alsoAnInteger(IntFunction<T> alsoAnIntegerVisitor);
     }
 
     public interface IfStageVisitorBuilder<T> {
-        NewStageVisitorBuilder<T> if_(IntFunction<T> ifVisitor);
-    }
-
-    public interface NewStageVisitorBuilder<T> {
-        InterfaceStageVisitorBuilder<T> new_(IntFunction<T> newVisitor);
+        InterfaceStageVisitorBuilder<T> if_(IntFunction<T> ifVisitor);
     }
 
     public interface InterfaceStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> interface_(IntFunction<T> interfaceVisitor);
+        NewStageVisitorBuilder<T> interface_(IntFunction<T> interfaceVisitor);
+    }
+
+    public interface NewStageVisitorBuilder<T> {
+        SetStageVisitorBuilder<T> new_(IntFunction<T> newVisitor);
+    }
+
+    public interface SetStageVisitorBuilder<T> {
+        StringExampleStageVisitorBuilder<T> set(Function<Set<String>, T> setVisitor);
+    }
+
+    public interface StringExampleStageVisitorBuilder<T> {
+        ThisFieldIsAnIntegerStageVisitorBuilder<T> stringExample(
+                Function<StringExample, T> stringExampleVisitor);
+    }
+
+    public interface ThisFieldIsAnIntegerStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> thisFieldIsAnInteger(
+                IntFunction<T> thisFieldIsAnIntegerVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -57,7 +57,6 @@ import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
 import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
 
@@ -459,9 +458,7 @@ public final class UnionGenerator {
             ClassName nextBuilderStage) {
         TypeName visitorObject = visitorObjectTypeName(memberType, visitResultType);
         return MethodSpec.methodBuilder(JavaNameSanitizer.sanitize(memberName))
-                .addParameter(ParameterSpec.builder(visitorObject, visitorFieldName(memberName))
-                        .addAnnotation(Nonnull.class)
-                        .build())
+                .addParameter(ParameterSpec.builder(visitorObject, visitorFieldName(memberName)).build())
                 .returns(ParameterizedTypeName.get(nextBuilderStage, visitResultType));
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -436,7 +436,6 @@ public final class UnionGenerator {
             ClassName unionClass,
             ClassName visitorClass,
             Map<FieldName, TypeName> memberTypes) {
-
         // Prepare pairs of stage names and types...
         List<Pair<String, TypeName>> stagesNamesAndTypes = new ArrayList<>();
         for (Map.Entry<FieldName, TypeName> entry : memberTypes.entrySet()) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -55,7 +55,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
 import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
 


### PR DESCRIPTION
## Before this PR
Visitors are used to do case splits on union types. For example

    String sound = pet.accept(new Animal.Visitor<String>() {

        @Override
        public String visitDog(String name) {
            return "Woof!";
        }

        @Override
        public String visitCat(String name) {
            return "Meow!";
        }

        @Override
        public String visitUnknown(String unknownType) {
            return "beep?";
        }
    });

There's a lot of cruft here unfortunately. We have basically three semantically interesting lines, out of 17 lines in total. Judging from a big code base that uses Conjure, short handler methods are quite common, so the signal-to-noise ratio is quite low in practice.

## After this PR
The `UnionGenerator` now includes a builder for the `Visitor` class, which allows us to do:

    String sound = pet.accept(Animal.Visitor.<String>builder()
            .dog(name -> "Woof!")
            .cat(name -> "Meow!")
            .unknown(unknownType -> "beep?"));

The solution uses staged builders so case omissions are caught in compile time (thanks @carterkozak). A single builder object is used through out the build, and the separate stages are enforced simply through interfaces (thanks @dxiao).

## Possible downsides?
None that I can think of.
