### PR TITLE
break: Match parameter order between jax-rs and retrofit clients

### DIFF
--- a/changelog/@unreleased/pr-499.v2.yml
+++ b/changelog/@unreleased/pr-499.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Match parameter order between jax-rs and retrofit clients
+  links:
+  - https://github.com/palantir/conjure-java/pull/499

--- a/changelog/@unreleased/pr-499.v2.yml
+++ b/changelog/@unreleased/pr-499.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: break
+break:
   description: Match parameter order between jax-rs and retrofit clients
   links:
   - https://github.com/palantir/conjure-java/pull/499

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
@@ -5,6 +5,7 @@ import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
 import java.time.OffsetDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Generated;
@@ -171,4 +172,39 @@ public interface EteServiceRetrofit {
     Call<Optional<LongAlias>> aliasLongEndpoint(
             @Header("Authorization") AuthHeader authHeader,
             @Query("input") Optional<LongAlias> input);
+
+    @Deprecated
+    default Call<Optional<Long>> optionalExternalLongQuery(
+            @Header("Authorization") AuthHeader authHeader) {
+        return optionalExternalLongQuery(authHeader, Optional.empty());
+    }
+
+    @Deprecated
+    default Call<StringAliasExample> optionalAliasOne(
+            @Header("Authorization") AuthHeader authHeader) {
+        return optionalAliasOne(authHeader, Optional.empty());
+    }
+
+    @Deprecated
+    default Call<Optional<StringAliasExample>> optionalQueryExternalImport(
+            @Header("Authorization") AuthHeader authHeader) {
+        return optionalQueryExternalImport(authHeader, Optional.empty());
+    }
+
+    @Deprecated
+    default Call<List<SimpleEnum>> enumListQuery(@Header("Authorization") AuthHeader authHeader) {
+        return enumListQuery(authHeader, Collections.emptyList());
+    }
+
+    @Deprecated
+    default Call<Optional<SimpleEnum>> optionalEnumQuery(
+            @Header("Authorization") AuthHeader authHeader) {
+        return optionalEnumQuery(authHeader, Optional.empty());
+    }
+
+    @Deprecated
+    default Call<Optional<LongAlias>> aliasLongEndpoint(
+            @Header("Authorization") AuthHeader authHeader) {
+        return aliasLongEndpoint(authHeader, Optional.empty());
+    }
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/DefaultTypeValueVisitor.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/DefaultTypeValueVisitor.java
@@ -69,7 +69,6 @@ enum DefaultTypeValueVisitor implements Type.Visitor<CodeBlock> {
         throw new SafeIllegalArgumentException("Cannot backfill non-defaultable parameter type.");
     }
 
-
     @Override
     public CodeBlock visitReference(TypeName value) {
         throw new SafeIllegalArgumentException("Cannot backfill non-defaultable parameter type.");

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/DefaultTypeValueVisitor.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/DefaultTypeValueVisitor.java
@@ -1,0 +1,87 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.services;
+
+import com.palantir.conjure.spec.ExternalReference;
+import com.palantir.conjure.spec.ListType;
+import com.palantir.conjure.spec.MapType;
+import com.palantir.conjure.spec.OptionalType;
+import com.palantir.conjure.spec.PrimitiveType;
+import com.palantir.conjure.spec.SetType;
+import com.palantir.conjure.spec.Type;
+import com.palantir.conjure.spec.TypeName;
+import com.palantir.conjure.visitor.TypeVisitor;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.squareup.javapoet.CodeBlock;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+
+enum DefaultTypeValueVisitor implements Type.Visitor<CodeBlock> {
+    INSTANCE;
+
+    @Override
+    public CodeBlock visitOptional(OptionalType value) {
+        if (value.getItemType().accept(TypeVisitor.IS_PRIMITIVE)) {
+            PrimitiveType primitiveType = value.getItemType().accept(TypeVisitor.PRIMITIVE);
+            // special handling for primitive optionals with Java 8
+            if (primitiveType.equals(PrimitiveType.DOUBLE)) {
+                return CodeBlock.of("$T.empty()", OptionalDouble.class);
+            } else if (primitiveType.equals(PrimitiveType.INTEGER)) {
+                return CodeBlock.of("$T.empty()", OptionalInt.class);
+            }
+        }
+        return CodeBlock.of("$T.empty()", Optional.class);
+    }
+
+    @Override
+    public CodeBlock visitList(ListType value) {
+        return CodeBlock.of("$T.emptyList()", Collections.class);
+    }
+
+    @Override
+    public CodeBlock visitSet(SetType value) {
+        return CodeBlock.of("$T.emptySet()", Collections.class);
+    }
+
+    @Override
+    public CodeBlock visitMap(MapType value) {
+        return CodeBlock.of("$T.emptyMap()", Collections.class);
+    }
+
+    @Override
+    public CodeBlock visitPrimitive(PrimitiveType value) {
+        throw new SafeIllegalArgumentException("Cannot backfill non-defaultable parameter type.");
+    }
+
+
+    @Override
+    public CodeBlock visitReference(TypeName value) {
+        throw new SafeIllegalArgumentException("Cannot backfill non-defaultable parameter type.");
+    }
+
+    @Override
+    public CodeBlock visitExternal(ExternalReference value) {
+        throw new SafeIllegalArgumentException("Cannot backfill non-defaultable parameter type.");
+    }
+
+    @Override
+    public CodeBlock visitUnknown(String unknownType) {
+        throw new SafeIllegalArgumentException("Cannot backfill non-defaultable parameter type.");
+    }
+}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/DefaultableTypeVisitor.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/DefaultableTypeVisitor.java
@@ -1,0 +1,70 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.services;
+
+import com.palantir.conjure.spec.ExternalReference;
+import com.palantir.conjure.spec.ListType;
+import com.palantir.conjure.spec.MapType;
+import com.palantir.conjure.spec.OptionalType;
+import com.palantir.conjure.spec.PrimitiveType;
+import com.palantir.conjure.spec.SetType;
+import com.palantir.conjure.spec.Type;
+import com.palantir.conjure.spec.TypeName;
+
+enum DefaultableTypeVisitor implements Type.Visitor<Boolean> {
+    INSTANCE;
+
+    @Override
+    public Boolean visitOptional(OptionalType value) {
+        return true;
+    }
+
+    @Override
+    public Boolean visitList(ListType value) {
+        return true;
+    }
+
+    @Override
+    public Boolean visitSet(SetType value) {
+        return true;
+    }
+
+    @Override
+    public Boolean visitMap(MapType value) {
+        return true;
+    }
+
+    @Override
+    public Boolean visitPrimitive(PrimitiveType value) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitReference(TypeName value) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitExternal(ExternalReference value) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitUnknown(String unknownType) {
+        return false;
+    }
+}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
@@ -387,4 +387,5 @@ public final class Retrofit2ServiceGenerator implements ServiceGenerator {
         }
         throw new IllegalArgumentException("Unrecognized HTTP method: " + method);
     }
+
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
@@ -28,32 +28,22 @@ import com.palantir.conjure.java.types.SpecializeBinaryClassNameVisitor;
 import com.palantir.conjure.java.types.TypeMapper;
 import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.java.util.ParameterOrder;
-import com.palantir.conjure.java.visitor.DefaultTypeVisitor;
 import com.palantir.conjure.spec.ArgumentDefinition;
 import com.palantir.conjure.spec.ArgumentName;
 import com.palantir.conjure.spec.AuthType;
 import com.palantir.conjure.spec.ConjureDefinition;
 import com.palantir.conjure.spec.EndpointDefinition;
 import com.palantir.conjure.spec.HttpPath;
-import com.palantir.conjure.spec.ListType;
-import com.palantir.conjure.spec.MapType;
-import com.palantir.conjure.spec.OptionalType;
 import com.palantir.conjure.spec.ParameterId;
 import com.palantir.conjure.spec.ParameterType;
-import com.palantir.conjure.spec.PrimitiveType;
 import com.palantir.conjure.spec.ServiceDefinition;
-import com.palantir.conjure.spec.SetType;
-import com.palantir.conjure.spec.Type;
 import com.palantir.conjure.visitor.AuthTypeVisitor;
 import com.palantir.conjure.visitor.ParameterTypeVisitor;
-import com.palantir.conjure.visitor.TypeVisitor;
 import com.palantir.logsafe.Preconditions;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.util.syntacticpath.Path;
 import com.palantir.util.syntacticpath.Paths;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
-import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
@@ -62,11 +52,8 @@ import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalDouble;
-import java.util.OptionalInt;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -238,7 +225,7 @@ public final class Retrofit2ServiceGenerator implements ServiceGenerator {
 
         for (ArgumentDefinition arg : endpointDef.getArgs()) {
             if (arg.getParamType().accept(ParameterTypeVisitor.IS_QUERY)
-                    && arg.getType().accept(TYPE_DEFAULTABLE_PREDICATE)) {
+                    && arg.getType().accept(DefaultableTypeVisitor.INSTANCE)) {
                 queryArgs.add(arg);
             }
         }
@@ -292,7 +279,7 @@ public final class Retrofit2ServiceGenerator implements ServiceGenerator {
             Optional<ArgumentDefinition> maybeArgDef = sortedMaybeExtraArgs.get(i);
             if (maybeArgDef.isPresent()) {
                 sb.append("$L, ");
-                return maybeArgDef.get().getType().accept(TYPE_DEFAULT_VALUE);
+                return maybeArgDef.get().getType().accept(DefaultTypeValueVisitor.INSTANCE);
             } else {
                 sb.append("$N, ");
                 return sortedParams.get(i);
@@ -400,70 +387,4 @@ public final class Retrofit2ServiceGenerator implements ServiceGenerator {
         }
         throw new IllegalArgumentException("Unrecognized HTTP method: " + method);
     }
-
-    /**
-     * Indicates whether a particular type has a defaultable value.
-     */
-    private static final Type.Visitor<Boolean> TYPE_DEFAULTABLE_PREDICATE = new DefaultTypeVisitor<Boolean>() {
-        @Override
-        public Boolean visitOptional(OptionalType value) {
-            return true;
-        }
-
-        @Override
-        public Boolean visitList(ListType value) {
-            return true;
-        }
-
-        @Override
-        public Boolean visitSet(SetType value) {
-            return true;
-        }
-
-        @Override
-        public Boolean visitMap(MapType value) {
-            return true;
-        }
-
-        @Override
-        public Boolean visitDefault() {
-            return false;
-        }
-    };
-
-    private static final Type.Visitor<CodeBlock> TYPE_DEFAULT_VALUE = new DefaultTypeVisitor<CodeBlock>() {
-        @Override
-        public CodeBlock visitOptional(OptionalType value) {
-            if (value.getItemType().accept(TypeVisitor.IS_PRIMITIVE)) {
-                PrimitiveType primitiveType = value.getItemType().accept(TypeVisitor.PRIMITIVE);
-                // special handling for primitive optionals with Java 8
-                if (primitiveType.equals(PrimitiveType.DOUBLE)) {
-                    return CodeBlock.of("$T.empty()", OptionalDouble.class);
-                } else if (primitiveType.equals(PrimitiveType.INTEGER)) {
-                    return CodeBlock.of("$T.empty()", OptionalInt.class);
-                }
-            }
-            return CodeBlock.of("$T.empty()", Optional.class);
-        }
-
-        @Override
-        public CodeBlock visitList(ListType value) {
-            return CodeBlock.of("$T.emptyList()", Collections.class);
-        }
-
-        @Override
-        public CodeBlock visitSet(SetType value) {
-            return CodeBlock.of("$T.emptySet()", Collections.class);
-        }
-
-        @Override
-        public CodeBlock visitMap(MapType value) {
-            return CodeBlock.of("$T.emptyMap()", Collections.class);
-        }
-
-        @Override
-        public CodeBlock visitDefault() {
-            throw new SafeIllegalArgumentException("Cannot backfill non-defaultable parameter type.");
-        }
-    };
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
@@ -191,8 +191,6 @@ public final class Retrofit2ServiceGenerator implements ServiceGenerator {
 
         methodBuilder.returns(ParameterizedTypeName.get(getReturnType(), returnType.box()));
 
-        getAuthParameter(endpointDef.getAuth()).ifPresent(methodBuilder::addParameter);
-
         methodBuilder.addParameters(createServiceMethodParameters(endpointDef, argumentTypeMapper, encodedPathArgs));
 
         return methodBuilder.build();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
@@ -82,8 +82,7 @@ public final class Retrofit2ServiceGenerator implements ServiceGenerator {
     @SuppressWarnings("deprecation")
     public Retrofit2ServiceGenerator(Set<FeatureFlags> experimentalFeatures) {
         this.featureFlags = ImmutableSet.copyOf(experimentalFeatures);
-        Preconditions.checkArgument(
-                !featureFlags.contains(FeatureFlags.RetrofitListenableFutures)
+        Preconditions.checkArgument(!featureFlags.contains(FeatureFlags.RetrofitListenableFutures)
                         || !featureFlags.contains(FeatureFlags.RetrofitCompletableFutures),
                 "Cannot enable both the RetrofitListenableFutures and RetrofitCompletableFutures "
                         + "Conjure experimental features. Please remove one.");
@@ -107,8 +106,7 @@ public final class Retrofit2ServiceGenerator implements ServiceGenerator {
                 .collect(Collectors.toSet());
     }
 
-    private JavaFile generateService(
-            ServiceDefinition serviceDefinition,
+    private JavaFile generateService(ServiceDefinition serviceDefinition,
             TypeMapper returnTypeMapper, TypeMapper argumentTypeMapper) {
         TypeSpec.Builder serviceBuilder = TypeSpec.interfaceBuilder(serviceName(serviceDefinition))
                 .addModifiers(Modifier.PUBLIC)

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
@@ -192,7 +192,7 @@ public interface TestServiceRetrofit {
             @Query("maybeDouble") OptionalDouble maybeDouble);
 
     @Deprecated
-    default int testQueryParams(
+    default Call<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
             @Query("different") ResourceIdentifier something,
             @Query("implicit") ResourceIdentifier implicit,
@@ -208,7 +208,7 @@ public interface TestServiceRetrofit {
     }
 
     @Deprecated
-    default int testQueryParams(
+    default Call<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
             @Query("different") ResourceIdentifier something,
             @Query("implicit") ResourceIdentifier implicit,
@@ -225,7 +225,7 @@ public interface TestServiceRetrofit {
     }
 
     @Deprecated
-    default int testQueryParams(
+    default Call<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
             @Query("different") ResourceIdentifier something,
             @Query("implicit") ResourceIdentifier implicit,

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
@@ -7,6 +7,7 @@ import com.palantir.product.datasets.BackingFileSystem;
 import com.palantir.product.datasets.Dataset;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -38,8 +39,8 @@ public interface TestServiceRetrofit {
     @Headers({"hr-path-template: /catalog/datasets", "Accept: application/json"})
     Call<Dataset> createDataset(
             @Header("Authorization") AuthHeader authHeader,
-            @Body CreateDatasetRequest request,
-            @Header("Test-Header") String testHeaderArg);
+            @Header("Test-Header") String testHeaderArg,
+            @Body CreateDatasetRequest request);
 
     @GET("./catalog/datasets/{datasetRid}")
     @Headers({"hr-path-template: /catalog/datasets/{datasetRid}", "Accept: application/json"})
@@ -145,12 +146,12 @@ public interface TestServiceRetrofit {
     @Headers({"hr-path-template: /catalog/test-query-params", "Accept: application/json"})
     Call<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
-            @Body String query,
             @Query("different") ResourceIdentifier something,
-            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("setEnd") Set<String> setEnd,
-            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
+            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
+            @Body String query);
 
     @POST("./catalog/test-no-response-query-params")
     @Headers({
@@ -159,12 +160,12 @@ public interface TestServiceRetrofit {
     })
     Call<Void> testNoResponseQueryParams(
             @Header("Authorization") AuthHeader authHeader,
-            @Body String query,
             @Query("different") ResourceIdentifier something,
-            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("setEnd") Set<String> setEnd,
-            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
+            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
+            @Body String query);
 
     @GET("./catalog/boolean")
     @Headers({"hr-path-template: /catalog/boolean", "Accept: application/json"})
@@ -189,4 +190,106 @@ public interface TestServiceRetrofit {
             @Header("Authorization") AuthHeader authHeader,
             @Query("maybeInteger") OptionalInt maybeInteger,
             @Query("maybeDouble") OptionalDouble maybeDouble);
+
+    @Deprecated
+    default int testQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("different") ResourceIdentifier something,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Body String query) {
+        return testQueryParams(
+                authHeader,
+                something,
+                implicit,
+                Optional.empty(),
+                Collections.emptySet(),
+                Optional.empty(),
+                query);
+    }
+
+    @Deprecated
+    default int testQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("different") ResourceIdentifier something,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
+            @Body String query) {
+        return testQueryParams(
+                authHeader,
+                something,
+                implicit,
+                optionalMiddle,
+                Collections.emptySet(),
+                Optional.empty(),
+                query);
+    }
+
+    @Deprecated
+    default int testQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("different") ResourceIdentifier something,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
+            @Query("setEnd") Set<String> setEnd,
+            @Body String query) {
+        return testQueryParams(
+                authHeader, something, implicit, optionalMiddle, setEnd, Optional.empty(), query);
+    }
+
+    @Deprecated
+    default void testNoResponseQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("different") ResourceIdentifier something,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Body String query) {
+        testNoResponseQueryParams(
+                authHeader,
+                something,
+                implicit,
+                Optional.empty(),
+                Collections.emptySet(),
+                Optional.empty(),
+                query);
+    }
+
+    @Deprecated
+    default void testNoResponseQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("different") ResourceIdentifier something,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
+            @Body String query) {
+        testNoResponseQueryParams(
+                authHeader,
+                something,
+                implicit,
+                optionalMiddle,
+                Collections.emptySet(),
+                Optional.empty(),
+                query);
+    }
+
+    @Deprecated
+    default void testNoResponseQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("different") ResourceIdentifier something,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
+            @Query("setEnd") Set<String> setEnd,
+            @Body String query) {
+        testNoResponseQueryParams(
+                authHeader, something, implicit, optionalMiddle, setEnd, Optional.empty(), query);
+    }
+
+    @Deprecated
+    default void testOptionalIntegerAndDouble(@Header("Authorization") AuthHeader authHeader) {
+        testOptionalIntegerAndDouble(authHeader, OptionalInt.empty(), OptionalDouble.empty());
+    }
+
+    @Deprecated
+    default void testOptionalIntegerAndDouble(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("maybeInteger") OptionalInt maybeInteger) {
+        testOptionalIntegerAndDouble(authHeader, maybeInteger, OptionalDouble.empty());
+    }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
@@ -192,7 +192,7 @@ public interface TestServiceRetrofit {
             @Query("maybeDouble") OptionalDouble maybeDouble);
 
     @Deprecated
-    default int testQueryParams(
+    default CompletableFuture<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
             @Query("different") ResourceIdentifier something,
             @Query("implicit") ResourceIdentifier implicit,
@@ -208,7 +208,7 @@ public interface TestServiceRetrofit {
     }
 
     @Deprecated
-    default int testQueryParams(
+    default CompletableFuture<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
             @Query("different") ResourceIdentifier something,
             @Query("implicit") ResourceIdentifier implicit,
@@ -225,7 +225,7 @@ public interface TestServiceRetrofit {
     }
 
     @Deprecated
-    default int testQueryParams(
+    default CompletableFuture<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
             @Query("different") ResourceIdentifier something,
             @Query("implicit") ResourceIdentifier implicit,

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
@@ -7,6 +7,7 @@ import com.palantir.product.datasets.BackingFileSystem;
 import com.palantir.product.datasets.Dataset;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -38,8 +39,8 @@ public interface TestServiceRetrofit {
     @Headers({"hr-path-template: /catalog/datasets", "Accept: application/json"})
     CompletableFuture<Dataset> createDataset(
             @Header("Authorization") AuthHeader authHeader,
-            @Body CreateDatasetRequest request,
-            @Header("Test-Header") String testHeaderArg);
+            @Header("Test-Header") String testHeaderArg,
+            @Body CreateDatasetRequest request);
 
     @GET("./catalog/datasets/{datasetRid}")
     @Headers({"hr-path-template: /catalog/datasets/{datasetRid}", "Accept: application/json"})
@@ -145,12 +146,12 @@ public interface TestServiceRetrofit {
     @Headers({"hr-path-template: /catalog/test-query-params", "Accept: application/json"})
     CompletableFuture<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
-            @Body String query,
             @Query("different") ResourceIdentifier something,
-            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("setEnd") Set<String> setEnd,
-            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
+            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
+            @Body String query);
 
     @POST("./catalog/test-no-response-query-params")
     @Headers({
@@ -159,12 +160,12 @@ public interface TestServiceRetrofit {
     })
     CompletableFuture<Void> testNoResponseQueryParams(
             @Header("Authorization") AuthHeader authHeader,
-            @Body String query,
             @Query("different") ResourceIdentifier something,
-            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("setEnd") Set<String> setEnd,
-            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
+            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
+            @Body String query);
 
     @GET("./catalog/boolean")
     @Headers({"hr-path-template: /catalog/boolean", "Accept: application/json"})
@@ -189,4 +190,106 @@ public interface TestServiceRetrofit {
             @Header("Authorization") AuthHeader authHeader,
             @Query("maybeInteger") OptionalInt maybeInteger,
             @Query("maybeDouble") OptionalDouble maybeDouble);
+
+    @Deprecated
+    default int testQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("different") ResourceIdentifier something,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Body String query) {
+        return testQueryParams(
+                authHeader,
+                something,
+                implicit,
+                Optional.empty(),
+                Collections.emptySet(),
+                Optional.empty(),
+                query);
+    }
+
+    @Deprecated
+    default int testQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("different") ResourceIdentifier something,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
+            @Body String query) {
+        return testQueryParams(
+                authHeader,
+                something,
+                implicit,
+                optionalMiddle,
+                Collections.emptySet(),
+                Optional.empty(),
+                query);
+    }
+
+    @Deprecated
+    default int testQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("different") ResourceIdentifier something,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
+            @Query("setEnd") Set<String> setEnd,
+            @Body String query) {
+        return testQueryParams(
+                authHeader, something, implicit, optionalMiddle, setEnd, Optional.empty(), query);
+    }
+
+    @Deprecated
+    default void testNoResponseQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("different") ResourceIdentifier something,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Body String query) {
+        testNoResponseQueryParams(
+                authHeader,
+                something,
+                implicit,
+                Optional.empty(),
+                Collections.emptySet(),
+                Optional.empty(),
+                query);
+    }
+
+    @Deprecated
+    default void testNoResponseQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("different") ResourceIdentifier something,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
+            @Body String query) {
+        testNoResponseQueryParams(
+                authHeader,
+                something,
+                implicit,
+                optionalMiddle,
+                Collections.emptySet(),
+                Optional.empty(),
+                query);
+    }
+
+    @Deprecated
+    default void testNoResponseQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("different") ResourceIdentifier something,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
+            @Query("setEnd") Set<String> setEnd,
+            @Body String query) {
+        testNoResponseQueryParams(
+                authHeader, something, implicit, optionalMiddle, setEnd, Optional.empty(), query);
+    }
+
+    @Deprecated
+    default void testOptionalIntegerAndDouble(@Header("Authorization") AuthHeader authHeader) {
+        testOptionalIntegerAndDouble(authHeader, OptionalInt.empty(), OptionalDouble.empty());
+    }
+
+    @Deprecated
+    default void testOptionalIntegerAndDouble(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("maybeInteger") OptionalInt maybeInteger) {
+        testOptionalIntegerAndDouble(authHeader, maybeInteger, OptionalDouble.empty());
+    }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_listenable_future
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_listenable_future
@@ -192,7 +192,7 @@ public interface TestServiceRetrofit {
             @Query("maybeDouble") OptionalDouble maybeDouble);
 
     @Deprecated
-    default int testQueryParams(
+    default ListenableFuture<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
             @Query("different") ResourceIdentifier something,
             @Query("implicit") ResourceIdentifier implicit,
@@ -208,7 +208,7 @@ public interface TestServiceRetrofit {
     }
 
     @Deprecated
-    default int testQueryParams(
+    default ListenableFuture<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
             @Query("different") ResourceIdentifier something,
             @Query("implicit") ResourceIdentifier implicit,
@@ -225,7 +225,7 @@ public interface TestServiceRetrofit {
     }
 
     @Deprecated
-    default int testQueryParams(
+    default ListenableFuture<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
             @Query("different") ResourceIdentifier something,
             @Query("implicit") ResourceIdentifier implicit,

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_listenable_future
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_listenable_future
@@ -8,6 +8,7 @@ import com.palantir.product.datasets.BackingFileSystem;
 import com.palantir.product.datasets.Dataset;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -38,8 +39,8 @@ public interface TestServiceRetrofit {
     @Headers({"hr-path-template: /catalog/datasets", "Accept: application/json"})
     ListenableFuture<Dataset> createDataset(
             @Header("Authorization") AuthHeader authHeader,
-            @Body CreateDatasetRequest request,
-            @Header("Test-Header") String testHeaderArg);
+            @Header("Test-Header") String testHeaderArg,
+            @Body CreateDatasetRequest request);
 
     @GET("./catalog/datasets/{datasetRid}")
     @Headers({"hr-path-template: /catalog/datasets/{datasetRid}", "Accept: application/json"})
@@ -145,12 +146,12 @@ public interface TestServiceRetrofit {
     @Headers({"hr-path-template: /catalog/test-query-params", "Accept: application/json"})
     ListenableFuture<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
-            @Body String query,
             @Query("different") ResourceIdentifier something,
-            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("setEnd") Set<String> setEnd,
-            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
+            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
+            @Body String query);
 
     @POST("./catalog/test-no-response-query-params")
     @Headers({
@@ -159,12 +160,12 @@ public interface TestServiceRetrofit {
     })
     ListenableFuture<Void> testNoResponseQueryParams(
             @Header("Authorization") AuthHeader authHeader,
-            @Body String query,
             @Query("different") ResourceIdentifier something,
-            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @Query("setEnd") Set<String> setEnd,
-            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd);
+            @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
+            @Body String query);
 
     @GET("./catalog/boolean")
     @Headers({"hr-path-template: /catalog/boolean", "Accept: application/json"})
@@ -189,4 +190,106 @@ public interface TestServiceRetrofit {
             @Header("Authorization") AuthHeader authHeader,
             @Query("maybeInteger") OptionalInt maybeInteger,
             @Query("maybeDouble") OptionalDouble maybeDouble);
+
+    @Deprecated
+    default int testQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("different") ResourceIdentifier something,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Body String query) {
+        return testQueryParams(
+                authHeader,
+                something,
+                implicit,
+                Optional.empty(),
+                Collections.emptySet(),
+                Optional.empty(),
+                query);
+    }
+
+    @Deprecated
+    default int testQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("different") ResourceIdentifier something,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
+            @Body String query) {
+        return testQueryParams(
+                authHeader,
+                something,
+                implicit,
+                optionalMiddle,
+                Collections.emptySet(),
+                Optional.empty(),
+                query);
+    }
+
+    @Deprecated
+    default int testQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("different") ResourceIdentifier something,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
+            @Query("setEnd") Set<String> setEnd,
+            @Body String query) {
+        return testQueryParams(
+                authHeader, something, implicit, optionalMiddle, setEnd, Optional.empty(), query);
+    }
+
+    @Deprecated
+    default void testNoResponseQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("different") ResourceIdentifier something,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Body String query) {
+        testNoResponseQueryParams(
+                authHeader,
+                something,
+                implicit,
+                Optional.empty(),
+                Collections.emptySet(),
+                Optional.empty(),
+                query);
+    }
+
+    @Deprecated
+    default void testNoResponseQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("different") ResourceIdentifier something,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
+            @Body String query) {
+        testNoResponseQueryParams(
+                authHeader,
+                something,
+                implicit,
+                optionalMiddle,
+                Collections.emptySet(),
+                Optional.empty(),
+                query);
+    }
+
+    @Deprecated
+    default void testNoResponseQueryParams(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("different") ResourceIdentifier something,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Query("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
+            @Query("setEnd") Set<String> setEnd,
+            @Body String query) {
+        testNoResponseQueryParams(
+                authHeader, something, implicit, optionalMiddle, setEnd, Optional.empty(), query);
+    }
+
+    @Deprecated
+    default void testOptionalIntegerAndDouble(@Header("Authorization") AuthHeader authHeader) {
+        testOptionalIntegerAndDouble(authHeader, OptionalInt.empty(), OptionalDouble.empty());
+    }
+
+    @Deprecated
+    default void testOptionalIntegerAndDouble(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("maybeInteger") OptionalInt maybeInteger) {
+        testOptionalIntegerAndDouble(authHeader, maybeInteger, OptionalDouble.empty());
+    }
 }


### PR DESCRIPTION
## Before this PR
Retrofit generated interfaces didn't have their parameters sorted and didn't have the backcompat methods for optional arguments

## After this PR
==COMMIT_MSG==
Match jax-rs client generator behaviour in retrofit. Retrofit clients now have their arguments sorted the same way jax-rs does and have backcompat methods for optional arguments.
==COMMIT_MSG==

## Possible downsides?
The argument order of generated methods will change which will require fixing up by users

fixes #339 