### PR TITLE
Dialogue endpoints use version '0.0.0' over 'unknown' by default

### DIFF
--- a/changelog/@unreleased/pr-830.v2.yml
+++ b/changelog/@unreleased/pr-830.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Dialogue endpoints use version '0.0.0' over 'unknown' by default
+  links:
+  - https://github.com/palantir/conjure-java/pull/830

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -175,7 +175,7 @@ public final class ConjureJavaCli implements Runnable {
                 ServiceGenerator jerseyGenerator = new JerseyServiceGenerator(config.options());
                 ServiceGenerator retrofitGenerator = new Retrofit2ServiceGenerator(config.options());
                 ServiceGenerator undertowGenerator = new UndertowServiceGenerator(config.options());
-                ServiceGenerator dialogueServiceGenerator = new DialogueServiceGenerator(config.options(), "unknown");
+                ServiceGenerator dialogueServiceGenerator = new DialogueServiceGenerator(config.options(), "0.0.0");
 
                 if (config.generateObjects()) {
                     typeGenerator.emit(conjureDefinition, config.outputDirectory());


### PR DESCRIPTION
This prevents dialogue clients from spewing warnings on every
request.

## After this PR
==COMMIT_MSG==
Dialogue endpoints use version '0.0.0' over 'unknown' by default
==COMMIT_MSG==

