### PR TITLE
Undertow generation fails w/ collection query param

### DIFF
--- a/conjure-java-core/src/test/resources/example-service.yml
+++ b/conjure-java-core/src/test/resources/example-service.yml
@@ -118,6 +118,17 @@ services:
              - Safe
         returns: AliasedString
 
+      getForStrings:
+        http: GET /datasets/{datasetRid}/strings
+        args:
+          datasetRid:
+            type: rid
+            markers:
+              - Safe
+          strings:
+            type: set<AliasedString>
+            param-type: query
+
       uploadRawData:
         http: POST /datasets/upload-raw
         args:

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
@@ -81,6 +81,13 @@ public interface TestService {
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
 
+    @GET
+    @Path("catalog/datasets/{datasetRid}/strings")
+    void getForStrings(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid,
+            @QueryParam("strings") Set<AliasedString> strings);
+
     @POST
     @Path("catalog/datasets/upload-raw")
     @Consumes(MediaType.APPLICATION_OCTET_STREAM)
@@ -173,6 +180,11 @@ public interface TestService {
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @QueryParam("maybeInteger") OptionalInt maybeInteger,
             @QueryParam("maybeDouble") OptionalDouble maybeDouble);
+
+    @Deprecated
+    default void getForStrings(AuthHeader authHeader, ResourceIdentifier datasetRid) {
+        getForStrings(authHeader, datasetRid, Collections.emptySet());
+    }
 
     @Deprecated
     default int testQueryParams(

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
@@ -81,6 +81,13 @@ public interface TestService {
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
 
+    @GET
+    @Path("catalog/datasets/{datasetRid}/strings")
+    void getForStrings(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid,
+            @QueryParam("strings") Set<AliasedString> strings);
+
     @POST
     @Path("catalog/datasets/upload-raw")
     @Consumes(MediaType.APPLICATION_OCTET_STREAM)
@@ -173,6 +180,11 @@ public interface TestService {
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @QueryParam("maybeInteger") OptionalInt maybeInteger,
             @QueryParam("maybeDouble") OptionalDouble maybeDouble);
+
+    @Deprecated
+    default void getForStrings(AuthHeader authHeader, ResourceIdentifier datasetRid) {
+        getForStrings(authHeader, datasetRid, Collections.emptySet());
+    }
 
     @Deprecated
     default int testQueryParams(

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
@@ -36,6 +36,9 @@ public interface TestService {
 
     AliasedString getAliasedString(AuthHeader authHeader, ResourceIdentifier datasetRid);
 
+    void getForStrings(
+            AuthHeader authHeader, ResourceIdentifier datasetRid, Set<AliasedString> strings);
+
     void uploadRawData(AuthHeader authHeader, InputStream input);
 
     void uploadAliasedRawData(AuthHeader authHeader, NestedAliasedBinary input);

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
@@ -57,6 +57,7 @@ public final class TestServiceEndpoints implements UndertowService {
                         new GetAliasedRawDataEndpoint(runtime, delegate),
                         new MaybeGetRawDataEndpoint(runtime, delegate),
                         new GetAliasedStringEndpoint(runtime, delegate),
+                        new GetForStringsEndpoint(runtime, delegate),
                         new UploadRawDataEndpoint(runtime, delegate),
                         new UploadAliasedRawDataEndpoint(runtime, delegate),
                         new GetBranchesEndpoint(runtime, delegate),
@@ -433,6 +434,60 @@ public final class TestServiceEndpoints implements UndertowService {
         @Override
         public String name() {
             return "getAliasedString";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class GetForStringsEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final TestService delegate;
+
+        GetForStringsEndpoint(UndertowRuntime runtime, TestService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            Map<String, String> pathParams =
+                    exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
+            ResourceIdentifier datasetRid =
+                    runtime.plainSerDe().deserializeRid(pathParams.get("datasetRid"));
+            runtime.markers()
+                    .param("com.palantir.redaction.Safe", "datasetRid", datasetRid, exchange);
+            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            Set<String> stringsRaw =
+                    runtime.plainSerDe().deserializeStringSet(queryParams.get("strings"));
+            Set<AliasedString> strings =
+                    runtime.plainSerDe().deserializeComplexSet(stringsRaw, AliasedString::valueOf);
+            delegate.getForStrings(authHeader, datasetRid, strings);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/catalog/datasets/{datasetRid}/strings";
+        }
+
+        @Override
+        public String serviceName() {
+            return "TestService";
+        }
+
+        @Override
+        public String name() {
+            return "getForStrings";
         }
 
         @Override

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
@@ -87,6 +87,16 @@ public interface TestServiceRetrofit {
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
+    @GET("./catalog/datasets/{datasetRid}/strings")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/strings",
+        "Accept: application/json"
+    })
+    Call<Void> getForStrings(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid,
+            @Query("strings") Set<AliasedString> strings);
+
     @POST("./catalog/datasets/upload-raw")
     @Headers({"hr-path-template: /catalog/datasets/upload-raw", "Accept: application/json"})
     Call<Void> uploadRawData(
@@ -190,6 +200,13 @@ public interface TestServiceRetrofit {
             @Header("Authorization") AuthHeader authHeader,
             @Query("maybeInteger") OptionalInt maybeInteger,
             @Query("maybeDouble") OptionalDouble maybeDouble);
+
+    @Deprecated
+    default void getForStrings(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid) {
+        getForStrings(authHeader, datasetRid, Collections.emptySet());
+    }
 
     @Deprecated
     default Call<Integer> testQueryParams(

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
@@ -87,6 +87,16 @@ public interface TestServiceRetrofit {
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
+    @GET("./catalog/datasets/{datasetRid}/strings")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/strings",
+        "Accept: application/json"
+    })
+    CompletableFuture<Void> getForStrings(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid,
+            @Query("strings") Set<AliasedString> strings);
+
     @POST("./catalog/datasets/upload-raw")
     @Headers({"hr-path-template: /catalog/datasets/upload-raw", "Accept: application/json"})
     CompletableFuture<Void> uploadRawData(
@@ -190,6 +200,13 @@ public interface TestServiceRetrofit {
             @Header("Authorization") AuthHeader authHeader,
             @Query("maybeInteger") OptionalInt maybeInteger,
             @Query("maybeDouble") OptionalDouble maybeDouble);
+
+    @Deprecated
+    default void getForStrings(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid) {
+        getForStrings(authHeader, datasetRid, Collections.emptySet());
+    }
 
     @Deprecated
     default CompletableFuture<Integer> testQueryParams(

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_listenable_future
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_listenable_future
@@ -87,6 +87,16 @@ public interface TestServiceRetrofit {
             @Header("Authorization") AuthHeader authHeader,
             @Path("datasetRid") ResourceIdentifier datasetRid);
 
+    @GET("./catalog/datasets/{datasetRid}/strings")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/strings",
+        "Accept: application/json"
+    })
+    ListenableFuture<Void> getForStrings(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid,
+            @Query("strings") Set<AliasedString> strings);
+
     @POST("./catalog/datasets/upload-raw")
     @Headers({"hr-path-template: /catalog/datasets/upload-raw", "Accept: application/json"})
     ListenableFuture<Void> uploadRawData(
@@ -190,6 +200,13 @@ public interface TestServiceRetrofit {
             @Header("Authorization") AuthHeader authHeader,
             @Query("maybeInteger") OptionalInt maybeInteger,
             @Query("maybeDouble") OptionalDouble maybeDouble);
+
+    @Deprecated
+    default void getForStrings(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid) {
+        getForStrings(authHeader, datasetRid, Collections.emptySet());
+    }
 
     @Deprecated
     default ListenableFuture<Integer> testQueryParams(


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Undertow generation fails with collection-of-alias query param

## After this PR
==COMMIT_MSG==
Fix bug in Undertow endpoint generation for query params that are collections of aliases.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

