### PR TITLE
Errors are logged from the ConjureExceptions class

### DIFF
--- a/changelog/@unreleased/pr-589.v2.yml
+++ b/changelog/@unreleased/pr-589.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Errors are logged from the ConjureExceptions class to provide more
+    helpful metadata for debugging, and making the safe parts of the stack trace available
+    in the log pipeline.
+  links:
+  - https://github.com/palantir/conjure-java/pull/589

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/HttpServerExchanges.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/HttpServerExchanges.java
@@ -23,6 +23,7 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.server.ServerConnection;
 import io.undertow.server.protocol.http.HttpServerConnection;
 import io.undertow.util.HeaderMap;
+import io.undertow.util.Methods;
 import io.undertow.util.Protocols;
 import org.xnio.OptionMap;
 import org.xnio.StreamConnection;
@@ -56,6 +57,7 @@ public final class HttpServerExchanges {
         HttpServerExchange httpServerExchange =
                 new HttpServerExchange(connection, new HeaderMap(), new HeaderMap(), 200);
         httpServerExchange.setProtocol(Protocols.HTTP_1_1);
+        httpServerExchange.setRequestMethod(Methods.GET);
         httpServerExchange.startBlocking();
         return httpServerExchange;
     }

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptionHandlerTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptionHandlerTest.java
@@ -178,7 +178,7 @@ public final class ConjureExceptionHandlerTest {
     }
 
     @Test
-    public void doesNotHandleErrors() throws IOException {
+    public void handlesErrorWithoutSendingResponseBody() throws IOException {
         server.stop();
         server = Undertow.builder()
                 .addHttpListener(12345, "localhost")

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptionHandlerTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptionHandlerTest.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.java.undertow.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.api.errors.ErrorType;
@@ -24,9 +25,11 @@ import com.palantir.conjure.java.api.errors.QosException;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.SerializableError;
 import com.palantir.conjure.java.api.errors.ServiceException;
+import com.palantir.conjure.java.undertow.HttpServerExchanges;
 import com.palantir.conjure.java.undertow.lib.TypeMarker;
 import com.palantir.logsafe.SafeArg;
 import io.undertow.Undertow;
+import io.undertow.server.HttpHandler;
 import io.undertow.server.handlers.BlockingHandler;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -191,6 +194,15 @@ public final class ConjureExceptionHandlerTest {
         Response response = execute();
         assertThat(response.body().string()).isEmpty();
         assertThat(response.code()).isEqualTo(500);
+    }
+
+    @Test
+    public void handlesErrorWithoutRethrowing() {
+        HttpHandler handler = new ConjureExceptionHandler(exchange -> {
+            throw new Error();
+        });
+        assertThatCode(() -> handler.handleRequest(HttpServerExchanges.createStub()))
+                .doesNotThrowAnyException();
     }
 
     private static Response execute() {


### PR DESCRIPTION
This is whitelisted for safe-logging, and includes trace/user
metadata where the server exception handler logs from a different scope.
This allows us to terminate partial responses when data has already
been sent.

## After this PR
==COMMIT_MSG==
Errors are logged from the ConjureExceptions class to provide more helpful metadata for debugging, and making the safe parts of the stack trace available in the log pipeline.
==COMMIT_MSG==

## Possible downsides?
none

