### PR TITLE
Fix Content-Type comparison to be case-insensitive

### DIFF
--- a/changelog/@unreleased/pr-686.v2.yml
+++ b/changelog/@unreleased/pr-686.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Undertow endpoints now perform a case-insensitive comparison when checking
+    the request `Content-Type` header.
+  links:
+  - https://github.com/palantir/conjure-java/pull/686

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encoding.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encoding.java
@@ -48,9 +48,9 @@ public interface Encoding {
 
     /**
      * Checks if a <pre>Content-Type</pre> or <pre>Accept</pre> value is supported by this encoding. This is not an
-     * exact match on {@link #getContentType()} because values may contain additional metadata, for
-     * example <pre>Content-Type: application/json; charset=utf-8</pre> may be supported by an {@link Encoding}
-     * which returns <pre>application/json</pre> from {@link #getContentType()}.
+     * exact match on {@link #getContentType()} because values are case-insensitive and may contain additional
+     * metadata, for example <pre>Content-Type: application/json; charset=utf-8</pre> may be supported by an
+     * {@link Encoding} which returns <pre>application/json</pre> from {@link #getContentType()}.
      */
     boolean supportsContentType(String contentType);
 

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encoding.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encoding.java
@@ -48,9 +48,10 @@ public interface Encoding {
 
     /**
      * Checks if a <pre>Content-Type</pre> or <pre>Accept</pre> value is supported by this encoding. This is not an
-     * exact match on {@link #getContentType()} because values are case-insensitive and may contain additional
-     * metadata, for example <pre>Content-Type: application/json; charset=utf-8</pre> may be supported by an
-     * {@link Encoding} which returns <pre>application/json</pre> from {@link #getContentType()}.
+     * exact match on {@link #getContentType()} because values are case-insensitive, see
+     * <a href="https://tools.ietf.org/html/rfc7231#section-3.1.1.1">RFC 7231</a>, and may contain additional metadata,
+     * for example <pre>Content-Type: application/json; charset=utf-8</pre> may be supported by an {@link Encoding}
+     * which returns <pre>application/json</pre> from {@link #getContentType()}.
      */
     boolean supportsContentType(String contentType);
 

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encodings.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encodings.java
@@ -31,6 +31,7 @@ import com.palantir.logsafe.exceptions.SafeIoException;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Locale;
 
 // TODO(rfink): Consider async Jackson, see
 //              https://github.com/spring-projects/spring-framework/commit/31e0e537500c0763a36d3af2570d5c253a374690
@@ -102,7 +103,7 @@ public final class Encodings {
                 // TODO(ckozak): support wildcards? See javax.ws.rs.core.MediaType.isCompatible
                 return contentType != null
                         // Use startsWith to avoid failures due to charset
-                        && contentType.startsWith(CONTENT_TYPE);
+                        && contentType.toLowerCase(Locale.ROOT).startsWith(CONTENT_TYPE);
             }
         };
     }
@@ -119,7 +120,8 @@ public final class Encodings {
 
             @Override
             public boolean supportsContentType(String contentType) {
-                return contentType != null && contentType.startsWith(CONTENT_TYPE);
+                return contentType != null
+                        && contentType.toLowerCase(Locale.ROOT).startsWith(CONTENT_TYPE);
             }
 
             @Override

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/EncodingsTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/EncodingsTest.java
@@ -42,8 +42,19 @@ import org.junit.jupiter.api.Test;
 final class EncodingsTest {
 
     private final Encoding json = Encodings.json();
+    private final Encoding cbor = Encodings.cbor();
 
     // TODO(rfink): Wire tests for JSON serializer
+
+    @Test
+    void json_supportsContentType() {
+        assertThat(json.supportsContentType("application/json")).isTrue();
+        assertThat(json.supportsContentType("application/json; charset=utf-8")).isTrue();
+        assertThat(json.supportsContentType("Application/json")).isTrue();
+        assertThat(json.supportsContentType("application/Json")).isTrue();
+
+        assertThat(json.supportsContentType("application/unknown")).isFalse();
+    }
 
     @Test
     void json_deserialize_throwsDeserializationErrorsAsIllegalArgumentException() {
@@ -140,6 +151,16 @@ final class EncodingsTest {
         OutputStream outputStream = mock(OutputStream.class);
         serialize("test", outputStream);
         verify(outputStream, never()).close();
+    }
+
+    @Test
+    void cbor_supportsContentType() {
+        assertThat(cbor.supportsContentType("application/cbor")).isTrue();
+        assertThat(cbor.supportsContentType("application/cbor; charset=utf-8")).isTrue();
+        assertThat(cbor.supportsContentType("Application/cbor")).isTrue();
+        assertThat(cbor.supportsContentType("application/Cbor")).isTrue();
+
+        assertThat(cbor.supportsContentType("application/unknown")).isFalse();
     }
 
     private static InputStream asStream(String data) {


### PR DESCRIPTION
## Before this PR
The request `Content-Type` header comparison is case-sensitive. This results in errors when clients make request with `Content-Type` headers like `Application/json; charset=utf-8`.

## After this PR
The request `Content-Type` header comparison is case-insensitive. The HTTP spec states that media types values are case-insensitive:
https://tools.ietf.org/html/rfc7231#section-3.1.1.1

