### PR TITLE
[fix] Add @Override annotations to visitor builder methods

### DIFF
--- a/changelog/@unreleased/pr-483.v2.yml
+++ b/changelog/@unreleased/pr-483.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Adds @Override annotations to union type visitor builder methods.
+  links:
+  - https://github.com/palantir/conjure-java/pull/483

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -87,24 +87,29 @@ public final class SingleUnion {
 
         private Function<String, T> unknownVisitor;
 
+        @Override
         public UnknownStageVisitorBuilder<T> foo(Function<String, T> fooVisitor) {
             Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
             this.fooVisitor = fooVisitor;
             return this;
         }
 
+        @Override
         public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
         }
 
+        @Override
         public Visitor<T> build() {
             return new Visitor<T>() {
+                @Override
                 public T visitFoo(String value) {
                     return fooVisitor.apply(value);
                 }
 
+                @Override
                 public T visitUnknown(String value) {
                     return unknownVisitor.apply(value);
                 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -79,7 +79,7 @@ public final class SingleUnion {
         }
     }
 
-    private static class VisitorBuilder<T>
+    private static final class VisitorBuilder<T>
             implements FooStageVisitorBuilder<T>,
                     UnknownStageVisitorBuilder<T>,
                     CompletedStageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -110,44 +110,53 @@ public final class Union {
 
         private Function<String, T> unknownVisitor;
 
+        @Override
         public BazStageVisitorBuilder<T> bar(IntFunction<T> barVisitor) {
             Preconditions.checkNotNull(barVisitor, "barVisitor cannot be null");
             this.barVisitor = barVisitor;
             return this;
         }
 
+        @Override
         public FooStageVisitorBuilder<T> baz(Function<Long, T> bazVisitor) {
             Preconditions.checkNotNull(bazVisitor, "bazVisitor cannot be null");
             this.bazVisitor = bazVisitor;
             return this;
         }
 
+        @Override
         public UnknownStageVisitorBuilder<T> foo(Function<String, T> fooVisitor) {
             Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
             this.fooVisitor = fooVisitor;
             return this;
         }
 
+        @Override
         public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
         }
 
+        @Override
         public Visitor<T> build() {
             return new Visitor<T>() {
+                @Override
                 public T visitFoo(String value) {
                     return fooVisitor.apply(value);
                 }
 
+                @Override
                 public T visitBar(int value) {
                     return barVisitor.apply(value);
                 }
 
+                @Override
                 public T visitBaz(long value) {
                     return bazVisitor.apply(value);
                 }
 
+                @Override
                 public T visitUnknown(String value) {
                     return unknownVisitor.apply(value);
                 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -96,7 +96,7 @@ public final class Union {
         }
     }
 
-    private static class VisitorBuilder<T>
+    private static final class VisitorBuilder<T>
             implements BarStageVisitorBuilder<T>,
                     BazStageVisitorBuilder<T>,
                     FooStageVisitorBuilder<T>,

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -158,36 +158,42 @@ public final class UnionTypeExample {
 
         private Function<String, T> unknownVisitor;
 
+        @Override
         public IfStageVisitorBuilder<T> alsoAnInteger(IntFunction<T> alsoAnIntegerVisitor) {
             Preconditions.checkNotNull(alsoAnIntegerVisitor, "alsoAnIntegerVisitor cannot be null");
             this.alsoAnIntegerVisitor = alsoAnIntegerVisitor;
             return this;
         }
 
+        @Override
         public InterfaceStageVisitorBuilder<T> if_(IntFunction<T> ifVisitor) {
             Preconditions.checkNotNull(ifVisitor, "ifVisitor cannot be null");
             this.ifVisitor = ifVisitor;
             return this;
         }
 
+        @Override
         public NewStageVisitorBuilder<T> interface_(IntFunction<T> interfaceVisitor) {
             Preconditions.checkNotNull(interfaceVisitor, "interfaceVisitor cannot be null");
             this.interfaceVisitor = interfaceVisitor;
             return this;
         }
 
+        @Override
         public SetStageVisitorBuilder<T> new_(IntFunction<T> newVisitor) {
             Preconditions.checkNotNull(newVisitor, "newVisitor cannot be null");
             this.newVisitor = newVisitor;
             return this;
         }
 
+        @Override
         public StringExampleStageVisitorBuilder<T> set(Function<Set<String>, T> setVisitor) {
             Preconditions.checkNotNull(setVisitor, "setVisitor cannot be null");
             this.setVisitor = setVisitor;
             return this;
         }
 
+        @Override
         public ThisFieldIsAnIntegerStageVisitorBuilder<T> stringExample(
                 Function<StringExample, T> stringExampleVisitor) {
             Preconditions.checkNotNull(stringExampleVisitor, "stringExampleVisitor cannot be null");
@@ -195,6 +201,7 @@ public final class UnionTypeExample {
             return this;
         }
 
+        @Override
         public UnknownStageVisitorBuilder<T> thisFieldIsAnInteger(
                 IntFunction<T> thisFieldIsAnIntegerVisitor) {
             Preconditions.checkNotNull(
@@ -203,42 +210,52 @@ public final class UnionTypeExample {
             return this;
         }
 
+        @Override
         public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
         }
 
+        @Override
         public Visitor<T> build() {
             return new Visitor<T>() {
+                @Override
                 public T visitStringExample(StringExample value) {
                     return stringExampleVisitor.apply(value);
                 }
 
+                @Override
                 public T visitSet(Set<String> value) {
                     return setVisitor.apply(value);
                 }
 
+                @Override
                 public T visitThisFieldIsAnInteger(int value) {
                     return thisFieldIsAnIntegerVisitor.apply(value);
                 }
 
+                @Override
                 public T visitAlsoAnInteger(int value) {
                     return alsoAnIntegerVisitor.apply(value);
                 }
 
+                @Override
                 public T visitIf(int value) {
                     return ifVisitor.apply(value);
                 }
 
+                @Override
                 public T visitNew(int value) {
                     return newVisitor.apply(value);
                 }
 
+                @Override
                 public T visitInterface(int value) {
                     return interfaceVisitor.apply(value);
                 }
 
+                @Override
                 public T visitUnknown(String value) {
                     return unknownVisitor.apply(value);
                 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -132,7 +132,7 @@ public final class UnionTypeExample {
         }
     }
 
-    private static class VisitorBuilder<T>
+    private static final class VisitorBuilder<T>
             implements AlsoAnIntegerStageVisitorBuilder<T>,
                     IfStageVisitorBuilder<T>,
                     InterfaceStageVisitorBuilder<T>,

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -251,7 +251,7 @@ public final class UnionGenerator {
             Map<FieldName, TypeName> memberTypeMap) {
         TypeVariableName visitResultType = TypeVariableName.get("T");
         return TypeSpec.classBuilder(visitorBuilder)
-                .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+                .addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
                 .addTypeVariable(visitResultType)
                 .addSuperinterfaces(allVisitorBuilderStages(enclosingClass, memberTypeMap, visitResultType))
                 .addFields(allVisitorBuilderFields(memberTypeMap, visitResultType))

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -287,6 +287,7 @@ public final class UnionGenerator {
                     visitorStageInterfaceName(unionClass, nextBuilderStage));
             setterMethods.add(setterPrototype
                     .addModifiers(Modifier.PUBLIC)
+                    .addAnnotation(Override.class)
                     .addStatement("$L", Expressions.requireNonNull(visitorFieldName(pair.memberName),
                             String.format("%s cannot be null", visitorFieldName(pair.memberName))))
                     .addStatement("this.$1L = $1L", visitorFieldName(pair.memberName))
@@ -312,6 +313,7 @@ public final class UnionGenerator {
         return MethodSpec.methodBuilder("build")
                 .returns(ParameterizedTypeName.get(visitorClass, visitResultType))
                 .addModifiers(Modifier.PUBLIC)
+                .addAnnotation(Override.class)
                 .addStatement("return $L",
                         TypeSpec.anonymousClassBuilder("")
                                 .addSuperinterface(ParameterizedTypeName.get(visitorClass, visitResultType))
@@ -336,6 +338,7 @@ public final class UnionGenerator {
         return Stream.concat(memberTypes, Stream.of(NameTypePair.UNKNOWN))
                 .map(pair -> MethodSpec.methodBuilder(visitMethodName(pair.memberName))
                         .addModifiers(Modifier.PUBLIC)
+                        .addAnnotation(Override.class)
                         .addParameter(pair.type, variableName())
                         .addStatement("return $L.apply($L)", visitorFieldName(pair.memberName), variableName())
                         .returns(visitorResultType)


### PR DESCRIPTION
## Before this PR
The recently introduced visitor builder for union type visitors does not include `@Override` annotations on generated builder methods. This sometimes causes compile errors in generated code.

## After this PR
==COMMIT_MSG==
[fix] Adds override annotations to union type visitor builder methods.
==COMMIT_MSG==

## Possible downsides?
None.