### PR TITLE
conjure-undertow non-service-exceptions are no longer wrapped

### DIFF
--- a/changelog/@unreleased/pr-683.v2.yml
+++ b/changelog/@unreleased/pr-683.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: conjure-undertow non-service-exceptions are no longer wrapped
+  links:
+  - https://github.com/palantir/conjure-java/pull/683


### PR DESCRIPTION
This produces cleaner stack traces without synthetic top-level
ServiceExceptions.

## Before this PR
```
com.palantir.conjure.java.api.errors.ServiceException: ServiceException: INVALID_ARGUMENT (Default:InvalidArgument)
        at com.palantir.conjure.java.undertow.runtime.ConjureExceptions.illegalArgumentException(ConjureExceptions.java:153)
        at com.palantir.conjure.java.undertow.runtime.ConjureExceptions.handle(ConjureExceptions.java:64)
        at com.palantir.conjure.java.undertow.runtime.ConjureExceptionHandler.handleRequest(ConjureExceptionHandler.java:49)
        at com.palantir.tracing.undertow.TracedOperationHandler.handleRequest(TracedOperationHandler.java:69)
        at com.palantir.conjure.java.undertow.runtime.LoggingContextHandler.handleRequest(LoggingContextHandler.java:40)
        at io.undertow.server.Connectors.executeRootHandler(Connectors.java:376)
        at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:830)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: com.palantir.logsafe.exceptions.SafeIllegalArgumentException: cannot deserialize a JSON null value
        at com.palantir.logsafe.Preconditions.checkArgument(Preconditions.java:52)
        at com.palantir.conjure.java.undertow.runtime.Encodings$AbstractJacksonEncoding.lambda$deserializer$1(Encodings.java:66)
        at com.palantir.conjure.java.undertow.runtime.TracedEncoding$TracedDeserializer.deserialize(TracedEncoding.java:108)
        at com.palantir.conjure.java.undertow.runtime.ConjureBodySerDe$EncodingDeserializerRegistry.deserializeInternal(ConjureBodySerDe.java:184)
        at com.palantir.conjure.java.undertow.runtime.ConjureBodySerDe$EncodingDeserializerRegistry.deserialize(ConjureBodySerDe.java:165)
        at com.palantir.product.EteServiceEndpoints$NotNullBodyEndpoint.handleRequest(EteServiceEndpoints.java:764)
        at com.palantir.conjure.java.undertow.runtime.ConjureExceptionHandler.handleRequest(ConjureExceptionHandler.java:47)
        ... 7 common frames omitted
```

## After this PR
```
14:17:31.197 [XNIO-1 task-1] INFO com.palantir.conjure.java.undertow.runtime.ConjureExceptions - Error handling request
com.palantir.logsafe.exceptions.SafeIllegalArgumentException: cannot deserialize a JSON null value
        at com.palantir.logsafe.Preconditions.checkArgument(Preconditions.java:52)
        at com.palantir.conjure.java.undertow.runtime.Encodings$AbstractJacksonEncoding.lambda$deserializer$1(Encodings.java:66)
        at com.palantir.conjure.java.undertow.runtime.TracedEncoding$TracedDeserializer.deserialize(TracedEncoding.java:108)
        at com.palantir.conjure.java.undertow.runtime.ConjureBodySerDe$EncodingDeserializerRegistry.deserializeInternal(ConjureBodySerDe.java:184)
        at com.palantir.conjure.java.undertow.runtime.ConjureBodySerDe$EncodingDeserializerRegistry.deserialize(ConjureBodySerDe.java:165)
        at com.palantir.product.EteServiceEndpoints$NotNullBodyEndpoint.handleRequest(EteServiceEndpoints.java:764)
        at com.palantir.conjure.java.undertow.runtime.ConjureExceptionHandler.handleRequest(ConjureExceptionHandler.java:47)
        at com.palantir.tracing.undertow.TracedOperationHandler.handleRequest(TracedOperationHandler.java:69)
        at com.palantir.conjure.java.undertow.runtime.LoggingContextHandler.handleRequest(LoggingContextHandler.java:40)
        at io.undertow.server.Connectors.executeRootHandler(Connectors.java:376)
        at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:830)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```

==COMMIT_MSG==
conjure-undertow non-service-exceptions are no longer wrapped
==COMMIT_MSG==

## Possible downsides?
It's possible the ServiceException may be updated to produce additional information that we don't immediately add as an argument to the log line.

