### PR TITLE
UndertowServices propagate 403s

### DIFF
--- a/changelog/@unreleased/pr-552.v2.yml
+++ b/changelog/@unreleased/pr-552.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Undertow Services propagate 403s.
+  links:
+  - https://github.com/palantir/conjure-java/pull/552

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
@@ -33,7 +33,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Consumer;
-import javax.ws.rs.core.Response.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnio.IoUtils;
@@ -119,14 +118,12 @@ final class ConjureExceptions {
     }
 
     private static ErrorType mapRemoteExceptionErrorType(RemoteException exception) {
-        Status status = Status.fromStatusCode(exception.getStatus());
-
-        if (status.getStatusCode() == 403) {
+        if (exception.getStatus() == 403) {
             log.info("Encountered a remote permission denied exception."
                             + " Mapping to a default permission denied exception before propagating",
                     SafeArg.of("errorInstanceId", exception.getError().errorInstanceId()),
                     SafeArg.of("errorName", exception.getError().errorName()),
-                    SafeArg.of("statusCode", status.getStatusCode()),
+                    SafeArg.of("statusCode", exception.getStatus()),
                     exception);
 
             return ErrorType.PERMISSION_DENIED;
@@ -135,7 +132,7 @@ final class ConjureExceptions {
             log.warn("Encountered a remote exception. Mapping to an internal error before propagating",
                     SafeArg.of("errorInstanceId", exception.getError().errorInstanceId()),
                     SafeArg.of("errorName", exception.getError().errorName()),
-                    SafeArg.of("statusCode", status.getStatusCode()),
+                    SafeArg.of("statusCode", exception.getStatus()),
                     exception);
 
             return ErrorType.INTERNAL;

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
@@ -33,6 +33,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Consumer;
+import javax.ws.rs.core.Response.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnio.IoUtils;
@@ -99,20 +100,14 @@ final class ConjureExceptions {
     }
 
     // RemoteExceptions are thrown by Conjure clients to indicate a remote/service-side problem.
-    // We forward these exceptions, but change the ErrorType to INTERNAL, i.e., the problem is now
+    // We forward these exceptions, but change the ErrorType to INTERNAL unless it was a 403, i.e., the problem is now
     // considered internal to *this* service rather than the originating service. This means in particular
     // that Conjure errors are defined only local to a given service and these error types don't
     // propagate through other services.
     private static void remoteException(
             HttpServerExchange exchange, Serializer<SerializableError> serializer, RemoteException exception) {
-        // log at WARN instead of ERROR because although this indicates an issue in a remote server
-        log.warn("Encountered a remote exception. Mapping to an internal error before propagating",
-                SafeArg.of("errorInstanceId", exception.getError().errorInstanceId()),
-                SafeArg.of("errorName", exception.getError().errorName()),
-                SafeArg.of("statusCode", exception.getStatus()),
-                exception);
 
-        ErrorType errorType = ErrorType.INTERNAL;
+        ErrorType errorType = mapRemoteExceptionErrorType(exception);
         writeResponse(exchange,
                 Optional.of(SerializableError.builder()
                         .errorName(errorType.name())
@@ -121,6 +116,30 @@ final class ConjureExceptions {
                         .build()),
                 errorType.httpErrorCode(),
                 serializer);
+    }
+
+    private static ErrorType mapRemoteExceptionErrorType(RemoteException exception) {
+        Status status = Status.fromStatusCode(exception.getStatus());
+
+        if (status.getStatusCode() == 403) {
+            log.info("Encountered a remote permission denied exception."
+                            + " Mapping to a default permission denied exception before propagating",
+                    SafeArg.of("errorInstanceId", exception.getError().errorInstanceId()),
+                    SafeArg.of("errorName", exception.getError().errorName()),
+                    SafeArg.of("statusCode", status.getStatusCode()),
+                    exception);
+
+            return ErrorType.PERMISSION_DENIED;
+        } else {
+            // log at WARN instead of ERROR because this indicates an issue in a remote server
+            log.warn("Encountered a remote exception. Mapping to an internal error before propagating",
+                    SafeArg.of("errorInstanceId", exception.getError().errorInstanceId()),
+                    SafeArg.of("errorName", exception.getError().errorName()),
+                    SafeArg.of("statusCode", status.getStatusCode()),
+                    exception);
+
+            return ErrorType.INTERNAL;
+        }
     }
 
     private static void illegalArgumentException(


### PR DESCRIPTION
## Before this PR
Undertow Services do not propagate 403s, which is inconsistent with the conjure jersey implementation (palantir/conjure-java-runtime#904)

## After this PR
==COMMIT_MSG==
Undertow Services propagate 403s.
==COMMIT_MSG==
