### PR TITLE
Fix empty unions

### DIFF
--- a/changelog/@unreleased/pr-733.v2.yml
+++ b/changelog/@unreleased/pr-733.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Defining an empty union no longer causes conjure-java to crash.
+  links:
+  - https://github.com/palantir/conjure-java/pull/733

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
@@ -1,0 +1,164 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.types.UnionGenerator")
+public final class EmptyUnionTypeExample {
+    private final Base value;
+
+    @JsonCreator
+    private EmptyUnionTypeExample(Base value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    private Base getValue() {
+        return value;
+    }
+
+    public <T> T accept(Visitor<T> visitor) {
+        if (value instanceof UnknownWrapper) {
+            return visitor.visitUnknown(((UnknownWrapper) value).getType());
+        }
+        throw new IllegalStateException(
+                String.format("Could not identify type %s", value.getClass()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof EmptyUnionTypeExample
+                        && equalTo((EmptyUnionTypeExample) other));
+    }
+
+    private boolean equalTo(EmptyUnionTypeExample other) {
+        return this.value.equals(other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.value);
+    }
+
+    @Override
+    public String toString() {
+        return "EmptyUnionTypeExample{value: " + value + '}';
+    }
+
+    public interface Visitor<T> {
+        T visitUnknown(String unknownType);
+
+        static <T> UnknownStageVisitorBuilder<T> builder() {
+            return new VisitorBuilder<T>();
+        }
+    }
+
+    private static final class VisitorBuilder<T>
+            implements UnknownStageVisitorBuilder<T>, CompletedStageVisitorBuilder<T> {
+        private Function<String, T> unknownVisitor;
+
+        @Override
+        public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
+            Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
+            this.unknownVisitor = unknownVisitor;
+            return this;
+        }
+
+        @Override
+        public Visitor<T> build() {
+            final Function<String, T> unknownVisitor = this.unknownVisitor;
+            return new Visitor<T>() {
+                @Override
+                public T visitUnknown(String value) {
+                    return unknownVisitor.apply(value);
+                }
+            };
+        }
+    }
+
+    public interface UnknownStageVisitorBuilder<T> {
+        CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor);
+    }
+
+    public interface CompletedStageVisitorBuilder<T> {
+        Visitor<T> build();
+    }
+
+    @JsonTypeInfo(
+            use = JsonTypeInfo.Id.NAME,
+            property = "type",
+            visible = true,
+            defaultImpl = UnknownWrapper.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private interface Base {}
+
+    @JsonTypeInfo(
+            use = JsonTypeInfo.Id.NAME,
+            include = JsonTypeInfo.As.EXISTING_PROPERTY,
+            property = "type",
+            visible = true)
+    private static final class UnknownWrapper implements Base {
+        private final String type;
+
+        private final Map<String, Object> value;
+
+        @JsonCreator
+        private UnknownWrapper(@JsonProperty("type") String type) {
+            this(type, new HashMap<String, Object>());
+        }
+
+        private UnknownWrapper(String type, Map<String, Object> value) {
+            Preconditions.checkNotNull(type, "type cannot be null");
+            Preconditions.checkNotNull(value, "value cannot be null");
+            this.type = type;
+            this.value = value;
+        }
+
+        @JsonProperty
+        private String getType() {
+            return type;
+        }
+
+        @JsonAnyGetter
+        private Map<String, Object> getValue() {
+            return value;
+        }
+
+        @JsonAnySetter
+        private void put(String key, Object val) {
+            value.put(key, val);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other
+                    || (other instanceof UnknownWrapper && equalTo((UnknownWrapper) other));
+        }
+
+        private boolean equalTo(UnknownWrapper other) {
+            return this.type.equals(other.type) && this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.type, this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "UnknownWrapper{type: " + type + ", value: " + value + '}';
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
@@ -1,0 +1,164 @@
+package test.prefix.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.types.UnionGenerator")
+public final class EmptyUnionTypeExample {
+    private final Base value;
+
+    @JsonCreator
+    private EmptyUnionTypeExample(Base value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    private Base getValue() {
+        return value;
+    }
+
+    public <T> T accept(Visitor<T> visitor) {
+        if (value instanceof UnknownWrapper) {
+            return visitor.visitUnknown(((UnknownWrapper) value).getType());
+        }
+        throw new IllegalStateException(
+                String.format("Could not identify type %s", value.getClass()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof EmptyUnionTypeExample
+                        && equalTo((EmptyUnionTypeExample) other));
+    }
+
+    private boolean equalTo(EmptyUnionTypeExample other) {
+        return this.value.equals(other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.value);
+    }
+
+    @Override
+    public String toString() {
+        return "EmptyUnionTypeExample{value: " + value + '}';
+    }
+
+    public interface Visitor<T> {
+        T visitUnknown(String unknownType);
+
+        static <T> UnknownStageVisitorBuilder<T> builder() {
+            return new VisitorBuilder<T>();
+        }
+    }
+
+    private static final class VisitorBuilder<T>
+            implements UnknownStageVisitorBuilder<T>, CompletedStageVisitorBuilder<T> {
+        private Function<String, T> unknownVisitor;
+
+        @Override
+        public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
+            Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
+            this.unknownVisitor = unknownVisitor;
+            return this;
+        }
+
+        @Override
+        public Visitor<T> build() {
+            final Function<String, T> unknownVisitor = this.unknownVisitor;
+            return new Visitor<T>() {
+                @Override
+                public T visitUnknown(String value) {
+                    return unknownVisitor.apply(value);
+                }
+            };
+        }
+    }
+
+    public interface UnknownStageVisitorBuilder<T> {
+        CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor);
+    }
+
+    public interface CompletedStageVisitorBuilder<T> {
+        Visitor<T> build();
+    }
+
+    @JsonTypeInfo(
+            use = JsonTypeInfo.Id.NAME,
+            property = "type",
+            visible = true,
+            defaultImpl = UnknownWrapper.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private interface Base {}
+
+    @JsonTypeInfo(
+            use = JsonTypeInfo.Id.NAME,
+            include = JsonTypeInfo.As.EXISTING_PROPERTY,
+            property = "type",
+            visible = true)
+    private static final class UnknownWrapper implements Base {
+        private final String type;
+
+        private final Map<String, Object> value;
+
+        @JsonCreator
+        private UnknownWrapper(@JsonProperty("type") String type) {
+            this(type, new HashMap<String, Object>());
+        }
+
+        private UnknownWrapper(String type, Map<String, Object> value) {
+            Preconditions.checkNotNull(type, "type cannot be null");
+            Preconditions.checkNotNull(value, "value cannot be null");
+            this.type = type;
+            this.value = value;
+        }
+
+        @JsonProperty
+        private String getType() {
+            return type;
+        }
+
+        @JsonAnyGetter
+        private Map<String, Object> getValue() {
+            return value;
+        }
+
+        @JsonAnySetter
+        private void put(String key, Object val) {
+            value.put(key, val);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other
+                    || (other instanceof UnknownWrapper && equalTo((UnknownWrapper) other));
+        }
+
+        private boolean equalTo(UnknownWrapper other) {
+            return this.type.equals(other.type) && this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.type, this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "UnknownWrapper{type: " + type + ", value: " + value + '}';
+        }
+    }
+}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -204,7 +204,12 @@ public final class UnionGenerator {
                     VALUE_FIELD_NAME);
         }
         ClassName unknownWrapperClass = visitorClass.peerClass(UNKNOWN_WRAPPER_CLASS_NAME);
-        codeBuilder.nextControlFlow("else if ($L instanceof $T)", VALUE_FIELD_NAME, unknownWrapperClass);
+        CodeBlock ifStatement = CodeBlock.of("if ($L instanceof $T)", VALUE_FIELD_NAME, unknownWrapperClass);
+        if (beginControlFlow) {
+            codeBuilder.beginControlFlow("$L", ifStatement);
+        } else {
+            codeBuilder.nextControlFlow("else $L", ifStatement);
+        }
         codeBuilder.addStatement(
                 "return $N.$L((($T) $L).getType())",
                 visitor,
@@ -520,17 +525,19 @@ public final class UnionGenerator {
                         .addMember("visible", "$L", true)
                         .addMember("defaultImpl", "$T.class", unknownWrapperClass)
                         .build());
-        List<AnnotationSpec> subAnnotations = memberTypes.entrySet().stream()
-                .map(entry -> AnnotationSpec.builder(JsonSubTypes.Type.class)
-                        .addMember(
-                                "value",
-                                "$T.class",
-                                peerWrapperClass(baseClass, entry.getKey().getFieldName()))
-                        .build())
-                .collect(Collectors.toList());
-        AnnotationSpec.Builder annotationBuilder = AnnotationSpec.builder(JsonSubTypes.class);
-        subAnnotations.forEach(subAnnotation -> annotationBuilder.addMember("value", "$L", subAnnotation));
-        baseBuilder.addAnnotation(annotationBuilder.build());
+        if (!memberTypes.isEmpty()) {
+            List<AnnotationSpec> subAnnotations = memberTypes.entrySet().stream()
+                    .map(entry -> AnnotationSpec.builder(JsonSubTypes.Type.class)
+                            .addMember(
+                                    "value",
+                                    "$T.class",
+                                    peerWrapperClass(baseClass, entry.getKey().getFieldName()))
+                            .build())
+                    .collect(Collectors.toList());
+            AnnotationSpec.Builder annotationBuilder = AnnotationSpec.builder(JsonSubTypes.class);
+            subAnnotations.forEach(subAnnotation -> annotationBuilder.addMember("value", "$L", subAnnotation));
+            baseBuilder.addAnnotation(annotationBuilder.build());
+        }
         baseBuilder.addAnnotation(AnnotationSpec.builder(JsonIgnoreProperties.class)
                 .addMember("ignoreUnknown", "$L", true)
                 .build());

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -176,6 +176,8 @@ types:
           if: integer # some 'bad' member names!
           new: integer
           interface: integer
+      EmptyUnionTypeExample:
+        union: {}
       EmptyObjectExample:
         fields: {}
       AliasAsMapKeyExample:


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
If you try to define an empty union, the java codegen crashes.

## After this PR
==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
Empty unions are generated as expected. This is not especially useful on its own, but can be valuable when the union will actually contain values in a later version of the api and you want to force clients to implement reasonable ways of handling the unknown case.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

