### PR TITLE
Add endpoint that consumes set of aliases

### DIFF
--- a/conjure-java-core/src/test/resources/example-service.yml
+++ b/conjure-java-core/src/test/resources/example-service.yml
@@ -118,6 +118,16 @@ services:
              - Safe
         returns: AliasedString
 
+      putAliasedStrings:
+        http: POST /datasets/{datasetRid}/strings
+        args:
+          datasetRid:
+            type: rid
+            markers:
+              - Safe
+          strings:
+            type: set<AliasedString>
+
       uploadRawData:
         http: POST /datasets/upload-raw
         args:


### PR DESCRIPTION
This breaks undertow generator because https://github.com/palantir/conjure-java/blob/4.4.0/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java#L739-L749 doesn't consider collections of aliases

## After this PR
==COMMIT_MSG==
Fix undertow generator for endpoints that refer to collections of aliased types.
==COMMIT_MSG==


