### PR TITLE
conjure-undertow supports OPTIONS requests.

### DIFF
--- a/changelog/@unreleased/pr-480.v2.yml
+++ b/changelog/@unreleased/pr-480.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: conjure-undertow supports OPTIONS requests.
+  links:
+  - https://github.com/palantir/conjure-java/pull/480

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/OptionsHandler.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/OptionsHandler.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import com.google.common.base.Joiner;
+import com.palantir.logsafe.Preconditions;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import io.undertow.util.StatusCodes;
+import java.util.Set;
+
+final class OptionsHandler implements HttpHandler {
+
+    private final String allowValue;
+
+    OptionsHandler(Set<HttpString> methods) {
+        this.allowValue = Joiner.on(", ").join(methods);
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) {
+        Preconditions.checkState(Methods.OPTIONS.equals(exchange.getRequestMethod()), "Expected an OPTIONS request");
+        exchange.getResponseHeaders().put(Headers.ALLOW, allowValue);
+        exchange.setStatusCode(StatusCodes.NO_CONTENT);
+    }
+}

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/OptionsRequestTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/OptionsRequestTest.java
@@ -1,0 +1,105 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.net.HttpHeaders;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import io.undertow.Undertow;
+import io.undertow.server.handlers.ResponseCodeHandler;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import java.io.IOException;
+import java.util.UUID;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public final class OptionsRequestTest {
+
+    private static final OkHttpClient client = new OkHttpClient.Builder()
+            .followRedirects(false)
+            .retryOnConnectionFailure(false)
+            .build();
+
+    private Undertow server;
+
+    @BeforeEach
+    public void before() {
+        server = Undertow.builder()
+                .addHttpListener(12346, "localhost")
+                .setHandler(ConjureHandler.builder()
+                        .endpoints(endpoint(Methods.GET, "/first"))
+                        .endpoints(endpoint(Methods.POST, "/first"))
+                        .endpoints(endpoint(Methods.PUT, "/second/{param}"))
+                        .build())
+                .build();
+        server.start();
+    }
+
+    @AfterEach
+    public void after() {
+        server.stop();
+    }
+
+    @Test
+    public void test_getAndPost() {
+        Response response = execute("/first");
+        assertThat(response.code()).isEqualTo(204);
+        assertThat(response.header(HttpHeaders.ALLOW)).isEqualTo("GET, POST");
+    }
+
+    @Test
+    public void test_webSecurityHeaders() {
+        Response response = execute("/first");
+        assertThat(response.code()).isEqualTo(204);
+        assertThat(response.header(HttpHeaders.CONTENT_SECURITY_POLICY)).isNotNull();
+    }
+
+    @Test
+    public void test_parameterized() {
+        Response response = execute("/second/paramValue");
+        assertThat(response.code()).isEqualTo(204);
+        assertThat(response.header(HttpHeaders.ALLOW)).isEqualTo("PUT");
+    }
+
+    private static Response execute(String path) {
+        Request request = new Request.Builder()
+                .method("OPTIONS", null)
+                .url("http://localhost:12346" + path)
+                .build();
+        try {
+            return client.newCall(request).execute();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Endpoint endpoint(HttpString method, String template) {
+        return Endpoint.builder()
+                .handler(ResponseCodeHandler.HANDLE_500)
+                .method(method)
+                .template(template)
+                .serviceName(UUID.randomUUID().toString())
+                .name(UUID.randomUUID().toString())
+                .build();
+    }
+}

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/OptionsRequestTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/OptionsRequestTest.java
@@ -49,7 +49,7 @@ public final class OptionsRequestTest {
                 .setHandler(ConjureHandler.builder()
                         .endpoints(endpoint(Methods.GET, "/first"))
                         .endpoints(endpoint(Methods.POST, "/first"))
-                        .endpoints(endpoint(Methods.PUT, "/second/{param}"))
+                        .endpoints(endpoint(Methods.PUT, "/second/{p1}/and/{p2}"))
                         .build())
                 .build();
         server.start();
@@ -76,7 +76,7 @@ public final class OptionsRequestTest {
 
     @Test
     public void test_parameterized() {
-        Response response = execute("/second/paramValue");
+        Response response = execute("/second/paramValue/and/secondParam");
         assertThat(response.code()).isEqualTo(204);
         assertThat(response.header(HttpHeaders.ALLOW)).isEqualTo("PUT");
     }


### PR DESCRIPTION
## Before this PR
Previously they would result in 405 method not allowed responses.

## After this PR
==COMMIT_MSG==
conjure-undertow supports OPTIONS requests.
==COMMIT_MSG==

