### PR TITLE
Make verifier use random port

### DIFF
--- a/conjure-java-server-verifier/src/test/java/com/palantir/conjure/java/verification/server/undertest/UndertowServerUnderTestExtension.java
+++ b/conjure-java-server-verifier/src/test/java/com/palantir/conjure/java/verification/server/undertest/UndertowServerUnderTestExtension.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.verification.server.undertest;
 
+import com.google.common.collect.Iterables;
 import com.google.common.reflect.Reflection;
 import com.palantir.conjure.java.undertow.lib.UndertowService;
 import com.palantir.conjure.java.undertow.runtime.ConjureHandler;
@@ -25,13 +26,12 @@ import com.palantir.conjure.verification.client.UndertowAutoDeserializeService;
 import io.undertow.Handlers;
 import io.undertow.Undertow;
 import io.undertow.server.HttpHandler;
+import java.net.InetSocketAddress;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 public final class UndertowServerUnderTestExtension implements BeforeAllCallback, AfterAllCallback {
-
-    private static final int PORT = 12346;
 
     private Undertow server;
 
@@ -46,7 +46,7 @@ public final class UndertowServerUnderTestExtension implements BeforeAllCallback
                 .build();
 
         server = Undertow.builder()
-                .addHttpListener(PORT, "0.0.0.0")
+                .addHttpListener(0, "0.0.0.0")
                 .setHandler(Handlers.path().addPrefixPath("/test/api", handler))
                 .build();
         server.start();
@@ -60,6 +60,6 @@ public final class UndertowServerUnderTestExtension implements BeforeAllCallback
     }
 
     public int getLocalPort() {
-        return PORT;
+        return ((InetSocketAddress) Iterables.getOnlyElement(server.getListenerInfo()).getAddress()).getPort();
     }
 }

--- a/conjure-java-server-verifier/src/test/resources/config.yml
+++ b/conjure-java-server-verifier/src/test/resources/config.yml
@@ -2,7 +2,7 @@ server:
   applicationContextPath: /test
   applicationConnectors:
     - type: http
-      port: 12345
+      port: 0
   adminConnectors: []
   rootPath: /api/*
 webSecurity:


### PR DESCRIPTION
## Before this PR
develop is broken as `:conjure-java-server-verifier:test` and ` :conjure-java-undertow-runtime:test` both attempt to bind to ports 12345 12346.

## After this PR
==COMMIT_MSG==
Fix multiple test suites that run in parallel binding to ports 12345 and 12346.

conjure-java-server-verifier now instructs each of its dropwizard and undertow "servers-under-test" to bind to a random port.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

