### PR TITLE
On enum, generate values() similar to java enums.

### DIFF
--- a/changelog/@unreleased/pr-768.v2.yml
+++ b/changelog/@unreleased/pr-768.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: On enum, generate values() similar to java enums, which returns a list
+    containing all possible valid values.
+  links:
+  - https://github.com/palantir/conjure-java/pull/768

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -3,6 +3,9 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -34,6 +37,9 @@ public final class EnumExample {
      */
     @Deprecated
     public static final EnumExample ONE_HUNDRED = new EnumExample(Value.ONE_HUNDRED, "ONE_HUNDRED");
+
+    private static final List<EnumExample> values =
+            Collections.unmodifiableList(Arrays.asList(ONE, TWO, ONE_HUNDRED));
 
     private final Value value;
 
@@ -95,6 +101,10 @@ public final class EnumExample {
             default:
                 return visitor.visitUnknown(string);
         }
+    }
+
+    public static List<EnumExample> values() {
+        return values;
     }
 
     @Generated("com.palantir.conjure.java.types.EnumGenerator")

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
@@ -3,6 +3,9 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -21,6 +24,9 @@ import javax.annotation.Nonnull;
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
 public final class SimpleEnum {
     public static final SimpleEnum VALUE = new SimpleEnum(Value.VALUE, "VALUE");
+
+    private static final List<SimpleEnum> values =
+            Collections.unmodifiableList(Arrays.asList(VALUE));
 
     private final Value value;
 
@@ -71,6 +77,10 @@ public final class SimpleEnum {
             default:
                 return visitor.visitUnknown(string);
         }
+    }
+
+    public static List<SimpleEnum> values() {
+        return values;
     }
 
     @Generated("com.palantir.conjure.java.types.EnumGenerator")

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
@@ -3,6 +3,9 @@ package test.prefix.com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -34,6 +37,9 @@ public final class EnumExample {
      */
     @Deprecated
     public static final EnumExample ONE_HUNDRED = new EnumExample(Value.ONE_HUNDRED, "ONE_HUNDRED");
+
+    private static final List<EnumExample> values =
+            Collections.unmodifiableList(Arrays.asList(ONE, TWO, ONE_HUNDRED));
 
     private final Value value;
 
@@ -95,6 +101,10 @@ public final class EnumExample {
             default:
                 return visitor.visitUnknown(string);
         }
+    }
+
+    public static List<EnumExample> values() {
+        return values;
     }
 
     @Generated("com.palantir.conjure.java.types.EnumGenerator")

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
@@ -3,6 +3,9 @@ package test.prefix.com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -21,6 +24,9 @@ import javax.annotation.Nonnull;
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
 public final class SimpleEnum {
     public static final SimpleEnum VALUE = new SimpleEnum(Value.VALUE, "VALUE");
+
+    private static final List<SimpleEnum> values =
+            Collections.unmodifiableList(Arrays.asList(VALUE));
 
     private final Value value;
 
@@ -71,6 +77,10 @@ public final class SimpleEnum {
             default:
                 return visitor.visitUnknown(string);
         }
+    }
+
+    public static List<SimpleEnum> values() {
+        return values;
     }
 
     @Generated("com.palantir.conjure.java.types.EnumGenerator")

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
@@ -20,6 +20,9 @@ import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptio
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.product.EnumExample;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 public class EnumTests {
@@ -51,6 +54,16 @@ public class EnumTests {
     @Test
     public void testNullValidationUsesSafeLoggable() {
         assertThatLoggableExceptionThrownBy(() -> EnumExample.valueOf(null)).hasLogMessage("value cannot be null");
+    }
+
+    @Test
+    public void testValues() {
+        Set<EnumExample.Value> valuesFromClass =
+                EnumExample.values().stream().map(v -> v.get()).collect(Collectors.toSet());
+        Set<EnumExample.Value> valuesFromEnum = Arrays.stream(EnumExample.Value.values())
+                .filter(v -> !v.equals(EnumExample.Value.UNKNOWN))
+                .collect(Collectors.toSet());
+        assertThat(valuesFromClass).isEqualTo(valuesFromEnum);
     }
 
     private enum Visitor implements EnumExample.Visitor<String> {


### PR DESCRIPTION
I ran across the fact that conjure enums do no contain a `values` method like Java enums. I heard from others that ran into this in the past, so I figured I'd add it. Curious to hear what you think.