### PR TITLE
conjure-undertow handles multi-value accept headers

### DIFF
--- a/changelog/@unreleased/pr-812.v2.yml
+++ b/changelog/@unreleased/pr-812.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: conjure-undertow handles comma-separated multi-value accept headers
+  links:
+  - https://github.com/palantir/conjure-java/pull/812

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.undertow.runtime;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.conjure.java.undertow.lib.BodySerDe;
@@ -38,6 +39,8 @@ import java.util.List;
 final class ConjureBodySerDe implements BodySerDe {
 
     private static final String BINARY_CONTENT_TYPE = "application/octet-stream";
+    private static final Splitter ACCEPT_VALUE_SPLITTER =
+            Splitter.on(',').trimResults().omitEmptyStrings();
 
     private final List<Encoding> encodings;
 
@@ -114,11 +117,12 @@ final class ConjureBodySerDe implements BodySerDe {
             if (acceptValues != null) {
                 // This implementation prefers the client "Accept" order
                 for (int i = 0; i < acceptValues.size(); i++) {
-                    String acceptValue = acceptValues.get(i);
-                    for (int j = 0; j < encodings.size(); j++) {
-                        EncodingSerializerContainer<T> container = encodings.get(j);
-                        if (container.encoding.supportsContentType(acceptValue)) {
-                            return container;
+                    for (String acceptValue : ACCEPT_VALUE_SPLITTER.split(acceptValues.get(i))) {
+                        for (int j = 0; j < encodings.size(); j++) {
+                            EncodingSerializerContainer<T> container = encodings.get(j);
+                            if (container.encoding.supportsContentType(acceptValue)) {
+                                return container;
+                            }
                         }
                     }
                 }

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDeTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDeTest.java
@@ -88,6 +88,18 @@ public class ConjureBodySerDeTest {
     }
 
     @Test
+    public void testResponseContentType_singleHeader() throws IOException {
+        Encoding json = new StubEncoding("application/json");
+        Encoding plain = new StubEncoding("text/plain");
+
+        HttpServerExchange exchange = HttpServerExchanges.createStub();
+        exchange.getRequestHeaders().put(Headers.ACCEPT, "application/unknown, text/plain, application/json");
+        BodySerDe serializers = new ConjureBodySerDe(ImmutableList.of(json, plain));
+        serializers.serializer(TYPE).serialize("test", exchange);
+        assertThat(exchange.getResponseHeaders().getFirst(Headers.CONTENT_TYPE)).isSameAs(plain.getContentType());
+    }
+
+    @Test
     public void testResponseNoContentType() throws IOException {
         Encoding json = new StubEncoding("application/json");
         Encoding plain = new StubEncoding("text/plain");


### PR DESCRIPTION
## Before this PR
We previously handled requests with multiple accept headers

## After this PR
now we also support accept headers with multiple comma-separated values.
==COMMIT_MSG==
conjure-undertow handles comma-separated multi-value accept headers
==COMMIT_MSG==

## Possible downsides?
a bit more complicated

