### PR TITLE
Prevent ISE when rst_stream is received prior to async register-callback

### DIFF
--- a/changelog/@unreleased/pr-840.v2.yml
+++ b/changelog/@unreleased/pr-840.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Prevent ISE when the exchange is completed prior to async register-callback
+  links:
+  - https://github.com/palantir/conjure-java/pull/840


### PR DESCRIPTION
## Before this PR
```
java.lang.IllegalStateException: {throwable0_message}
	at io.undertow.server.HttpServerExchange.addExchangeCompleteListener(HttpServerExchange.java:941)
	at com.palantir.conjure.java.undertow.runtime.ConjureAsyncRequestProcessing.registerCallback(ConjureAsyncRequestProcessing.java:120)
	at com.palantir.conjure.java.undertow.runtime.ConjureAsyncRequestProcessing.register(ConjureAsyncRequestProcessing.java:98)
..etc
```

## After this PR
==COMMIT_MSG==
Prevent ISE when the exchange is completed prior to async register-callback
==COMMIT_MSG==

## Possible downsides?
Unfortunately I was not able to produce a test to reproduce this scenario, possibly due to okhttp h2-prior-knowledge shortcomings.

