### PR TITLE
Union wrapper types are final

### DIFF
--- a/changelog/@unreleased/pr-626.v2.yml
+++ b/changelog/@unreleased/pr-626.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Union wrapper types are final
+  links:
+  - https://github.com/palantir/conjure-java/pull/626

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -135,7 +135,7 @@ public final class SingleUnion {
     private interface Base {}
 
     @JsonTypeName("foo")
-    private static class FooWrapper implements Base {
+    private static final class FooWrapper implements Base {
         private final String value;
 
         @JsonCreator
@@ -174,7 +174,7 @@ public final class SingleUnion {
             include = JsonTypeInfo.As.EXISTING_PROPERTY,
             property = "type",
             visible = true)
-    private static class UnknownWrapper implements Base {
+    private static final class UnknownWrapper implements Base {
         private final String type;
 
         private final Map<String, Object> value;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -196,7 +196,7 @@ public final class Union {
     private interface Base {}
 
     @JsonTypeName("foo")
-    private static class FooWrapper implements Base {
+    private static final class FooWrapper implements Base {
         private final String value;
 
         @JsonCreator
@@ -231,7 +231,7 @@ public final class Union {
     }
 
     @JsonTypeName("bar")
-    private static class BarWrapper implements Base {
+    private static final class BarWrapper implements Base {
         private final int value;
 
         @JsonCreator
@@ -266,7 +266,7 @@ public final class Union {
     }
 
     @JsonTypeName("baz")
-    private static class BazWrapper implements Base {
+    private static final class BazWrapper implements Base {
         private final long value;
 
         @JsonCreator
@@ -305,7 +305,7 @@ public final class Union {
             include = JsonTypeInfo.As.EXISTING_PROPERTY,
             property = "type",
             visible = true)
-    private static class UnknownWrapper implements Base {
+    private static final class UnknownWrapper implements Base {
         private final String type;
 
         private final Map<String, Object> value;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -321,7 +321,7 @@ public final class UnionTypeExample {
     private interface Base {}
 
     @JsonTypeName("stringExample")
-    private static class StringExampleWrapper implements Base {
+    private static final class StringExampleWrapper implements Base {
         private final StringExample value;
 
         @JsonCreator
@@ -358,7 +358,7 @@ public final class UnionTypeExample {
     }
 
     @JsonTypeName("set")
-    private static class SetWrapper implements Base {
+    private static final class SetWrapper implements Base {
         private final Set<String> value;
 
         @JsonCreator
@@ -393,7 +393,7 @@ public final class UnionTypeExample {
     }
 
     @JsonTypeName("thisFieldIsAnInteger")
-    private static class ThisFieldIsAnIntegerWrapper implements Base {
+    private static final class ThisFieldIsAnIntegerWrapper implements Base {
         private final int value;
 
         @JsonCreator
@@ -430,7 +430,7 @@ public final class UnionTypeExample {
     }
 
     @JsonTypeName("alsoAnInteger")
-    private static class AlsoAnIntegerWrapper implements Base {
+    private static final class AlsoAnIntegerWrapper implements Base {
         private final int value;
 
         @JsonCreator
@@ -467,7 +467,7 @@ public final class UnionTypeExample {
     }
 
     @JsonTypeName("if")
-    private static class IfWrapper implements Base {
+    private static final class IfWrapper implements Base {
         private final int value;
 
         @JsonCreator
@@ -502,7 +502,7 @@ public final class UnionTypeExample {
     }
 
     @JsonTypeName("new")
-    private static class NewWrapper implements Base {
+    private static final class NewWrapper implements Base {
         private final int value;
 
         @JsonCreator
@@ -537,7 +537,7 @@ public final class UnionTypeExample {
     }
 
     @JsonTypeName("interface")
-    private static class InterfaceWrapper implements Base {
+    private static final class InterfaceWrapper implements Base {
         private final int value;
 
         @JsonCreator
@@ -577,7 +577,7 @@ public final class UnionTypeExample {
             include = JsonTypeInfo.As.EXISTING_PROPERTY,
             property = "type",
             visible = true)
-    private static class UnknownWrapper implements Base {
+    private static final class UnknownWrapper implements Base {
         private final String type;
 
         private final Map<String, Object> value;

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -514,7 +514,7 @@ public final class UnionGenerator {
                     FieldSpec.builder(memberType, VALUE_FIELD_NAME, Modifier.PRIVATE, Modifier.FINAL).build());
 
             TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(wrapperClass)
-                    .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+                    .addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
                     .addSuperinterface(baseClass)
                     .addAnnotation(AnnotationSpec.builder(JsonTypeName.class)
                             .addMember("value", "$S", memberName.get())
@@ -561,7 +561,7 @@ public final class UnionGenerator {
                 FieldSpec.builder(UNKNOWN_MEMBER_TYPE, "type", Modifier.PRIVATE, Modifier.FINAL).build(),
                 FieldSpec.builder(genericMapType, VALUE_FIELD_NAME, Modifier.PRIVATE, Modifier.FINAL).build());
         TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(wrapperClass)
-                .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+                .addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
                 .addSuperinterface(baseClass)
                 .addAnnotation(AnnotationSpec.builder(JsonTypeInfo.class)
                         .addMember("use", "JsonTypeInfo.Id.NAME")


### PR DESCRIPTION
Fixes `FinalClass` validation failures.

## Before this PR
Classes with private constructors were not marked final.

## After this PR
==COMMIT_MSG==
Union wrapper types are final
==COMMIT_MSG==

## Possible downsides?
none.

