### PR TITLE
add strictObjects flag to CLI

### DIFF
--- a/changelog/@unreleased/pr-645.v2.yml
+++ b/changelog/@unreleased/pr-645.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Conjure-Java CLI correctly supports the `strictObjects` feature flag
+  links:
+  - https://github.com/palantir/conjure-java/pull/645

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/CliConfiguration.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/CliConfiguration.java
@@ -105,5 +105,9 @@ public abstract class CliConfiguration {
         Builder experimentalUndertowAsyncMarkers(boolean flag) {
             return flag ? addFeatureFlags(FeatureFlags.ExperimentalUndertowAsyncMarkers) : this;
         }
+
+        Builder strictObjects(boolean flag) {
+            return flag ? addFeatureFlags(FeatureFlags.StrictObjects) : this;
+        }
     }
 }

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -122,6 +122,11 @@ public final class ConjureJavaCli implements Runnable {
                         + "processing")
         private boolean undertowListenableFutures;
 
+        @CommandLine.Option(names = "--strictObjects",
+                defaultValue = "false",
+                description = "Generate POJOs that by default will fail to deserialize unknown fields")
+        private boolean strictObjects;
+
         @Beta
         @CommandLine.Option(
                 names = "--experimentalUndertowAsyncMarkers",
@@ -188,6 +193,7 @@ public final class ConjureJavaCli implements Runnable {
                     .useImmutableBytes(useImmutableBytes)
                     .undertowListenableFutures(undertowListenableFutures)
                     .experimentalUndertowAsyncMarkers(experimentalUndertowAsyncMarkers)
+                    .strictObjects(strictObjects)
                     .build();
         }
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
Conjure-Java CLI correctly supports the `strictObjects` feature flag
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

