### PR TITLE
[Improvement] Add several interfaces that allow for compile-time type-checking for various Conjure enum operations

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -21,7 +21,7 @@ import javax.annotation.Generated;
  * compile time.
  */
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
-public final class EnumExample implements ConjureEnum<EnumExample> {
+public final class EnumExample implements ConjureEnum<EnumExample.Value> {
     public static final EnumExample ONE = new EnumExample(Value.ONE, "ONE");
 
     public static final EnumExample TWO = new EnumExample(Value.TWO, "TWO");
@@ -38,6 +38,7 @@ public final class EnumExample implements ConjureEnum<EnumExample> {
         this.string = string;
     }
 
+    @Override
     public Value get() {
         return this.value;
     }
@@ -74,10 +75,6 @@ public final class EnumExample implements ConjureEnum<EnumExample> {
             default:
                 return new EnumExample(Value.UNKNOWN, upperCasedValue);
         }
-    }
-
-    public static EnumExample[] values() {
-        return new EnumExample[] {ONE, TWO, ONE_HUNDRED};
     }
 
     public <T> T accept(Visitor<T> visitor) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -75,6 +75,10 @@ public final class EnumExample {
         }
     }
 
+    public static EnumExample[] values() {
+        return new EnumExample[] {ONE, TWO, ONE_HUNDRED};
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         switch (value) {
             case ONE:

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -3,6 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.ConjureEnum;
+import com.palantir.conjure.java.lib.WrappedConjureEnum;
 import com.palantir.logsafe.Preconditions;
 import java.util.Locale;
 import javax.annotation.Generated;
@@ -21,7 +22,7 @@ import javax.annotation.Generated;
  * compile time.
  */
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
-public final class EnumExample implements ConjureEnum<EnumExample.Value> {
+public final class EnumExample implements ConjureEnum<EnumExample, EnumExample.Value> {
     public static final EnumExample ONE = new EnumExample(Value.ONE, "ONE");
 
     public static final EnumExample TWO = new EnumExample(Value.TWO, "TWO");
@@ -91,7 +92,7 @@ public final class EnumExample implements ConjureEnum<EnumExample.Value> {
     }
 
     @Generated("com.palantir.conjure.java.types.EnumGenerator")
-    public enum Value {
+    public enum Value implements WrappedConjureEnum<Value, EnumExample> {
         ONE,
 
         TWO,
@@ -99,7 +100,12 @@ public final class EnumExample implements ConjureEnum<EnumExample.Value> {
         /** Value of 100. */
         ONE_HUNDRED,
 
-        UNKNOWN
+        UNKNOWN;
+
+        @Override
+        public EnumExample toWrapper() {
+            return EnumExample.valueOf(name().toUpperCase(Locale.ROOT));
+        }
     }
 
     @Generated("com.palantir.conjure.java.types.EnumGenerator")

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -2,6 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.conjure.java.lib.ConjureEnum;
 import com.palantir.logsafe.Preconditions;
 import java.util.Locale;
 import javax.annotation.Generated;
@@ -20,7 +21,7 @@ import javax.annotation.Generated;
  * compile time.
  */
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
-public final class EnumExample {
+public final class EnumExample implements ConjureEnum<EnumExample> {
     public static final EnumExample ONE = new EnumExample(Value.ONE, "ONE");
 
     public static final EnumExample TWO = new EnumExample(Value.TWO, "TWO");

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
@@ -3,6 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.ConjureEnum;
+import com.palantir.conjure.java.lib.WrappedConjureEnum;
 import com.palantir.logsafe.Preconditions;
 import java.util.Locale;
 import javax.annotation.Generated;
@@ -19,7 +20,7 @@ import javax.annotation.Generated;
  * compile time.
  */
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
-public final class SimpleEnum implements ConjureEnum<SimpleEnum.Value> {
+public final class SimpleEnum implements ConjureEnum<SimpleEnum, SimpleEnum.Value> {
     public static final SimpleEnum VALUE = new SimpleEnum(Value.VALUE, "VALUE");
 
     private final Value value;
@@ -75,10 +76,15 @@ public final class SimpleEnum implements ConjureEnum<SimpleEnum.Value> {
     }
 
     @Generated("com.palantir.conjure.java.types.EnumGenerator")
-    public enum Value {
+    public enum Value implements WrappedConjureEnum<Value, SimpleEnum> {
         VALUE,
 
-        UNKNOWN
+        UNKNOWN;
+
+        @Override
+        public SimpleEnum toWrapper() {
+            return SimpleEnum.valueOf(name().toUpperCase(Locale.ROOT));
+        }
     }
 
     @Generated("com.palantir.conjure.java.types.EnumGenerator")

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
@@ -2,6 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.conjure.java.lib.ConjureEnum;
 import com.palantir.logsafe.Preconditions;
 import java.util.Locale;
 import javax.annotation.Generated;
@@ -18,7 +19,7 @@ import javax.annotation.Generated;
  * compile time.
  */
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
-public final class SimpleEnum {
+public final class SimpleEnum implements ConjureEnum<SimpleEnum> {
     public static final SimpleEnum VALUE = new SimpleEnum(Value.VALUE, "VALUE");
 
     private final Value value;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
@@ -63,6 +63,10 @@ public final class SimpleEnum {
         }
     }
 
+    public static SimpleEnum[] values() {
+        return new SimpleEnum[] {VALUE};
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         switch (value) {
             case VALUE:

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
@@ -19,7 +19,7 @@ import javax.annotation.Generated;
  * compile time.
  */
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
-public final class SimpleEnum implements ConjureEnum<SimpleEnum> {
+public final class SimpleEnum implements ConjureEnum<SimpleEnum.Value> {
     public static final SimpleEnum VALUE = new SimpleEnum(Value.VALUE, "VALUE");
 
     private final Value value;
@@ -31,6 +31,7 @@ public final class SimpleEnum implements ConjureEnum<SimpleEnum> {
         this.string = string;
     }
 
+    @Override
     public Value get() {
         return this.value;
     }
@@ -62,10 +63,6 @@ public final class SimpleEnum implements ConjureEnum<SimpleEnum> {
             default:
                 return new SimpleEnum(Value.UNKNOWN, upperCasedValue);
         }
-    }
-
-    public static SimpleEnum[] values() {
-        return new SimpleEnum[] {VALUE};
     }
 
     public <T> T accept(Visitor<T> visitor) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -142,11 +142,11 @@ public final class EnumGenerator {
             enumBuilder.addEnumConstant(value.getValue(), anonymousClassBuilder.build());
         }
         enumBuilder.addMethod(MethodSpec.methodBuilder("toWrapper")
-            .addModifiers(Modifier.PUBLIC)
-            .addAnnotation(Override.class)
-            .returns(outerClass)
-            .addStatement("return $T.valueOf(name().toUpperCase($T.ROOT))", outerClass, Locale.class)
-            .build());
+                .addModifiers(Modifier.PUBLIC)
+                .addAnnotation(Override.class)
+                .returns(outerClass)
+                .addStatement("return $T.valueOf(name().toUpperCase($T.ROOT))", outerClass, Locale.class)
+                .build());
         if (withUnknown) {
             enumBuilder.addEnumConstant("UNKNOWN");
         } else {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -22,6 +22,7 @@ import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.palantir.conjure.java.ConjureAnnotations;
+import com.palantir.conjure.java.lib.ConjureEnum;
 import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.spec.EnumDefinition;
 import com.palantir.conjure.spec.EnumValueDefinition;
@@ -68,6 +69,7 @@ public final class EnumGenerator {
     private static TypeSpec createSafeEnum(
             EnumDefinition typeDef, ClassName thisClass, ClassName enumClass, ClassName visitorClass) {
         TypeSpec.Builder wrapper = TypeSpec.classBuilder(typeDef.getTypeName().getName())
+                .addSuperinterface(ParameterizedTypeName.get(ClassName.get(ConjureEnum.class), thisClass))
                 .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(EnumGenerator.class))
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                 .addType(createEnum(enumClass, typeDef.getValues(), true))

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.types;
 import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.palantir.conjure.java.lib.ConjureEnum;
 import com.palantir.product.EnumExample;
 import org.junit.Test;
 
@@ -59,6 +60,15 @@ public class EnumTests {
     @Test
     public void testNullValidationUsesSafeLoggable() {
         assertThatLoggableExceptionThrownBy(() -> EnumExample.valueOf(null)).hasLogMessage("value cannot be null");
+    }
+
+    @Test
+    public void testInterfaceMethods() {
+        assertThat(EnumExample.values()).isEqualTo(ConjureEnum.values(EnumExample.class));
+        for (EnumExample val : ConjureEnum.values(EnumExample.class)) {
+            assertThat(ConjureEnum.valueOf(val.toString(), EnumExample.class)).isEqualTo(val);
+            assertThat(ConjureEnum.valueOf(val.get().name(), EnumExample.class)).isEqualTo(val);
+        }
     }
 
     private enum Visitor implements EnumExample.Visitor<String> {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
@@ -31,6 +31,14 @@ public class EnumTests {
     }
 
     @Test
+    public void testValueInvertability() {
+        for (EnumExample val : EnumExample.values()) {
+            assertThat(EnumExample.valueOf(val.toString())).isEqualTo(val);
+            assertThat(EnumExample.valueOf(val.get().name())).isEqualTo(val);
+        }
+    }
+
+    @Test
     public void testValueOfProducesSameInstance() {
         assertThat(EnumExample.valueOf("ONE")).isSameAs(EnumExample.ONE);
     }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
@@ -19,7 +19,6 @@ package com.palantir.conjure.java.types;
 import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.palantir.conjure.java.lib.ConjureEnum;
 import com.palantir.product.EnumExample;
 import org.junit.Test;
 
@@ -34,7 +33,7 @@ public class EnumTests {
     @Test
     public void testValueInvertability() {
         for (EnumExample.Value val : EnumExample.Value.class.getEnumConstants()) {
-            assertThat(ConjureEnum.valueOf(val, EnumExample.class).get()).isEqualTo(val);
+            assertThat(val.toWrapper().get()).isEqualTo(val);
         }
     }
 

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
@@ -33,9 +33,8 @@ public class EnumTests {
 
     @Test
     public void testValueInvertability() {
-        for (EnumExample val : EnumExample.values()) {
-            assertThat(EnumExample.valueOf(val.toString())).isEqualTo(val);
-            assertThat(EnumExample.valueOf(val.get().name())).isEqualTo(val);
+        for (EnumExample.Value val : EnumExample.Value.class.getEnumConstants()) {
+            assertThat(ConjureEnum.valueOf(val, EnumExample.class).get()).isEqualTo(val);
         }
     }
 
@@ -60,15 +59,6 @@ public class EnumTests {
     @Test
     public void testNullValidationUsesSafeLoggable() {
         assertThatLoggableExceptionThrownBy(() -> EnumExample.valueOf(null)).hasLogMessage("value cannot be null");
-    }
-
-    @Test
-    public void testInterfaceMethods() {
-        assertThat(EnumExample.values()).isEqualTo(ConjureEnum.values(EnumExample.class));
-        for (EnumExample val : ConjureEnum.values(EnumExample.class)) {
-            assertThat(ConjureEnum.valueOf(val.toString(), EnumExample.class)).isEqualTo(val);
-            assertThat(ConjureEnum.valueOf(val.get().name(), EnumExample.class)).isEqualTo(val);
-        }
     }
 
     private enum Visitor implements EnumExample.Visitor<String> {

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/ConjureEnum.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/ConjureEnum.java
@@ -1,0 +1,58 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.lib;
+
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * This is the common interface for all Conjure-generated Enum types.
+ */
+public interface ConjureEnum<E extends ConjureEnum<E>> {
+
+    /**
+     * This method is intended to function roughly equivalently to {@link Enum#valueOf(Class, String)} for
+     * Conjure-generated enum types.
+     */
+    @SuppressWarnings("unchecked")
+    static <T extends ConjureEnum<T>> T valueOf(String value,
+                                                Class<T> conjureEnumClass) {
+        // Reflection and casts are safe here, since all Conjure-generated enums will have a valueOf method.
+        // Tests on the generators will verify that this works.
+        try {
+            return (T) conjureEnumClass.getMethod("valueOf", String.class).invoke(null, value);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException("Conjure error: unable to find valueOf method.", e);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException("Conjure error: unable to call valueOf method.", e);
+        }
+    }
+
+    /**
+     * This method is intended to function roughly equivalently to {@link Class#getEnumConstants()} for
+     * Conjure-generated enum types.
+     */
+    @SuppressWarnings("unchecked")
+    static <T extends ConjureEnum<T>> T[] values(Class<T> conjureEnumClass) {
+        try {
+            return (T[]) conjureEnumClass.getMethod("values").invoke(null);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException("Conjure error: unable to find values method.", e);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException("Conjure error: unable to call values method.", e);
+        }
+    }
+}

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/ConjureEnum.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/ConjureEnum.java
@@ -21,19 +21,17 @@ import java.lang.reflect.InvocationTargetException;
 /**
  * This is the common interface for all Conjure-generated Enum types.
  */
-public interface ConjureEnum<E extends ConjureEnum<E>> {
+public interface ConjureEnum<E extends Enum<E>> {
 
-    /**
-     * This method is intended to function roughly equivalently to {@link Enum#valueOf(Class, String)} for
-     * Conjure-generated enum types.
-     */
+    E get();
+
     @SuppressWarnings("unchecked")
-    static <T extends ConjureEnum<T>> T valueOf(String value,
-                                                Class<T> conjureEnumClass) {
+    static <E extends Enum<E>, T extends ConjureEnum<E>> T valueOf(E enumValue,
+                                                                   Class<T> conjureEnumClass) {
         // Reflection and casts are safe here, since all Conjure-generated enums will have a valueOf method.
         // Tests on the generators will verify that this works.
         try {
-            return (T) conjureEnumClass.getMethod("valueOf", String.class).invoke(null, value);
+            return (T) conjureEnumClass.getMethod("valueOf", String.class).invoke(null, enumValue.name());
         } catch (NoSuchMethodException e) {
             throw new RuntimeException("Conjure error: unable to find valueOf method.", e);
         } catch (IllegalAccessException | InvocationTargetException e) {
@@ -41,18 +39,4 @@ public interface ConjureEnum<E extends ConjureEnum<E>> {
         }
     }
 
-    /**
-     * This method is intended to function roughly equivalently to {@link Class#getEnumConstants()} for
-     * Conjure-generated enum types.
-     */
-    @SuppressWarnings("unchecked")
-    static <T extends ConjureEnum<T>> T[] values(Class<T> conjureEnumClass) {
-        try {
-            return (T[]) conjureEnumClass.getMethod("values").invoke(null);
-        } catch (NoSuchMethodException e) {
-            throw new RuntimeException("Conjure error: unable to find values method.", e);
-        } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException("Conjure error: unable to call values method.", e);
-        }
-    }
 }

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/WrappedConjureEnum.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/WrappedConjureEnum.java
@@ -21,7 +21,7 @@ package com.palantir.conjure.java.lib;
  */
 public interface WrappedConjureEnum<E extends Enum<E> & WrappedConjureEnum<E, T>, T extends ConjureEnum<T, E>> {
     /**
-     * Returns the wrapped
+     * Returns the wrapped Conjure-generated enum corresponding to this enum entry.
      *
      * This method satisfies the contract that if {@code e} is a {@code WrappedConjureEnum}, then {@code e.toWrapped()
      * .get() == e}.

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/WrappedConjureEnum.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/WrappedConjureEnum.java
@@ -17,14 +17,14 @@
 package com.palantir.conjure.java.lib;
 
 /**
- * This is the common interface for all Conjure-generated Enum types.
+ * Represents a native Java enum that is the underlying value of a {@link ConjureEnum}.
  */
-public interface ConjureEnum<T extends ConjureEnum<T, E>, E extends Enum<E> & WrappedConjureEnum<E, T>> {
+public interface WrappedConjureEnum<E extends Enum<E> & WrappedConjureEnum<E, T>, T extends ConjureEnum<T, E>> {
     /**
-     * Gets the underlying value enum for this wrapped value.
+     * Returns the wrapped
      *
-     * In general, if {@code t} is a {@code ConjureEnum}, then {@code t.get().toWrapper().equals(t)}. The exception
-     * to this is if {@code t.get() == UNKNOWN}.
+     * This method satisfies the contract that if {@code e} is a {@code WrappedConjureEnum}, then {@code e.toWrapped()
+     * .get() == e}.
      */
-    E get();
+    T toWrapper();
 }


### PR DESCRIPTION
Fixes the issues described in #78 and #79 in a slightly different way than originally envisioned.

## Before this PR
There is currently no way to tell that a type is a Conjure-generated enum (and thus that it will have methods like `values` or `valueOf`). This means that if I want to write a generic utility method, I tend to have to pass both the conjure enum class and the underlying java enum class, but have no type safety in doing so. 

For example, instead of:
```
    @Override
    public <T extends Enum<T>, U> U getEnum(PeerPropertyLookup remoteSystemId,
                                            NPPeerProperty prop,
                                            Class<T> enumClass,
                                            Class<U> returnClass) {
        Validate.isTrue(prop.getConjureEnumReturnType().equals(returnClass));
        // This validates that it's a valid entry in the enum.
        T enumReturn = getEnum(remoteSystemId, prop, enumClass);
        // This is a tricksy way to call #valueOf that doesn't rely on reflection but does rely on the fairly safe
        // assumption that Conjure will continue to make their enums Jackson-serializable in the future.
        try {
            return new ObjectMapper().readValue("\"" + enumReturn.name() + "\"", returnClass);
        } catch (IOException e) {
            throw new RuntimeException("Failed to parse enum for peer property " + prop + " into class " + returnClass.getName(),
                    e);
        }
    }
```

I can write:

```
    @Override
    public <E extends Enum<E> & WrappedConjureEnum<E, T>, T extends ConjureEnum<T, E>> T getEnum(PeerPropertyLookup remoteSystemId,
                                            NPPeerProperty prop,
                                            Class<T> conjureClass,
                                            Class<E> enumClass) {
        Validate.isTrue(prop.getReturnType().equals(conjureClass));
        E enumValue = Enum.valueOf(enumClass, getString(remoteSystemId, prop));
        return enumValue.toWrapper();
    }
```

## After this PR
==COMMIT_MSG==
The underlying value enum of all Conjure-generated enums now implement a common interface, `WrappedConjureEnum`, and Conjure-generated enums themselves now implement a common interface `ConjureEnum`, allowing for compile-time type-checking and generic code that deals with generated enums.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
The new interfaces are a little bit more complex than what most developers are used to working with when it comes to interfaces, however this is mitigated by the fact that users of the enums do not need to use the interfaces.

