### PR TITLE
Add non-null annotation to all parameters with corresponding precondition

### DIFF
--- a/changelog/@unreleased/pr-769.v2.yml
+++ b/changelog/@unreleased/pr-769.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add non-null annotation to all parameters that cannot be null.
+  links:
+  - https://github.com/palantir/conjure-java/pull/769

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryAliasExample.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.nio.ByteBuffer;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class BinaryAliasExample {
     private final ByteBuffer value;
 
-    private BinaryAliasExample(ByteBuffer value) {
+    private BinaryAliasExample(@Nonnull ByteBuffer value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -37,7 +38,7 @@ public final class BinaryAliasExample {
     }
 
     @JsonCreator
-    public static BinaryAliasExample of(ByteBuffer value) {
+    public static BinaryAliasExample of(@Nonnull ByteBuffer value) {
         return new BinaryAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryExample.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = BinaryExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -91,7 +92,7 @@ public final class BinaryExample {
         }
 
         @JsonSetter("binary")
-        public Builder binary(ByteBuffer binary) {
+        public Builder binary(@Nonnull ByteBuffer binary) {
             Preconditions.checkNotNull(binary, "binary cannot be null");
             this.binary = ByteBuffer.allocate(binary.remaining()).put(binary.duplicate());
             ((Buffer) this.binary).rewind();

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = OptionalExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -93,12 +94,12 @@ public final class OptionalExample {
         }
 
         @JsonSetter(value = "item", nulls = Nulls.SKIP)
-        public Builder item(Optional<ByteBuffer> item) {
+        public Builder item(@Nonnull Optional<ByteBuffer> item) {
             this.item = Preconditions.checkNotNull(item, "item cannot be null");
             return this;
         }
 
-        public Builder item(ByteBuffer item) {
+        public Builder item(@Nonnull ByteBuffer item) {
             this.item = Optional.of(Preconditions.checkNotNull(item, "item cannot be null"));
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = AliasAsMapKeyExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -209,13 +210,13 @@ public final class AliasAsMapKeyExample {
         }
 
         @JsonSetter(value = "strings", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder strings(Map<StringAliasExample, ManyFieldExample> strings) {
+        public Builder strings(@Nonnull Map<StringAliasExample, ManyFieldExample> strings) {
             this.strings.clear();
             this.strings.putAll(Preconditions.checkNotNull(strings, "strings cannot be null"));
             return this;
         }
 
-        public Builder putAllStrings(Map<StringAliasExample, ManyFieldExample> strings) {
+        public Builder putAllStrings(@Nonnull Map<StringAliasExample, ManyFieldExample> strings) {
             this.strings.putAll(Preconditions.checkNotNull(strings, "strings cannot be null"));
             return this;
         }
@@ -226,13 +227,13 @@ public final class AliasAsMapKeyExample {
         }
 
         @JsonSetter(value = "rids", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder rids(Map<RidAliasExample, ManyFieldExample> rids) {
+        public Builder rids(@Nonnull Map<RidAliasExample, ManyFieldExample> rids) {
             this.rids.clear();
             this.rids.putAll(Preconditions.checkNotNull(rids, "rids cannot be null"));
             return this;
         }
 
-        public Builder putAllRids(Map<RidAliasExample, ManyFieldExample> rids) {
+        public Builder putAllRids(@Nonnull Map<RidAliasExample, ManyFieldExample> rids) {
             this.rids.putAll(Preconditions.checkNotNull(rids, "rids cannot be null"));
             return this;
         }
@@ -243,7 +244,8 @@ public final class AliasAsMapKeyExample {
         }
 
         @JsonSetter(value = "bearertokens", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder bearertokens(Map<BearerTokenAliasExample, ManyFieldExample> bearertokens) {
+        public Builder bearertokens(
+                @Nonnull Map<BearerTokenAliasExample, ManyFieldExample> bearertokens) {
             this.bearertokens.clear();
             this.bearertokens.putAll(
                     Preconditions.checkNotNull(bearertokens, "bearertokens cannot be null"));
@@ -251,7 +253,7 @@ public final class AliasAsMapKeyExample {
         }
 
         public Builder putAllBearertokens(
-                Map<BearerTokenAliasExample, ManyFieldExample> bearertokens) {
+                @Nonnull Map<BearerTokenAliasExample, ManyFieldExample> bearertokens) {
             this.bearertokens.putAll(
                     Preconditions.checkNotNull(bearertokens, "bearertokens cannot be null"));
             return this;
@@ -263,13 +265,14 @@ public final class AliasAsMapKeyExample {
         }
 
         @JsonSetter(value = "integers", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder integers(Map<IntegerAliasExample, ManyFieldExample> integers) {
+        public Builder integers(@Nonnull Map<IntegerAliasExample, ManyFieldExample> integers) {
             this.integers.clear();
             this.integers.putAll(Preconditions.checkNotNull(integers, "integers cannot be null"));
             return this;
         }
 
-        public Builder putAllIntegers(Map<IntegerAliasExample, ManyFieldExample> integers) {
+        public Builder putAllIntegers(
+                @Nonnull Map<IntegerAliasExample, ManyFieldExample> integers) {
             this.integers.putAll(Preconditions.checkNotNull(integers, "integers cannot be null"));
             return this;
         }
@@ -280,14 +283,15 @@ public final class AliasAsMapKeyExample {
         }
 
         @JsonSetter(value = "safelongs", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder safelongs(Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
+        public Builder safelongs(@Nonnull Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
             this.safelongs.clear();
             this.safelongs.putAll(
                     Preconditions.checkNotNull(safelongs, "safelongs cannot be null"));
             return this;
         }
 
-        public Builder putAllSafelongs(Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
+        public Builder putAllSafelongs(
+                @Nonnull Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
             this.safelongs.putAll(
                     Preconditions.checkNotNull(safelongs, "safelongs cannot be null"));
             return this;
@@ -299,14 +303,15 @@ public final class AliasAsMapKeyExample {
         }
 
         @JsonSetter(value = "datetimes", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder datetimes(Map<DateTimeAliasExample, ManyFieldExample> datetimes) {
+        public Builder datetimes(@Nonnull Map<DateTimeAliasExample, ManyFieldExample> datetimes) {
             this.datetimes.clear();
             this.datetimes.putAll(
                     Preconditions.checkNotNull(datetimes, "datetimes cannot be null"));
             return this;
         }
 
-        public Builder putAllDatetimes(Map<DateTimeAliasExample, ManyFieldExample> datetimes) {
+        public Builder putAllDatetimes(
+                @Nonnull Map<DateTimeAliasExample, ManyFieldExample> datetimes) {
             this.datetimes.putAll(
                     Preconditions.checkNotNull(datetimes, "datetimes cannot be null"));
             return this;
@@ -318,13 +323,13 @@ public final class AliasAsMapKeyExample {
         }
 
         @JsonSetter(value = "uuids", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder uuids(Map<UuidAliasExample, ManyFieldExample> uuids) {
+        public Builder uuids(@Nonnull Map<UuidAliasExample, ManyFieldExample> uuids) {
             this.uuids.clear();
             this.uuids.putAll(Preconditions.checkNotNull(uuids, "uuids cannot be null"));
             return this;
         }
 
-        public Builder putAllUuids(Map<UuidAliasExample, ManyFieldExample> uuids) {
+        public Builder putAllUuids(@Nonnull Map<UuidAliasExample, ManyFieldExample> uuids) {
             this.uuids.putAll(Preconditions.checkNotNull(uuids, "uuids cannot be null"));
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = AnyExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -87,7 +88,7 @@ public final class AnyExample {
         }
 
         @JsonSetter("any")
-        public Builder any(Object any) {
+        public Builder any(@Nonnull Object any) {
             this.any = Preconditions.checkNotNull(any, "any cannot be null");
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = AnyMapExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -98,13 +99,13 @@ public final class AnyMapExample {
         }
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder items(Map<String, Object> items) {
+        public Builder items(@Nonnull Map<String, Object> items) {
             this.items.clear();
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
-        public Builder putAllItems(Map<String, Object> items) {
+        public Builder putAllItems(@Nonnull Map<String, Object> items) {
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenAliasExample.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.tokens.auth.BearerToken;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class BearerTokenAliasExample {
     private final BearerToken value;
 
-    private BearerTokenAliasExample(BearerToken value) {
+    private BearerTokenAliasExample(@Nonnull BearerToken value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -41,7 +42,7 @@ public final class BearerTokenAliasExample {
     }
 
     @JsonCreator
-    public static BearerTokenAliasExample of(BearerToken value) {
+    public static BearerTokenAliasExample of(@Nonnull BearerToken value) {
         return new BearerTokenAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = BearerTokenExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -89,7 +90,7 @@ public final class BearerTokenExample {
         }
 
         @JsonSetter("bearerTokenValue")
-        public Builder bearerTokenValue(BearerToken bearerTokenValue) {
+        public Builder bearerTokenValue(@Nonnull BearerToken bearerTokenValue) {
             this.bearerTokenValue =
                     Preconditions.checkNotNull(bearerTokenValue, "bearerTokenValue cannot be null");
             return this;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasExample.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.Bytes;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class BinaryAliasExample {
     private final Bytes value;
 
-    private BinaryAliasExample(Bytes value) {
+    private BinaryAliasExample(@Nonnull Bytes value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -37,7 +38,7 @@ public final class BinaryAliasExample {
     }
 
     @JsonCreator
-    public static BinaryAliasExample of(Bytes value) {
+    public static BinaryAliasExample of(@Nonnull Bytes value) {
         return new BinaryAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasOne.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.Bytes;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class BinaryAliasOne {
     private final Bytes value;
 
-    private BinaryAliasOne(Bytes value) {
+    private BinaryAliasOne(@Nonnull Bytes value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -37,7 +38,7 @@ public final class BinaryAliasOne {
     }
 
     @JsonCreator
-    public static BinaryAliasOne of(Bytes value) {
+    public static BinaryAliasOne of(@Nonnull Bytes value) {
         return new BinaryAliasOne(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasTwo.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class BinaryAliasTwo {
     private final BinaryAliasOne value;
 
-    private BinaryAliasTwo(BinaryAliasOne value) {
+    private BinaryAliasTwo(@Nonnull BinaryAliasOne value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -36,7 +37,7 @@ public final class BinaryAliasTwo {
     }
 
     @JsonCreator
-    public static BinaryAliasTwo of(BinaryAliasOne value) {
+    public static BinaryAliasTwo of(@Nonnull BinaryAliasOne value) {
         return new BinaryAliasTwo(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = BinaryExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -88,7 +89,7 @@ public final class BinaryExample {
         }
 
         @JsonSetter("binary")
-        public Builder binary(Bytes binary) {
+        public Builder binary(@Nonnull Bytes binary) {
             this.binary = Preconditions.checkNotNull(binary, "binary cannot be null");
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 import test.api.ExampleExternalReference;
 
 @JsonDeserialize(builder = CovariantListExample.Builder.class)
@@ -113,14 +114,14 @@ public final class CovariantListExample {
         }
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder items(Iterable<?> items) {
+        public Builder items(@Nonnull Iterable<?> items) {
             this.items.clear();
             ConjureCollections.addAll(
                     this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
-        public Builder addAllItems(Iterable<?> items) {
+        public Builder addAllItems(@Nonnull Iterable<?> items) {
             ConjureCollections.addAll(
                     this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
@@ -132,7 +133,8 @@ public final class CovariantListExample {
         }
 
         @JsonSetter(value = "externalItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder externalItems(Iterable<? extends ExampleExternalReference> externalItems) {
+        public Builder externalItems(
+                @Nonnull Iterable<? extends ExampleExternalReference> externalItems) {
             this.externalItems.clear();
             ConjureCollections.addAll(
                     this.externalItems,
@@ -141,7 +143,7 @@ public final class CovariantListExample {
         }
 
         public Builder addAllExternalItems(
-                Iterable<? extends ExampleExternalReference> externalItems) {
+                @Nonnull Iterable<? extends ExampleExternalReference> externalItems) {
             ConjureCollections.addAll(
                     this.externalItems,
                     Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = CovariantOptionalExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -114,27 +115,27 @@ public final class CovariantOptionalExample {
         }
 
         @JsonSetter(value = "item", nulls = Nulls.SKIP)
-        public Builder item(Optional<?> item) {
+        public Builder item(@Nonnull Optional<?> item) {
             this.item =
                     Preconditions.checkNotNull(item, "item cannot be null")
                             .map(Function.identity());
             return this;
         }
 
-        public Builder item(Object item) {
+        public Builder item(@Nonnull Object item) {
             this.item = Optional.of(Preconditions.checkNotNull(item, "item cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "setItem", nulls = Nulls.SKIP)
-        public Builder setItem(Optional<? extends Set<StringAliasExample>> setItem) {
+        public Builder setItem(@Nonnull Optional<? extends Set<StringAliasExample>> setItem) {
             this.setItem =
                     Preconditions.checkNotNull(setItem, "setItem cannot be null")
                             .map(Function.identity());
             return this;
         }
 
-        public Builder setItem(Set<StringAliasExample> setItem) {
+        public Builder setItem(@Nonnull Set<StringAliasExample> setItem) {
             this.setItem =
                     Optional.of(Preconditions.checkNotNull(setItem, "setItem cannot be null"));
             return this;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeAliasExample.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.time.OffsetDateTime;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class DateTimeAliasExample {
     private final OffsetDateTime value;
 
-    private DateTimeAliasExample(OffsetDateTime value) {
+    private DateTimeAliasExample(@Nonnull OffsetDateTime value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -41,7 +42,7 @@ public final class DateTimeAliasExample {
     }
 
     @JsonCreator
-    public static DateTimeAliasExample of(OffsetDateTime value) {
+    public static DateTimeAliasExample of(@Nonnull OffsetDateTime value) {
         return new DateTimeAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = DateTimeExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -96,7 +97,7 @@ public final class DateTimeExample {
         }
 
         @JsonSetter("datetime")
-        public Builder datetime(OffsetDateTime datetime) {
+        public Builder datetime(@Nonnull OffsetDateTime datetime) {
             this.datetime = Preconditions.checkNotNull(datetime, "datetime cannot be null");
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class EmptyUnionTypeExample {
@@ -70,7 +71,8 @@ public final class EmptyUnionTypeExample {
         private Function<String, T> unknownVisitor;
 
         @Override
-        public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
+        public CompletedStageVisitorBuilder<T> unknown(
+                @Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -89,7 +91,7 @@ public final class EmptyUnionTypeExample {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor);
+        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
     }
 
     public interface CompletedStageVisitorBuilder<T> {
@@ -119,7 +121,7 @@ public final class EmptyUnionTypeExample {
             this(type, new HashMap<String, Object>());
         }
 
-        private UnknownWrapper(String type, Map<String, Object> value) {
+        private UnknownWrapper(@Nonnull String type, @Nonnull Map<String, Object> value) {
             Preconditions.checkNotNull(type, "type cannot be null");
             Preconditions.checkNotNull(value, "value cannot be null");
             this.type = type;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.Locale;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 /**
  * This enumerates the numbers 1:2 also 100.
@@ -67,7 +68,7 @@ public final class EnumExample {
 
     @JsonCreator
     @SuppressWarnings("deprecation")
-    public static EnumExample valueOf(String value) {
+    public static EnumExample valueOf(@Nonnull String value) {
         Preconditions.checkNotNull(value, "value cannot be null");
         String upperCasedValue = value.toUpperCase(Locale.ROOT);
         switch (upperCasedValue) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = EnumFieldExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -88,7 +89,7 @@ public final class EnumFieldExample {
         }
 
         @JsonSetter("enum")
-        public Builder enum_(EnumExample enum_) {
+        public Builder enum_(@Nonnull EnumExample enum_) {
             this.enum_ = Preconditions.checkNotNull(enum_, "enum cannot be null");
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasTwo.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class ExternalLongAliasTwo {
     private final ExternalLongAliasOne value;
 
-    private ExternalLongAliasTwo(ExternalLongAliasOne value) {
+    private ExternalLongAliasTwo(@Nonnull ExternalLongAliasOne value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -40,7 +41,7 @@ public final class ExternalLongAliasTwo {
     }
 
     @JsonCreator
-    public static ExternalLongAliasTwo of(ExternalLongAliasOne value) {
+    public static ExternalLongAliasTwo of(@Nonnull ExternalLongAliasOne value) {
         return new ExternalLongAliasTwo(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = ExternalLongExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -150,7 +151,8 @@ public final class ExternalLongExample {
         }
 
         @JsonSetter(value = "optionalExternalLong", nulls = Nulls.SKIP)
-        public Builder optionalExternalLong(Optional<? extends Long> optionalExternalLong) {
+        public Builder optionalExternalLong(
+                @Nonnull Optional<? extends Long> optionalExternalLong) {
             this.optionalExternalLong =
                     Preconditions.checkNotNull(
                                     optionalExternalLong, "optionalExternalLong cannot be null")
@@ -167,7 +169,7 @@ public final class ExternalLongExample {
         }
 
         @JsonSetter(value = "listExternalLong", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder listExternalLong(Iterable<? extends Long> listExternalLong) {
+        public Builder listExternalLong(@Nonnull Iterable<? extends Long> listExternalLong) {
             this.listExternalLong.clear();
             ConjureCollections.addAll(
                     this.listExternalLong,
@@ -176,7 +178,7 @@ public final class ExternalLongExample {
             return this;
         }
 
-        public Builder addAllListExternalLong(Iterable<? extends Long> listExternalLong) {
+        public Builder addAllListExternalLong(@Nonnull Iterable<? extends Long> listExternalLong) {
             ConjureCollections.addAll(
                     this.listExternalLong,
                     Preconditions.checkNotNull(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalStringAliasExample.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class ExternalStringAliasExample {
     private final String value;
 
-    private ExternalStringAliasExample(String value) {
+    private ExternalStringAliasExample(@Nonnull String value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -36,7 +37,7 @@ public final class ExternalStringAliasExample {
     }
 
     @JsonCreator
-    public static ExternalStringAliasExample of(String value) {
+    public static ExternalStringAliasExample of(@Nonnull String value) {
         return new ExternalStringAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = ListExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -191,14 +192,14 @@ public final class ListExample {
         }
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder items(Iterable<String> items) {
+        public Builder items(@Nonnull Iterable<String> items) {
             this.items.clear();
             ConjureCollections.addAll(
                     this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
-        public Builder addAllItems(Iterable<String> items) {
+        public Builder addAllItems(@Nonnull Iterable<String> items) {
             ConjureCollections.addAll(
                     this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
@@ -210,7 +211,7 @@ public final class ListExample {
         }
 
         @JsonSetter(value = "primitiveItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder primitiveItems(Iterable<Integer> primitiveItems) {
+        public Builder primitiveItems(@Nonnull Iterable<Integer> primitiveItems) {
             this.primitiveItems.clear();
             ConjureCollections.addAll(
                     this.primitiveItems,
@@ -218,7 +219,7 @@ public final class ListExample {
             return this;
         }
 
-        public Builder addAllPrimitiveItems(Iterable<Integer> primitiveItems) {
+        public Builder addAllPrimitiveItems(@Nonnull Iterable<Integer> primitiveItems) {
             ConjureCollections.addAll(
                     this.primitiveItems,
                     Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
@@ -231,7 +232,7 @@ public final class ListExample {
         }
 
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder doubleItems(Iterable<Double> doubleItems) {
+        public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
             this.doubleItems.clear();
             ConjureCollections.addAll(
                     this.doubleItems,
@@ -239,7 +240,7 @@ public final class ListExample {
             return this;
         }
 
-        public Builder addAllDoubleItems(Iterable<Double> doubleItems) {
+        public Builder addAllDoubleItems(@Nonnull Iterable<Double> doubleItems) {
             ConjureCollections.addAll(
                     this.doubleItems,
                     Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
@@ -252,7 +253,7 @@ public final class ListExample {
         }
 
         @JsonSetter(value = "optionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
-        public Builder optionalItems(Iterable<Optional<String>> optionalItems) {
+        public Builder optionalItems(@Nonnull Iterable<Optional<String>> optionalItems) {
             this.optionalItems.clear();
             ConjureCollections.addAll(
                     this.optionalItems,
@@ -260,7 +261,7 @@ public final class ListExample {
             return this;
         }
 
-        public Builder addAllOptionalItems(Iterable<Optional<String>> optionalItems) {
+        public Builder addAllOptionalItems(@Nonnull Iterable<Optional<String>> optionalItems) {
             ConjureCollections.addAll(
                     this.optionalItems,
                     Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
@@ -273,7 +274,7 @@ public final class ListExample {
         }
 
         @JsonSetter(value = "aliasOptionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
-        public Builder aliasOptionalItems(Iterable<OptionalAlias> aliasOptionalItems) {
+        public Builder aliasOptionalItems(@Nonnull Iterable<OptionalAlias> aliasOptionalItems) {
             this.aliasOptionalItems.clear();
             ConjureCollections.addAll(
                     this.aliasOptionalItems,
@@ -282,7 +283,8 @@ public final class ListExample {
             return this;
         }
 
-        public Builder addAllAliasOptionalItems(Iterable<OptionalAlias> aliasOptionalItems) {
+        public Builder addAllAliasOptionalItems(
+                @Nonnull Iterable<OptionalAlias> aliasOptionalItems) {
             ConjureCollections.addAll(
                     this.aliasOptionalItems,
                     Preconditions.checkNotNull(
@@ -296,7 +298,7 @@ public final class ListExample {
         }
 
         @JsonSetter(value = "nestedItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder nestedItems(Iterable<? extends List<String>> nestedItems) {
+        public Builder nestedItems(@Nonnull Iterable<? extends List<String>> nestedItems) {
             this.nestedItems.clear();
             ConjureCollections.addAll(
                     this.nestedItems,
@@ -304,7 +306,7 @@ public final class ListExample {
             return this;
         }
 
-        public Builder addAllNestedItems(Iterable<? extends List<String>> nestedItems) {
+        public Builder addAllNestedItems(@Nonnull Iterable<? extends List<String>> nestedItems) {
             ConjureCollections.addAll(
                     this.nestedItems,
                     Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = ManyFieldExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -246,7 +247,7 @@ public final class ManyFieldExample {
 
         /** docs for string field */
         @JsonSetter("string")
-        public Builder string(String string) {
+        public Builder string(@Nonnull String string) {
             this.string = Preconditions.checkNotNull(string, "string cannot be null");
             return this;
         }
@@ -269,14 +270,14 @@ public final class ManyFieldExample {
 
         /** docs for optionalItem field */
         @JsonSetter(value = "optionalItem", nulls = Nulls.SKIP)
-        public Builder optionalItem(Optional<String> optionalItem) {
+        public Builder optionalItem(@Nonnull Optional<String> optionalItem) {
             this.optionalItem =
                     Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null");
             return this;
         }
 
         /** docs for optionalItem field */
-        public Builder optionalItem(String optionalItem) {
+        public Builder optionalItem(@Nonnull String optionalItem) {
             this.optionalItem =
                     Optional.of(
                             Preconditions.checkNotNull(
@@ -286,7 +287,7 @@ public final class ManyFieldExample {
 
         /** docs for items field */
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder items(Iterable<String> items) {
+        public Builder items(@Nonnull Iterable<String> items) {
             this.items.clear();
             ConjureCollections.addAll(
                     this.items, Preconditions.checkNotNull(items, "items cannot be null"));
@@ -294,7 +295,7 @@ public final class ManyFieldExample {
         }
 
         /** docs for items field */
-        public Builder addAllItems(Iterable<String> items) {
+        public Builder addAllItems(@Nonnull Iterable<String> items) {
             ConjureCollections.addAll(
                     this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
@@ -308,7 +309,7 @@ public final class ManyFieldExample {
 
         /** docs for set field */
         @JsonSetter(value = "set", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder set(Iterable<String> set) {
+        public Builder set(@Nonnull Iterable<String> set) {
             this.set.clear();
             ConjureCollections.addAll(
                     this.set, Preconditions.checkNotNull(set, "set cannot be null"));
@@ -316,7 +317,7 @@ public final class ManyFieldExample {
         }
 
         /** docs for set field */
-        public Builder addAllSet(Iterable<String> set) {
+        public Builder addAllSet(@Nonnull Iterable<String> set) {
             ConjureCollections.addAll(
                     this.set, Preconditions.checkNotNull(set, "set cannot be null"));
             return this;
@@ -331,7 +332,7 @@ public final class ManyFieldExample {
         /** @deprecated deprecation documentation. */
         @Deprecated
         @JsonSetter(value = "map", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder map(Map<String, String> map) {
+        public Builder map(@Nonnull Map<String, String> map) {
             this.map.clear();
             this.map.putAll(Preconditions.checkNotNull(map, "map cannot be null"));
             return this;
@@ -339,7 +340,7 @@ public final class ManyFieldExample {
 
         /** @deprecated deprecation documentation. */
         @Deprecated
-        public Builder putAllMap(Map<String, String> map) {
+        public Builder putAllMap(@Nonnull Map<String, String> map) {
             this.map.putAll(Preconditions.checkNotNull(map, "map cannot be null"));
             return this;
         }
@@ -358,7 +359,7 @@ public final class ManyFieldExample {
          */
         @Deprecated
         @JsonSetter("alias")
-        public Builder alias(StringAliasExample alias) {
+        public Builder alias(@Nonnull StringAliasExample alias) {
             this.alias = Preconditions.checkNotNull(alias, "alias cannot be null");
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapAliasExample.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.Map;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class MapAliasExample {
     private final Map<String, Object> value;
 
-    private MapAliasExample(Map<String, Object> value) {
+    private MapAliasExample(@Nonnull Map<String, Object> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -37,7 +38,7 @@ public final class MapAliasExample {
     }
 
     @JsonCreator
-    public static MapAliasExample of(Map<String, Object> value) {
+    public static MapAliasExample of(@Nonnull Map<String, Object> value) {
         return new MapAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = MapExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -144,13 +145,13 @@ public final class MapExample {
         }
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder items(Map<String, String> items) {
+        public Builder items(@Nonnull Map<String, String> items) {
             this.items.clear();
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
-        public Builder putAllItems(Map<String, String> items) {
+        public Builder putAllItems(@Nonnull Map<String, String> items) {
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
@@ -161,14 +162,14 @@ public final class MapExample {
         }
 
         @JsonSetter(value = "optionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
-        public Builder optionalItems(Map<String, Optional<String>> optionalItems) {
+        public Builder optionalItems(@Nonnull Map<String, Optional<String>> optionalItems) {
             this.optionalItems.clear();
             this.optionalItems.putAll(
                     Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
         }
 
-        public Builder putAllOptionalItems(Map<String, Optional<String>> optionalItems) {
+        public Builder putAllOptionalItems(@Nonnull Map<String, Optional<String>> optionalItems) {
             this.optionalItems.putAll(
                     Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
@@ -180,7 +181,7 @@ public final class MapExample {
         }
 
         @JsonSetter(value = "aliasOptionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
-        public Builder aliasOptionalItems(Map<String, OptionalAlias> aliasOptionalItems) {
+        public Builder aliasOptionalItems(@Nonnull Map<String, OptionalAlias> aliasOptionalItems) {
             this.aliasOptionalItems.clear();
             this.aliasOptionalItems.putAll(
                     Preconditions.checkNotNull(
@@ -188,7 +189,8 @@ public final class MapExample {
             return this;
         }
 
-        public Builder putAllAliasOptionalItems(Map<String, OptionalAlias> aliasOptionalItems) {
+        public Builder putAllAliasOptionalItems(
+                @Nonnull Map<String, OptionalAlias> aliasOptionalItems) {
             this.aliasOptionalItems.putAll(
                     Preconditions.checkNotNull(
                             aliasOptionalItems, "aliasOptionalItems cannot be null"));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/NestedStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/NestedStringAliasExample.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class NestedStringAliasExample {
     private final StringAliasExample value;
 
-    private NestedStringAliasExample(StringAliasExample value) {
+    private NestedStringAliasExample(@Nonnull StringAliasExample value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -40,7 +41,7 @@ public final class NestedStringAliasExample {
     }
 
     @JsonCreator
-    public static NestedStringAliasExample of(StringAliasExample value) {
+    public static NestedStringAliasExample of(@Nonnull StringAliasExample value) {
         return new NestedStringAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAlias.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class OptionalAlias {
     private final Optional<String> value;
 
-    private OptionalAlias(Optional<String> value) {
+    private OptionalAlias(@Nonnull Optional<String> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -41,7 +42,7 @@ public final class OptionalAlias {
     }
 
     @JsonCreator
-    public static OptionalAlias of(Optional<String> value) {
+    public static OptionalAlias of(@Nonnull Optional<String> value) {
         return new OptionalAlias(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = OptionalExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -90,12 +91,12 @@ public final class OptionalExample {
         }
 
         @JsonSetter(value = "item", nulls = Nulls.SKIP)
-        public Builder item(Optional<String> item) {
+        public Builder item(@Nonnull Optional<String> item) {
             this.item = Preconditions.checkNotNull(item, "item cannot be null");
             return this;
         }
 
-        public Builder item(String item) {
+        public Builder item(@Nonnull String item) {
             this.item = Optional.of(Preconditions.checkNotNull(item, "item cannot be null"));
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
@@ -18,6 +18,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.UUID;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = PrimitiveOptionalsExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -214,7 +215,7 @@ public final class PrimitiveOptionalsExample {
         }
 
         @JsonSetter(value = "num", nulls = Nulls.SKIP)
-        public Builder num(OptionalDouble num) {
+        public Builder num(@Nonnull OptionalDouble num) {
             this.num = Preconditions.checkNotNull(num, "num cannot be null");
             return this;
         }
@@ -225,7 +226,7 @@ public final class PrimitiveOptionalsExample {
         }
 
         @JsonSetter(value = "bool", nulls = Nulls.SKIP)
-        public Builder bool(Optional<Boolean> bool) {
+        public Builder bool(@Nonnull Optional<Boolean> bool) {
             this.bool = Preconditions.checkNotNull(bool, "bool cannot be null");
             return this;
         }
@@ -236,7 +237,7 @@ public final class PrimitiveOptionalsExample {
         }
 
         @JsonSetter(value = "integer", nulls = Nulls.SKIP)
-        public Builder integer(OptionalInt integer) {
+        public Builder integer(@Nonnull OptionalInt integer) {
             this.integer = Preconditions.checkNotNull(integer, "integer cannot be null");
             return this;
         }
@@ -247,36 +248,36 @@ public final class PrimitiveOptionalsExample {
         }
 
         @JsonSetter(value = "safelong", nulls = Nulls.SKIP)
-        public Builder safelong(Optional<SafeLong> safelong) {
+        public Builder safelong(@Nonnull Optional<SafeLong> safelong) {
             this.safelong = Preconditions.checkNotNull(safelong, "safelong cannot be null");
             return this;
         }
 
-        public Builder safelong(SafeLong safelong) {
+        public Builder safelong(@Nonnull SafeLong safelong) {
             this.safelong =
                     Optional.of(Preconditions.checkNotNull(safelong, "safelong cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "rid", nulls = Nulls.SKIP)
-        public Builder rid(Optional<ResourceIdentifier> rid) {
+        public Builder rid(@Nonnull Optional<ResourceIdentifier> rid) {
             this.rid = Preconditions.checkNotNull(rid, "rid cannot be null");
             return this;
         }
 
-        public Builder rid(ResourceIdentifier rid) {
+        public Builder rid(@Nonnull ResourceIdentifier rid) {
             this.rid = Optional.of(Preconditions.checkNotNull(rid, "rid cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "bearertoken", nulls = Nulls.SKIP)
-        public Builder bearertoken(Optional<BearerToken> bearertoken) {
+        public Builder bearertoken(@Nonnull Optional<BearerToken> bearertoken) {
             this.bearertoken =
                     Preconditions.checkNotNull(bearertoken, "bearertoken cannot be null");
             return this;
         }
 
-        public Builder bearertoken(BearerToken bearertoken) {
+        public Builder bearertoken(@Nonnull BearerToken bearertoken) {
             this.bearertoken =
                     Optional.of(
                             Preconditions.checkNotNull(bearertoken, "bearertoken cannot be null"));
@@ -284,12 +285,12 @@ public final class PrimitiveOptionalsExample {
         }
 
         @JsonSetter(value = "uuid", nulls = Nulls.SKIP)
-        public Builder uuid(Optional<UUID> uuid) {
+        public Builder uuid(@Nonnull Optional<UUID> uuid) {
             this.uuid = Preconditions.checkNotNull(uuid, "uuid cannot be null");
             return this;
         }
 
-        public Builder uuid(UUID uuid) {
+        public Builder uuid(@Nonnull UUID uuid) {
             this.uuid = Optional.of(Preconditions.checkNotNull(uuid, "uuid cannot be null"));
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReferenceAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReferenceAliasExample.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class ReferenceAliasExample {
     private final AnyExample value;
 
-    private ReferenceAliasExample(AnyExample value) {
+    private ReferenceAliasExample(@Nonnull AnyExample value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -36,7 +37,7 @@ public final class ReferenceAliasExample {
     }
 
     @JsonCreator
-    public static ReferenceAliasExample of(AnyExample value) {
+    public static ReferenceAliasExample of(@Nonnull AnyExample value) {
         return new ReferenceAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = ReservedKeyExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -186,19 +187,19 @@ public final class ReservedKeyExample {
         }
 
         @JsonSetter("package")
-        public Builder package_(String package_) {
+        public Builder package_(@Nonnull String package_) {
             this.package_ = Preconditions.checkNotNull(package_, "package cannot be null");
             return this;
         }
 
         @JsonSetter("interface")
-        public Builder interface_(String interface_) {
+        public Builder interface_(@Nonnull String interface_) {
             this.interface_ = Preconditions.checkNotNull(interface_, "interface cannot be null");
             return this;
         }
 
         @JsonSetter("field-name-with-dashes")
-        public Builder fieldNameWithDashes(String fieldNameWithDashes) {
+        public Builder fieldNameWithDashes(@Nonnull String fieldNameWithDashes) {
             this.fieldNameWithDashes =
                     Preconditions.checkNotNull(
                             fieldNameWithDashes, "field-name-with-dashes cannot be null");

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RidAliasExample.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.ri.ResourceIdentifier;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class RidAliasExample {
     private final ResourceIdentifier value;
 
-    private RidAliasExample(ResourceIdentifier value) {
+    private RidAliasExample(@Nonnull ResourceIdentifier value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -41,7 +42,7 @@ public final class RidAliasExample {
     }
 
     @JsonCreator
-    public static RidAliasExample of(ResourceIdentifier value) {
+    public static RidAliasExample of(@Nonnull ResourceIdentifier value) {
         return new RidAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = RidExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -88,7 +89,7 @@ public final class RidExample {
         }
 
         @JsonSetter("ridValue")
-        public Builder ridValue(ResourceIdentifier ridValue) {
+        public Builder ridValue(@Nonnull ResourceIdentifier ridValue) {
             this.ridValue = Preconditions.checkNotNull(ridValue, "ridValue cannot be null");
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongAliasExample.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class SafeLongAliasExample {
     private final SafeLong value;
 
-    private SafeLongAliasExample(SafeLong value) {
+    private SafeLongAliasExample(@Nonnull SafeLong value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -41,7 +42,7 @@ public final class SafeLongAliasExample {
     }
 
     @JsonCreator
-    public static SafeLongAliasExample of(SafeLong value) {
+    public static SafeLongAliasExample of(@Nonnull SafeLong value) {
         return new SafeLongAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = SafeLongExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -89,7 +90,7 @@ public final class SafeLongExample {
         }
 
         @JsonSetter("safeLongValue")
-        public Builder safeLongValue(SafeLong safeLongValue) {
+        public Builder safeLongValue(@Nonnull SafeLong safeLongValue) {
             this.safeLongValue =
                     Preconditions.checkNotNull(safeLongValue, "safeLongValue cannot be null");
             return this;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = SetExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -111,14 +112,14 @@ public final class SetExample {
         }
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder items(Iterable<String> items) {
+        public Builder items(@Nonnull Iterable<String> items) {
             this.items.clear();
             ConjureCollections.addAll(
                     this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
-        public Builder addAllItems(Iterable<String> items) {
+        public Builder addAllItems(@Nonnull Iterable<String> items) {
             ConjureCollections.addAll(
                     this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
@@ -130,7 +131,7 @@ public final class SetExample {
         }
 
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder doubleItems(Iterable<Double> doubleItems) {
+        public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
             this.doubleItems.clear();
             ConjureCollections.addAll(
                     this.doubleItems,
@@ -138,7 +139,7 @@ public final class SetExample {
             return this;
         }
 
-        public Builder addAllDoubleItems(Iterable<Double> doubleItems) {
+        public Builder addAllDoubleItems(@Nonnull Iterable<Double> doubleItems) {
             ConjureCollections.addAll(
                     this.doubleItems,
                     Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.Locale;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 /**
  * This class is used instead of a native enum to support unknown values. Rather than throw an
@@ -52,7 +53,7 @@ public final class SimpleEnum {
     }
 
     @JsonCreator
-    public static SimpleEnum valueOf(String value) {
+    public static SimpleEnum valueOf(@Nonnull String value) {
         Preconditions.checkNotNull(value, "value cannot be null");
         String upperCasedValue = value.toUpperCase(Locale.ROOT);
         switch (upperCasedValue) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class SingleUnion {
@@ -82,14 +83,15 @@ public final class SingleUnion {
         private Function<String, T> unknownVisitor;
 
         @Override
-        public UnknownStageVisitorBuilder<T> foo(Function<String, T> fooVisitor) {
+        public UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor) {
             Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
             this.fooVisitor = fooVisitor;
             return this;
         }
 
         @Override
-        public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
+        public CompletedStageVisitorBuilder<T> unknown(
+                @Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -114,11 +116,11 @@ public final class SingleUnion {
     }
 
     public interface FooStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> foo(Function<String, T> fooVisitor);
+        UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor);
+        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
     }
 
     public interface CompletedStageVisitorBuilder<T> {
@@ -139,7 +141,7 @@ public final class SingleUnion {
         private final String value;
 
         @JsonCreator
-        private FooWrapper(@JsonProperty("foo") String value) {
+        private FooWrapper(@JsonProperty("foo") @Nonnull String value) {
             Preconditions.checkNotNull(value, "foo cannot be null");
             this.value = value;
         }
@@ -184,7 +186,7 @@ public final class SingleUnion {
             this(type, new HashMap<String, Object>());
         }
 
-        private UnknownWrapper(String type, Map<String, Object> value) {
+        private UnknownWrapper(@Nonnull String type, @Nonnull Map<String, Object> value) {
             Preconditions.checkNotNull(type, "type cannot be null");
             Preconditions.checkNotNull(value, "value cannot be null");
             this.type = type;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasExample.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class StringAliasExample {
     private final String value;
 
-    private StringAliasExample(String value) {
+    private StringAliasExample(@Nonnull String value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -40,7 +41,7 @@ public final class StringAliasExample {
     }
 
     @JsonCreator
-    public static StringAliasExample of(String value) {
+    public static StringAliasExample of(@Nonnull String value) {
         return new StringAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasOne.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class StringAliasOne {
     private final String value;
 
-    private StringAliasOne(String value) {
+    private StringAliasOne(@Nonnull String value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -40,7 +41,7 @@ public final class StringAliasOne {
     }
 
     @JsonCreator
-    public static StringAliasOne of(String value) {
+    public static StringAliasOne of(@Nonnull String value) {
         return new StringAliasOne(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasThree.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasThree.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class StringAliasThree {
     private final StringAliasTwo value;
 
-    private StringAliasThree(StringAliasTwo value) {
+    private StringAliasThree(@Nonnull StringAliasTwo value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -36,7 +37,7 @@ public final class StringAliasThree {
     }
 
     @JsonCreator
-    public static StringAliasThree of(StringAliasTwo value) {
+    public static StringAliasThree of(@Nonnull StringAliasTwo value) {
         return new StringAliasThree(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasTwo.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class StringAliasTwo {
     private final Optional<StringAliasOne> value;
 
-    private StringAliasTwo(Optional<StringAliasOne> value) {
+    private StringAliasTwo(@Nonnull Optional<StringAliasOne> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -41,7 +42,7 @@ public final class StringAliasTwo {
     }
 
     @JsonCreator
-    public static StringAliasTwo of(Optional<StringAliasOne> value) {
+    public static StringAliasTwo of(@Nonnull Optional<StringAliasOne> value) {
         return new StringAliasTwo(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = StringExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -87,7 +88,7 @@ public final class StringExample {
         }
 
         @JsonSetter("string")
-        public Builder string(String string) {
+        public Builder string(@Nonnull String string) {
             this.string = Preconditions.checkNotNull(string, "string cannot be null");
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class Union {
@@ -122,28 +123,29 @@ public final class Union {
         private Function<String, T> unknownVisitor;
 
         @Override
-        public BazStageVisitorBuilder<T> bar(IntFunction<T> barVisitor) {
+        public BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor) {
             Preconditions.checkNotNull(barVisitor, "barVisitor cannot be null");
             this.barVisitor = barVisitor;
             return this;
         }
 
         @Override
-        public FooStageVisitorBuilder<T> baz(Function<Long, T> bazVisitor) {
+        public FooStageVisitorBuilder<T> baz(@Nonnull Function<Long, T> bazVisitor) {
             Preconditions.checkNotNull(bazVisitor, "bazVisitor cannot be null");
             this.bazVisitor = bazVisitor;
             return this;
         }
 
         @Override
-        public UnknownStageVisitorBuilder<T> foo(Function<String, T> fooVisitor) {
+        public UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor) {
             Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
             this.fooVisitor = fooVisitor;
             return this;
         }
 
         @Override
-        public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
+        public CompletedStageVisitorBuilder<T> unknown(
+                @Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -180,19 +182,19 @@ public final class Union {
     }
 
     public interface BarStageVisitorBuilder<T> {
-        BazStageVisitorBuilder<T> bar(IntFunction<T> barVisitor);
+        BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor);
     }
 
     public interface BazStageVisitorBuilder<T> {
-        FooStageVisitorBuilder<T> baz(Function<Long, T> bazVisitor);
+        FooStageVisitorBuilder<T> baz(@Nonnull Function<Long, T> bazVisitor);
     }
 
     public interface FooStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> foo(Function<String, T> fooVisitor);
+        UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor);
+        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
     }
 
     public interface CompletedStageVisitorBuilder<T> {
@@ -217,7 +219,7 @@ public final class Union {
         private final String value;
 
         @JsonCreator
-        private FooWrapper(@JsonProperty("foo") String value) {
+        private FooWrapper(@JsonProperty("foo") @Nonnull String value) {
             Preconditions.checkNotNull(value, "foo cannot be null");
             this.value = value;
         }
@@ -252,7 +254,7 @@ public final class Union {
         private final int value;
 
         @JsonCreator
-        private BarWrapper(@JsonProperty("bar") int value) {
+        private BarWrapper(@JsonProperty("bar") @Nonnull int value) {
             Preconditions.checkNotNull(value, "bar cannot be null");
             this.value = value;
         }
@@ -287,7 +289,7 @@ public final class Union {
         private final long value;
 
         @JsonCreator
-        private BazWrapper(@JsonProperty("baz") long value) {
+        private BazWrapper(@JsonProperty("baz") @Nonnull long value) {
             Preconditions.checkNotNull(value, "baz cannot be null");
             this.value = value;
         }
@@ -332,7 +334,7 @@ public final class Union {
             this(type, new HashMap<String, Object>());
         }
 
-        private UnknownWrapper(String type, Map<String, Object> value) {
+        private UnknownWrapper(@Nonnull String type, @Nonnull Map<String, Object> value) {
             Preconditions.checkNotNull(type, "type cannot be null");
             Preconditions.checkNotNull(value, "value cannot be null");
             this.type = type;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 /** A type which can either be a StringExample, a set of strings, or an integer. */
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
@@ -154,35 +155,37 @@ public final class UnionTypeExample {
         private Function<String, T> unknownVisitor;
 
         @Override
-        public IfStageVisitorBuilder<T> alsoAnInteger(IntFunction<T> alsoAnIntegerVisitor) {
+        public IfStageVisitorBuilder<T> alsoAnInteger(
+                @Nonnull IntFunction<T> alsoAnIntegerVisitor) {
             Preconditions.checkNotNull(alsoAnIntegerVisitor, "alsoAnIntegerVisitor cannot be null");
             this.alsoAnIntegerVisitor = alsoAnIntegerVisitor;
             return this;
         }
 
         @Override
-        public InterfaceStageVisitorBuilder<T> if_(IntFunction<T> ifVisitor) {
+        public InterfaceStageVisitorBuilder<T> if_(@Nonnull IntFunction<T> ifVisitor) {
             Preconditions.checkNotNull(ifVisitor, "ifVisitor cannot be null");
             this.ifVisitor = ifVisitor;
             return this;
         }
 
         @Override
-        public NewStageVisitorBuilder<T> interface_(IntFunction<T> interfaceVisitor) {
+        public NewStageVisitorBuilder<T> interface_(@Nonnull IntFunction<T> interfaceVisitor) {
             Preconditions.checkNotNull(interfaceVisitor, "interfaceVisitor cannot be null");
             this.interfaceVisitor = interfaceVisitor;
             return this;
         }
 
         @Override
-        public SetStageVisitorBuilder<T> new_(IntFunction<T> newVisitor) {
+        public SetStageVisitorBuilder<T> new_(@Nonnull IntFunction<T> newVisitor) {
             Preconditions.checkNotNull(newVisitor, "newVisitor cannot be null");
             this.newVisitor = newVisitor;
             return this;
         }
 
         @Override
-        public StringExampleStageVisitorBuilder<T> set(Function<Set<String>, T> setVisitor) {
+        public StringExampleStageVisitorBuilder<T> set(
+                @Nonnull Function<Set<String>, T> setVisitor) {
             Preconditions.checkNotNull(setVisitor, "setVisitor cannot be null");
             this.setVisitor = setVisitor;
             return this;
@@ -190,7 +193,7 @@ public final class UnionTypeExample {
 
         @Override
         public ThisFieldIsAnIntegerStageVisitorBuilder<T> stringExample(
-                Function<StringExample, T> stringExampleVisitor) {
+                @Nonnull Function<StringExample, T> stringExampleVisitor) {
             Preconditions.checkNotNull(stringExampleVisitor, "stringExampleVisitor cannot be null");
             this.stringExampleVisitor = stringExampleVisitor;
             return this;
@@ -198,7 +201,7 @@ public final class UnionTypeExample {
 
         @Override
         public UnknownStageVisitorBuilder<T> thisFieldIsAnInteger(
-                IntFunction<T> thisFieldIsAnIntegerVisitor) {
+                @Nonnull IntFunction<T> thisFieldIsAnIntegerVisitor) {
             Preconditions.checkNotNull(
                     thisFieldIsAnIntegerVisitor, "thisFieldIsAnIntegerVisitor cannot be null");
             this.thisFieldIsAnIntegerVisitor = thisFieldIsAnIntegerVisitor;
@@ -206,7 +209,8 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
+        public CompletedStageVisitorBuilder<T> unknown(
+                @Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -267,37 +271,37 @@ public final class UnionTypeExample {
     }
 
     public interface AlsoAnIntegerStageVisitorBuilder<T> {
-        IfStageVisitorBuilder<T> alsoAnInteger(IntFunction<T> alsoAnIntegerVisitor);
+        IfStageVisitorBuilder<T> alsoAnInteger(@Nonnull IntFunction<T> alsoAnIntegerVisitor);
     }
 
     public interface IfStageVisitorBuilder<T> {
-        InterfaceStageVisitorBuilder<T> if_(IntFunction<T> ifVisitor);
+        InterfaceStageVisitorBuilder<T> if_(@Nonnull IntFunction<T> ifVisitor);
     }
 
     public interface InterfaceStageVisitorBuilder<T> {
-        NewStageVisitorBuilder<T> interface_(IntFunction<T> interfaceVisitor);
+        NewStageVisitorBuilder<T> interface_(@Nonnull IntFunction<T> interfaceVisitor);
     }
 
     public interface NewStageVisitorBuilder<T> {
-        SetStageVisitorBuilder<T> new_(IntFunction<T> newVisitor);
+        SetStageVisitorBuilder<T> new_(@Nonnull IntFunction<T> newVisitor);
     }
 
     public interface SetStageVisitorBuilder<T> {
-        StringExampleStageVisitorBuilder<T> set(Function<Set<String>, T> setVisitor);
+        StringExampleStageVisitorBuilder<T> set(@Nonnull Function<Set<String>, T> setVisitor);
     }
 
     public interface StringExampleStageVisitorBuilder<T> {
         ThisFieldIsAnIntegerStageVisitorBuilder<T> stringExample(
-                Function<StringExample, T> stringExampleVisitor);
+                @Nonnull Function<StringExample, T> stringExampleVisitor);
     }
 
     public interface ThisFieldIsAnIntegerStageVisitorBuilder<T> {
         UnknownStageVisitorBuilder<T> thisFieldIsAnInteger(
-                IntFunction<T> thisFieldIsAnIntegerVisitor);
+                @Nonnull IntFunction<T> thisFieldIsAnIntegerVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor);
+        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
     }
 
     public interface CompletedStageVisitorBuilder<T> {
@@ -326,7 +330,7 @@ public final class UnionTypeExample {
         private final StringExample value;
 
         @JsonCreator
-        private StringExampleWrapper(@JsonProperty("stringExample") StringExample value) {
+        private StringExampleWrapper(@JsonProperty("stringExample") @Nonnull StringExample value) {
             Preconditions.checkNotNull(value, "stringExample cannot be null");
             this.value = value;
         }
@@ -363,7 +367,7 @@ public final class UnionTypeExample {
         private final Set<String> value;
 
         @JsonCreator
-        private SetWrapper(@JsonProperty("set") Set<String> value) {
+        private SetWrapper(@JsonProperty("set") @Nonnull Set<String> value) {
             Preconditions.checkNotNull(value, "set cannot be null");
             this.value = value;
         }
@@ -398,7 +402,8 @@ public final class UnionTypeExample {
         private final int value;
 
         @JsonCreator
-        private ThisFieldIsAnIntegerWrapper(@JsonProperty("thisFieldIsAnInteger") int value) {
+        private ThisFieldIsAnIntegerWrapper(
+                @JsonProperty("thisFieldIsAnInteger") @Nonnull int value) {
             Preconditions.checkNotNull(value, "thisFieldIsAnInteger cannot be null");
             this.value = value;
         }
@@ -435,7 +440,7 @@ public final class UnionTypeExample {
         private final int value;
 
         @JsonCreator
-        private AlsoAnIntegerWrapper(@JsonProperty("alsoAnInteger") int value) {
+        private AlsoAnIntegerWrapper(@JsonProperty("alsoAnInteger") @Nonnull int value) {
             Preconditions.checkNotNull(value, "alsoAnInteger cannot be null");
             this.value = value;
         }
@@ -472,7 +477,7 @@ public final class UnionTypeExample {
         private final int value;
 
         @JsonCreator
-        private IfWrapper(@JsonProperty("if") int value) {
+        private IfWrapper(@JsonProperty("if") @Nonnull int value) {
             Preconditions.checkNotNull(value, "if cannot be null");
             this.value = value;
         }
@@ -507,7 +512,7 @@ public final class UnionTypeExample {
         private final int value;
 
         @JsonCreator
-        private NewWrapper(@JsonProperty("new") int value) {
+        private NewWrapper(@JsonProperty("new") @Nonnull int value) {
             Preconditions.checkNotNull(value, "new cannot be null");
             this.value = value;
         }
@@ -542,7 +547,7 @@ public final class UnionTypeExample {
         private final int value;
 
         @JsonCreator
-        private InterfaceWrapper(@JsonProperty("interface") int value) {
+        private InterfaceWrapper(@JsonProperty("interface") @Nonnull int value) {
             Preconditions.checkNotNull(value, "interface cannot be null");
             this.value = value;
         }
@@ -588,7 +593,7 @@ public final class UnionTypeExample {
             this(type, new HashMap<String, Object>());
         }
 
-        private UnknownWrapper(String type, Map<String, Object> value) {
+        private UnknownWrapper(@Nonnull String type, @Nonnull Map<String, Object> value) {
             Preconditions.checkNotNull(type, "type cannot be null");
             Preconditions.checkNotNull(value, "value cannot be null");
             this.type = type;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidAliasExample.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.UUID;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class UuidAliasExample {
     private final UUID value;
 
-    private UuidAliasExample(UUID value) {
+    private UuidAliasExample(@Nonnull UUID value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -41,7 +42,7 @@ public final class UuidAliasExample {
     }
 
     @JsonCreator
-    public static UuidAliasExample of(UUID value) {
+    public static UuidAliasExample of(@Nonnull UUID value) {
         return new UuidAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = UuidExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -88,7 +89,7 @@ public final class UuidExample {
         }
 
         @JsonSetter("uuid")
-        public Builder uuid(UUID uuid) {
+        public Builder uuid(@Nonnull UUID uuid) {
             this.uuid = Preconditions.checkNotNull(uuid, "uuid cannot be null");
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AliasAsMapKeyExample.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = AliasAsMapKeyExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -211,13 +212,13 @@ public final class AliasAsMapKeyExample {
         }
 
         @JsonSetter(value = "strings", nulls = Nulls.SKIP)
-        public Builder strings(Map<StringAliasExample, ManyFieldExample> strings) {
+        public Builder strings(@Nonnull Map<StringAliasExample, ManyFieldExample> strings) {
             this.strings.clear();
             this.strings.putAll(Preconditions.checkNotNull(strings, "strings cannot be null"));
             return this;
         }
 
-        public Builder putAllStrings(Map<StringAliasExample, ManyFieldExample> strings) {
+        public Builder putAllStrings(@Nonnull Map<StringAliasExample, ManyFieldExample> strings) {
             this.strings.putAll(Preconditions.checkNotNull(strings, "strings cannot be null"));
             return this;
         }
@@ -228,13 +229,13 @@ public final class AliasAsMapKeyExample {
         }
 
         @JsonSetter(value = "rids", nulls = Nulls.SKIP)
-        public Builder rids(Map<RidAliasExample, ManyFieldExample> rids) {
+        public Builder rids(@Nonnull Map<RidAliasExample, ManyFieldExample> rids) {
             this.rids.clear();
             this.rids.putAll(Preconditions.checkNotNull(rids, "rids cannot be null"));
             return this;
         }
 
-        public Builder putAllRids(Map<RidAliasExample, ManyFieldExample> rids) {
+        public Builder putAllRids(@Nonnull Map<RidAliasExample, ManyFieldExample> rids) {
             this.rids.putAll(Preconditions.checkNotNull(rids, "rids cannot be null"));
             return this;
         }
@@ -245,7 +246,8 @@ public final class AliasAsMapKeyExample {
         }
 
         @JsonSetter(value = "bearertokens", nulls = Nulls.SKIP)
-        public Builder bearertokens(Map<BearerTokenAliasExample, ManyFieldExample> bearertokens) {
+        public Builder bearertokens(
+                @Nonnull Map<BearerTokenAliasExample, ManyFieldExample> bearertokens) {
             this.bearertokens.clear();
             this.bearertokens.putAll(
                     Preconditions.checkNotNull(bearertokens, "bearertokens cannot be null"));
@@ -253,7 +255,7 @@ public final class AliasAsMapKeyExample {
         }
 
         public Builder putAllBearertokens(
-                Map<BearerTokenAliasExample, ManyFieldExample> bearertokens) {
+                @Nonnull Map<BearerTokenAliasExample, ManyFieldExample> bearertokens) {
             this.bearertokens.putAll(
                     Preconditions.checkNotNull(bearertokens, "bearertokens cannot be null"));
             return this;
@@ -265,13 +267,14 @@ public final class AliasAsMapKeyExample {
         }
 
         @JsonSetter(value = "integers", nulls = Nulls.SKIP)
-        public Builder integers(Map<IntegerAliasExample, ManyFieldExample> integers) {
+        public Builder integers(@Nonnull Map<IntegerAliasExample, ManyFieldExample> integers) {
             this.integers.clear();
             this.integers.putAll(Preconditions.checkNotNull(integers, "integers cannot be null"));
             return this;
         }
 
-        public Builder putAllIntegers(Map<IntegerAliasExample, ManyFieldExample> integers) {
+        public Builder putAllIntegers(
+                @Nonnull Map<IntegerAliasExample, ManyFieldExample> integers) {
             this.integers.putAll(Preconditions.checkNotNull(integers, "integers cannot be null"));
             return this;
         }
@@ -282,14 +285,15 @@ public final class AliasAsMapKeyExample {
         }
 
         @JsonSetter(value = "safelongs", nulls = Nulls.SKIP)
-        public Builder safelongs(Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
+        public Builder safelongs(@Nonnull Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
             this.safelongs.clear();
             this.safelongs.putAll(
                     Preconditions.checkNotNull(safelongs, "safelongs cannot be null"));
             return this;
         }
 
-        public Builder putAllSafelongs(Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
+        public Builder putAllSafelongs(
+                @Nonnull Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
             this.safelongs.putAll(
                     Preconditions.checkNotNull(safelongs, "safelongs cannot be null"));
             return this;
@@ -301,14 +305,15 @@ public final class AliasAsMapKeyExample {
         }
 
         @JsonSetter(value = "datetimes", nulls = Nulls.SKIP)
-        public Builder datetimes(Map<DateTimeAliasExample, ManyFieldExample> datetimes) {
+        public Builder datetimes(@Nonnull Map<DateTimeAliasExample, ManyFieldExample> datetimes) {
             this.datetimes.clear();
             this.datetimes.putAll(
                     Preconditions.checkNotNull(datetimes, "datetimes cannot be null"));
             return this;
         }
 
-        public Builder putAllDatetimes(Map<DateTimeAliasExample, ManyFieldExample> datetimes) {
+        public Builder putAllDatetimes(
+                @Nonnull Map<DateTimeAliasExample, ManyFieldExample> datetimes) {
             this.datetimes.putAll(
                     Preconditions.checkNotNull(datetimes, "datetimes cannot be null"));
             return this;
@@ -320,13 +325,13 @@ public final class AliasAsMapKeyExample {
         }
 
         @JsonSetter(value = "uuids", nulls = Nulls.SKIP)
-        public Builder uuids(Map<UuidAliasExample, ManyFieldExample> uuids) {
+        public Builder uuids(@Nonnull Map<UuidAliasExample, ManyFieldExample> uuids) {
             this.uuids.clear();
             this.uuids.putAll(Preconditions.checkNotNull(uuids, "uuids cannot be null"));
             return this;
         }
 
-        public Builder putAllUuids(Map<UuidAliasExample, ManyFieldExample> uuids) {
+        public Builder putAllUuids(@Nonnull Map<UuidAliasExample, ManyFieldExample> uuids) {
             this.uuids.putAll(Preconditions.checkNotNull(uuids, "uuids cannot be null"));
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyExample.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = AnyExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -89,7 +90,7 @@ public final class AnyExample {
         }
 
         @JsonSetter("any")
-        public Builder any(Object any) {
+        public Builder any(@Nonnull Object any) {
             this.any = Preconditions.checkNotNull(any, "any cannot be null");
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyMapExample.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = AnyMapExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -100,13 +101,13 @@ public final class AnyMapExample {
         }
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
-        public Builder items(Map<String, Object> items) {
+        public Builder items(@Nonnull Map<String, Object> items) {
             this.items.clear();
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
-        public Builder putAllItems(Map<String, Object> items) {
+        public Builder putAllItems(@Nonnull Map<String, Object> items) {
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BearerTokenAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BearerTokenAliasExample.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.tokens.auth.BearerToken;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class BearerTokenAliasExample {
     private final BearerToken value;
 
-    private BearerTokenAliasExample(BearerToken value) {
+    private BearerTokenAliasExample(@Nonnull BearerToken value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -41,7 +42,7 @@ public final class BearerTokenAliasExample {
     }
 
     @JsonCreator
-    public static BearerTokenAliasExample of(BearerToken value) {
+    public static BearerTokenAliasExample of(@Nonnull BearerToken value) {
         return new BearerTokenAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BearerTokenExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BearerTokenExample.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = BearerTokenExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -91,7 +92,7 @@ public final class BearerTokenExample {
         }
 
         @JsonSetter("bearerTokenValue")
-        public Builder bearerTokenValue(BearerToken bearerTokenValue) {
+        public Builder bearerTokenValue(@Nonnull BearerToken bearerTokenValue) {
             this.bearerTokenValue =
                     Preconditions.checkNotNull(bearerTokenValue, "bearerTokenValue cannot be null");
             return this;

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasExample.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.nio.ByteBuffer;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class BinaryAliasExample {
     private final ByteBuffer value;
 
-    private BinaryAliasExample(ByteBuffer value) {
+    private BinaryAliasExample(@Nonnull ByteBuffer value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -37,7 +38,7 @@ public final class BinaryAliasExample {
     }
 
     @JsonCreator
-    public static BinaryAliasExample of(ByteBuffer value) {
+    public static BinaryAliasExample of(@Nonnull ByteBuffer value) {
         return new BinaryAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasOne.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.nio.ByteBuffer;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class BinaryAliasOne {
     private final ByteBuffer value;
 
-    private BinaryAliasOne(ByteBuffer value) {
+    private BinaryAliasOne(@Nonnull ByteBuffer value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -37,7 +38,7 @@ public final class BinaryAliasOne {
     }
 
     @JsonCreator
-    public static BinaryAliasOne of(ByteBuffer value) {
+    public static BinaryAliasOne of(@Nonnull ByteBuffer value) {
         return new BinaryAliasOne(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasTwo.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class BinaryAliasTwo {
     private final BinaryAliasOne value;
 
-    private BinaryAliasTwo(BinaryAliasOne value) {
+    private BinaryAliasTwo(@Nonnull BinaryAliasOne value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -36,7 +37,7 @@ public final class BinaryAliasTwo {
     }
 
     @JsonCreator
-    public static BinaryAliasTwo of(BinaryAliasOne value) {
+    public static BinaryAliasTwo of(@Nonnull BinaryAliasOne value) {
         return new BinaryAliasTwo(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryExample.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = BinaryExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -91,7 +92,7 @@ public final class BinaryExample {
         }
 
         @JsonSetter("binary")
-        public Builder binary(ByteBuffer binary) {
+        public Builder binary(@Nonnull ByteBuffer binary) {
             Preconditions.checkNotNull(binary, "binary cannot be null");
             this.binary = ByteBuffer.allocate(binary.remaining()).put(binary.duplicate());
             ((Buffer) this.binary).rewind();

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 import test.api.ExampleExternalReference;
 
 @JsonDeserialize(builder = CovariantListExample.Builder.class)
@@ -115,14 +116,14 @@ public final class CovariantListExample {
         }
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
-        public Builder items(Iterable<?> items) {
+        public Builder items(@Nonnull Iterable<?> items) {
             this.items.clear();
             ConjureCollections.addAll(
                     this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
-        public Builder addAllItems(Iterable<?> items) {
+        public Builder addAllItems(@Nonnull Iterable<?> items) {
             ConjureCollections.addAll(
                     this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
@@ -134,7 +135,8 @@ public final class CovariantListExample {
         }
 
         @JsonSetter(value = "externalItems", nulls = Nulls.SKIP)
-        public Builder externalItems(Iterable<? extends ExampleExternalReference> externalItems) {
+        public Builder externalItems(
+                @Nonnull Iterable<? extends ExampleExternalReference> externalItems) {
             this.externalItems.clear();
             ConjureCollections.addAll(
                     this.externalItems,
@@ -143,7 +145,7 @@ public final class CovariantListExample {
         }
 
         public Builder addAllExternalItems(
-                Iterable<? extends ExampleExternalReference> externalItems) {
+                @Nonnull Iterable<? extends ExampleExternalReference> externalItems) {
             ConjureCollections.addAll(
                     this.externalItems,
                     Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantOptionalExample.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = CovariantOptionalExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -116,27 +117,27 @@ public final class CovariantOptionalExample {
         }
 
         @JsonSetter(value = "item", nulls = Nulls.SKIP)
-        public Builder item(Optional<?> item) {
+        public Builder item(@Nonnull Optional<?> item) {
             this.item =
                     Preconditions.checkNotNull(item, "item cannot be null")
                             .map(Function.identity());
             return this;
         }
 
-        public Builder item(Object item) {
+        public Builder item(@Nonnull Object item) {
             this.item = Optional.of(Preconditions.checkNotNull(item, "item cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "setItem", nulls = Nulls.SKIP)
-        public Builder setItem(Optional<? extends Set<StringAliasExample>> setItem) {
+        public Builder setItem(@Nonnull Optional<? extends Set<StringAliasExample>> setItem) {
             this.setItem =
                     Preconditions.checkNotNull(setItem, "setItem cannot be null")
                             .map(Function.identity());
             return this;
         }
 
-        public Builder setItem(Set<StringAliasExample> setItem) {
+        public Builder setItem(@Nonnull Set<StringAliasExample> setItem) {
             this.setItem =
                     Optional.of(Preconditions.checkNotNull(setItem, "setItem cannot be null"));
             return this;

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeAliasExample.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.time.OffsetDateTime;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class DateTimeAliasExample {
     private final OffsetDateTime value;
 
-    private DateTimeAliasExample(OffsetDateTime value) {
+    private DateTimeAliasExample(@Nonnull OffsetDateTime value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -41,7 +42,7 @@ public final class DateTimeAliasExample {
     }
 
     @JsonCreator
-    public static DateTimeAliasExample of(OffsetDateTime value) {
+    public static DateTimeAliasExample of(@Nonnull OffsetDateTime value) {
         return new DateTimeAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeExample.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = DateTimeExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -98,7 +99,7 @@ public final class DateTimeExample {
         }
 
         @JsonSetter("datetime")
-        public Builder datetime(OffsetDateTime datetime) {
+        public Builder datetime(@Nonnull OffsetDateTime datetime) {
             this.datetime = Preconditions.checkNotNull(datetime, "datetime cannot be null");
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class EmptyUnionTypeExample {
@@ -70,7 +71,8 @@ public final class EmptyUnionTypeExample {
         private Function<String, T> unknownVisitor;
 
         @Override
-        public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
+        public CompletedStageVisitorBuilder<T> unknown(
+                @Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -89,7 +91,7 @@ public final class EmptyUnionTypeExample {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor);
+        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
     }
 
     public interface CompletedStageVisitorBuilder<T> {
@@ -119,7 +121,7 @@ public final class EmptyUnionTypeExample {
             this(type, new HashMap<String, Object>());
         }
 
-        private UnknownWrapper(String type, Map<String, Object> value) {
+        private UnknownWrapper(@Nonnull String type, @Nonnull Map<String, Object> value) {
             Preconditions.checkNotNull(type, "type cannot be null");
             Preconditions.checkNotNull(value, "value cannot be null");
             this.type = type;

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.Locale;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 /**
  * This enumerates the numbers 1:2 also 100.
@@ -67,7 +68,7 @@ public final class EnumExample {
 
     @JsonCreator
     @SuppressWarnings("deprecation")
-    public static EnumExample valueOf(String value) {
+    public static EnumExample valueOf(@Nonnull String value) {
         Preconditions.checkNotNull(value, "value cannot be null");
         String upperCasedValue = value.toUpperCase(Locale.ROOT);
         switch (upperCasedValue) {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumFieldExample.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = EnumFieldExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -90,7 +91,7 @@ public final class EnumFieldExample {
         }
 
         @JsonSetter("enum")
-        public Builder enum_(EnumExample enum_) {
+        public Builder enum_(@Nonnull EnumExample enum_) {
             this.enum_ = Preconditions.checkNotNull(enum_, "enum cannot be null");
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasTwo.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class ExternalLongAliasTwo {
     private final ExternalLongAliasOne value;
 
-    private ExternalLongAliasTwo(ExternalLongAliasOne value) {
+    private ExternalLongAliasTwo(@Nonnull ExternalLongAliasOne value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -40,7 +41,7 @@ public final class ExternalLongAliasTwo {
     }
 
     @JsonCreator
-    public static ExternalLongAliasTwo of(ExternalLongAliasOne value) {
+    public static ExternalLongAliasTwo of(@Nonnull ExternalLongAliasOne value) {
         return new ExternalLongAliasTwo(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = ExternalLongExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -152,7 +153,8 @@ public final class ExternalLongExample {
         }
 
         @JsonSetter(value = "optionalExternalLong", nulls = Nulls.SKIP)
-        public Builder optionalExternalLong(Optional<? extends Long> optionalExternalLong) {
+        public Builder optionalExternalLong(
+                @Nonnull Optional<? extends Long> optionalExternalLong) {
             this.optionalExternalLong =
                     Preconditions.checkNotNull(
                                     optionalExternalLong, "optionalExternalLong cannot be null")
@@ -169,7 +171,7 @@ public final class ExternalLongExample {
         }
 
         @JsonSetter(value = "listExternalLong", nulls = Nulls.SKIP)
-        public Builder listExternalLong(Iterable<? extends Long> listExternalLong) {
+        public Builder listExternalLong(@Nonnull Iterable<? extends Long> listExternalLong) {
             this.listExternalLong.clear();
             ConjureCollections.addAll(
                     this.listExternalLong,
@@ -178,7 +180,7 @@ public final class ExternalLongExample {
             return this;
         }
 
-        public Builder addAllListExternalLong(Iterable<? extends Long> listExternalLong) {
+        public Builder addAllListExternalLong(@Nonnull Iterable<? extends Long> listExternalLong) {
             ConjureCollections.addAll(
                     this.listExternalLong,
                     Preconditions.checkNotNull(

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalStringAliasExample.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class ExternalStringAliasExample {
     private final String value;
 
-    private ExternalStringAliasExample(String value) {
+    private ExternalStringAliasExample(@Nonnull String value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -36,7 +37,7 @@ public final class ExternalStringAliasExample {
     }
 
     @JsonCreator
-    public static ExternalStringAliasExample of(String value) {
+    public static ExternalStringAliasExample of(@Nonnull String value) {
         return new ExternalStringAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListExample.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = ListExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -193,14 +194,14 @@ public final class ListExample {
         }
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
-        public Builder items(Iterable<String> items) {
+        public Builder items(@Nonnull Iterable<String> items) {
             this.items.clear();
             ConjureCollections.addAll(
                     this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
-        public Builder addAllItems(Iterable<String> items) {
+        public Builder addAllItems(@Nonnull Iterable<String> items) {
             ConjureCollections.addAll(
                     this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
@@ -212,7 +213,7 @@ public final class ListExample {
         }
 
         @JsonSetter(value = "primitiveItems", nulls = Nulls.SKIP)
-        public Builder primitiveItems(Iterable<Integer> primitiveItems) {
+        public Builder primitiveItems(@Nonnull Iterable<Integer> primitiveItems) {
             this.primitiveItems.clear();
             ConjureCollections.addAll(
                     this.primitiveItems,
@@ -220,7 +221,7 @@ public final class ListExample {
             return this;
         }
 
-        public Builder addAllPrimitiveItems(Iterable<Integer> primitiveItems) {
+        public Builder addAllPrimitiveItems(@Nonnull Iterable<Integer> primitiveItems) {
             ConjureCollections.addAll(
                     this.primitiveItems,
                     Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
@@ -233,7 +234,7 @@ public final class ListExample {
         }
 
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP)
-        public Builder doubleItems(Iterable<Double> doubleItems) {
+        public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
             this.doubleItems.clear();
             ConjureCollections.addAll(
                     this.doubleItems,
@@ -241,7 +242,7 @@ public final class ListExample {
             return this;
         }
 
-        public Builder addAllDoubleItems(Iterable<Double> doubleItems) {
+        public Builder addAllDoubleItems(@Nonnull Iterable<Double> doubleItems) {
             ConjureCollections.addAll(
                     this.doubleItems,
                     Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
@@ -254,7 +255,7 @@ public final class ListExample {
         }
 
         @JsonSetter(value = "optionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
-        public Builder optionalItems(Iterable<Optional<String>> optionalItems) {
+        public Builder optionalItems(@Nonnull Iterable<Optional<String>> optionalItems) {
             this.optionalItems.clear();
             ConjureCollections.addAll(
                     this.optionalItems,
@@ -262,7 +263,7 @@ public final class ListExample {
             return this;
         }
 
-        public Builder addAllOptionalItems(Iterable<Optional<String>> optionalItems) {
+        public Builder addAllOptionalItems(@Nonnull Iterable<Optional<String>> optionalItems) {
             ConjureCollections.addAll(
                     this.optionalItems,
                     Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
@@ -275,7 +276,7 @@ public final class ListExample {
         }
 
         @JsonSetter(value = "aliasOptionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
-        public Builder aliasOptionalItems(Iterable<OptionalAlias> aliasOptionalItems) {
+        public Builder aliasOptionalItems(@Nonnull Iterable<OptionalAlias> aliasOptionalItems) {
             this.aliasOptionalItems.clear();
             ConjureCollections.addAll(
                     this.aliasOptionalItems,
@@ -284,7 +285,8 @@ public final class ListExample {
             return this;
         }
 
-        public Builder addAllAliasOptionalItems(Iterable<OptionalAlias> aliasOptionalItems) {
+        public Builder addAllAliasOptionalItems(
+                @Nonnull Iterable<OptionalAlias> aliasOptionalItems) {
             ConjureCollections.addAll(
                     this.aliasOptionalItems,
                     Preconditions.checkNotNull(
@@ -298,7 +300,7 @@ public final class ListExample {
         }
 
         @JsonSetter(value = "nestedItems", nulls = Nulls.SKIP)
-        public Builder nestedItems(Iterable<? extends List<String>> nestedItems) {
+        public Builder nestedItems(@Nonnull Iterable<? extends List<String>> nestedItems) {
             this.nestedItems.clear();
             ConjureCollections.addAll(
                     this.nestedItems,
@@ -306,7 +308,7 @@ public final class ListExample {
             return this;
         }
 
-        public Builder addAllNestedItems(Iterable<? extends List<String>> nestedItems) {
+        public Builder addAllNestedItems(@Nonnull Iterable<? extends List<String>> nestedItems) {
             ConjureCollections.addAll(
                     this.nestedItems,
                     Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = ManyFieldExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -248,7 +249,7 @@ public final class ManyFieldExample {
 
         /** docs for string field */
         @JsonSetter("string")
-        public Builder string(String string) {
+        public Builder string(@Nonnull String string) {
             this.string = Preconditions.checkNotNull(string, "string cannot be null");
             return this;
         }
@@ -271,14 +272,14 @@ public final class ManyFieldExample {
 
         /** docs for optionalItem field */
         @JsonSetter(value = "optionalItem", nulls = Nulls.SKIP)
-        public Builder optionalItem(Optional<String> optionalItem) {
+        public Builder optionalItem(@Nonnull Optional<String> optionalItem) {
             this.optionalItem =
                     Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null");
             return this;
         }
 
         /** docs for optionalItem field */
-        public Builder optionalItem(String optionalItem) {
+        public Builder optionalItem(@Nonnull String optionalItem) {
             this.optionalItem =
                     Optional.of(
                             Preconditions.checkNotNull(
@@ -288,7 +289,7 @@ public final class ManyFieldExample {
 
         /** docs for items field */
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
-        public Builder items(Iterable<String> items) {
+        public Builder items(@Nonnull Iterable<String> items) {
             this.items.clear();
             ConjureCollections.addAll(
                     this.items, Preconditions.checkNotNull(items, "items cannot be null"));
@@ -296,7 +297,7 @@ public final class ManyFieldExample {
         }
 
         /** docs for items field */
-        public Builder addAllItems(Iterable<String> items) {
+        public Builder addAllItems(@Nonnull Iterable<String> items) {
             ConjureCollections.addAll(
                     this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
@@ -310,7 +311,7 @@ public final class ManyFieldExample {
 
         /** docs for set field */
         @JsonSetter(value = "set", nulls = Nulls.SKIP)
-        public Builder set(Iterable<String> set) {
+        public Builder set(@Nonnull Iterable<String> set) {
             this.set.clear();
             ConjureCollections.addAll(
                     this.set, Preconditions.checkNotNull(set, "set cannot be null"));
@@ -318,7 +319,7 @@ public final class ManyFieldExample {
         }
 
         /** docs for set field */
-        public Builder addAllSet(Iterable<String> set) {
+        public Builder addAllSet(@Nonnull Iterable<String> set) {
             ConjureCollections.addAll(
                     this.set, Preconditions.checkNotNull(set, "set cannot be null"));
             return this;
@@ -333,7 +334,7 @@ public final class ManyFieldExample {
         /** @deprecated deprecation documentation. */
         @Deprecated
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
-        public Builder map(Map<String, String> map) {
+        public Builder map(@Nonnull Map<String, String> map) {
             this.map.clear();
             this.map.putAll(Preconditions.checkNotNull(map, "map cannot be null"));
             return this;
@@ -341,7 +342,7 @@ public final class ManyFieldExample {
 
         /** @deprecated deprecation documentation. */
         @Deprecated
-        public Builder putAllMap(Map<String, String> map) {
+        public Builder putAllMap(@Nonnull Map<String, String> map) {
             this.map.putAll(Preconditions.checkNotNull(map, "map cannot be null"));
             return this;
         }
@@ -360,7 +361,7 @@ public final class ManyFieldExample {
          */
         @Deprecated
         @JsonSetter("alias")
-        public Builder alias(StringAliasExample alias) {
+        public Builder alias(@Nonnull StringAliasExample alias) {
             this.alias = Preconditions.checkNotNull(alias, "alias cannot be null");
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapAliasExample.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.Map;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class MapAliasExample {
     private final Map<String, Object> value;
 
-    private MapAliasExample(Map<String, Object> value) {
+    private MapAliasExample(@Nonnull Map<String, Object> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -37,7 +38,7 @@ public final class MapAliasExample {
     }
 
     @JsonCreator
-    public static MapAliasExample of(Map<String, Object> value) {
+    public static MapAliasExample of(@Nonnull Map<String, Object> value) {
         return new MapAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapExample.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = MapExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -146,13 +147,13 @@ public final class MapExample {
         }
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
-        public Builder items(Map<String, String> items) {
+        public Builder items(@Nonnull Map<String, String> items) {
             this.items.clear();
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
-        public Builder putAllItems(Map<String, String> items) {
+        public Builder putAllItems(@Nonnull Map<String, String> items) {
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
@@ -163,14 +164,14 @@ public final class MapExample {
         }
 
         @JsonSetter(value = "optionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
-        public Builder optionalItems(Map<String, Optional<String>> optionalItems) {
+        public Builder optionalItems(@Nonnull Map<String, Optional<String>> optionalItems) {
             this.optionalItems.clear();
             this.optionalItems.putAll(
                     Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
         }
 
-        public Builder putAllOptionalItems(Map<String, Optional<String>> optionalItems) {
+        public Builder putAllOptionalItems(@Nonnull Map<String, Optional<String>> optionalItems) {
             this.optionalItems.putAll(
                     Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
@@ -182,7 +183,7 @@ public final class MapExample {
         }
 
         @JsonSetter(value = "aliasOptionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
-        public Builder aliasOptionalItems(Map<String, OptionalAlias> aliasOptionalItems) {
+        public Builder aliasOptionalItems(@Nonnull Map<String, OptionalAlias> aliasOptionalItems) {
             this.aliasOptionalItems.clear();
             this.aliasOptionalItems.putAll(
                     Preconditions.checkNotNull(
@@ -190,7 +191,8 @@ public final class MapExample {
             return this;
         }
 
-        public Builder putAllAliasOptionalItems(Map<String, OptionalAlias> aliasOptionalItems) {
+        public Builder putAllAliasOptionalItems(
+                @Nonnull Map<String, OptionalAlias> aliasOptionalItems) {
             this.aliasOptionalItems.putAll(
                     Preconditions.checkNotNull(
                             aliasOptionalItems, "aliasOptionalItems cannot be null"));

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/NestedStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/NestedStringAliasExample.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class NestedStringAliasExample {
     private final StringAliasExample value;
 
-    private NestedStringAliasExample(StringAliasExample value) {
+    private NestedStringAliasExample(@Nonnull StringAliasExample value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -40,7 +41,7 @@ public final class NestedStringAliasExample {
     }
 
     @JsonCreator
-    public static NestedStringAliasExample of(StringAliasExample value) {
+    public static NestedStringAliasExample of(@Nonnull StringAliasExample value) {
         return new NestedStringAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAlias.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAlias.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class OptionalAlias {
     private final Optional<String> value;
 
-    private OptionalAlias(Optional<String> value) {
+    private OptionalAlias(@Nonnull Optional<String> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -41,7 +42,7 @@ public final class OptionalAlias {
     }
 
     @JsonCreator
-    public static OptionalAlias of(Optional<String> value) {
+    public static OptionalAlias of(@Nonnull Optional<String> value) {
         return new OptionalAlias(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalExample.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = OptionalExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -92,12 +93,12 @@ public final class OptionalExample {
         }
 
         @JsonSetter(value = "item", nulls = Nulls.SKIP)
-        public Builder item(Optional<String> item) {
+        public Builder item(@Nonnull Optional<String> item) {
             this.item = Preconditions.checkNotNull(item, "item cannot be null");
             return this;
         }
 
-        public Builder item(String item) {
+        public Builder item(@Nonnull String item) {
             this.item = Optional.of(Preconditions.checkNotNull(item, "item cannot be null"));
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
@@ -19,6 +19,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.UUID;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = PrimitiveOptionalsExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -216,7 +217,7 @@ public final class PrimitiveOptionalsExample {
         }
 
         @JsonSetter(value = "num", nulls = Nulls.SKIP)
-        public Builder num(OptionalDouble num) {
+        public Builder num(@Nonnull OptionalDouble num) {
             this.num = Preconditions.checkNotNull(num, "num cannot be null");
             return this;
         }
@@ -227,7 +228,7 @@ public final class PrimitiveOptionalsExample {
         }
 
         @JsonSetter(value = "bool", nulls = Nulls.SKIP)
-        public Builder bool(Optional<Boolean> bool) {
+        public Builder bool(@Nonnull Optional<Boolean> bool) {
             this.bool = Preconditions.checkNotNull(bool, "bool cannot be null");
             return this;
         }
@@ -238,7 +239,7 @@ public final class PrimitiveOptionalsExample {
         }
 
         @JsonSetter(value = "integer", nulls = Nulls.SKIP)
-        public Builder integer(OptionalInt integer) {
+        public Builder integer(@Nonnull OptionalInt integer) {
             this.integer = Preconditions.checkNotNull(integer, "integer cannot be null");
             return this;
         }
@@ -249,36 +250,36 @@ public final class PrimitiveOptionalsExample {
         }
 
         @JsonSetter(value = "safelong", nulls = Nulls.SKIP)
-        public Builder safelong(Optional<SafeLong> safelong) {
+        public Builder safelong(@Nonnull Optional<SafeLong> safelong) {
             this.safelong = Preconditions.checkNotNull(safelong, "safelong cannot be null");
             return this;
         }
 
-        public Builder safelong(SafeLong safelong) {
+        public Builder safelong(@Nonnull SafeLong safelong) {
             this.safelong =
                     Optional.of(Preconditions.checkNotNull(safelong, "safelong cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "rid", nulls = Nulls.SKIP)
-        public Builder rid(Optional<ResourceIdentifier> rid) {
+        public Builder rid(@Nonnull Optional<ResourceIdentifier> rid) {
             this.rid = Preconditions.checkNotNull(rid, "rid cannot be null");
             return this;
         }
 
-        public Builder rid(ResourceIdentifier rid) {
+        public Builder rid(@Nonnull ResourceIdentifier rid) {
             this.rid = Optional.of(Preconditions.checkNotNull(rid, "rid cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "bearertoken", nulls = Nulls.SKIP)
-        public Builder bearertoken(Optional<BearerToken> bearertoken) {
+        public Builder bearertoken(@Nonnull Optional<BearerToken> bearertoken) {
             this.bearertoken =
                     Preconditions.checkNotNull(bearertoken, "bearertoken cannot be null");
             return this;
         }
 
-        public Builder bearertoken(BearerToken bearertoken) {
+        public Builder bearertoken(@Nonnull BearerToken bearertoken) {
             this.bearertoken =
                     Optional.of(
                             Preconditions.checkNotNull(bearertoken, "bearertoken cannot be null"));
@@ -286,12 +287,12 @@ public final class PrimitiveOptionalsExample {
         }
 
         @JsonSetter(value = "uuid", nulls = Nulls.SKIP)
-        public Builder uuid(Optional<UUID> uuid) {
+        public Builder uuid(@Nonnull Optional<UUID> uuid) {
             this.uuid = Preconditions.checkNotNull(uuid, "uuid cannot be null");
             return this;
         }
 
-        public Builder uuid(UUID uuid) {
+        public Builder uuid(@Nonnull UUID uuid) {
             this.uuid = Optional.of(Preconditions.checkNotNull(uuid, "uuid cannot be null"));
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReferenceAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReferenceAliasExample.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class ReferenceAliasExample {
     private final AnyExample value;
 
-    private ReferenceAliasExample(AnyExample value) {
+    private ReferenceAliasExample(@Nonnull AnyExample value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -36,7 +37,7 @@ public final class ReferenceAliasExample {
     }
 
     @JsonCreator
-    public static ReferenceAliasExample of(AnyExample value) {
+    public static ReferenceAliasExample of(@Nonnull AnyExample value) {
         return new ReferenceAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReservedKeyExample.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = ReservedKeyExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -188,19 +189,19 @@ public final class ReservedKeyExample {
         }
 
         @JsonSetter("package")
-        public Builder package_(String package_) {
+        public Builder package_(@Nonnull String package_) {
             this.package_ = Preconditions.checkNotNull(package_, "package cannot be null");
             return this;
         }
 
         @JsonSetter("interface")
-        public Builder interface_(String interface_) {
+        public Builder interface_(@Nonnull String interface_) {
             this.interface_ = Preconditions.checkNotNull(interface_, "interface cannot be null");
             return this;
         }
 
         @JsonSetter("field-name-with-dashes")
-        public Builder fieldNameWithDashes(String fieldNameWithDashes) {
+        public Builder fieldNameWithDashes(@Nonnull String fieldNameWithDashes) {
             this.fieldNameWithDashes =
                     Preconditions.checkNotNull(
                             fieldNameWithDashes, "field-name-with-dashes cannot be null");

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RidAliasExample.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.ri.ResourceIdentifier;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class RidAliasExample {
     private final ResourceIdentifier value;
 
-    private RidAliasExample(ResourceIdentifier value) {
+    private RidAliasExample(@Nonnull ResourceIdentifier value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -41,7 +42,7 @@ public final class RidAliasExample {
     }
 
     @JsonCreator
-    public static RidAliasExample of(ResourceIdentifier value) {
+    public static RidAliasExample of(@Nonnull ResourceIdentifier value) {
         return new RidAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RidExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RidExample.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = RidExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -90,7 +91,7 @@ public final class RidExample {
         }
 
         @JsonSetter("ridValue")
-        public Builder ridValue(ResourceIdentifier ridValue) {
+        public Builder ridValue(@Nonnull ResourceIdentifier ridValue) {
             this.ridValue = Preconditions.checkNotNull(ridValue, "ridValue cannot be null");
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeLongAliasExample.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class SafeLongAliasExample {
     private final SafeLong value;
 
-    private SafeLongAliasExample(SafeLong value) {
+    private SafeLongAliasExample(@Nonnull SafeLong value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -41,7 +42,7 @@ public final class SafeLongAliasExample {
     }
 
     @JsonCreator
-    public static SafeLongAliasExample of(SafeLong value) {
+    public static SafeLongAliasExample of(@Nonnull SafeLong value) {
         return new SafeLongAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeLongExample.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = SafeLongExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -91,7 +92,7 @@ public final class SafeLongExample {
         }
 
         @JsonSetter("safeLongValue")
-        public Builder safeLongValue(SafeLong safeLongValue) {
+        public Builder safeLongValue(@Nonnull SafeLong safeLongValue) {
             this.safeLongValue =
                     Preconditions.checkNotNull(safeLongValue, "safeLongValue cannot be null");
             return this;

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetExample.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = SetExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -113,14 +114,14 @@ public final class SetExample {
         }
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
-        public Builder items(Iterable<String> items) {
+        public Builder items(@Nonnull Iterable<String> items) {
             this.items.clear();
             ConjureCollections.addAll(
                     this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
-        public Builder addAllItems(Iterable<String> items) {
+        public Builder addAllItems(@Nonnull Iterable<String> items) {
             ConjureCollections.addAll(
                     this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
@@ -132,7 +133,7 @@ public final class SetExample {
         }
 
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP)
-        public Builder doubleItems(Iterable<Double> doubleItems) {
+        public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
             this.doubleItems.clear();
             ConjureCollections.addAll(
                     this.doubleItems,
@@ -140,7 +141,7 @@ public final class SetExample {
             return this;
         }
 
-        public Builder addAllDoubleItems(Iterable<Double> doubleItems) {
+        public Builder addAllDoubleItems(@Nonnull Iterable<Double> doubleItems) {
             ConjureCollections.addAll(
                     this.doubleItems,
                     Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.Locale;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 /**
  * This class is used instead of a native enum to support unknown values. Rather than throw an
@@ -52,7 +53,7 @@ public final class SimpleEnum {
     }
 
     @JsonCreator
-    public static SimpleEnum valueOf(String value) {
+    public static SimpleEnum valueOf(@Nonnull String value) {
         Preconditions.checkNotNull(value, "value cannot be null");
         String upperCasedValue = value.toUpperCase(Locale.ROOT);
         switch (upperCasedValue) {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class SingleUnion {
@@ -82,14 +83,15 @@ public final class SingleUnion {
         private Function<String, T> unknownVisitor;
 
         @Override
-        public UnknownStageVisitorBuilder<T> foo(Function<String, T> fooVisitor) {
+        public UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor) {
             Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
             this.fooVisitor = fooVisitor;
             return this;
         }
 
         @Override
-        public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
+        public CompletedStageVisitorBuilder<T> unknown(
+                @Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -114,11 +116,11 @@ public final class SingleUnion {
     }
 
     public interface FooStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> foo(Function<String, T> fooVisitor);
+        UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor);
+        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
     }
 
     public interface CompletedStageVisitorBuilder<T> {
@@ -139,7 +141,7 @@ public final class SingleUnion {
         private final String value;
 
         @JsonCreator
-        private FooWrapper(@JsonProperty("foo") String value) {
+        private FooWrapper(@JsonProperty("foo") @Nonnull String value) {
             Preconditions.checkNotNull(value, "foo cannot be null");
             this.value = value;
         }
@@ -184,7 +186,7 @@ public final class SingleUnion {
             this(type, new HashMap<String, Object>());
         }
 
-        private UnknownWrapper(String type, Map<String, Object> value) {
+        private UnknownWrapper(@Nonnull String type, @Nonnull Map<String, Object> value) {
             Preconditions.checkNotNull(type, "type cannot be null");
             Preconditions.checkNotNull(value, "value cannot be null");
             this.type = type;

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasExample.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class StringAliasExample {
     private final String value;
 
-    private StringAliasExample(String value) {
+    private StringAliasExample(@Nonnull String value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -40,7 +41,7 @@ public final class StringAliasExample {
     }
 
     @JsonCreator
-    public static StringAliasExample of(String value) {
+    public static StringAliasExample of(@Nonnull String value) {
         return new StringAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasOne.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class StringAliasOne {
     private final String value;
 
-    private StringAliasOne(String value) {
+    private StringAliasOne(@Nonnull String value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -40,7 +41,7 @@ public final class StringAliasOne {
     }
 
     @JsonCreator
-    public static StringAliasOne of(String value) {
+    public static StringAliasOne of(@Nonnull String value) {
         return new StringAliasOne(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasThree.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasThree.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class StringAliasThree {
     private final StringAliasTwo value;
 
-    private StringAliasThree(StringAliasTwo value) {
+    private StringAliasThree(@Nonnull StringAliasTwo value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -36,7 +37,7 @@ public final class StringAliasThree {
     }
 
     @JsonCreator
-    public static StringAliasThree of(StringAliasTwo value) {
+    public static StringAliasThree of(@Nonnull StringAliasTwo value) {
         return new StringAliasThree(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasTwo.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class StringAliasTwo {
     private final Optional<StringAliasOne> value;
 
-    private StringAliasTwo(Optional<StringAliasOne> value) {
+    private StringAliasTwo(@Nonnull Optional<StringAliasOne> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -41,7 +42,7 @@ public final class StringAliasTwo {
     }
 
     @JsonCreator
-    public static StringAliasTwo of(Optional<StringAliasOne> value) {
+    public static StringAliasTwo of(@Nonnull Optional<StringAliasOne> value) {
         return new StringAliasTwo(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringExample.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = StringExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -89,7 +90,7 @@ public final class StringExample {
         }
 
         @JsonSetter("string")
-        public Builder string(String string) {
+        public Builder string(@Nonnull String string) {
             this.string = Preconditions.checkNotNull(string, "string cannot be null");
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class Union {
@@ -122,28 +123,29 @@ public final class Union {
         private Function<String, T> unknownVisitor;
 
         @Override
-        public BazStageVisitorBuilder<T> bar(IntFunction<T> barVisitor) {
+        public BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor) {
             Preconditions.checkNotNull(barVisitor, "barVisitor cannot be null");
             this.barVisitor = barVisitor;
             return this;
         }
 
         @Override
-        public FooStageVisitorBuilder<T> baz(Function<Long, T> bazVisitor) {
+        public FooStageVisitorBuilder<T> baz(@Nonnull Function<Long, T> bazVisitor) {
             Preconditions.checkNotNull(bazVisitor, "bazVisitor cannot be null");
             this.bazVisitor = bazVisitor;
             return this;
         }
 
         @Override
-        public UnknownStageVisitorBuilder<T> foo(Function<String, T> fooVisitor) {
+        public UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor) {
             Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
             this.fooVisitor = fooVisitor;
             return this;
         }
 
         @Override
-        public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
+        public CompletedStageVisitorBuilder<T> unknown(
+                @Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -180,19 +182,19 @@ public final class Union {
     }
 
     public interface BarStageVisitorBuilder<T> {
-        BazStageVisitorBuilder<T> bar(IntFunction<T> barVisitor);
+        BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor);
     }
 
     public interface BazStageVisitorBuilder<T> {
-        FooStageVisitorBuilder<T> baz(Function<Long, T> bazVisitor);
+        FooStageVisitorBuilder<T> baz(@Nonnull Function<Long, T> bazVisitor);
     }
 
     public interface FooStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> foo(Function<String, T> fooVisitor);
+        UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor);
+        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
     }
 
     public interface CompletedStageVisitorBuilder<T> {
@@ -217,7 +219,7 @@ public final class Union {
         private final String value;
 
         @JsonCreator
-        private FooWrapper(@JsonProperty("foo") String value) {
+        private FooWrapper(@JsonProperty("foo") @Nonnull String value) {
             Preconditions.checkNotNull(value, "foo cannot be null");
             this.value = value;
         }
@@ -252,7 +254,7 @@ public final class Union {
         private final int value;
 
         @JsonCreator
-        private BarWrapper(@JsonProperty("bar") int value) {
+        private BarWrapper(@JsonProperty("bar") @Nonnull int value) {
             Preconditions.checkNotNull(value, "bar cannot be null");
             this.value = value;
         }
@@ -287,7 +289,7 @@ public final class Union {
         private final long value;
 
         @JsonCreator
-        private BazWrapper(@JsonProperty("baz") long value) {
+        private BazWrapper(@JsonProperty("baz") @Nonnull long value) {
             Preconditions.checkNotNull(value, "baz cannot be null");
             this.value = value;
         }
@@ -332,7 +334,7 @@ public final class Union {
             this(type, new HashMap<String, Object>());
         }
 
-        private UnknownWrapper(String type, Map<String, Object> value) {
+        private UnknownWrapper(@Nonnull String type, @Nonnull Map<String, Object> value) {
             Preconditions.checkNotNull(type, "type cannot be null");
             Preconditions.checkNotNull(value, "value cannot be null");
             this.type = type;

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 /** A type which can either be a StringExample, a set of strings, or an integer. */
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
@@ -154,35 +155,37 @@ public final class UnionTypeExample {
         private Function<String, T> unknownVisitor;
 
         @Override
-        public IfStageVisitorBuilder<T> alsoAnInteger(IntFunction<T> alsoAnIntegerVisitor) {
+        public IfStageVisitorBuilder<T> alsoAnInteger(
+                @Nonnull IntFunction<T> alsoAnIntegerVisitor) {
             Preconditions.checkNotNull(alsoAnIntegerVisitor, "alsoAnIntegerVisitor cannot be null");
             this.alsoAnIntegerVisitor = alsoAnIntegerVisitor;
             return this;
         }
 
         @Override
-        public InterfaceStageVisitorBuilder<T> if_(IntFunction<T> ifVisitor) {
+        public InterfaceStageVisitorBuilder<T> if_(@Nonnull IntFunction<T> ifVisitor) {
             Preconditions.checkNotNull(ifVisitor, "ifVisitor cannot be null");
             this.ifVisitor = ifVisitor;
             return this;
         }
 
         @Override
-        public NewStageVisitorBuilder<T> interface_(IntFunction<T> interfaceVisitor) {
+        public NewStageVisitorBuilder<T> interface_(@Nonnull IntFunction<T> interfaceVisitor) {
             Preconditions.checkNotNull(interfaceVisitor, "interfaceVisitor cannot be null");
             this.interfaceVisitor = interfaceVisitor;
             return this;
         }
 
         @Override
-        public SetStageVisitorBuilder<T> new_(IntFunction<T> newVisitor) {
+        public SetStageVisitorBuilder<T> new_(@Nonnull IntFunction<T> newVisitor) {
             Preconditions.checkNotNull(newVisitor, "newVisitor cannot be null");
             this.newVisitor = newVisitor;
             return this;
         }
 
         @Override
-        public StringExampleStageVisitorBuilder<T> set(Function<Set<String>, T> setVisitor) {
+        public StringExampleStageVisitorBuilder<T> set(
+                @Nonnull Function<Set<String>, T> setVisitor) {
             Preconditions.checkNotNull(setVisitor, "setVisitor cannot be null");
             this.setVisitor = setVisitor;
             return this;
@@ -190,7 +193,7 @@ public final class UnionTypeExample {
 
         @Override
         public ThisFieldIsAnIntegerStageVisitorBuilder<T> stringExample(
-                Function<StringExample, T> stringExampleVisitor) {
+                @Nonnull Function<StringExample, T> stringExampleVisitor) {
             Preconditions.checkNotNull(stringExampleVisitor, "stringExampleVisitor cannot be null");
             this.stringExampleVisitor = stringExampleVisitor;
             return this;
@@ -198,7 +201,7 @@ public final class UnionTypeExample {
 
         @Override
         public UnknownStageVisitorBuilder<T> thisFieldIsAnInteger(
-                IntFunction<T> thisFieldIsAnIntegerVisitor) {
+                @Nonnull IntFunction<T> thisFieldIsAnIntegerVisitor) {
             Preconditions.checkNotNull(
                     thisFieldIsAnIntegerVisitor, "thisFieldIsAnIntegerVisitor cannot be null");
             this.thisFieldIsAnIntegerVisitor = thisFieldIsAnIntegerVisitor;
@@ -206,7 +209,8 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor) {
+        public CompletedStageVisitorBuilder<T> unknown(
+                @Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -267,37 +271,37 @@ public final class UnionTypeExample {
     }
 
     public interface AlsoAnIntegerStageVisitorBuilder<T> {
-        IfStageVisitorBuilder<T> alsoAnInteger(IntFunction<T> alsoAnIntegerVisitor);
+        IfStageVisitorBuilder<T> alsoAnInteger(@Nonnull IntFunction<T> alsoAnIntegerVisitor);
     }
 
     public interface IfStageVisitorBuilder<T> {
-        InterfaceStageVisitorBuilder<T> if_(IntFunction<T> ifVisitor);
+        InterfaceStageVisitorBuilder<T> if_(@Nonnull IntFunction<T> ifVisitor);
     }
 
     public interface InterfaceStageVisitorBuilder<T> {
-        NewStageVisitorBuilder<T> interface_(IntFunction<T> interfaceVisitor);
+        NewStageVisitorBuilder<T> interface_(@Nonnull IntFunction<T> interfaceVisitor);
     }
 
     public interface NewStageVisitorBuilder<T> {
-        SetStageVisitorBuilder<T> new_(IntFunction<T> newVisitor);
+        SetStageVisitorBuilder<T> new_(@Nonnull IntFunction<T> newVisitor);
     }
 
     public interface SetStageVisitorBuilder<T> {
-        StringExampleStageVisitorBuilder<T> set(Function<Set<String>, T> setVisitor);
+        StringExampleStageVisitorBuilder<T> set(@Nonnull Function<Set<String>, T> setVisitor);
     }
 
     public interface StringExampleStageVisitorBuilder<T> {
         ThisFieldIsAnIntegerStageVisitorBuilder<T> stringExample(
-                Function<StringExample, T> stringExampleVisitor);
+                @Nonnull Function<StringExample, T> stringExampleVisitor);
     }
 
     public interface ThisFieldIsAnIntegerStageVisitorBuilder<T> {
         UnknownStageVisitorBuilder<T> thisFieldIsAnInteger(
-                IntFunction<T> thisFieldIsAnIntegerVisitor);
+                @Nonnull IntFunction<T> thisFieldIsAnIntegerVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(Function<String, T> unknownVisitor);
+        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
     }
 
     public interface CompletedStageVisitorBuilder<T> {
@@ -326,7 +330,7 @@ public final class UnionTypeExample {
         private final StringExample value;
 
         @JsonCreator
-        private StringExampleWrapper(@JsonProperty("stringExample") StringExample value) {
+        private StringExampleWrapper(@JsonProperty("stringExample") @Nonnull StringExample value) {
             Preconditions.checkNotNull(value, "stringExample cannot be null");
             this.value = value;
         }
@@ -363,7 +367,7 @@ public final class UnionTypeExample {
         private final Set<String> value;
 
         @JsonCreator
-        private SetWrapper(@JsonProperty("set") Set<String> value) {
+        private SetWrapper(@JsonProperty("set") @Nonnull Set<String> value) {
             Preconditions.checkNotNull(value, "set cannot be null");
             this.value = value;
         }
@@ -398,7 +402,8 @@ public final class UnionTypeExample {
         private final int value;
 
         @JsonCreator
-        private ThisFieldIsAnIntegerWrapper(@JsonProperty("thisFieldIsAnInteger") int value) {
+        private ThisFieldIsAnIntegerWrapper(
+                @JsonProperty("thisFieldIsAnInteger") @Nonnull int value) {
             Preconditions.checkNotNull(value, "thisFieldIsAnInteger cannot be null");
             this.value = value;
         }
@@ -435,7 +440,7 @@ public final class UnionTypeExample {
         private final int value;
 
         @JsonCreator
-        private AlsoAnIntegerWrapper(@JsonProperty("alsoAnInteger") int value) {
+        private AlsoAnIntegerWrapper(@JsonProperty("alsoAnInteger") @Nonnull int value) {
             Preconditions.checkNotNull(value, "alsoAnInteger cannot be null");
             this.value = value;
         }
@@ -472,7 +477,7 @@ public final class UnionTypeExample {
         private final int value;
 
         @JsonCreator
-        private IfWrapper(@JsonProperty("if") int value) {
+        private IfWrapper(@JsonProperty("if") @Nonnull int value) {
             Preconditions.checkNotNull(value, "if cannot be null");
             this.value = value;
         }
@@ -507,7 +512,7 @@ public final class UnionTypeExample {
         private final int value;
 
         @JsonCreator
-        private NewWrapper(@JsonProperty("new") int value) {
+        private NewWrapper(@JsonProperty("new") @Nonnull int value) {
             Preconditions.checkNotNull(value, "new cannot be null");
             this.value = value;
         }
@@ -542,7 +547,7 @@ public final class UnionTypeExample {
         private final int value;
 
         @JsonCreator
-        private InterfaceWrapper(@JsonProperty("interface") int value) {
+        private InterfaceWrapper(@JsonProperty("interface") @Nonnull int value) {
             Preconditions.checkNotNull(value, "interface cannot be null");
             this.value = value;
         }
@@ -588,7 +593,7 @@ public final class UnionTypeExample {
             this(type, new HashMap<String, Object>());
         }
 
-        private UnknownWrapper(String type, Map<String, Object> value) {
+        private UnknownWrapper(@Nonnull String type, @Nonnull Map<String, Object> value) {
             Preconditions.checkNotNull(type, "type cannot be null");
             Preconditions.checkNotNull(value, "value cannot be null");
             this.type = type;

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UuidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UuidAliasExample.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.UUID;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class UuidAliasExample {
     private final UUID value;
 
-    private UuidAliasExample(UUID value) {
+    private UuidAliasExample(@Nonnull UUID value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
@@ -41,7 +42,7 @@ public final class UuidAliasExample {
     }
 
     @JsonCreator
-    public static UuidAliasExample of(UUID value) {
+    public static UuidAliasExample of(@Nonnull UUID value) {
         return new UuidAliasExample(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UuidExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UuidExample.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 @JsonDeserialize(builder = UuidExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
@@ -90,7 +91,7 @@ public final class UuidExample {
         }
 
         @JsonSetter("uuid")
-        public Builder uuid(UUID uuid) {
+        public Builder uuid(@Nonnull UUID uuid) {
             this.uuid = Preconditions.checkNotNull(uuid, "uuid cannot be null");
             return this;
         }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -41,6 +41,7 @@ import com.squareup.javapoet.TypeSpec;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 import javax.lang.model.element.Modifier;
 
 public final class AliasGenerator {
@@ -105,10 +106,13 @@ public final class AliasGenerator {
                     .build());
         }
 
+        TypeName paramTypeName = aliasTypeName.isPrimitive()
+                ? aliasTypeName
+                : aliasTypeName.annotated(AnnotationSpec.builder(Nonnull.class).build());
         spec.addMethod(MethodSpec.methodBuilder("of")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .addAnnotation(JsonCreator.class)
-                .addParameter(aliasTypeName, "value")
+                .addParameter(paramTypeName, "value")
                 .returns(thisClass)
                 .addStatement("return new $T(value)", thisClass)
                 .build());
@@ -279,8 +283,11 @@ public final class AliasGenerator {
     }
 
     private static MethodSpec createConstructor(TypeName aliasTypeName) {
+        TypeName paramTypeName = aliasTypeName.isPrimitive()
+                ? aliasTypeName
+                : aliasTypeName.annotated(AnnotationSpec.builder(Nonnull.class).build());
         MethodSpec.Builder builder =
-                MethodSpec.constructorBuilder().addModifiers(Modifier.PRIVATE).addParameter(aliasTypeName, "value");
+                MethodSpec.constructorBuilder().addModifiers(Modifier.PRIVATE).addParameter(paramTypeName, "value");
         if (!aliasTypeName.isPrimitive()) {
             builder.addStatement("this.value = $T.checkNotNull(value, \"value cannot be null\")", Preconditions.class);
         } else {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -40,6 +40,7 @@ import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
 import java.util.List;
 import java.util.Locale;
+import javax.annotation.Nonnull;
 import javax.lang.model.element.Modifier;
 
 public final class EnumGenerator {
@@ -230,8 +231,9 @@ public final class EnumGenerator {
     }
 
     private static MethodSpec createValueOf(ClassName thisClass, List<EnumValueDefinition> values) {
-        ParameterSpec param =
-                ParameterSpec.builder(ClassName.get(String.class), "value").build();
+        ParameterSpec param = ParameterSpec.builder(ClassName.get(String.class), "value")
+                .addAnnotation(Nonnull.class)
+                .build();
 
         CodeBlock.Builder parser = CodeBlock.builder().beginControlFlow("switch (upperCasedValue)");
         for (EnumValueDefinition value : values) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -59,6 +59,7 @@ import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
 
@@ -512,6 +513,7 @@ public final class UnionGenerator {
         TypeName visitorObject = visitorObjectTypeName(memberType, visitResultType);
         return MethodSpec.methodBuilder(JavaNameSanitizer.sanitize(memberName))
                 .addParameter(ParameterSpec.builder(visitorObject, visitorFieldName(memberName))
+                        .addAnnotation(Nonnull.class)
                         .build())
                 .returns(ParameterizedTypeName.get(nextBuilderStage, visitResultType));
     }
@@ -574,6 +576,7 @@ public final class UnionGenerator {
                                             .build())
                                     .addParameter(ParameterSpec.builder(memberType, VALUE_FIELD_NAME)
                                             .addAnnotation(jsonPropertyAnnotation)
+                                            .addAnnotation(Nonnull.class)
                                             .build())
                                     .addStatement(
                                             "$L",
@@ -605,8 +608,9 @@ public final class UnionGenerator {
     private static TypeSpec generateUnknownWrapper(ClassName baseClass) {
         ParameterizedTypeName genericMapType = ParameterizedTypeName.get(Map.class, String.class, Object.class);
         ParameterizedTypeName genericHashMapType = ParameterizedTypeName.get(HashMap.class, String.class, Object.class);
-        ParameterSpec typeParameter =
-                ParameterSpec.builder(String.class, "type").build();
+        ParameterSpec typeParameter = ParameterSpec.builder(String.class, "type")
+                .addAnnotation(Nonnull.class)
+                .build();
         ParameterSpec annotatedTypeParameter = ParameterSpec.builder(UNKNOWN_MEMBER_TYPE, "type")
                 .addAnnotation(AnnotationSpec.builder(JsonProperty.class)
                         .addMember("value", "\"type\"")
@@ -639,6 +643,7 @@ public final class UnionGenerator {
                         .addModifiers(Modifier.PRIVATE)
                         .addParameter(typeParameter)
                         .addParameter(ParameterSpec.builder(genericMapType, VALUE_FIELD_NAME)
+                                .addAnnotation(Nonnull.class)
                                 .build())
                         .addStatement("$L", Expressions.requireNonNull(typeParameter.name, "type cannot be null"))
                         .addStatement(


### PR DESCRIPTION
Conjure generates precondition nonnull checks, but doesn't annotate the function parameters as `Nonnull`. This means you can pass `Nullable` values without getting a warning, and get a runtime crash. This PR adds `Nonnull` annotations to all parameters with a nonnull precondition check.