### PR TITLE
Invariant typecasting on covariant optionals

### DIFF
--- a/changelog/@unreleased/pr-538.v2.yml
+++ b/changelog/@unreleased/pr-538.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: No warning-generating typecast is present in the setter methods for optional fields.
+  links:
+  - https://github.com/palantir/conjure-java/pull/538

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Generated;
 
 @JsonDeserialize(builder = CovariantOptionalExample.Builder.class)
@@ -19,16 +20,25 @@ import javax.annotation.Generated;
 public final class CovariantOptionalExample {
     private final Optional<Object> item;
 
+    private final Optional<Set<StringAliasExample>> setItem;
+
     private volatile int memoizedHashCode;
 
-    private CovariantOptionalExample(Optional<Object> item) {
-        validateFields(item);
+    private CovariantOptionalExample(
+            Optional<Object> item, Optional<Set<StringAliasExample>> setItem) {
+        validateFields(item, setItem);
         this.item = item;
+        this.setItem = setItem;
     }
 
     @JsonProperty("item")
     public Optional<Object> getItem() {
         return this.item;
+    }
+
+    @JsonProperty("setItem")
+    public Optional<Set<StringAliasExample>> getSetItem() {
+        return this.setItem;
     }
 
     @Override
@@ -39,13 +49,13 @@ public final class CovariantOptionalExample {
     }
 
     private boolean equalTo(CovariantOptionalExample other) {
-        return this.item.equals(other.item);
+        return this.item.equals(other.item) && this.setItem.equals(other.setItem);
     }
 
     @Override
     public int hashCode() {
         if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(item);
+            memoizedHashCode = Objects.hash(item, setItem);
         }
         return memoizedHashCode;
     }
@@ -57,17 +67,23 @@ public final class CovariantOptionalExample {
                 .append("item")
                 .append(": ")
                 .append(item)
+                .append(", ")
+                .append("setItem")
+                .append(": ")
+                .append(setItem)
                 .append('}')
                 .toString();
     }
 
-    public static CovariantOptionalExample of(Object item) {
-        return builder().item(Optional.of(item)).build();
+    public static CovariantOptionalExample of(Object item, Set<StringAliasExample> setItem) {
+        return builder().item(Optional.of(item)).setItem(Optional.of(setItem)).build();
     }
 
-    private static void validateFields(Optional<Object> item) {
+    private static void validateFields(
+            Optional<Object> item, Optional<Set<StringAliasExample>> setItem) {
         List<String> missingFields = null;
         missingFields = addFieldIfMissing(missingFields, item, "item");
+        missingFields = addFieldIfMissing(missingFields, setItem, "setItem");
         if (missingFields != null) {
             throw new SafeIllegalArgumentException(
                     "Some required fields have not been set",
@@ -80,7 +96,7 @@ public final class CovariantOptionalExample {
         List<String> missingFields = prev;
         if (fieldValue == null) {
             if (missingFields == null) {
-                missingFields = new ArrayList<>(1);
+                missingFields = new ArrayList<>(2);
             }
             missingFields.add(fieldName);
         }
@@ -96,16 +112,21 @@ public final class CovariantOptionalExample {
     public static final class Builder {
         private Optional<Object> item = Optional.empty();
 
+        private Optional<Set<StringAliasExample>> setItem = Optional.empty();
+
         private Builder() {}
 
         public Builder from(CovariantOptionalExample other) {
             item(other.getItem());
+            setItem(other.getSetItem());
             return this;
         }
 
         @JsonSetter(value = "item", nulls = Nulls.SKIP)
         public Builder item(Optional<?> item) {
-            this.item = (Optional<Object>) Preconditions.checkNotNull(item, "item cannot be null");
+            this.item =
+                    Preconditions.checkNotNull(item, "item cannot be null")
+                            .map(_item -> (Object) _item);
             return this;
         }
 
@@ -114,8 +135,22 @@ public final class CovariantOptionalExample {
             return this;
         }
 
+        @JsonSetter(value = "setItem", nulls = Nulls.SKIP)
+        public Builder setItem(Optional<? extends Set<StringAliasExample>> setItem) {
+            this.setItem =
+                    Preconditions.checkNotNull(setItem, "setItem cannot be null")
+                            .map(_setItem -> (Set<StringAliasExample>) _setItem);
+            return this;
+        }
+
+        public Builder setItem(Set<StringAliasExample> setItem) {
+            this.setItem =
+                    Optional.of(Preconditions.checkNotNull(setItem, "setItem cannot be null"));
+            return this;
+        }
+
         public CovariantOptionalExample build() {
-            return new CovariantOptionalExample(item);
+            return new CovariantOptionalExample(item, setItem);
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import javax.annotation.Generated;
 
 @JsonDeserialize(builder = CovariantOptionalExample.Builder.class)
@@ -126,7 +127,7 @@ public final class CovariantOptionalExample {
         public Builder item(Optional<?> item) {
             this.item =
                     Preconditions.checkNotNull(item, "item cannot be null")
-                            .map(_item -> (Object) _item);
+                            .map(Function.identity());
             return this;
         }
 
@@ -139,7 +140,7 @@ public final class CovariantOptionalExample {
         public Builder setItem(Optional<? extends Set<StringAliasExample>> setItem) {
             this.setItem =
                     Preconditions.checkNotNull(setItem, "setItem cannot be null")
-                            .map(_setItem -> (Set<StringAliasExample>) _setItem);
+                            .map(Function.identity());
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -157,9 +157,9 @@ public final class ExternalLongExample {
         @JsonSetter(value = "optionalExternalLong", nulls = Nulls.SKIP)
         public Builder optionalExternalLong(Optional<? extends Long> optionalExternalLong) {
             this.optionalExternalLong =
-                    (Optional<Long>)
-                            Preconditions.checkNotNull(
-                                    optionalExternalLong, "optionalExternalLong cannot be null");
+                    Preconditions.checkNotNull(
+                                    optionalExternalLong, "optionalExternalLong cannot be null")
+                            .map(_optionalExternalLong -> (Long) _optionalExternalLong);
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import javax.annotation.Generated;
 
 @JsonDeserialize(builder = ExternalLongExample.Builder.class)
@@ -159,7 +160,7 @@ public final class ExternalLongExample {
             this.optionalExternalLong =
                     Preconditions.checkNotNull(
                                     optionalExternalLong, "optionalExternalLong cannot be null")
-                            .map(_optionalExternalLong -> (Long) _optionalExternalLong);
+                            .map(Function.identity());
             return this;
         }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -336,6 +336,7 @@ public final class BeanBuilderGenerator {
                     .build();
         } else if (type.accept(TypeVisitor.IS_OPTIONAL)) {
             OptionalType optionalType = type.accept(TypeVisitor.OPTIONAL);
+            String parameterName = enriched.poetSpec().name;
             CodeBlock nullCheckedValue = Expressions.requireNonNull(
                     spec.name, enriched.fieldName().get() + " cannot be null");
 
@@ -343,8 +344,8 @@ public final class BeanBuilderGenerator {
                 // covariant optionals need to be narrowed to invariant type before assignment
                 Type innerType = optionalType.getItemType();
                 return CodeBlock.builder()
-                        .addStatement("this.$1N = ($3T<$4T>) $2L",
-                                spec.name, nullCheckedValue, Optional.class, typeMapper.getClassName(innerType).box())
+                        .addStatement("this.$1N = $2L.map(_$3L -> ($4T) _$3L)",
+                                spec.name, nullCheckedValue, parameterName, typeMapper.getClassName(innerType).box())
                         .build();
             } else {
                 return CodeBlocks.statement("this.$1L = $2L", spec.name, nullCheckedValue);

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -341,7 +341,8 @@ public final class BeanBuilderGenerator {
                     spec.name, enriched.fieldName().get() + " cannot be null");
 
             if (isWidenableContainedType(optionalType.getItemType())) {
-                // we need to capture covariant type before assignment to invariant inner variable
+                // we capture covariant type via generic Function#identity mapping before assignment to bind
+                // the resultant optional to the invariant inner variable type
                 return CodeBlock.builder()
                         .addStatement("this.$1N = $2L.map($3T.identity())",
                                 spec.name, nullCheckedValue, Function.class)

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -46,6 +46,7 @@ types:
       CovariantOptionalExample:
         fields:
           item: optional<any>
+          setItem: optional<set<StringAliasExample>>
       ListExample:
         fields:
           items: list<string>


### PR DESCRIPTION
## Before this PR
Fixes https://github.com/palantir/conjure-java/issues/536

For optional fields, the generated builder objects contain setters accepting covariant inputs. A typecast is necessary to assign to the inner (invariant) variables, but this typecast generates a warning. 
## After this PR
==COMMIT_MSG==
No warning-generating typecast is present in the setter methods for optional fields.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

