### PR TITLE
add Strict Objects flag

### DIFF
--- a/changelog/@unreleased/pr-644.v2.yml
+++ b/changelog/@unreleased/pr-644.v2.yml
@@ -1,0 +1,7 @@
+type: feature
+feature:
+  description: Add `StrictObjects` feature flag to generate objects that will fail
+    to deserialize unknown properties. Users will still be able to ignore unknown
+    properties by configuring their object mapper to do so
+  links:
+  - https://github.com/palantir/conjure-java/pull/644

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -181,7 +180,6 @@ public final class AliasAsMapKeyExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private Map<StringAliasExample, ManyFieldExample> strings = new LinkedHashMap<>();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -77,7 +76,6 @@ public final class AnyExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private Object any;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -88,7 +87,6 @@ public final class AnyMapExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private Map<String, Object> items = new LinkedHashMap<>();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -79,7 +78,6 @@ public final class BearerTokenExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private BearerToken bearerTokenValue;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -78,7 +77,6 @@ public final class BinaryExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private Bytes binary;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -53,7 +52,6 @@ public final class BooleanExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private boolean coin;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -100,7 +99,6 @@ public final class CovariantListExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private List<Object> items = new ArrayList<>();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -101,7 +100,6 @@ public final class CovariantOptionalExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private Optional<Object> item = Optional.empty();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -86,7 +85,6 @@ public final class DateTimeExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private OffsetDateTime datetime;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -52,7 +51,6 @@ public final class DoubleExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private double doubleValue;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -78,7 +77,6 @@ public final class EnumFieldExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private EnumExample enum_;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -125,7 +124,6 @@ public final class ExternalLongExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private long externalLong;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -53,7 +52,6 @@ public final class IntegerExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private int integer;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -120,7 +119,6 @@ public final class ListExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private List<String> items = new ArrayList<>();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -204,7 +203,6 @@ public final class ManyFieldExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private String string;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -88,7 +87,6 @@ public final class MapExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private Map<String, String> items = new LinkedHashMap<>();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -80,7 +79,6 @@ public final class OptionalExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private Optional<String> item = Optional.empty();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -186,7 +185,6 @@ public final class PrimitiveOptionalsExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private OptionalDouble num = OptionalDouble.empty();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -155,7 +154,6 @@ public final class ReservedKeyExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private String package_;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -78,7 +77,6 @@ public final class RidExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private ResourceIdentifier ridValue;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -79,7 +78,6 @@ public final class SafeLongExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private SafeLong safeLongValue;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -98,7 +97,6 @@ public final class SetExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private Set<String> items = new LinkedHashSet<>();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -77,7 +76,6 @@ public final class StringExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private String string;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
@@ -1,6 +1,5 @@
 package com.palantir.product;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -78,7 +77,6 @@ public final class UuidExample {
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
         private UUID uuid;
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/FeatureFlags.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/FeatureFlags.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java;
 import com.google.common.annotations.Beta;
 import com.palantir.conjure.java.services.JerseyServiceGenerator;
 import com.palantir.conjure.java.services.Retrofit2ServiceGenerator;
+import com.palantir.conjure.java.types.ObjectGenerator;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.Response;
 
@@ -75,4 +76,10 @@ public enum FeatureFlags {
      */
     @Beta
     ExperimentalUndertowAsyncMarkers,
+
+    /**
+     * Instructs the {@link ObjectGenerator} to not generate objects that fail to deserialize if unknown fields
+     * are encountered.
+     */
+    StrictObjects,
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -104,11 +104,13 @@ public final class BeanBuilderGenerator {
                 .addMethod(createFromObject(enrichedFields))
                 .addMethods(createSetters(enrichedFields))
                 .addMethods(maybeCreateValidateFieldsMethods(enrichedFields))
-                .addMethod(createBuild(enrichedFields, poetFields))
-                .addAnnotation(
-                        AnnotationSpec.builder(JsonIgnoreProperties.class)
-                                .addMember("ignoreUnknown", "$L", true)
-                                .build());
+                .addMethod(createBuild(enrichedFields, poetFields));
+
+        if (!featureFlags.contains(FeatureFlags.StrictObjects)) {
+            builder.addAnnotation(AnnotationSpec.builder(JsonIgnoreProperties.class)
+                    .addMember("ignoreUnknown", "$L", true)
+                    .build());
+        }
 
         return builder.build();
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ObjectGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ObjectGenerator.java
@@ -43,8 +43,7 @@ public final class ObjectGenerator implements TypeGenerator {
                 return BeanGenerator.generateBeanType(typeMapper,
                         typeDef.accept(TypeDefinitionVisitor.OBJECT), featureFlags);
             } else if (typeDef.accept(TypeDefinitionVisitor.IS_UNION)) {
-                return UnionGenerator.generateUnionType(
-                        typeMapper, typeDef.accept(TypeDefinitionVisitor.UNION), featureFlags);
+                return UnionGenerator.generateUnionType(typeMapper, typeDef.accept(TypeDefinitionVisitor.UNION));
             } else if (typeDef.accept(TypeDefinitionVisitor.IS_ENUM)) {
                 return EnumGenerator.generateEnumType(
                         typeDef.accept(TypeDefinitionVisitor.ENUM));

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ObjectGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ObjectGenerator.java
@@ -44,7 +44,7 @@ public final class ObjectGenerator implements TypeGenerator {
                         typeDef.accept(TypeDefinitionVisitor.OBJECT), featureFlags);
             } else if (typeDef.accept(TypeDefinitionVisitor.IS_UNION)) {
                 return UnionGenerator.generateUnionType(
-                        typeMapper, typeDef.accept(TypeDefinitionVisitor.UNION));
+                        typeMapper, typeDef.accept(TypeDefinitionVisitor.UNION), featureFlags);
             } else if (typeDef.accept(TypeDefinitionVisitor.IS_ENUM)) {
                 return EnumGenerator.generateEnumType(
                         typeDef.accept(TypeDefinitionVisitor.ENUM));

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -29,7 +29,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.PeekingIterator;
 import com.palantir.conjure.java.ConjureAnnotations;
-import com.palantir.conjure.java.FeatureFlags;
 import com.palantir.conjure.java.util.JavaNameSanitizer;
 import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.java.util.StableCollectors;

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/BeanSerdeIntegrationTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/BeanSerdeIntegrationTests.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.google.common.collect.Iterables;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.product.BearerTokenExample;
@@ -69,8 +70,11 @@ public final class BeanSerdeIntegrationTests {
 
     @Test
     public void testIgnoreProperties() throws Exception {
+        assertThatThrownBy(() -> mapper.readValue("{\"coin\": true, \"ignored\": \"field\"}", BooleanExample.class))
+            .isInstanceOf(UnrecognizedPropertyException.class);
         // Important for ensuring additive changes don't affect clients adversely
-        BooleanExample boolExample = mapper.readValue("{\"coin\": true, \"ignored\": \"field\"}", BooleanExample.class);
+        BooleanExample boolExample = ObjectMappers.newClientObjectMapper()
+                .readValue("{\"coin\": true, \"ignored\": \"field\"}", BooleanExample.class);
         assertThat(boolExample.getCoin()).isTrue();
     }
 

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/NullFieldWireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/NullFieldWireFormatTests.java
@@ -83,10 +83,9 @@ public class NullFieldWireFormatTests {
 
     @Test
     public void null_double_field_should_throw() {
-        assertThatLoggableExceptionThrownBy(() -> mapper.readValue("{\"double\":null}", DoubleExample.class))
-                .isInstanceOf(SafeIllegalArgumentException.class)
-                .hasMessageContaining("Some required fields have not been set")
-                .hasExactlyArgs(SafeArg.of("missingFields", ImmutableList.of("doubleValue")));
+        assertThatThrownBy(() -> mapper.readValue("{\"doubleValue\":null}", DoubleExample.class))
+                .isInstanceOf(JsonMappingException.class)
+                .hasMessageContaining("Cannot map `null` into type double");
     }
 
     @Test
@@ -103,9 +102,9 @@ public class NullFieldWireFormatTests {
 
     @Test
     public void null_collection_fields_should_deserialize_as_empty() throws Exception {
-        assertThat(mapper.readValue("{\"foo\":null}", SetExample.class).getItems()).isEmpty();
-        assertThat(mapper.readValue("{\"foo\":null}", ListExample.class).getItems()).isEmpty();
-        assertThat(mapper.readValue("{\"foo\":null}", MapExample.class).getItems()).isEmpty();
+        assertThat(mapper.readValue("{\"items\":null}", SetExample.class).getItems()).isEmpty();
+        assertThat(mapper.readValue("{\"items\":null}", ListExample.class).getItems()).isEmpty();
+        assertThat(mapper.readValue("{\"items\":null}", MapExample.class).getItems()).isEmpty();
     }
 
     @Test

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/NullFieldWireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/NullFieldWireFormatTests.java
@@ -4,16 +4,12 @@
 
 package com.palantir.conjure.java.types;
 
-import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.serialization.ObjectMappers;
-import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.product.AnyExample;
 import com.palantir.product.BearerTokenExample;
 import com.palantir.product.BinaryExample;

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
@@ -7,8 +7,10 @@ package com.palantir.conjure.java.types;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.palantir.conjure.defs.Conjure;
 import com.palantir.conjure.java.FeatureFlags;
+import com.palantir.conjure.java.TestBase;
 import com.palantir.conjure.spec.ConjureDefinition;
 import java.io.File;
 import java.io.IOException;
@@ -32,8 +34,8 @@ public final class ObjectGeneratorTests {
     public void testObjectGenerator_allExamples() throws IOException {
         ConjureDefinition def = Conjure.parse(
                 ImmutableList.of(new File("src/test/resources/example-types.yml")));
-        List<Path> files = new ObjectGenerator(Collections.singleton(FeatureFlags.UseImmutableBytes))
-                .emit(def, tempDir);
+        List<Path> files = new ObjectGenerator(
+                ImmutableSet.of(FeatureFlags.UseImmutableBytes, FeatureFlags.StrictObjects)).emit(def, tempDir);
 
         assertThatFilesAreTheSame(files, REFERENCE_FILES_FOLDER);
     }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
@@ -10,7 +10,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.conjure.defs.Conjure;
 import com.palantir.conjure.java.FeatureFlags;
-import com.palantir.conjure.java.TestBase;
 import com.palantir.conjure.spec.ConjureDefinition;
 import java.io.File;
 import java.io.IOException;

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -196,7 +196,7 @@ public final class WireFormatTests {
 
     @Test
     public void testIgnoreUnknownValuesDuringDeserialization() throws Exception {
-        assertThat(mapper.readValue("{\"fake\": \"fake\"}", OptionalExample.class))
+        assertThat(ObjectMappers.newClientObjectMapper().readValue("{\"fake\": \"fake\"}", OptionalExample.class))
                 .isEqualTo(OptionalExample.builder().build());
     }
 


### PR DESCRIPTION
## Before this PR
We generated bean builders with `@JsonIgnoreProperties(ignoreUnknown = true)` which caused jackson to always leniently deserialize beans, even when using the server object mapper

## After this PR
==COMMIT_MSG==
Add `StrictObjects` feature flag to generate objects that will fail to deserialize unknown properties. Users will still be able to ignore unknown properties by configuring their object mapper to do so
==COMMIT_MSG==

## Possible downsides?
N/A. This moves us towards the world where servers are actually strict

