### PR TITLE
[fix] Makes union type visitor handlers immutable in build method.

### DIFF
--- a/changelog/@unreleased/pr-485.v2.yml
+++ b/changelog/@unreleased/pr-485.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Copies union type visitor builder fields to local variables to ensure immutability.
+  links:
+  - https://github.com/palantir/conjure-java/pull/485

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -103,6 +103,8 @@ public final class SingleUnion {
 
         @Override
         public Visitor<T> build() {
+            final Function<String, T> fooVisitor = this.fooVisitor;
+            final Function<String, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
                 public T visitFoo(String value) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -102,11 +102,11 @@ public final class Union {
                     FooStageVisitorBuilder<T>,
                     UnknownStageVisitorBuilder<T>,
                     CompletedStageVisitorBuilder<T> {
-        private Function<String, T> fooVisitor;
-
         private IntFunction<T> barVisitor;
 
         private Function<Long, T> bazVisitor;
+
+        private Function<String, T> fooVisitor;
 
         private Function<String, T> unknownVisitor;
 
@@ -140,12 +140,11 @@ public final class Union {
 
         @Override
         public Visitor<T> build() {
+            final IntFunction<T> barVisitor = this.barVisitor;
+            final Function<Long, T> bazVisitor = this.bazVisitor;
+            final Function<String, T> fooVisitor = this.fooVisitor;
+            final Function<String, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
-                @Override
-                public T visitFoo(String value) {
-                    return fooVisitor.apply(value);
-                }
-
                 @Override
                 public T visitBar(int value) {
                     return barVisitor.apply(value);
@@ -154,6 +153,11 @@ public final class Union {
                 @Override
                 public T visitBaz(long value) {
                     return bazVisitor.apply(value);
+                }
+
+                @Override
+                public T visitFoo(String value) {
+                    return fooVisitor.apply(value);
                 }
 
                 @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -142,19 +142,19 @@ public final class UnionTypeExample {
                     ThisFieldIsAnIntegerStageVisitorBuilder<T>,
                     UnknownStageVisitorBuilder<T>,
                     CompletedStageVisitorBuilder<T> {
-        private Function<StringExample, T> stringExampleVisitor;
-
-        private Function<Set<String>, T> setVisitor;
-
-        private IntFunction<T> thisFieldIsAnIntegerVisitor;
-
         private IntFunction<T> alsoAnIntegerVisitor;
 
         private IntFunction<T> ifVisitor;
 
+        private IntFunction<T> interfaceVisitor;
+
         private IntFunction<T> newVisitor;
 
-        private IntFunction<T> interfaceVisitor;
+        private Function<Set<String>, T> setVisitor;
+
+        private Function<StringExample, T> stringExampleVisitor;
+
+        private IntFunction<T> thisFieldIsAnIntegerVisitor;
 
         private Function<String, T> unknownVisitor;
 
@@ -219,22 +219,15 @@ public final class UnionTypeExample {
 
         @Override
         public Visitor<T> build() {
+            final IntFunction<T> alsoAnIntegerVisitor = this.alsoAnIntegerVisitor;
+            final IntFunction<T> ifVisitor = this.ifVisitor;
+            final IntFunction<T> interfaceVisitor = this.interfaceVisitor;
+            final IntFunction<T> newVisitor = this.newVisitor;
+            final Function<Set<String>, T> setVisitor = this.setVisitor;
+            final Function<StringExample, T> stringExampleVisitor = this.stringExampleVisitor;
+            final IntFunction<T> thisFieldIsAnIntegerVisitor = this.thisFieldIsAnIntegerVisitor;
+            final Function<String, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
-                @Override
-                public T visitStringExample(StringExample value) {
-                    return stringExampleVisitor.apply(value);
-                }
-
-                @Override
-                public T visitSet(Set<String> value) {
-                    return setVisitor.apply(value);
-                }
-
-                @Override
-                public T visitThisFieldIsAnInteger(int value) {
-                    return thisFieldIsAnIntegerVisitor.apply(value);
-                }
-
                 @Override
                 public T visitAlsoAnInteger(int value) {
                     return alsoAnIntegerVisitor.apply(value);
@@ -246,13 +239,28 @@ public final class UnionTypeExample {
                 }
 
                 @Override
+                public T visitInterface(int value) {
+                    return interfaceVisitor.apply(value);
+                }
+
+                @Override
                 public T visitNew(int value) {
                     return newVisitor.apply(value);
                 }
 
                 @Override
-                public T visitInterface(int value) {
-                    return interfaceVisitor.apply(value);
+                public T visitSet(Set<String> value) {
+                    return setVisitor.apply(value);
+                }
+
+                @Override
+                public T visitStringExample(StringExample value) {
+                    return stringExampleVisitor.apply(value);
+                }
+
+                @Override
+                public T visitThisFieldIsAnInteger(int value) {
+                    return thisFieldIsAnIntegerVisitor.apply(value);
                 }
 
                 @Override


### PR DESCRIPTION
## Before this PR
By holding on to a visitor builder stage, a visitor handler can be updated after `build()` has been called.

## After this PR
==COMMIT_MSG==
[fix] Makes union type visitor handlers immutable in build method.
==COMMIT_MSG==

## Possible downsides?
None, unless someone thinks this is a feature (but it's not).

