### PR TITLE
s/deprecated/deprecation/

### DIFF
--- a/changelog/@unreleased/pr-843.v2.yml
+++ b/changelog/@unreleased/pr-843.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: '`@SuppressWarnings("deprecation")` not `"deprecated"`'
+  links:
+  - https://github.com/palantir/conjure-java/pull/843

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/BlockingGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/BlockingGenerator.java
@@ -78,7 +78,7 @@ public final class BlockingGenerator implements StaticFactoryMethodGenerator {
 
         if (def.getDeprecated().isPresent()) {
             methodBuilder.addAnnotation(AnnotationSpec.builder(SuppressWarnings.class)
-                    .addMember("value", "$S", "deprecated")
+                    .addMember("value", "$S", "deprecation")
                     .build());
         }
 

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
@@ -154,7 +154,7 @@ public interface TestServiceBlocking {
             }
 
             @Override
-            @SuppressWarnings("deprecated")
+            @SuppressWarnings("deprecation")
             public Set<String> getBranchesDeprecated(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 return runtime.clients()

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
@@ -154,7 +154,7 @@ public interface TestServiceBlocking {
             }
 
             @Override
-            @SuppressWarnings("deprecated")
+            @SuppressWarnings("deprecation")
             public Set<String> getBranchesDeprecated(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 return runtime.clients()


### PR DESCRIPTION
## Before this PR

Typo made my last PR not work.

## After this PR
==COMMIT_MSG==
`@SuppressWarnings("deprecation")` not `"deprecated"`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

