### PR TITLE
Fix: Unbox primitive types from optionals when generating `of` factory method

### DIFF
--- a/changelog/@unreleased/pr-639.v2.yml
+++ b/changelog/@unreleased/pr-639.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Unbox primitive types when generating `of` factory method
+  links:
+  - https://github.com/palantir/conjure-java/pull/639

--- a/changelog/@unreleased/pr-639.v2.yml
+++ b/changelog/@unreleased/pr-639.v2.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: Unbox primitive types when generating `of` factory method
+  description: Unbox primitive types from optionals when generating `of` factory method
   links:
   - https://github.com/palantir/conjure-java/pull/639

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -87,7 +87,7 @@ public final class ExternalLongExample {
     }
 
     public static ExternalLongExample of(
-            long externalLong, Long optionalExternalLong, List<Long> listExternalLong) {
+            long externalLong, long optionalExternalLong, List<Long> listExternalLong) {
         return builder()
                 .externalLong(externalLong)
                 .optionalExternalLong(Optional.of(optionalExternalLong))

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -47,6 +47,7 @@ import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -306,7 +307,8 @@ public final class BeanGenerator {
         if (!isOptional(spec)) {
             return spec.type;
         }
-        return ((ParameterizedTypeName) spec.type).typeArguments.get(0);
+        TypeName typeName = ((ParameterizedTypeName) spec.type).typeArguments.get(0);
+        return typeName.isBoxedPrimitive() ? typeName.unbox() : typeName;
     }
 
     private static boolean isOptional(FieldSpec spec) {


### PR DESCRIPTION
## Before this PR
Of factory method had an boxed type for any optional argument

## After this PR
==COMMIT_MSG==
Unbox primitive types when generating `of` factory method
==COMMIT_MSG==

## Possible downsides?
Since we are wrapping with `Optional.of` always there's no possibility of someone passing in null 

