### PR TITLE
dialogue properly supports optionalInt and optionalDouble

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ apply plugin: 'com.palantir.consistent-versions'
 
 allprojects {
     apply plugin: 'com.palantir.java-format'
-    version gitVersion()
+    version System.env.CIRCLE_TAG ?: gitVersion()
     group 'com.palantir.conjure.java'
 
     repositories {

--- a/changelog/@unreleased/pr-763.v2.yml
+++ b/changelog/@unreleased/pr-763.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Dialogue properly supports `optional<integer>` and `optional<double>`
+    parameters
+  links:
+  - https://github.com/palantir/conjure-java/pull/763

--- a/conjure-java-core/src/test/resources/test/api/DialogueTestService.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/DialogueTestService.java.dialogue
@@ -1313,11 +1313,11 @@ public final class DialogueTestService {
                         plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 if (maybeInteger.isPresent()) {
                     _request.putQueryParams(
-                            "maybeInteger", plainSerDe.serializeInteger(maybeInteger.get()));
+                            "maybeInteger", plainSerDe.serializeInteger(maybeInteger.getAsInt()));
                 }
                 if (maybeDouble.isPresent()) {
                     _request.putQueryParams(
-                            "maybeDouble", plainSerDe.serializeDouble(maybeDouble.get()));
+                            "maybeDouble", plainSerDe.serializeDouble(maybeDouble.getAsDouble()));
                 }
                 return Futures.transform(
                         channel.execute(

--- a/conjure-java-core/src/test/resources/test/api/DialogueTestService.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/DialogueTestService.java.dialogue.prefix
@@ -1313,11 +1313,11 @@ public final class DialogueTestService {
                         plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 if (maybeInteger.isPresent()) {
                     _request.putQueryParams(
-                            "maybeInteger", plainSerDe.serializeInteger(maybeInteger.get()));
+                            "maybeInteger", plainSerDe.serializeInteger(maybeInteger.getAsInt()));
                 }
                 if (maybeDouble.isPresent()) {
                     _request.putQueryParams(
-                            "maybeDouble", plainSerDe.serializeDouble(maybeDouble.get()));
+                            "maybeDouble", plainSerDe.serializeDouble(maybeDouble.getAsDouble()));
                 }
                 return Futures.transform(
                         channel.execute(


### PR DESCRIPTION
## Before this PR
We generated invalid code for parameters of type `optional<integer>` and `optional<double>`

## After this PR
==COMMIT_MSG==
Dialogue properly supports `optional<integer>` and `optional<double>` parameters
==COMMIT_MSG==

## Possible downsides?
N/A

