### PR TITLE
[Improvement] Adds values() type to all generated enum classes

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -75,6 +75,10 @@ public final class EnumExample {
         }
     }
 
+    public static EnumExample[] values() {
+        return new EnumExample[] {ONE, TWO, ONE_HUNDRED};
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         switch (value) {
             case ONE:

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -3,6 +3,9 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import javax.annotation.Generated;
 
@@ -27,6 +30,9 @@ public final class EnumExample {
 
     /** Value of 100. */
     public static final EnumExample ONE_HUNDRED = new EnumExample(Value.ONE_HUNDRED, "ONE_HUNDRED");
+
+    public static final List<EnumExample> VALUES =
+            Collections.unmodifiableList(Arrays.asList(ONE, TWO, ONE_HUNDRED));
 
     private final Value value;
 
@@ -75,8 +81,8 @@ public final class EnumExample {
         }
     }
 
-    public static EnumExample[] values() {
-        return new EnumExample[] {ONE, TWO, ONE_HUNDRED};
+    public static List<EnumExample> values() {
+        return VALUES;
     }
 
     public <T> T accept(Visitor<T> visitor) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
@@ -63,6 +63,10 @@ public final class SimpleEnum {
         }
     }
 
+    public static SimpleEnum[] values() {
+        return new SimpleEnum[] {VALUE};
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         switch (value) {
             case VALUE:

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
@@ -3,6 +3,9 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import javax.annotation.Generated;
 
@@ -20,6 +23,9 @@ import javax.annotation.Generated;
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
 public final class SimpleEnum {
     public static final SimpleEnum VALUE = new SimpleEnum(Value.VALUE, "VALUE");
+
+    public static final List<SimpleEnum> VALUES =
+            Collections.unmodifiableList(Arrays.asList(VALUE));
 
     private final Value value;
 
@@ -63,8 +69,8 @@ public final class SimpleEnum {
         }
     }
 
-    public static SimpleEnum[] values() {
-        return new SimpleEnum[] {VALUE};
+    public static List<SimpleEnum> values() {
+        return VALUES;
     }
 
     public <T> T accept(Visitor<T> visitor) {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
@@ -31,6 +31,14 @@ public class EnumTests {
     }
 
     @Test
+    public void testValueInvertability() {
+        for (EnumExample val : EnumExample.values()) {
+            assertThat(EnumExample.valueOf(val.toString())).isEqualTo(val);
+            assertThat(EnumExample.valueOf(val.get().name())).isEqualTo(val);
+        }
+    }
+
+    @Test
     public void testValueOfProducesSameInstance() {
         assertThat(EnumExample.valueOf("ONE")).isSameAs(EnumExample.ONE);
     }


### PR DESCRIPTION
Fixes #78

## Before this PR
There isn't a good existing way to loop over all valid values for a conjure-generated enum type in the same way that I can do for Java native types. This frequently results in having to reach down into the underlying native Java enum class in a way that feels like a leaky abstraction.

## After this PR
==COMMIT_MSG==
Conjure-generated enum types now have a `values()` method, which returns a list of all valid values for that type.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

