### PR TITLE
dialogue: suppress deprecation

### DIFF
--- a/changelog/@unreleased/pr-842.v2.yml
+++ b/changelog/@unreleased/pr-842.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: dialogue now adds a `@SuppressWarnings("deprecated")` to its own code
+    when it needs to call out to a known deprecated method.
+  links:
+  - https://github.com/palantir/conjure-java/pull/842

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/BlockingGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/BlockingGenerator.java
@@ -21,6 +21,7 @@ import com.palantir.conjure.spec.EndpointDefinition;
 import com.palantir.conjure.spec.ServiceDefinition;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
+import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
@@ -74,6 +75,13 @@ public final class BlockingGenerator implements StaticFactoryMethodGenerator {
                 .addModifiers(Modifier.PUBLIC)
                 .addParameters(params)
                 .addAnnotation(Override.class);
+
+        if (def.getDeprecated().isPresent()) {
+            methodBuilder.addAnnotation(AnnotationSpec.builder(SuppressWarnings.class)
+                    .addMember("value", "$S", "deprecated")
+                    .build());
+        }
+
         methodBuilder.returns(returnTypes.baseType(def.getReturns()));
 
         CodeBlock argList =

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -153,6 +154,7 @@ public interface TestServiceBlocking {
             }
 
             @Override
+            @SuppressWarnings("deprecated")
             public Set<String> getBranchesDeprecated(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 return runtime.clients()

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -153,6 +154,7 @@ public interface TestServiceBlocking {
             }
 
             @Override
+            @SuppressWarnings("deprecated")
             public Set<String> getBranchesDeprecated(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 return runtime.clients()


### PR DESCRIPTION
## Before this PR

Dialogue produces a couple of classes, FooBlocking and FooAsync, where FooBlocking delegates to FooAsync. However, if a method on FooAsync is deprecated, then the caller in FooBlocking gets flagged by `-Xlint:deprecation`.

We discovered this on one of @pkoenig10's projects, https://internal-github/foundry/provenance/pull/1567

## After this PR
==COMMIT_MSG==
dialogue now adds a `@SuppressWarnings("deprecated")` to its own code when it needs to call out to a known deprecated method.
==COMMIT_MSG==

## Possible downsides?


