### PR TITLE
Suppress deprecation building enum values list when necessary

### DIFF
--- a/changelog/@unreleased/pr-850.v2.yml
+++ b/changelog/@unreleased/pr-850.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Suppress deprecation building enum values list when necessary
+  links:
+  - https://github.com/palantir/conjure-java/pull/850

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -38,6 +38,7 @@ public final class EnumExample {
     @Deprecated
     public static final EnumExample ONE_HUNDRED = new EnumExample(Value.ONE_HUNDRED, "ONE_HUNDRED");
 
+    @SuppressWarnings("deprecation")
     private static final List<EnumExample> values =
             Collections.unmodifiableList(Arrays.asList(ONE, TWO, ONE_HUNDRED));
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
@@ -38,6 +38,7 @@ public final class EnumExample {
     @Deprecated
     public static final EnumExample ONE_HUNDRED = new EnumExample(Value.ONE_HUNDRED, "ONE_HUNDRED");
 
+    @SuppressWarnings("deprecation")
     private static final List<EnumExample> values =
             Collections.unmodifiableList(Arrays.asList(ONE, TWO, ONE_HUNDRED));
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -274,6 +274,8 @@ public final class EnumGenerator {
     private static FieldSpec createValuesList(ClassName thisClass, List<EnumValueDefinition> values) {
         CodeBlock arrayValues =
                 CodeBlock.join(values.stream().map(value -> CodeBlock.of("$L", value.getValue()))::iterator, "," + " ");
+        boolean anyDeprecatedValues = values.stream()
+                .anyMatch(definition -> definition.getDeprecated().isPresent());
         return FieldSpec.builder(
                         ParameterizedTypeName.get(ClassName.get(List.class), thisClass),
                         "values",
@@ -282,6 +284,12 @@ public final class EnumGenerator {
                         Modifier.FINAL)
                 .initializer(CodeBlock.of(
                         "$T.unmodifiableList($T.asList(" + arrayValues + "))", Collections.class, Arrays.class))
+                .addAnnotations(
+                        anyDeprecatedValues
+                                ? ImmutableList.of(AnnotationSpec.builder(SuppressWarnings.class)
+                                .addMember("value", "$S", "deprecation")
+                                .build())
+                                : ImmutableList.of())
                 .build();
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -287,8 +287,8 @@ public final class EnumGenerator {
                 .addAnnotations(
                         anyDeprecatedValues
                                 ? ImmutableList.of(AnnotationSpec.builder(SuppressWarnings.class)
-                                .addMember("value", "$S", "deprecation")
-                                .build())
+                                        .addMember("value", "$S", "deprecation")
+                                        .build())
                                 : ImmutableList.of())
                 .build();
     }


### PR DESCRIPTION
Prevent noise from deprecation warnings when enum values have been
deprecated.

## After this PR
==COMMIT_MSG==
Suppress deprecation building enum values list when necessary
==COMMIT_MSG==
