### PR TITLE
Fix conjure-undertow handling complex query parameter collections

### DIFF
--- a/changelog/@unreleased/pr-595.v2.yml
+++ b/changelog/@unreleased/pr-595.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix conjure-undertow handling complex query parameter collections
+  links:
+  - https://github.com/palantir/conjure-java/pull/595

--- a/changelog/@unreleased/pr-595.v2.yml
+++ b/changelog/@unreleased/pr-595.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: fix
+fix:
   description: Fix conjure-undertow handling complex query parameter collections
   links:
   - https://github.com/palantir/conjure-java/pull/595

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
@@ -8,6 +8,7 @@ import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Generated;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -183,6 +184,15 @@ public interface EteService {
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @QueryParam("input") Optional<LongAlias> input);
 
+    @GET
+    @Path("base/datasets/{datasetRid}/strings")
+    void complexQueryParameters(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @PathParam("datasetRid") ResourceIdentifier datasetRid,
+            @QueryParam("strings") Set<StringAliasExample> strings,
+            @QueryParam("longs") Set<Long> longs,
+            @QueryParam("ints") Set<Integer> ints);
+
     @Deprecated
     default Optional<Long> optionalExternalLongQuery(AuthHeader authHeader) {
         return optionalExternalLongQuery(authHeader, Optional.empty());
@@ -211,5 +221,31 @@ public interface EteService {
     @Deprecated
     default Optional<LongAlias> aliasLongEndpoint(AuthHeader authHeader) {
         return aliasLongEndpoint(authHeader, Optional.empty());
+    }
+
+    @Deprecated
+    default void complexQueryParameters(AuthHeader authHeader, ResourceIdentifier datasetRid) {
+        complexQueryParameters(
+                authHeader,
+                datasetRid,
+                Collections.emptySet(),
+                Collections.emptySet(),
+                Collections.emptySet());
+    }
+
+    @Deprecated
+    default void complexQueryParameters(
+            AuthHeader authHeader, ResourceIdentifier datasetRid, Set<StringAliasExample> strings) {
+        complexQueryParameters(
+                authHeader, datasetRid, strings, Collections.emptySet(), Collections.emptySet());
+    }
+
+    @Deprecated
+    default void complexQueryParameters(
+            AuthHeader authHeader,
+            ResourceIdentifier datasetRid,
+            Set<StringAliasExample> strings,
+            Set<Long> longs) {
+        complexQueryParameters(authHeader, datasetRid, strings, longs, Collections.emptySet());
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
@@ -8,6 +8,7 @@ import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Generated;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
@@ -173,6 +174,15 @@ public interface EteServiceRetrofit {
             @Header("Authorization") AuthHeader authHeader,
             @Query("input") Optional<LongAlias> input);
 
+    @GET("./base/datasets/{datasetRid}/strings")
+    @Headers({"hr-path-template: /base/datasets/{datasetRid}/strings", "Accept: application/json"})
+    Call<Void> complexQueryParameters(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid,
+            @Query("strings") Set<StringAliasExample> strings,
+            @Query("longs") Set<Long> longs,
+            @Query("ints") Set<Integer> ints);
+
     @Deprecated
     default Call<Optional<Long>> optionalExternalLongQuery(
             @Header("Authorization") AuthHeader authHeader) {
@@ -206,5 +216,35 @@ public interface EteServiceRetrofit {
     default Call<Optional<LongAlias>> aliasLongEndpoint(
             @Header("Authorization") AuthHeader authHeader) {
         return aliasLongEndpoint(authHeader, Optional.empty());
+    }
+
+    @Deprecated
+    default void complexQueryParameters(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid) {
+        complexQueryParameters(
+                authHeader,
+                datasetRid,
+                Collections.emptySet(),
+                Collections.emptySet(),
+                Collections.emptySet());
+    }
+
+    @Deprecated
+    default void complexQueryParameters(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid,
+            @Query("strings") Set<StringAliasExample> strings) {
+        complexQueryParameters(
+                authHeader, datasetRid, strings, Collections.emptySet(), Collections.emptySet());
+    }
+
+    @Deprecated
+    default void complexQueryParameters(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid,
+            @Query("strings") Set<StringAliasExample> strings,
+            @Query("longs") Set<Long> longs) {
+        complexQueryParameters(authHeader, datasetRid, strings, longs, Collections.emptySet());
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
@@ -8,6 +8,7 @@ import com.palantir.tokens.auth.BearerToken;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
@@ -89,4 +90,11 @@ public interface UndertowEteService {
     SimpleEnum enumHeader(AuthHeader authHeader, SimpleEnum headerParameter);
 
     Optional<LongAlias> aliasLongEndpoint(AuthHeader authHeader, Optional<LongAlias> input);
+
+    void complexQueryParameters(
+            AuthHeader authHeader,
+            ResourceIdentifier datasetRid,
+            Set<StringAliasExample> strings,
+            Set<Long> longs,
+            Set<Integer> ints);
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -580,7 +580,7 @@ final class UndertowServiceHandlerGenerator {
                     if (normalizedType.equals(arg.getType())
                             // Collections of alias types are handled the same way as external imports
                             || UndertowTypeFunctions.isCollectionType(arg.getType())) {
-                        // type is not contain an alias or optional of an alias
+                        // type is not an alias or optional of an alias
                         retrieveParam = decodePlainParameterCodeBlock(arg.getType(), typeMapper, paramName,
                                 paramsVarName,
                                 toParamId.apply(arg));

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -577,9 +577,11 @@ final class UndertowServiceHandlerGenerator {
                             typeDefinitions);
                     String paramName = sanitizeVarName(arg.getArgName().get(), endpoint);
                     final CodeBlock retrieveParam;
-                    if (normalizedType.equals(arg.getType())) {
-                        // type does not contain any aliases
-                        retrieveParam = decodePlainParameterCodeBlock(normalizedType, typeMapper, paramName,
+                    if (normalizedType.equals(arg.getType())
+                            // Collections of alias types are handled the same way as external imports
+                            || UndertowTypeFunctions.isCollectionType(arg.getType())) {
+                        // type is not contain an alias or optional of an alias
+                        retrieveParam = decodePlainParameterCodeBlock(arg.getType(), typeMapper, paramName,
                                 paramsVarName,
                                 toParamId.apply(arg));
                     } else {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowTypeFunctions.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowTypeFunctions.java
@@ -62,11 +62,16 @@ final class UndertowTypeFunctions {
         });
     }
 
+    static boolean isCollectionType(Type type) {
+        return type.accept(TypeVisitor.IS_LIST) || type.accept(TypeVisitor.IS_SET);
+    }
+
     // Returns the type that the given alias type refers to. For example, if the input type is defined as
     // "alias: integer", the returned type will be the type for "integer". The provided type must be an alias
     // (reference) type.
     static Type getAliasedType(Type type, List<TypeDefinition> typeDefinitions) {
-        com.palantir.logsafe.Preconditions.checkArgument(isAliasType(type));
+        com.palantir.logsafe.Preconditions.checkArgument(isAliasType(type),
+                "Expected an alias", SafeArg.of("type", type));
         return getAliasedType(type.accept(
                 new AbstractTypeVisitor<com.palantir.conjure.spec.TypeName>() {
                     @Override

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/EteResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/EteResource.java
@@ -33,6 +33,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.StreamingOutput;
 
@@ -175,6 +176,16 @@ public class EteResource implements EteService {
     public Optional<LongAlias> aliasLongEndpoint(
             AuthHeader _authHeader, Optional<LongAlias> input) {
         return input;
+    }
+
+    @Override
+    public void complexQueryParameters(
+            AuthHeader _authHeader,
+            ResourceIdentifier _datasetRid,
+            Set<StringAliasExample> _strings,
+            Set<Long> _longs,
+            Set<Integer> _ints) {
+        // nop
     }
 
     interface Streaming extends StreamingOutput, BinaryResponseBody {}

--- a/conjure-java-core/src/test/resources/ete-service.yml
+++ b/conjure-java-core/src/test/resources/ete-service.yml
@@ -208,3 +208,18 @@ services:
             type: optional<LongAlias>
             param-type: query
         returns: optional<LongAlias>
+
+      complexQueryParameters:
+        http: GET /datasets/{datasetRid}/strings
+        args:
+          datasetRid:
+            type: rid
+          strings:
+            type: set<StringAliasExample>
+            param-type: query
+          longs:
+            type: set<Long>
+            param-type: query
+          ints:
+            type: set<integer>
+            param-type: query

--- a/conjure-java-core/src/test/resources/example-service.yml
+++ b/conjure-java-core/src/test/resources/example-service.yml
@@ -251,3 +251,14 @@ services:
           maybeDouble:
             type: optional<double>
             param-type: query
+
+      getForStrings:
+        http: GET /datasets/{datasetRid}/strings
+        args:
+          datasetRid:
+            type: rid
+            markers:
+              - Safe
+          strings:
+            type: set<AliasedString>
+            param-type: query

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
@@ -174,6 +174,13 @@ public interface TestService {
             @QueryParam("maybeInteger") OptionalInt maybeInteger,
             @QueryParam("maybeDouble") OptionalDouble maybeDouble);
 
+    @GET
+    @Path("catalog/datasets/{datasetRid}/strings")
+    void getForStrings(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid,
+            @QueryParam("strings") Set<AliasedString> strings);
+
     @Deprecated
     default int testQueryParams(
             AuthHeader authHeader,
@@ -272,5 +279,10 @@ public interface TestService {
     @Deprecated
     default void testOptionalIntegerAndDouble(AuthHeader authHeader, OptionalInt maybeInteger) {
         testOptionalIntegerAndDouble(authHeader, maybeInteger, OptionalDouble.empty());
+    }
+
+    @Deprecated
+    default void getForStrings(AuthHeader authHeader, ResourceIdentifier datasetRid) {
+        getForStrings(authHeader, datasetRid, Collections.emptySet());
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
@@ -174,6 +174,13 @@ public interface TestService {
             @QueryParam("maybeInteger") OptionalInt maybeInteger,
             @QueryParam("maybeDouble") OptionalDouble maybeDouble);
 
+    @GET
+    @Path("catalog/datasets/{datasetRid}/strings")
+    void getForStrings(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid,
+            @QueryParam("strings") Set<AliasedString> strings);
+
     @Deprecated
     default int testQueryParams(
             AuthHeader authHeader,
@@ -272,5 +279,10 @@ public interface TestService {
     @Deprecated
     default void testOptionalIntegerAndDouble(AuthHeader authHeader, OptionalInt maybeInteger) {
         testOptionalIntegerAndDouble(authHeader, maybeInteger, OptionalDouble.empty());
+    }
+
+    @Deprecated
+    default void getForStrings(AuthHeader authHeader, ResourceIdentifier datasetRid) {
+        getForStrings(authHeader, datasetRid, Collections.emptySet());
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
@@ -85,4 +85,7 @@ public interface TestService {
 
     void testOptionalIntegerAndDouble(
             AuthHeader authHeader, OptionalInt maybeInteger, OptionalDouble maybeDouble);
+
+    void getForStrings(
+            AuthHeader authHeader, ResourceIdentifier datasetRid, Set<AliasedString> strings);
 }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
@@ -69,7 +69,8 @@ public final class TestServiceEndpoints implements UndertowService {
                         new TestDoubleEndpoint(runtime, delegate),
                         new TestIntegerEndpoint(runtime, delegate),
                         new TestPostOptionalEndpoint(runtime, delegate),
-                        new TestOptionalIntegerAndDoubleEndpoint(runtime, delegate)));
+                        new TestOptionalIntegerAndDoubleEndpoint(runtime, delegate),
+                        new GetForStringsEndpoint(runtime, delegate)));
     }
 
     private static final class GetFileSystemsEndpoint implements HttpHandler, Endpoint {
@@ -1122,6 +1123,60 @@ public final class TestServiceEndpoints implements UndertowService {
         @Override
         public String name() {
             return "testOptionalIntegerAndDouble";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class GetForStringsEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final TestService delegate;
+
+        GetForStringsEndpoint(UndertowRuntime runtime, TestService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            Map<String, String> pathParams =
+                    exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
+            ResourceIdentifier datasetRid =
+                    runtime.plainSerDe().deserializeRid(pathParams.get("datasetRid"));
+            runtime.markers()
+                    .param("com.palantir.redaction.Safe", "datasetRid", datasetRid, exchange);
+            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            Set<AliasedString> strings =
+                    runtime.plainSerDe()
+                            .deserializeComplexSet(
+                                    queryParams.get("strings"), AliasedString::valueOf);
+            delegate.getForStrings(authHeader, datasetRid, strings);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/catalog/datasets/{datasetRid}/strings";
+        }
+
+        @Override
+        public String serviceName() {
+            return "TestService";
+        }
+
+        @Override
+        public String name() {
+            return "getForStrings";
         }
 
         @Override

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
@@ -191,6 +191,16 @@ public interface TestServiceRetrofit {
             @Query("maybeInteger") OptionalInt maybeInteger,
             @Query("maybeDouble") OptionalDouble maybeDouble);
 
+    @GET("./catalog/datasets/{datasetRid}/strings")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/strings",
+        "Accept: application/json"
+    })
+    Call<Void> getForStrings(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid,
+            @Query("strings") Set<AliasedString> strings);
+
     @Deprecated
     default Call<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
@@ -291,5 +301,12 @@ public interface TestServiceRetrofit {
             @Header("Authorization") AuthHeader authHeader,
             @Query("maybeInteger") OptionalInt maybeInteger) {
         testOptionalIntegerAndDouble(authHeader, maybeInteger, OptionalDouble.empty());
+    }
+
+    @Deprecated
+    default void getForStrings(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid) {
+        getForStrings(authHeader, datasetRid, Collections.emptySet());
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_completable_future
@@ -191,6 +191,16 @@ public interface TestServiceRetrofit {
             @Query("maybeInteger") OptionalInt maybeInteger,
             @Query("maybeDouble") OptionalDouble maybeDouble);
 
+    @GET("./catalog/datasets/{datasetRid}/strings")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/strings",
+        "Accept: application/json"
+    })
+    CompletableFuture<Void> getForStrings(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid,
+            @Query("strings") Set<AliasedString> strings);
+
     @Deprecated
     default CompletableFuture<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
@@ -291,5 +301,12 @@ public interface TestServiceRetrofit {
             @Header("Authorization") AuthHeader authHeader,
             @Query("maybeInteger") OptionalInt maybeInteger) {
         testOptionalIntegerAndDouble(authHeader, maybeInteger, OptionalDouble.empty());
+    }
+
+    @Deprecated
+    default void getForStrings(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid) {
+        getForStrings(authHeader, datasetRid, Collections.emptySet());
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_listenable_future
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit_listenable_future
@@ -191,6 +191,16 @@ public interface TestServiceRetrofit {
             @Query("maybeInteger") OptionalInt maybeInteger,
             @Query("maybeDouble") OptionalDouble maybeDouble);
 
+    @GET("./catalog/datasets/{datasetRid}/strings")
+    @Headers({
+        "hr-path-template: /catalog/datasets/{datasetRid}/strings",
+        "Accept: application/json"
+    })
+    ListenableFuture<Void> getForStrings(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid,
+            @Query("strings") Set<AliasedString> strings);
+
     @Deprecated
     default ListenableFuture<Integer> testQueryParams(
             @Header("Authorization") AuthHeader authHeader,
@@ -291,5 +301,12 @@ public interface TestServiceRetrofit {
             @Header("Authorization") AuthHeader authHeader,
             @Query("maybeInteger") OptionalInt maybeInteger) {
         testOptionalIntegerAndDouble(authHeader, maybeInteger, OptionalDouble.empty());
+    }
+
+    @Deprecated
+    default void getForStrings(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("datasetRid") ResourceIdentifier datasetRid) {
+        getForStrings(authHeader, datasetRid, Collections.emptySet());
     }
 }


### PR DESCRIPTION
Fixes code generation for query parameters of lists and sets of
aliases.

==COMMIT_MSG==
Fix conjure-undertow handling complex query parameter collections
==COMMIT_MSG==

