### PR TITLE
Indicate endpoint deprecation with a pseudo-standard header

### DIFF
--- a/changelog/@unreleased/pr-714.v2.yml
+++ b/changelog/@unreleased/pr-714.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Clients may discover endpoint deprecation by observing return headers.
+  links:
+  - https://github.com/palantir/conjure-java/pull/714

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureHandler.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureHandler.java
@@ -159,7 +159,9 @@ public final class ConjureHandler implements HttpHandler {
                                             // Only applies to GET methods
                                             ? Optional.of(new NoCachingResponseHandler(endpoint.handler()))
                                             : Optional.empty(),
-                            endpoint -> Optional.of(new WebSecurityHandler(endpoint.handler())))
+                            endpoint -> Optional.of(new WebSecurityHandler(endpoint.handler())),
+                            endpoint -> endpoint.deprecated()
+                                    .map(reason -> new DeprecationReportingResponseHandler(endpoint.handler())))
                     // Apply custom non-blocking handlers just before the BlockingHandler
                     .addAll(wrappersJustBeforeBlocking)
                     // It is vitally important to never run blocking operations on the initial IO thread otherwise

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/DeprecationReportingResponseHandler.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/DeprecationReportingResponseHandler.java
@@ -1,0 +1,44 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+
+/**
+ * Adds HTTP response headers to indicate endpoint deprecation.
+ *
+ * <p>https://tools.ietf.org/id/draft-dalal-deprecation-header-01.html#rfc.section.2.1
+ */
+final class DeprecationReportingResponseHandler implements HttpHandler {
+
+    private static final HttpString DEPRECATION = HttpString.tryFromString("deprecation");
+    private static final String IS_DEPRECATED = "true";
+
+    private final HttpHandler next;
+
+    DeprecationReportingResponseHandler(HttpHandler next) {
+        this.next = next;
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws Exception {
+        exchange.getResponseHeaders().put(DEPRECATION, IS_DEPRECATED);
+        next.handleRequest(exchange);
+    }
+}


### PR DESCRIPTION
## Before this PR
Clients only know about endpoint deprecation by taking API upgrades.

## After this PR
==COMMIT_MSG==
Clients may discover endpoint deprecation by observing return headers.
==COMMIT_MSG==

This unblocks our ability to localize deprecation warnings to the places where deprecated
endpoints are invoked.

## Possible downsides
None known.