### PR TITLE
Fix volatile memoizedHashCode access in generated code 

### DIFF
--- a/changelog/@unreleased/pr-556-b.v2.yml
+++ b/changelog/@unreleased/pr-556-b.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Avoid hashCode memoization for simple objects. This slightly reduces the memory footprint of simple objects.
+  links:
+  - https://github.com/palantir/conjure-java/pull/556

--- a/changelog/@unreleased/pr-556.v2.yml
+++ b/changelog/@unreleased/pr-556.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix volatile memoizedHashCode access in generated code
+  links:
+  - https://github.com/palantir/conjure-java/pull/556

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryExample.java
@@ -42,10 +42,12 @@ public final class BinaryExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(binary);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.binary);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryExample.java
@@ -19,8 +19,6 @@ import javax.annotation.Generated;
 public final class BinaryExample {
     private final ByteBuffer binary;
 
-    private volatile int memoizedHashCode;
-
     private BinaryExample(ByteBuffer binary) {
         validateFields(binary);
         this.binary = binary;
@@ -42,12 +40,7 @@ public final class BinaryExample {
 
     @Override
     public int hashCode() {
-        int result = memoizedHashCode;
-        if (result == 0) {
-            result = Objects.hash(this.binary);
-            memoizedHashCode = result;
-        }
-        return result;
+        return Objects.hashCode(this.binary);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
@@ -20,8 +20,6 @@ import javax.annotation.Generated;
 public final class OptionalExample {
     private final Optional<ByteBuffer> item;
 
-    private volatile int memoizedHashCode;
-
     private OptionalExample(Optional<ByteBuffer> item) {
         validateFields(item);
         this.item = item;
@@ -44,12 +42,7 @@ public final class OptionalExample {
 
     @Override
     public int hashCode() {
-        int result = memoizedHashCode;
-        if (result == 0) {
-            result = Objects.hash(this.item);
-            memoizedHashCode = result;
-        }
-        return result;
+        return Objects.hashCode(this.item);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
@@ -44,10 +44,12 @@ public final class OptionalExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(item);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.item);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
@@ -106,12 +106,20 @@ public final class AliasAsMapKeyExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode =
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result =
                     Objects.hash(
-                            strings, rids, bearertokens, integers, safelongs, datetimes, uuids);
+                            this.strings,
+                            this.rids,
+                            this.bearertokens,
+                            this.integers,
+                            this.safelongs,
+                            this.datetimes,
+                            this.uuids);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
@@ -40,10 +40,12 @@ public final class AnyExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(any);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.any);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
@@ -17,8 +17,6 @@ import javax.annotation.Generated;
 public final class AnyExample {
     private final Object any;
 
-    private volatile int memoizedHashCode;
-
     private AnyExample(Object any) {
         validateFields(any);
         this.any = any;
@@ -40,12 +38,7 @@ public final class AnyExample {
 
     @Override
     public int hashCode() {
-        int result = memoizedHashCode;
-        if (result == 0) {
-            result = Objects.hash(this.any);
-            memoizedHashCode = result;
-        }
-        return result;
+        return Objects.hashCode(this.any);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
@@ -46,7 +46,7 @@ public final class AnyMapExample {
     public int hashCode() {
         int result = memoizedHashCode;
         if (result == 0) {
-            result = Objects.hash(this.items);
+            result = Objects.hashCode(this.items);
             memoizedHashCode = result;
         }
         return result;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
@@ -44,10 +44,12 @@ public final class AnyMapExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(items);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.items);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
@@ -42,10 +42,12 @@ public final class BearerTokenExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(bearerTokenValue);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.bearerTokenValue);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
@@ -18,8 +18,6 @@ import javax.annotation.Generated;
 public final class BearerTokenExample {
     private final BearerToken bearerTokenValue;
 
-    private volatile int memoizedHashCode;
-
     private BearerTokenExample(BearerToken bearerTokenValue) {
         validateFields(bearerTokenValue);
         this.bearerTokenValue = bearerTokenValue;
@@ -42,12 +40,7 @@ public final class BearerTokenExample {
 
     @Override
     public int hashCode() {
-        int result = memoizedHashCode;
-        if (result == 0) {
-            result = Objects.hash(this.bearerTokenValue);
-            memoizedHashCode = result;
-        }
-        return result;
+        return Objects.hashCode(this.bearerTokenValue);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
@@ -41,10 +41,12 @@ public final class BinaryExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(binary);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.binary);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
@@ -18,8 +18,6 @@ import javax.annotation.Generated;
 public final class BinaryExample {
     private final Bytes binary;
 
-    private volatile int memoizedHashCode;
-
     private BinaryExample(Bytes binary) {
         validateFields(binary);
         this.binary = binary;
@@ -41,12 +39,7 @@ public final class BinaryExample {
 
     @Override
     public int hashCode() {
-        int result = memoizedHashCode;
-        if (result == 0) {
-            result = Objects.hash(this.binary);
-            memoizedHashCode = result;
-        }
-        return result;
+        return Objects.hashCode(this.binary);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
@@ -39,10 +39,12 @@ public final class BooleanExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(coin);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.coin);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
@@ -8,15 +8,12 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import javax.annotation.Generated;
 
 @JsonDeserialize(builder = BooleanExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
 public final class BooleanExample {
     private final boolean coin;
-
-    private volatile int memoizedHashCode;
 
     private BooleanExample(boolean coin) {
         this.coin = coin;
@@ -39,12 +36,7 @@ public final class BooleanExample {
 
     @Override
     public int hashCode() {
-        int result = memoizedHashCode;
-        if (result == 0) {
-            result = Objects.hash(this.coin);
-            memoizedHashCode = result;
-        }
-        return result;
+        return Boolean.hashCode(this.coin);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
@@ -53,10 +53,12 @@ public final class CovariantListExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(items, externalItems);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.items, this.externalItems);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
@@ -55,10 +55,12 @@ public final class CovariantOptionalExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(item, setItem);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.item, this.setItem);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
@@ -44,7 +44,7 @@ public final class DateTimeExample {
     public int hashCode() {
         int result = memoizedHashCode;
         if (result == 0) {
-            result = Objects.hash(this.datetime.toInstant());
+            result = Objects.hashCode(this.datetime.toInstant());
             memoizedHashCode = result;
         }
         return result;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
@@ -42,10 +42,12 @@ public final class DateTimeExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(datetime.toInstant());
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.datetime.toInstant());
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
@@ -8,15 +8,12 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import javax.annotation.Generated;
 
 @JsonDeserialize(builder = DoubleExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
 public final class DoubleExample {
     private final double doubleValue;
-
-    private volatile int memoizedHashCode;
 
     private DoubleExample(double doubleValue) {
         this.doubleValue = doubleValue;
@@ -38,12 +35,7 @@ public final class DoubleExample {
 
     @Override
     public int hashCode() {
-        int result = memoizedHashCode;
-        if (result == 0) {
-            result = Objects.hash(this.doubleValue);
-            memoizedHashCode = result;
-        }
-        return result;
+        return Double.hashCode(this.doubleValue);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
@@ -38,10 +38,12 @@ public final class DoubleExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(doubleValue);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.doubleValue);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
@@ -17,8 +17,6 @@ import javax.annotation.Generated;
 public final class EnumFieldExample {
     private final EnumExample enum_;
 
-    private volatile int memoizedHashCode;
-
     private EnumFieldExample(EnumExample enum_) {
         validateFields(enum_);
         this.enum_ = enum_;
@@ -41,12 +39,7 @@ public final class EnumFieldExample {
 
     @Override
     public int hashCode() {
-        int result = memoizedHashCode;
-        if (result == 0) {
-            result = Objects.hash(this.enum_);
-            memoizedHashCode = result;
-        }
-        return result;
+        return Objects.hashCode(this.enum_);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
@@ -41,10 +41,12 @@ public final class EnumFieldExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(enum_);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.enum_);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -65,10 +65,14 @@ public final class ExternalLongExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(externalLong, optionalExternalLong, listExternalLong);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result =
+                    Objects.hash(
+                            this.externalLong, this.optionalExternalLong, this.listExternalLong);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
@@ -39,10 +39,12 @@ public final class IntegerExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(integer);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.integer);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
@@ -8,15 +8,12 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import javax.annotation.Generated;
 
 @JsonDeserialize(builder = IntegerExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
 public final class IntegerExample {
     private final int integer;
-
-    private volatile int memoizedHashCode;
 
     private IntegerExample(int integer) {
         this.integer = integer;
@@ -39,12 +36,7 @@ public final class IntegerExample {
 
     @Override
     public int hashCode() {
-        int result = memoizedHashCode;
-        if (result == 0) {
-            result = Objects.hash(this.integer);
-            memoizedHashCode = result;
-        }
-        return result;
+        return Integer.hashCode(this.integer);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
@@ -62,10 +62,12 @@ public final class ListExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(items, primitiveItems, doubleItems);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.items, this.primitiveItems, this.doubleItems);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -128,12 +128,21 @@ public final class ManyFieldExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode =
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result =
                     Objects.hash(
-                            string, integer, doubleValue, optionalItem, items, set, map, alias);
+                            this.string,
+                            this.integer,
+                            this.doubleValue,
+                            this.optionalItem,
+                            this.items,
+                            this.set,
+                            this.map,
+                            this.alias);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
@@ -44,10 +44,12 @@ public final class MapExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(items);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.items);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
@@ -46,7 +46,7 @@ public final class MapExample {
     public int hashCode() {
         int result = memoizedHashCode;
         if (result == 0) {
-            result = Objects.hash(this.items);
+            result = Objects.hashCode(this.items);
             memoizedHashCode = result;
         }
         return result;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
@@ -43,10 +43,12 @@ public final class OptionalExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(item);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.item);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
@@ -19,8 +19,6 @@ import javax.annotation.Generated;
 public final class OptionalExample {
     private final Optional<String> item;
 
-    private volatile int memoizedHashCode;
-
     private OptionalExample(Optional<String> item) {
         validateFields(item);
         this.item = item;
@@ -43,12 +41,7 @@ public final class OptionalExample {
 
     @Override
     public int hashCode() {
-        int result = memoizedHashCode;
-        if (result == 0) {
-            result = Objects.hash(this.item);
-            memoizedHashCode = result;
-        }
-        return result;
+        return Objects.hashCode(this.item);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
@@ -111,10 +111,20 @@ public final class PrimitiveOptionalsExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(num, bool, integer, safelong, rid, bearertoken, uuid);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result =
+                    Objects.hash(
+                            this.num,
+                            this.bool,
+                            this.integer,
+                            this.safelong,
+                            this.rid,
+                            this.bearertoken,
+                            this.uuid);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -25,6 +25,8 @@ public final class ReservedKeyExample {
 
     private final int memoizedHashCode_;
 
+    private final int result;
+
     private volatile int memoizedHashCode;
 
     private ReservedKeyExample(
@@ -32,13 +34,15 @@ public final class ReservedKeyExample {
             String interface_,
             String fieldNameWithDashes,
             int primitveFieldNameWithDashes,
-            int memoizedHashCode_) {
+            int memoizedHashCode_,
+            int result) {
         validateFields(package_, interface_, fieldNameWithDashes);
         this.package_ = package_;
         this.interface_ = interface_;
         this.fieldNameWithDashes = fieldNameWithDashes;
         this.primitveFieldNameWithDashes = primitveFieldNameWithDashes;
         this.memoizedHashCode_ = memoizedHashCode_;
+        this.result = result;
     }
 
     @JsonProperty("package")
@@ -66,6 +70,11 @@ public final class ReservedKeyExample {
         return this.memoizedHashCode_;
     }
 
+    @JsonProperty("result")
+    public int getResult() {
+        return this.result;
+    }
+
     @Override
     public boolean equals(Object other) {
         return this == other
@@ -77,21 +86,25 @@ public final class ReservedKeyExample {
                 && this.interface_.equals(other.interface_)
                 && this.fieldNameWithDashes.equals(other.fieldNameWithDashes)
                 && this.primitveFieldNameWithDashes == other.primitveFieldNameWithDashes
-                && this.memoizedHashCode_ == other.memoizedHashCode_;
+                && this.memoizedHashCode_ == other.memoizedHashCode_
+                && this.result == other.result;
     }
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode =
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result =
                     Objects.hash(
-                            package_,
-                            interface_,
-                            fieldNameWithDashes,
-                            primitveFieldNameWithDashes,
-                            memoizedHashCode_);
+                            this.package_,
+                            this.interface_,
+                            this.fieldNameWithDashes,
+                            this.primitveFieldNameWithDashes,
+                            this.memoizedHashCode_,
+                            this.result);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override
@@ -117,6 +130,10 @@ public final class ReservedKeyExample {
                 .append("memoizedHashCode")
                 .append(": ")
                 .append(memoizedHashCode_)
+                .append(", ")
+                .append("result")
+                .append(": ")
+                .append(result)
                 .append('}')
                 .toString();
     }
@@ -164,9 +181,13 @@ public final class ReservedKeyExample {
 
         private int memoizedHashCode_;
 
+        private int result;
+
         private boolean _primitveFieldNameWithDashesInitialized = false;
 
         private boolean _memoizedHashCode_Initialized = false;
+
+        private boolean _resultInitialized = false;
 
         private Builder() {}
 
@@ -176,6 +197,7 @@ public final class ReservedKeyExample {
             fieldNameWithDashes(other.getFieldNameWithDashes());
             primitveFieldNameWithDashes(other.getPrimitveFieldNameWithDashes());
             memoizedHashCode_(other.getMemoizedHashCode());
+            result(other.getResult());
             return this;
         }
 
@@ -213,6 +235,13 @@ public final class ReservedKeyExample {
             return this;
         }
 
+        @JsonSetter("result")
+        public Builder result(int result) {
+            this.result = result;
+            this._resultInitialized = true;
+            return this;
+        }
+
         private void validatePrimitiveFieldsHaveBeenInitialized() {
             List<String> missingFields = null;
             missingFields =
@@ -223,6 +252,7 @@ public final class ReservedKeyExample {
             missingFields =
                     addFieldIfMissing(
                             missingFields, _memoizedHashCode_Initialized, "memoizedHashCode");
+            missingFields = addFieldIfMissing(missingFields, _resultInitialized, "result");
             if (missingFields != null) {
                 throw new SafeIllegalArgumentException(
                         "Some required fields have not been set",
@@ -235,7 +265,7 @@ public final class ReservedKeyExample {
             List<String> missingFields = prev;
             if (!initialized) {
                 if (missingFields == null) {
-                    missingFields = new ArrayList<>(2);
+                    missingFields = new ArrayList<>(3);
                 }
                 missingFields.add(fieldName);
             }
@@ -249,7 +279,8 @@ public final class ReservedKeyExample {
                     interface_,
                     fieldNameWithDashes,
                     primitveFieldNameWithDashes,
-                    memoizedHashCode_);
+                    memoizedHashCode_,
+                    result);
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
@@ -18,8 +18,6 @@ import javax.annotation.Generated;
 public final class RidExample {
     private final ResourceIdentifier ridValue;
 
-    private volatile int memoizedHashCode;
-
     private RidExample(ResourceIdentifier ridValue) {
         validateFields(ridValue);
         this.ridValue = ridValue;
@@ -41,12 +39,7 @@ public final class RidExample {
 
     @Override
     public int hashCode() {
-        int result = memoizedHashCode;
-        if (result == 0) {
-            result = Objects.hash(this.ridValue);
-            memoizedHashCode = result;
-        }
-        return result;
+        return Objects.hashCode(this.ridValue);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
@@ -41,10 +41,12 @@ public final class RidExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(ridValue);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.ridValue);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
@@ -18,8 +18,6 @@ import javax.annotation.Generated;
 public final class SafeLongExample {
     private final SafeLong safeLongValue;
 
-    private volatile int memoizedHashCode;
-
     private SafeLongExample(SafeLong safeLongValue) {
         validateFields(safeLongValue);
         this.safeLongValue = safeLongValue;
@@ -42,12 +40,7 @@ public final class SafeLongExample {
 
     @Override
     public int hashCode() {
-        int result = memoizedHashCode;
-        if (result == 0) {
-            result = Objects.hash(this.safeLongValue);
-            memoizedHashCode = result;
-        }
-        return result;
+        return Objects.hashCode(this.safeLongValue);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
@@ -42,10 +42,12 @@ public final class SafeLongExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(safeLongValue);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.safeLongValue);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
@@ -53,10 +53,12 @@ public final class SetExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(items, doubleItems);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.items, this.doubleItems);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -55,7 +55,7 @@ public final class SingleUnion {
 
     @Override
     public int hashCode() {
-        return Objects.hash(value);
+        return Objects.hash(this.value);
     }
 
     @Override
@@ -166,7 +166,7 @@ public final class SingleUnion {
 
         @Override
         public int hashCode() {
-            return Objects.hash(value);
+            return Objects.hash(this.value);
         }
 
         @Override
@@ -230,7 +230,7 @@ public final class SingleUnion {
 
         @Override
         public int hashCode() {
-            return Objects.hash(type, value);
+            return Objects.hash(this.type, this.value);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -55,7 +55,7 @@ public final class SingleUnion {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.value);
+        return Objects.hashCode(this.value);
     }
 
     @Override
@@ -166,7 +166,7 @@ public final class SingleUnion {
 
         @Override
         public int hashCode() {
-            return Objects.hash(this.value);
+            return Objects.hashCode(this.value);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
@@ -17,8 +17,6 @@ import javax.annotation.Generated;
 public final class StringExample {
     private final String string;
 
-    private volatile int memoizedHashCode;
-
     private StringExample(String string) {
         validateFields(string);
         this.string = string;
@@ -40,12 +38,7 @@ public final class StringExample {
 
     @Override
     public int hashCode() {
-        int result = memoizedHashCode;
-        if (result == 0) {
-            result = Objects.hash(this.string);
-            memoizedHashCode = result;
-        }
-        return result;
+        return Objects.hashCode(this.string);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
@@ -40,10 +40,12 @@ public final class StringExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(string);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.string);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -68,7 +68,7 @@ public final class Union {
 
     @Override
     public int hashCode() {
-        return Objects.hash(value);
+        return Objects.hash(this.value);
     }
 
     @Override
@@ -227,7 +227,7 @@ public final class Union {
 
         @Override
         public int hashCode() {
-            return Objects.hash(value);
+            return Objects.hash(this.value);
         }
 
         @Override
@@ -268,7 +268,7 @@ public final class Union {
 
         @Override
         public int hashCode() {
-            return Objects.hash(value);
+            return Objects.hash(this.value);
         }
 
         @Override
@@ -309,7 +309,7 @@ public final class Union {
 
         @Override
         public int hashCode() {
-            return Objects.hash(value);
+            return Objects.hash(this.value);
         }
 
         @Override
@@ -373,7 +373,7 @@ public final class Union {
 
         @Override
         public int hashCode() {
-            return Objects.hash(type, value);
+            return Objects.hash(this.type, this.value);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -68,7 +68,7 @@ public final class Union {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.value);
+        return Objects.hashCode(this.value);
     }
 
     @Override
@@ -227,7 +227,7 @@ public final class Union {
 
         @Override
         public int hashCode() {
-            return Objects.hash(this.value);
+            return Objects.hashCode(this.value);
         }
 
         @Override
@@ -268,7 +268,7 @@ public final class Union {
 
         @Override
         public int hashCode() {
-            return Objects.hash(this.value);
+            return Integer.hashCode(this.value);
         }
 
         @Override
@@ -309,7 +309,7 @@ public final class Union {
 
         @Override
         public int hashCode() {
-            return Objects.hash(this.value);
+            return Long.hashCode(this.value);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -96,7 +96,7 @@ public final class UnionTypeExample {
 
     @Override
     public int hashCode() {
-        return Objects.hash(value);
+        return Objects.hash(this.value);
     }
 
     @Override
@@ -354,7 +354,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Objects.hash(value);
+            return Objects.hash(this.value);
         }
 
         @Override
@@ -395,7 +395,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Objects.hash(value);
+            return Objects.hash(this.value);
         }
 
         @Override
@@ -438,7 +438,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Objects.hash(value);
+            return Objects.hash(this.value);
         }
 
         @Override
@@ -481,7 +481,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Objects.hash(value);
+            return Objects.hash(this.value);
         }
 
         @Override
@@ -522,7 +522,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Objects.hash(value);
+            return Objects.hash(this.value);
         }
 
         @Override
@@ -563,7 +563,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Objects.hash(value);
+            return Objects.hash(this.value);
         }
 
         @Override
@@ -605,7 +605,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Objects.hash(value);
+            return Objects.hash(this.value);
         }
 
         @Override
@@ -669,7 +669,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Objects.hash(type, value);
+            return Objects.hash(this.type, this.value);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -96,7 +96,7 @@ public final class UnionTypeExample {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.value);
+        return Objects.hashCode(this.value);
     }
 
     @Override
@@ -354,7 +354,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Objects.hash(this.value);
+            return Objects.hashCode(this.value);
         }
 
         @Override
@@ -395,7 +395,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Objects.hash(this.value);
+            return Objects.hashCode(this.value);
         }
 
         @Override
@@ -438,7 +438,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Objects.hash(this.value);
+            return Integer.hashCode(this.value);
         }
 
         @Override
@@ -481,7 +481,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Objects.hash(this.value);
+            return Integer.hashCode(this.value);
         }
 
         @Override
@@ -522,7 +522,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Objects.hash(this.value);
+            return Integer.hashCode(this.value);
         }
 
         @Override
@@ -563,7 +563,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Objects.hash(this.value);
+            return Integer.hashCode(this.value);
         }
 
         @Override
@@ -605,7 +605,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Objects.hash(this.value);
+            return Integer.hashCode(this.value);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
@@ -18,8 +18,6 @@ import javax.annotation.Generated;
 public final class UuidExample {
     private final UUID uuid;
 
-    private volatile int memoizedHashCode;
-
     private UuidExample(UUID uuid) {
         validateFields(uuid);
         this.uuid = uuid;
@@ -41,12 +39,7 @@ public final class UuidExample {
 
     @Override
     public int hashCode() {
-        int result = memoizedHashCode;
-        if (result == 0) {
-            result = Objects.hash(this.uuid);
-            memoizedHashCode = result;
-        }
-        return result;
+        return Objects.hashCode(this.uuid);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
@@ -41,10 +41,12 @@ public final class UuidExample {
 
     @Override
     public int hashCode() {
-        if (memoizedHashCode == 0) {
-            memoizedHashCode = Objects.hash(uuid);
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = Objects.hash(this.uuid);
+            memoizedHashCode = result;
         }
-        return memoizedHashCode;
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/MethodSpecs.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/MethodSpecs.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.types;
 
+import com.google.common.collect.Iterables;
 import com.palantir.conjure.java.util.JavaNameSanitizer;
 import com.palantir.conjure.spec.FieldName;
 import com.squareup.javapoet.ClassName;
@@ -62,7 +63,7 @@ public final class MethodSpecs {
                 .addAnnotation(Override.class)
                 .addModifiers(Modifier.PUBLIC)
                 .returns(TypeName.INT)
-                .addStatement("return $1T.$2N($3L)", Objects.class, "hash", getHashInput(fields))
+                .addStatement("return $L", computeHashCode(fields))
                 .build();
     }
 
@@ -78,12 +79,23 @@ public final class MethodSpecs {
                 // Single volatile read
                 .addStatement("int result = memoizedHashCode")
                 .beginControlFlow("if (result == 0)")
-                .addStatement("result = $1T.$2N($3L)", Objects.class, "hash", getHashInput(fields))
+                .addStatement("result = $L", computeHashCode(fields))
                 // Single volatile write
                 .addStatement("memoizedHashCode = result")
                 .endControlFlow()
                 .addStatement("return result")
                 .build());
+    }
+
+    private static CodeBlock computeHashCode(Collection<FieldSpec> fields) {
+        if (fields.size() == 1) {
+            FieldSpec fieldSpec = Iterables.getOnlyElement(fields);
+            if (fieldSpec.type.isPrimitive()) {
+                return CodeBlock.of("$1T.$2N($3L)", fieldSpec.type.box(), "hashCode", createHashInput(fieldSpec));
+            }
+            return CodeBlock.of("$1T.$2N($3L)", Objects.class, "hashCode", createHashInput(fieldSpec));
+        }
+        return CodeBlock.of("$1T.$2N($3L)", Objects.class, "hash", getHashInput(fields));
     }
 
     private static CodeBlock getHashInput(Collection<FieldSpec> fields) {

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -192,6 +192,8 @@ types:
             type: integer
           memoizedHashCode:
             type: integer
+          result:
+            type: integer
       Union:
         union:
           foo: string


### PR DESCRIPTION
One volatile read, at most one volatile write. See Effective Java,
I am traveling and don't have the section number at hand.

## Before this PR
Multiple volatile field reads unnecessarily.

## After this PR
==COMMIT_MSG==
Fix volatile memoizedHashCode access in generated code 
==COMMIT_MSG==

## Possible downsides?
None

