### PR TITLE
[Improvement] Add new common features for enums

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -75,6 +75,10 @@ public final class EnumExample {
         }
     }
 
+    public static EnumExample[] values() {
+        return new EnumExample[] {ONE, TWO, ONE_HUNDRED};
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         switch (value) {
             case ONE:

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -2,6 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.conjure.java.lib.ConjureEnum;
 import com.palantir.logsafe.Preconditions;
 import java.util.Locale;
 import javax.annotation.Generated;
@@ -20,7 +21,7 @@ import javax.annotation.Generated;
  * compile time.
  */
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
-public final class EnumExample {
+public final class EnumExample implements ConjureEnum<EnumExample> {
     public static final EnumExample ONE = new EnumExample(Value.ONE, "ONE");
 
     public static final EnumExample TWO = new EnumExample(Value.TWO, "TWO");

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
@@ -2,6 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.conjure.java.lib.ConjureEnum;
 import com.palantir.logsafe.Preconditions;
 import java.util.Locale;
 import javax.annotation.Generated;
@@ -18,7 +19,7 @@ import javax.annotation.Generated;
  * compile time.
  */
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
-public final class SimpleEnum {
+public final class SimpleEnum implements ConjureEnum<SimpleEnum> {
     public static final SimpleEnum VALUE = new SimpleEnum(Value.VALUE, "VALUE");
 
     private final Value value;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
@@ -63,6 +63,10 @@ public final class SimpleEnum {
         }
     }
 
+    public static SimpleEnum[] values() {
+        return new SimpleEnum[] {VALUE};
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         switch (value) {
             case VALUE:

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -22,6 +22,7 @@ import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.palantir.conjure.java.ConjureAnnotations;
+import com.palantir.conjure.java.lib.ConjureEnum;
 import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.spec.EnumDefinition;
 import com.palantir.conjure.spec.EnumValueDefinition;
@@ -68,6 +69,7 @@ public final class EnumGenerator {
     private static TypeSpec createSafeEnum(
             EnumDefinition typeDef, ClassName thisClass, ClassName enumClass, ClassName visitorClass) {
         TypeSpec.Builder wrapper = TypeSpec.classBuilder(typeDef.getTypeName().getName())
+                .addSuperinterface(ParameterizedTypeName.get(ClassName.get(ConjureEnum.class), thisClass))
                 .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(EnumGenerator.class))
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                 .addType(createEnum(enumClass, typeDef.getValues(), true))

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.types;
 import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.palantir.conjure.java.lib.ConjureEnum;
 import com.palantir.product.EnumExample;
 import org.junit.Test;
 
@@ -59,6 +60,15 @@ public class EnumTests {
     @Test
     public void testNullValidationUsesSafeLoggable() {
         assertThatLoggableExceptionThrownBy(() -> EnumExample.valueOf(null)).hasLogMessage("value cannot be null");
+    }
+
+    @Test
+    public void testInterfaceMethods() {
+        assertThat(EnumExample.values()).isEqualTo(ConjureEnum.values(EnumExample.class));
+        for (EnumExample val : ConjureEnum.values(EnumExample.class)) {
+            assertThat(ConjureEnum.valueOf(val.toString(), EnumExample.class)).isEqualTo(val);
+            assertThat(ConjureEnum.valueOf(val.get().name(), EnumExample.class)).isEqualTo(val);
+        }
     }
 
     private enum Visitor implements EnumExample.Visitor<String> {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
@@ -31,6 +31,14 @@ public class EnumTests {
     }
 
     @Test
+    public void testValueInvertability() {
+        for (EnumExample val : EnumExample.values()) {
+            assertThat(EnumExample.valueOf(val.toString())).isEqualTo(val);
+            assertThat(EnumExample.valueOf(val.get().name())).isEqualTo(val);
+        }
+    }
+
+    @Test
     public void testValueOfProducesSameInstance() {
         assertThat(EnumExample.valueOf("ONE")).isSameAs(EnumExample.ONE);
     }

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/ConjureEnum.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/ConjureEnum.java
@@ -1,0 +1,58 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.lib;
+
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * This is the common interface for all Conjure-generated Enum types.
+ */
+public interface ConjureEnum<E extends ConjureEnum<E>> {
+
+    /**
+     * This method is intended to function roughly equivalently to {@link Enum#valueOf(Class, String)} for
+     * Conjure-generated enum types.
+     */
+    @SuppressWarnings("unchecked")
+    static <T extends ConjureEnum<T>> T valueOf(String value,
+                                                Class<T> conjureEnumClass) {
+        // Reflection and casts are safe here, since all Conjure-generated enums will have a valueOf method.
+        // Tests on the generators will verify that this works.
+        try {
+            return (T) conjureEnumClass.getMethod("valueOf", String.class).invoke(null, value);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException("Conjure error: unable to find valueOf method.", e);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException("Conjure error: unable to call valueOf method.", e);
+        }
+    }
+
+    /**
+     * This method is intended to function roughly equivalently to {@link Class#getEnumConstants()} for
+     * Conjure-generated enum types.
+     */
+    @SuppressWarnings("unchecked")
+    static <T extends ConjureEnum<T>> T[] values(Class<T> conjureEnumClass) {
+        try {
+            return (T[]) conjureEnumClass.getMethod("values").invoke(null);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException("Conjure error: unable to find values method.", e);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException("Conjure error: unable to call values method.", e);
+        }
+    }
+}


### PR DESCRIPTION
## Before this PR

Conjure-generated enums are missing several important features of native Java enums:
- The ability to iterate over all possible values
- A way to know that a given class is a Conjure-generated enum class and therefore to know that it will have a way to get its values and call valueOf.

## After this PR
==COMMIT_MSG==
Conjure-generated enums now all implement a common interface, `ConjureEnum<E extends ConjureEnum<E>>`, and also have a new static method, `values`, that returns an array of all possible values for the enum.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
None that I can think of. The extra code represents a slight amount of extra maintenance burden on the repo.

