### PR TITLE
Simplify conjure object toString implementation

### DIFF
--- a/changelog/@unreleased/pr-555.v2.yml
+++ b/changelog/@unreleased/pr-555.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Simplify conjure object toString implementation
+  links:
+  - https://github.com/palantir/conjure-java/pull/555

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryExample.java
@@ -50,13 +50,7 @@ public final class BinaryExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("BinaryExample")
-                .append('{')
-                .append("binary")
-                .append(": ")
-                .append(binary)
-                .append('}')
-                .toString();
+        return "BinaryExample{binary: " + binary + '}';
     }
 
     public static BinaryExample of(ByteBuffer binary) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
@@ -52,13 +52,7 @@ public final class OptionalExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("OptionalExample")
-                .append('{')
-                .append("item")
-                .append(": ")
-                .append(item)
-                .append('}')
-                .toString();
+        return "OptionalExample{item: " + item + '}';
     }
 
     public static OptionalExample of(ByteBuffer item) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
@@ -116,37 +116,21 @@ public final class AliasAsMapKeyExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("AliasAsMapKeyExample")
-                .append('{')
-                .append("strings")
-                .append(": ")
-                .append(strings)
-                .append(", ")
-                .append("rids")
-                .append(": ")
-                .append(rids)
-                .append(", ")
-                .append("bearertokens")
-                .append(": ")
-                .append(bearertokens)
-                .append(", ")
-                .append("integers")
-                .append(": ")
-                .append(integers)
-                .append(", ")
-                .append("safelongs")
-                .append(": ")
-                .append(safelongs)
-                .append(", ")
-                .append("datetimes")
-                .append(": ")
-                .append(datetimes)
-                .append(", ")
-                .append("uuids")
-                .append(": ")
-                .append(uuids)
-                .append('}')
-                .toString();
+        return "AliasAsMapKeyExample{strings: "
+                + strings
+                + ", rids: "
+                + rids
+                + ", bearertokens: "
+                + bearertokens
+                + ", integers: "
+                + integers
+                + ", safelongs: "
+                + safelongs
+                + ", datetimes: "
+                + datetimes
+                + ", uuids: "
+                + uuids
+                + '}';
     }
 
     private static void validateFields(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
@@ -48,13 +48,7 @@ public final class AnyExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("AnyExample")
-                .append('{')
-                .append("any")
-                .append(": ")
-                .append(any)
-                .append('}')
-                .toString();
+        return "AnyExample{any: " + any + '}';
     }
 
     public static AnyExample of(Object any) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
@@ -52,13 +52,7 @@ public final class AnyMapExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("AnyMapExample")
-                .append('{')
-                .append("items")
-                .append(": ")
-                .append(items)
-                .append('}')
-                .toString();
+        return "AnyMapExample{items: " + items + '}';
     }
 
     public static AnyMapExample of(Map<String, Object> items) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
@@ -50,13 +50,7 @@ public final class BearerTokenExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("BearerTokenExample")
-                .append('{')
-                .append("bearerTokenValue")
-                .append(": ")
-                .append(bearerTokenValue)
-                .append('}')
-                .toString();
+        return "BearerTokenExample{bearerTokenValue: " + bearerTokenValue + '}';
     }
 
     public static BearerTokenExample of(BearerToken bearerTokenValue) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
@@ -49,13 +49,7 @@ public final class BinaryExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("BinaryExample")
-                .append('{')
-                .append("binary")
-                .append(": ")
-                .append(binary)
-                .append('}')
-                .toString();
+        return "BinaryExample{binary: " + binary + '}';
     }
 
     public static BinaryExample of(Bytes binary) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
@@ -47,13 +47,7 @@ public final class BooleanExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("BooleanExample")
-                .append('{')
-                .append("coin")
-                .append(": ")
-                .append(coin)
-                .append('}')
-                .toString();
+        return "BooleanExample{coin: " + coin + '}';
     }
 
     public static BooleanExample of(boolean coin) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
@@ -61,17 +61,7 @@ public final class CovariantListExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("CovariantListExample")
-                .append('{')
-                .append("items")
-                .append(": ")
-                .append(items)
-                .append(", ")
-                .append("externalItems")
-                .append(": ")
-                .append(externalItems)
-                .append('}')
-                .toString();
+        return "CovariantListExample{items: " + items + ", externalItems: " + externalItems + '}';
     }
 
     public static CovariantListExample of(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
@@ -63,17 +63,7 @@ public final class CovariantOptionalExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("CovariantOptionalExample")
-                .append('{')
-                .append("item")
-                .append(": ")
-                .append(item)
-                .append(", ")
-                .append("setItem")
-                .append(": ")
-                .append(setItem)
-                .append('}')
-                .toString();
+        return "CovariantOptionalExample{item: " + item + ", setItem: " + setItem + '}';
     }
 
     public static CovariantOptionalExample of(Object item, Set<StringAliasExample> setItem) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
@@ -50,13 +50,7 @@ public final class DateTimeExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("DateTimeExample")
-                .append('{')
-                .append("datetime")
-                .append(": ")
-                .append(datetime)
-                .append('}')
-                .toString();
+        return "DateTimeExample{datetime: " + datetime + '}';
     }
 
     public static DateTimeExample of(OffsetDateTime datetime) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
@@ -46,13 +46,7 @@ public final class DoubleExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("DoubleExample")
-                .append('{')
-                .append("doubleValue")
-                .append(": ")
-                .append(doubleValue)
-                .append('}')
-                .toString();
+        return "DoubleExample{doubleValue: " + doubleValue + '}';
     }
 
     public static DoubleExample of(double doubleValue) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
@@ -49,13 +49,7 @@ public final class EnumFieldExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("EnumFieldExample")
-                .append('{')
-                .append("enum")
-                .append(": ")
-                .append(enum_)
-                .append('}')
-                .toString();
+        return "EnumFieldExample{enum: " + enum_ + '}';
     }
 
     public static EnumFieldExample of(EnumExample enum_) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -73,21 +73,13 @@ public final class ExternalLongExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("ExternalLongExample")
-                .append('{')
-                .append("externalLong")
-                .append(": ")
-                .append(externalLong)
-                .append(", ")
-                .append("optionalExternalLong")
-                .append(": ")
-                .append(optionalExternalLong)
-                .append(", ")
-                .append("listExternalLong")
-                .append(": ")
-                .append(listExternalLong)
-                .append('}')
-                .toString();
+        return "ExternalLongExample{externalLong: "
+                + externalLong
+                + ", optionalExternalLong: "
+                + optionalExternalLong
+                + ", listExternalLong: "
+                + listExternalLong
+                + '}';
     }
 
     public static ExternalLongExample of(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
@@ -47,13 +47,7 @@ public final class IntegerExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("IntegerExample")
-                .append('{')
-                .append("integer")
-                .append(": ")
-                .append(integer)
-                .append('}')
-                .toString();
+        return "IntegerExample{integer: " + integer + '}';
     }
 
     public static IntegerExample of(int integer) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
@@ -70,21 +70,13 @@ public final class ListExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("ListExample")
-                .append('{')
-                .append("items")
-                .append(": ")
-                .append(items)
-                .append(", ")
-                .append("primitiveItems")
-                .append(": ")
-                .append(primitiveItems)
-                .append(", ")
-                .append("doubleItems")
-                .append(": ")
-                .append(doubleItems)
-                .append('}')
-                .toString();
+        return "ListExample{items: "
+                + items
+                + ", primitiveItems: "
+                + primitiveItems
+                + ", doubleItems: "
+                + doubleItems
+                + '}';
     }
 
     public static ListExample of(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -138,41 +138,23 @@ public final class ManyFieldExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("ManyFieldExample")
-                .append('{')
-                .append("string")
-                .append(": ")
-                .append(string)
-                .append(", ")
-                .append("integer")
-                .append(": ")
-                .append(integer)
-                .append(", ")
-                .append("doubleValue")
-                .append(": ")
-                .append(doubleValue)
-                .append(", ")
-                .append("optionalItem")
-                .append(": ")
-                .append(optionalItem)
-                .append(", ")
-                .append("items")
-                .append(": ")
-                .append(items)
-                .append(", ")
-                .append("set")
-                .append(": ")
-                .append(set)
-                .append(", ")
-                .append("map")
-                .append(": ")
-                .append(map)
-                .append(", ")
-                .append("alias")
-                .append(": ")
-                .append(alias)
-                .append('}')
-                .toString();
+        return "ManyFieldExample{string: "
+                + string
+                + ", integer: "
+                + integer
+                + ", doubleValue: "
+                + doubleValue
+                + ", optionalItem: "
+                + optionalItem
+                + ", items: "
+                + items
+                + ", set: "
+                + set
+                + ", map: "
+                + map
+                + ", alias: "
+                + alias
+                + '}';
     }
 
     private static void validateFields(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
@@ -52,13 +52,7 @@ public final class MapExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("MapExample")
-                .append('{')
-                .append("items")
-                .append(": ")
-                .append(items)
-                .append('}')
-                .toString();
+        return "MapExample{items: " + items + '}';
     }
 
     public static MapExample of(Map<String, String> items) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
@@ -51,13 +51,7 @@ public final class OptionalExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("OptionalExample")
-                .append('{')
-                .append("item")
-                .append(": ")
-                .append(item)
-                .append('}')
-                .toString();
+        return "OptionalExample{item: " + item + '}';
     }
 
     public static OptionalExample of(String item) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
@@ -119,37 +119,21 @@ public final class PrimitiveOptionalsExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("PrimitiveOptionalsExample")
-                .append('{')
-                .append("num")
-                .append(": ")
-                .append(num)
-                .append(", ")
-                .append("bool")
-                .append(": ")
-                .append(bool)
-                .append(", ")
-                .append("integer")
-                .append(": ")
-                .append(integer)
-                .append(", ")
-                .append("safelong")
-                .append(": ")
-                .append(safelong)
-                .append(", ")
-                .append("rid")
-                .append(": ")
-                .append(rid)
-                .append(", ")
-                .append("bearertoken")
-                .append(": ")
-                .append(bearertoken)
-                .append(", ")
-                .append("uuid")
-                .append(": ")
-                .append(uuid)
-                .append('}')
-                .toString();
+        return "PrimitiveOptionalsExample{num: "
+                + num
+                + ", bool: "
+                + bool
+                + ", integer: "
+                + integer
+                + ", safelong: "
+                + safelong
+                + ", rid: "
+                + rid
+                + ", bearertoken: "
+                + bearertoken
+                + ", uuid: "
+                + uuid
+                + '}';
     }
 
     private static void validateFields(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -96,29 +96,17 @@ public final class ReservedKeyExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("ReservedKeyExample")
-                .append('{')
-                .append("package")
-                .append(": ")
-                .append(package_)
-                .append(", ")
-                .append("interface")
-                .append(": ")
-                .append(interface_)
-                .append(", ")
-                .append("field-name-with-dashes")
-                .append(": ")
-                .append(fieldNameWithDashes)
-                .append(", ")
-                .append("primitve-field-name-with-dashes")
-                .append(": ")
-                .append(primitveFieldNameWithDashes)
-                .append(", ")
-                .append("memoizedHashCode")
-                .append(": ")
-                .append(memoizedHashCode_)
-                .append('}')
-                .toString();
+        return "ReservedKeyExample{package: "
+                + package_
+                + ", interface: "
+                + interface_
+                + ", field-name-with-dashes: "
+                + fieldNameWithDashes
+                + ", primitve-field-name-with-dashes: "
+                + primitveFieldNameWithDashes
+                + ", memoizedHashCode: "
+                + memoizedHashCode_
+                + '}';
     }
 
     private static void validateFields(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
@@ -49,13 +49,7 @@ public final class RidExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("RidExample")
-                .append('{')
-                .append("ridValue")
-                .append(": ")
-                .append(ridValue)
-                .append('}')
-                .toString();
+        return "RidExample{ridValue: " + ridValue + '}';
     }
 
     public static RidExample of(ResourceIdentifier ridValue) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
@@ -50,13 +50,7 @@ public final class SafeLongExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("SafeLongExample")
-                .append('{')
-                .append("safeLongValue")
-                .append(": ")
-                .append(safeLongValue)
-                .append('}')
-                .toString();
+        return "SafeLongExample{safeLongValue: " + safeLongValue + '}';
     }
 
     public static SafeLongExample of(SafeLong safeLongValue) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
@@ -61,17 +61,7 @@ public final class SetExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("SetExample")
-                .append('{')
-                .append("items")
-                .append(": ")
-                .append(items)
-                .append(", ")
-                .append("doubleItems")
-                .append(": ")
-                .append(doubleItems)
-                .append('}')
-                .toString();
+        return "SetExample{items: " + items + ", doubleItems: " + doubleItems + '}';
     }
 
     public static SetExample of(Set<String> items, Set<Double> doubleItems) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -60,13 +60,7 @@ public final class SingleUnion {
 
     @Override
     public String toString() {
-        return new StringBuilder("SingleUnion")
-                .append('{')
-                .append("value")
-                .append(": ")
-                .append(value)
-                .append('}')
-                .toString();
+        return "SingleUnion{value: " + value + '}';
     }
 
     public interface Visitor<T> {
@@ -171,13 +165,7 @@ public final class SingleUnion {
 
         @Override
         public String toString() {
-            return new StringBuilder("FooWrapper")
-                    .append('{')
-                    .append("value")
-                    .append(": ")
-                    .append(value)
-                    .append('}')
-                    .toString();
+            return "FooWrapper{value: " + value + '}';
         }
     }
 
@@ -235,17 +223,7 @@ public final class SingleUnion {
 
         @Override
         public String toString() {
-            return new StringBuilder("UnknownWrapper")
-                    .append('{')
-                    .append("type")
-                    .append(": ")
-                    .append(type)
-                    .append(", ")
-                    .append("value")
-                    .append(": ")
-                    .append(value)
-                    .append('}')
-                    .toString();
+            return "UnknownWrapper{type: " + type + ", value: " + value + '}';
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
@@ -48,13 +48,7 @@ public final class StringExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("StringExample")
-                .append('{')
-                .append("string")
-                .append(": ")
-                .append(string)
-                .append('}')
-                .toString();
+        return "StringExample{string: " + string + '}';
     }
 
     public static StringExample of(String string) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -73,13 +73,7 @@ public final class Union {
 
     @Override
     public String toString() {
-        return new StringBuilder("Union")
-                .append('{')
-                .append("value")
-                .append(": ")
-                .append(value)
-                .append('}')
-                .toString();
+        return "Union{value: " + value + '}';
     }
 
     public interface Visitor<T> {
@@ -232,13 +226,7 @@ public final class Union {
 
         @Override
         public String toString() {
-            return new StringBuilder("FooWrapper")
-                    .append('{')
-                    .append("value")
-                    .append(": ")
-                    .append(value)
-                    .append('}')
-                    .toString();
+            return "FooWrapper{value: " + value + '}';
         }
     }
 
@@ -273,13 +261,7 @@ public final class Union {
 
         @Override
         public String toString() {
-            return new StringBuilder("BarWrapper")
-                    .append('{')
-                    .append("value")
-                    .append(": ")
-                    .append(value)
-                    .append('}')
-                    .toString();
+            return "BarWrapper{value: " + value + '}';
         }
     }
 
@@ -314,13 +296,7 @@ public final class Union {
 
         @Override
         public String toString() {
-            return new StringBuilder("BazWrapper")
-                    .append('{')
-                    .append("value")
-                    .append(": ")
-                    .append(value)
-                    .append('}')
-                    .toString();
+            return "BazWrapper{value: " + value + '}';
         }
     }
 
@@ -378,17 +354,7 @@ public final class Union {
 
         @Override
         public String toString() {
-            return new StringBuilder("UnknownWrapper")
-                    .append('{')
-                    .append("type")
-                    .append(": ")
-                    .append(type)
-                    .append(", ")
-                    .append("value")
-                    .append(": ")
-                    .append(value)
-                    .append('}')
-                    .toString();
+            return "UnknownWrapper{type: " + type + ", value: " + value + '}';
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -101,13 +101,7 @@ public final class UnionTypeExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("UnionTypeExample")
-                .append('{')
-                .append("value")
-                .append(": ")
-                .append(value)
-                .append('}')
-                .toString();
+        return "UnionTypeExample{value: " + value + '}';
     }
 
     public interface Visitor<T> {
@@ -359,13 +353,7 @@ public final class UnionTypeExample {
 
         @Override
         public String toString() {
-            return new StringBuilder("StringExampleWrapper")
-                    .append('{')
-                    .append("value")
-                    .append(": ")
-                    .append(value)
-                    .append('}')
-                    .toString();
+            return "StringExampleWrapper{value: " + value + '}';
         }
     }
 
@@ -400,13 +388,7 @@ public final class UnionTypeExample {
 
         @Override
         public String toString() {
-            return new StringBuilder("SetWrapper")
-                    .append('{')
-                    .append("value")
-                    .append(": ")
-                    .append(value)
-                    .append('}')
-                    .toString();
+            return "SetWrapper{value: " + value + '}';
         }
     }
 
@@ -443,13 +425,7 @@ public final class UnionTypeExample {
 
         @Override
         public String toString() {
-            return new StringBuilder("ThisFieldIsAnIntegerWrapper")
-                    .append('{')
-                    .append("value")
-                    .append(": ")
-                    .append(value)
-                    .append('}')
-                    .toString();
+            return "ThisFieldIsAnIntegerWrapper{value: " + value + '}';
         }
     }
 
@@ -486,13 +462,7 @@ public final class UnionTypeExample {
 
         @Override
         public String toString() {
-            return new StringBuilder("AlsoAnIntegerWrapper")
-                    .append('{')
-                    .append("value")
-                    .append(": ")
-                    .append(value)
-                    .append('}')
-                    .toString();
+            return "AlsoAnIntegerWrapper{value: " + value + '}';
         }
     }
 
@@ -527,13 +497,7 @@ public final class UnionTypeExample {
 
         @Override
         public String toString() {
-            return new StringBuilder("IfWrapper")
-                    .append('{')
-                    .append("value")
-                    .append(": ")
-                    .append(value)
-                    .append('}')
-                    .toString();
+            return "IfWrapper{value: " + value + '}';
         }
     }
 
@@ -568,13 +532,7 @@ public final class UnionTypeExample {
 
         @Override
         public String toString() {
-            return new StringBuilder("NewWrapper")
-                    .append('{')
-                    .append("value")
-                    .append(": ")
-                    .append(value)
-                    .append('}')
-                    .toString();
+            return "NewWrapper{value: " + value + '}';
         }
     }
 
@@ -610,13 +568,7 @@ public final class UnionTypeExample {
 
         @Override
         public String toString() {
-            return new StringBuilder("InterfaceWrapper")
-                    .append('{')
-                    .append("value")
-                    .append(": ")
-                    .append(value)
-                    .append('}')
-                    .toString();
+            return "InterfaceWrapper{value: " + value + '}';
         }
     }
 
@@ -674,17 +626,7 @@ public final class UnionTypeExample {
 
         @Override
         public String toString() {
-            return new StringBuilder("UnknownWrapper")
-                    .append('{')
-                    .append("type")
-                    .append(": ")
-                    .append(type)
-                    .append(", ")
-                    .append("value")
-                    .append(": ")
-                    .append(value)
-                    .append('}')
-                    .toString();
+            return "UnknownWrapper{type: " + type + ", value: " + value + '}';
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
@@ -49,13 +49,7 @@ public final class UuidExample {
 
     @Override
     public String toString() {
-        return new StringBuilder("UuidExample")
-                .append('{')
-                .append("uuid")
-                .append(": ")
-                .append(uuid)
-                .append('}')
-                .toString();
+        return "UuidExample{uuid: " + uuid + '}';
     }
 
     public static UuidExample of(UUID uuid) {


### PR DESCRIPTION
Avoid using unnecessary stringbuilders, in jdk8 javac generates
this code for us. Using a compiler target beyond jdk8 we can
take advantage of [jep 280](https://openjdk.java.net/jeps/280).

## After this PR
==COMMIT_MSG==
Simplify conjure object toString implementation
==COMMIT_MSG==

