### PR TITLE
Remove workaround for CBOR closing streams

### DIFF
--- a/changelog/@unreleased/pr-727.v2.yml
+++ b/changelog/@unreleased/pr-727.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Remove workaround for CBOR closing streams
+  links:
+  - https://github.com/palantir/conjure-java/pull/727
+  - https://github.com/FasterXML/jackson-dataformats-binary/issues/155

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encodings.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encodings.java
@@ -28,9 +28,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.exceptions.SafeIoException;
-import java.io.FilterOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 
 // TODO(rfink): Consider async Jackson, see
 //              https://github.com/spring-projects/spring-framework/commit/31e0e537500c0763a36d3af2570d5c253a374690
@@ -69,7 +67,7 @@ public final class Encodings {
         }
 
         @Override
-        public <T> Serializer<T> serializer(TypeMarker<T> type) {
+        public final <T> Serializer<T> serializer(TypeMarker<T> type) {
             ObjectWriter writer = mapper.writerFor(mapper.constructType(type.getType()));
             return (value, output) -> {
                 Preconditions.checkNotNull(value, "cannot serialize null value");
@@ -78,7 +76,7 @@ public final class Encodings {
         }
 
         @Override
-        public <T> Deserializer<T> deserializer(TypeMarker<T> type) {
+        public final <T> Deserializer<T> deserializer(TypeMarker<T> type) {
             ObjectReader reader = mapper.readerFor(mapper.constructType(type.getType()));
             return input -> {
                 try {
@@ -134,12 +132,6 @@ public final class Encodings {
             public String getContentType() {
                 return CONTENT_TYPE;
             }
-
-            @Override
-            public <T> Serializer<T> serializer(TypeMarker<T> type) {
-                Serializer<T> delegate = super.serializer(type);
-                return (value, output) -> delegate.serialize(value, new ShieldingOutputStream(output));
-            }
         };
     }
 
@@ -148,25 +140,5 @@ public final class Encodings {
         return mapper.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET)
                 // Avoid flushing, allowing us to set content-length if the length is below the buffer size.
                 .disable(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM);
-    }
-
-    /**
-     * Work around a CBORGenerator bug. For more information:
-     * https://github.com/FasterXML/jackson-dataformats-binary/issues/155
-     */
-    private static final class ShieldingOutputStream extends FilterOutputStream {
-        ShieldingOutputStream(OutputStream out) {
-            super(out);
-        }
-
-        @Override
-        public void flush() {
-            // nop
-        }
-
-        @Override
-        public void close() {
-            // nop
-        }
     }
 }


### PR DESCRIPTION
https://github.com/FasterXML/jackson-dataformats-binary/issues/155 was fixed in 2.10.

## After this PR
==COMMIT_MSG==
Remove workaround for CBOR closing streams
==COMMIT_MSG==

