### PR TITLE
add prefix to dialogue defined variables

### DIFF
--- a/changelog/@unreleased/pr-856.v2.yml
+++ b/changelog/@unreleased/pr-856.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Add prefix to internal variable names to avoid collisions with user
+    variables
+  links:
+  - https://github.com/palantir/conjure-java/pull/856

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceAsync.java
@@ -18,18 +18,18 @@ public interface EmptyPathServiceAsync {
     /**
      * Creates an asynchronous/non-blocking client for a EmptyPathService service.
      */
-    static EmptyPathServiceAsync of(Channel channel, ConjureRuntime runtime) {
+    static EmptyPathServiceAsync of(Channel _channel, ConjureRuntime _runtime) {
         return new EmptyPathServiceAsync() {
-            private final PlainSerDe plainSerDe = runtime.plainSerDe();
+            private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
 
             private final Deserializer<Boolean> emptyPathDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {});
 
             @Override
             public ListenableFuture<Boolean> emptyPath() {
                 Request.Builder _request = Request.builder();
-                return runtime.clients()
-                        .call(channel, DialogueEmptyPathEndpoints.emptyPath, _request.build(), emptyPathDeserializer);
+                return _runtime.clients()
+                        .call(_channel, DialogueEmptyPathEndpoints.emptyPath, _request.build(), emptyPathDeserializer);
             }
         };
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceBlocking.java
@@ -12,12 +12,12 @@ public interface EmptyPathServiceBlocking {
     /**
      * Creates a synchronous/blocking client for a EmptyPathService service.
      */
-    static EmptyPathServiceBlocking of(Channel channel, ConjureRuntime runtime) {
-        EmptyPathServiceAsync delegate = EmptyPathServiceAsync.of(channel, runtime);
+    static EmptyPathServiceBlocking of(Channel _channel, ConjureRuntime _runtime) {
+        EmptyPathServiceAsync delegate = EmptyPathServiceAsync.of(_channel, _runtime);
         return new EmptyPathServiceBlocking() {
             @Override
             public boolean emptyPath() {
-                return runtime.clients().block(delegate.emptyPath());
+                return _runtime.clients().block(delegate.emptyPath());
             }
         };
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceAsync.java
@@ -28,58 +28,62 @@ public interface EteBinaryServiceAsync {
     /**
      * Creates an asynchronous/non-blocking client for a EteBinaryService service.
      */
-    static EteBinaryServiceAsync of(Channel channel, ConjureRuntime runtime) {
+    static EteBinaryServiceAsync of(Channel _channel, ConjureRuntime _runtime) {
         return new EteBinaryServiceAsync() {
-            private final PlainSerDe plainSerDe = runtime.plainSerDe();
+            private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
 
             @Override
             public ListenableFuture<InputStream> postBinary(AuthHeader authHeader, BinaryRequestBody body) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.body(runtime.bodySerDe().serialize(body));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.body(_runtime.bodySerDe().serialize(body));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueEteBinaryEndpoints.postBinary,
                                 _request.build(),
-                                runtime.bodySerDe().inputStreamDeserializer());
+                                _runtime.bodySerDe().inputStreamDeserializer());
             }
 
             @Override
             public ListenableFuture<Optional<InputStream>> getOptionalBinaryPresent(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueEteBinaryEndpoints.getOptionalBinaryPresent,
                                 _request.build(),
-                                runtime.bodySerDe().optionalInputStreamDeserializer());
+                                _runtime.bodySerDe().optionalInputStreamDeserializer());
             }
 
             @Override
             public ListenableFuture<Optional<InputStream>> getOptionalBinaryEmpty(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueEteBinaryEndpoints.getOptionalBinaryEmpty,
                                 _request.build(),
-                                runtime.bodySerDe().optionalInputStreamDeserializer());
+                                _runtime.bodySerDe().optionalInputStreamDeserializer());
             }
 
             @Override
             public ListenableFuture<InputStream> getBinaryFailure(AuthHeader authHeader, int numBytes) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putQueryParams("numBytes", plainSerDe.serializeInteger(numBytes));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putQueryParams("numBytes", _plainSerDe.serializeInteger(numBytes));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueEteBinaryEndpoints.getBinaryFailure,
                                 _request.build(),
-                                runtime.bodySerDe().inputStreamDeserializer());
+                                _runtime.bodySerDe().inputStreamDeserializer());
             }
         };
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceBlocking.java
@@ -25,27 +25,27 @@ public interface EteBinaryServiceBlocking {
     /**
      * Creates a synchronous/blocking client for a EteBinaryService service.
      */
-    static EteBinaryServiceBlocking of(Channel channel, ConjureRuntime runtime) {
-        EteBinaryServiceAsync delegate = EteBinaryServiceAsync.of(channel, runtime);
+    static EteBinaryServiceBlocking of(Channel _channel, ConjureRuntime _runtime) {
+        EteBinaryServiceAsync delegate = EteBinaryServiceAsync.of(_channel, _runtime);
         return new EteBinaryServiceBlocking() {
             @Override
             public InputStream postBinary(AuthHeader authHeader, BinaryRequestBody body) {
-                return runtime.clients().block(delegate.postBinary(authHeader, body));
+                return _runtime.clients().block(delegate.postBinary(authHeader, body));
             }
 
             @Override
             public Optional<InputStream> getOptionalBinaryPresent(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.getOptionalBinaryPresent(authHeader));
+                return _runtime.clients().block(delegate.getOptionalBinaryPresent(authHeader));
             }
 
             @Override
             public Optional<InputStream> getOptionalBinaryEmpty(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.getOptionalBinaryEmpty(authHeader));
+                return _runtime.clients().block(delegate.getOptionalBinaryEmpty(authHeader));
             }
 
             @Override
             public InputStream getBinaryFailure(AuthHeader authHeader, int numBytes) {
-                return runtime.clients().block(delegate.getBinaryFailure(authHeader, numBytes));
+                return _runtime.clients().block(delegate.getBinaryFailure(authHeader, numBytes));
             }
         };
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceAsync.java
@@ -114,162 +114,170 @@ public interface EteServiceAsync {
     /**
      * Creates an asynchronous/non-blocking client for a EteService service.
      */
-    static EteServiceAsync of(Channel channel, ConjureRuntime runtime) {
+    static EteServiceAsync of(Channel _channel, ConjureRuntime _runtime) {
         return new EteServiceAsync() {
-            private final PlainSerDe plainSerDe = runtime.plainSerDe();
+            private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
 
             private final Deserializer<String> stringDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<String>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<String>() {});
 
             private final Deserializer<Integer> integerDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Integer>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Integer>() {});
 
             private final Deserializer<Double> double_Deserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Double>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Double>() {});
 
             private final Deserializer<Boolean> boolean_Deserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {});
 
             private final Deserializer<SafeLong> safelongDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<SafeLong>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<SafeLong>() {});
 
             private final Deserializer<ResourceIdentifier> ridDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<ResourceIdentifier>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<ResourceIdentifier>() {});
 
             private final Deserializer<BearerToken> bearertokenDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<BearerToken>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<BearerToken>() {});
 
             private final Deserializer<Optional<String>> optionalStringDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {});
 
             private final Deserializer<Optional<String>> optionalEmptyDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {});
 
             private final Deserializer<OffsetDateTime> datetimeDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<OffsetDateTime>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<OffsetDateTime>() {});
 
             private final Deserializer<String> pathDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<String>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<String>() {});
 
             private final Deserializer<Long> externalLongPathDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Long>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Long>() {});
 
             private final Deserializer<Optional<Long>> optionalExternalLongQueryDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Optional<Long>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Optional<Long>>() {});
 
             private final Serializer<StringAliasExample> notNullBodySerializer =
-                    runtime.bodySerDe().serializer(new TypeMarker<StringAliasExample>() {});
+                    _runtime.bodySerDe().serializer(new TypeMarker<StringAliasExample>() {});
 
             private final Deserializer<StringAliasExample> notNullBodyDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<StringAliasExample>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<StringAliasExample>() {});
 
             private final Deserializer<StringAliasExample> aliasOneDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<StringAliasExample>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<StringAliasExample>() {});
 
             private final Deserializer<StringAliasExample> optionalAliasOneDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<StringAliasExample>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<StringAliasExample>() {});
 
             private final Deserializer<NestedStringAliasExample> aliasTwoDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<NestedStringAliasExample>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<NestedStringAliasExample>() {});
 
             private final Serializer<StringAliasExample> notNullBodyExternalImportSerializer =
-                    runtime.bodySerDe().serializer(new TypeMarker<StringAliasExample>() {});
+                    _runtime.bodySerDe().serializer(new TypeMarker<StringAliasExample>() {});
 
             private final Deserializer<StringAliasExample> notNullBodyExternalImportDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<StringAliasExample>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<StringAliasExample>() {});
 
             private final Serializer<Optional<StringAliasExample>> optionalBodyExternalImportSerializer =
-                    runtime.bodySerDe().serializer(new TypeMarker<Optional<StringAliasExample>>() {});
+                    _runtime.bodySerDe().serializer(new TypeMarker<Optional<StringAliasExample>>() {});
 
             private final Deserializer<Optional<StringAliasExample>> optionalBodyExternalImportDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Optional<StringAliasExample>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Optional<StringAliasExample>>() {});
 
             private final Deserializer<Optional<StringAliasExample>> optionalQueryExternalImportDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Optional<StringAliasExample>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Optional<StringAliasExample>>() {});
 
             private final Deserializer<Void> noReturnDeserializer =
-                    runtime.bodySerDe().emptyBodyDeserializer();
+                    _runtime.bodySerDe().emptyBodyDeserializer();
 
             private final Deserializer<SimpleEnum> enumQueryDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<SimpleEnum>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<SimpleEnum>() {});
 
             private final Deserializer<List<SimpleEnum>> enumListQueryDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<List<SimpleEnum>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<List<SimpleEnum>>() {});
 
             private final Deserializer<Optional<SimpleEnum>> optionalEnumQueryDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Optional<SimpleEnum>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Optional<SimpleEnum>>() {});
 
             private final Deserializer<SimpleEnum> enumHeaderDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<SimpleEnum>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<SimpleEnum>() {});
 
             private final Deserializer<Optional<LongAlias>> aliasLongEndpointDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Optional<LongAlias>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Optional<LongAlias>>() {});
 
             private final Deserializer<Void> complexQueryParametersDeserializer =
-                    runtime.bodySerDe().emptyBodyDeserializer();
+                    _runtime.bodySerDe().emptyBodyDeserializer();
 
             @Override
             public ListenableFuture<String> string(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
-                        .call(channel, DialogueEteEndpoints.string, _request.build(), stringDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
+                        .call(_channel, DialogueEteEndpoints.string, _request.build(), stringDeserializer);
             }
 
             @Override
             public ListenableFuture<Integer> integer(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
-                        .call(channel, DialogueEteEndpoints.integer, _request.build(), integerDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
+                        .call(_channel, DialogueEteEndpoints.integer, _request.build(), integerDeserializer);
             }
 
             @Override
             public ListenableFuture<Double> double_(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
-                        .call(channel, DialogueEteEndpoints.double_, _request.build(), double_Deserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
+                        .call(_channel, DialogueEteEndpoints.double_, _request.build(), double_Deserializer);
             }
 
             @Override
             public ListenableFuture<Boolean> boolean_(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
-                        .call(channel, DialogueEteEndpoints.boolean_, _request.build(), boolean_Deserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
+                        .call(_channel, DialogueEteEndpoints.boolean_, _request.build(), boolean_Deserializer);
             }
 
             @Override
             public ListenableFuture<SafeLong> safelong(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
-                        .call(channel, DialogueEteEndpoints.safelong, _request.build(), safelongDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
+                        .call(_channel, DialogueEteEndpoints.safelong, _request.build(), safelongDeserializer);
             }
 
             @Override
             public ListenableFuture<ResourceIdentifier> rid(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients().call(channel, DialogueEteEndpoints.rid, _request.build(), ridDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients().call(_channel, DialogueEteEndpoints.rid, _request.build(), ridDeserializer);
             }
 
             @Override
             public ListenableFuture<BearerToken> bearertoken(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
-                        .call(channel, DialogueEteEndpoints.bearertoken, _request.build(), bearertokenDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
+                        .call(_channel, DialogueEteEndpoints.bearertoken, _request.build(), bearertokenDeserializer);
             }
 
             @Override
             public ListenableFuture<Optional<String>> optionalString(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueEteEndpoints.optionalString,
                                 _request.build(),
                                 optionalStringDeserializer);
@@ -278,47 +286,56 @@ public interface EteServiceAsync {
             @Override
             public ListenableFuture<Optional<String>> optionalEmpty(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
-                        .call(channel, DialogueEteEndpoints.optionalEmpty, _request.build(), optionalEmptyDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
+                        .call(
+                                _channel,
+                                DialogueEteEndpoints.optionalEmpty,
+                                _request.build(),
+                                optionalEmptyDeserializer);
             }
 
             @Override
             public ListenableFuture<OffsetDateTime> datetime(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
-                        .call(channel, DialogueEteEndpoints.datetime, _request.build(), datetimeDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
+                        .call(_channel, DialogueEteEndpoints.datetime, _request.build(), datetimeDeserializer);
             }
 
             @Override
             public ListenableFuture<InputStream> binary(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueEteEndpoints.binary,
                                 _request.build(),
-                                runtime.bodySerDe().inputStreamDeserializer());
+                                _runtime.bodySerDe().inputStreamDeserializer());
             }
 
             @Override
             public ListenableFuture<String> path(AuthHeader authHeader, String param) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("param", plainSerDe.serializeString(param));
-                return runtime.clients().call(channel, DialogueEteEndpoints.path, _request.build(), pathDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("param", _plainSerDe.serializeString(param));
+                return _runtime.clients().call(_channel, DialogueEteEndpoints.path, _request.build(), pathDeserializer);
             }
 
             @Override
             public ListenableFuture<Long> externalLongPath(AuthHeader authHeader, long param) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 _request.putPathParams("param", Objects.toString(param));
-                return runtime.clients()
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueEteEndpoints.externalLongPath,
                                 _request.build(),
                                 externalLongPathDeserializer);
@@ -328,13 +345,14 @@ public interface EteServiceAsync {
             public ListenableFuture<Optional<Long>> optionalExternalLongQuery(
                     AuthHeader authHeader, Optional<Long> param) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 if (param.isPresent()) {
                     _request.putQueryParams("param", Objects.toString(param.get()));
                 }
-                return runtime.clients()
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueEteEndpoints.optionalExternalLongQuery,
                                 _request.build(),
                                 optionalExternalLongQueryDeserializer);
@@ -344,35 +362,38 @@ public interface EteServiceAsync {
             public ListenableFuture<StringAliasExample> notNullBody(
                     AuthHeader authHeader, StringAliasExample notNullBody) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 _request.body(notNullBodySerializer.serialize(notNullBody));
-                return runtime.clients()
-                        .call(channel, DialogueEteEndpoints.notNullBody, _request.build(), notNullBodyDeserializer);
+                return _runtime.clients()
+                        .call(_channel, DialogueEteEndpoints.notNullBody, _request.build(), notNullBodyDeserializer);
             }
 
             @Override
             public ListenableFuture<StringAliasExample> aliasOne(
                     AuthHeader authHeader, StringAliasExample queryParamName) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putQueryParams("queryParamName", plainSerDe.serializeString(queryParamName.get()));
-                return runtime.clients()
-                        .call(channel, DialogueEteEndpoints.aliasOne, _request.build(), aliasOneDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putQueryParams("queryParamName", _plainSerDe.serializeString(queryParamName.get()));
+                return _runtime.clients()
+                        .call(_channel, DialogueEteEndpoints.aliasOne, _request.build(), aliasOneDeserializer);
             }
 
             @Override
             public ListenableFuture<StringAliasExample> optionalAliasOne(
                     AuthHeader authHeader, Optional<StringAliasExample> queryParamName) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 if (queryParamName.isPresent()) {
                     _request.putQueryParams(
                             "queryParamName",
-                            plainSerDe.serializeString(queryParamName.get().get()));
+                            _plainSerDe.serializeString(queryParamName.get().get()));
                 }
-                return runtime.clients()
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueEteEndpoints.optionalAliasOne,
                                 _request.build(),
                                 optionalAliasOneDeserializer);
@@ -382,23 +403,25 @@ public interface EteServiceAsync {
             public ListenableFuture<NestedStringAliasExample> aliasTwo(
                     AuthHeader authHeader, NestedStringAliasExample queryParamName) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 _request.putQueryParams(
                         "queryParamName",
-                        plainSerDe.serializeString(queryParamName.get().get()));
-                return runtime.clients()
-                        .call(channel, DialogueEteEndpoints.aliasTwo, _request.build(), aliasTwoDeserializer);
+                        _plainSerDe.serializeString(queryParamName.get().get()));
+                return _runtime.clients()
+                        .call(_channel, DialogueEteEndpoints.aliasTwo, _request.build(), aliasTwoDeserializer);
             }
 
             @Override
             public ListenableFuture<StringAliasExample> notNullBodyExternalImport(
                     AuthHeader authHeader, StringAliasExample notNullBody) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 _request.body(notNullBodyExternalImportSerializer.serialize(notNullBody));
-                return runtime.clients()
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueEteEndpoints.notNullBodyExternalImport,
                                 _request.build(),
                                 notNullBodyExternalImportDeserializer);
@@ -408,11 +431,12 @@ public interface EteServiceAsync {
             public ListenableFuture<Optional<StringAliasExample>> optionalBodyExternalImport(
                     AuthHeader authHeader, Optional<StringAliasExample> body) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 _request.body(optionalBodyExternalImportSerializer.serialize(body));
-                return runtime.clients()
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueEteEndpoints.optionalBodyExternalImport,
                                 _request.build(),
                                 optionalBodyExternalImportDeserializer);
@@ -422,13 +446,14 @@ public interface EteServiceAsync {
             public ListenableFuture<Optional<StringAliasExample>> optionalQueryExternalImport(
                     AuthHeader authHeader, Optional<StringAliasExample> query) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 if (query.isPresent()) {
                     _request.putQueryParams("query", Objects.toString(query.get()));
                 }
-                return runtime.clients()
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueEteEndpoints.optionalQueryExternalImport,
                                 _request.build(),
                                 optionalQueryExternalImportDeserializer);
@@ -437,43 +462,51 @@ public interface EteServiceAsync {
             @Override
             public ListenableFuture<Void> noReturn(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
-                        .call(channel, DialogueEteEndpoints.noReturn, _request.build(), noReturnDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
+                        .call(_channel, DialogueEteEndpoints.noReturn, _request.build(), noReturnDeserializer);
             }
 
             @Override
             public ListenableFuture<SimpleEnum> enumQuery(AuthHeader authHeader, SimpleEnum queryParamName) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 _request.putQueryParams("queryParamName", Objects.toString(queryParamName));
-                return runtime.clients()
-                        .call(channel, DialogueEteEndpoints.enumQuery, _request.build(), enumQueryDeserializer);
+                return _runtime.clients()
+                        .call(_channel, DialogueEteEndpoints.enumQuery, _request.build(), enumQueryDeserializer);
             }
 
             @Override
             public ListenableFuture<List<SimpleEnum>> enumListQuery(
                     AuthHeader authHeader, List<SimpleEnum> queryParamName) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 for (SimpleEnum queryParamNameElement : queryParamName) {
                     _request.putQueryParams("queryParamName", Objects.toString(queryParamNameElement));
                 }
-                return runtime.clients()
-                        .call(channel, DialogueEteEndpoints.enumListQuery, _request.build(), enumListQueryDeserializer);
+                return _runtime.clients()
+                        .call(
+                                _channel,
+                                DialogueEteEndpoints.enumListQuery,
+                                _request.build(),
+                                enumListQueryDeserializer);
             }
 
             @Override
             public ListenableFuture<Optional<SimpleEnum>> optionalEnumQuery(
                     AuthHeader authHeader, Optional<SimpleEnum> queryParamName) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 if (queryParamName.isPresent()) {
                     _request.putQueryParams("queryParamName", Objects.toString(queryParamName.get()));
                 }
-                return runtime.clients()
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueEteEndpoints.optionalEnumQuery,
                                 _request.build(),
                                 optionalEnumQueryDeserializer);
@@ -482,24 +515,26 @@ public interface EteServiceAsync {
             @Override
             public ListenableFuture<SimpleEnum> enumHeader(AuthHeader authHeader, SimpleEnum headerParameter) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 _request.putHeaderParams("Custom-Header", Objects.toString(headerParameter));
-                return runtime.clients()
-                        .call(channel, DialogueEteEndpoints.enumHeader, _request.build(), enumHeaderDeserializer);
+                return _runtime.clients()
+                        .call(_channel, DialogueEteEndpoints.enumHeader, _request.build(), enumHeaderDeserializer);
             }
 
             @Override
             public ListenableFuture<Optional<LongAlias>> aliasLongEndpoint(
                     AuthHeader authHeader, Optional<LongAlias> input) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 if (input.isPresent()) {
                     _request.putQueryParams(
                             "input", Objects.toString(input.get().get()));
                 }
-                return runtime.clients()
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueEteEndpoints.aliasLongEndpoint,
                                 _request.build(),
                                 aliasLongEndpointDeserializer);
@@ -513,20 +548,21 @@ public interface EteServiceAsync {
                     Set<Long> longs,
                     Set<Integer> ints) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 for (StringAliasExample stringsElement : strings) {
-                    _request.putQueryParams("strings", plainSerDe.serializeString(stringsElement.get()));
+                    _request.putQueryParams("strings", _plainSerDe.serializeString(stringsElement.get()));
                 }
                 for (long longsElement : longs) {
                     _request.putQueryParams("longs", Objects.toString(longsElement));
                 }
                 for (int intsElement : ints) {
-                    _request.putQueryParams("ints", plainSerDe.serializeInteger(intsElement));
+                    _request.putQueryParams("ints", _plainSerDe.serializeInteger(intsElement));
                 }
-                return runtime.clients()
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueEteEndpoints.complexQueryParameters,
                                 _request.build(),
                                 complexQueryParametersDeserializer);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceBlocking.java
@@ -99,145 +99,145 @@ public interface EteServiceBlocking {
     /**
      * Creates a synchronous/blocking client for a EteService service.
      */
-    static EteServiceBlocking of(Channel channel, ConjureRuntime runtime) {
-        EteServiceAsync delegate = EteServiceAsync.of(channel, runtime);
+    static EteServiceBlocking of(Channel _channel, ConjureRuntime _runtime) {
+        EteServiceAsync delegate = EteServiceAsync.of(_channel, _runtime);
         return new EteServiceBlocking() {
             @Override
             public String string(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.string(authHeader));
+                return _runtime.clients().block(delegate.string(authHeader));
             }
 
             @Override
             public int integer(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.integer(authHeader));
+                return _runtime.clients().block(delegate.integer(authHeader));
             }
 
             @Override
             public double double_(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.double_(authHeader));
+                return _runtime.clients().block(delegate.double_(authHeader));
             }
 
             @Override
             public boolean boolean_(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.boolean_(authHeader));
+                return _runtime.clients().block(delegate.boolean_(authHeader));
             }
 
             @Override
             public SafeLong safelong(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.safelong(authHeader));
+                return _runtime.clients().block(delegate.safelong(authHeader));
             }
 
             @Override
             public ResourceIdentifier rid(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.rid(authHeader));
+                return _runtime.clients().block(delegate.rid(authHeader));
             }
 
             @Override
             public BearerToken bearertoken(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.bearertoken(authHeader));
+                return _runtime.clients().block(delegate.bearertoken(authHeader));
             }
 
             @Override
             public Optional<String> optionalString(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.optionalString(authHeader));
+                return _runtime.clients().block(delegate.optionalString(authHeader));
             }
 
             @Override
             public Optional<String> optionalEmpty(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.optionalEmpty(authHeader));
+                return _runtime.clients().block(delegate.optionalEmpty(authHeader));
             }
 
             @Override
             public OffsetDateTime datetime(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.datetime(authHeader));
+                return _runtime.clients().block(delegate.datetime(authHeader));
             }
 
             @Override
             public InputStream binary(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.binary(authHeader));
+                return _runtime.clients().block(delegate.binary(authHeader));
             }
 
             @Override
             public String path(AuthHeader authHeader, String param) {
-                return runtime.clients().block(delegate.path(authHeader, param));
+                return _runtime.clients().block(delegate.path(authHeader, param));
             }
 
             @Override
             public long externalLongPath(AuthHeader authHeader, long param) {
-                return runtime.clients().block(delegate.externalLongPath(authHeader, param));
+                return _runtime.clients().block(delegate.externalLongPath(authHeader, param));
             }
 
             @Override
             public Optional<Long> optionalExternalLongQuery(AuthHeader authHeader, Optional<Long> param) {
-                return runtime.clients().block(delegate.optionalExternalLongQuery(authHeader, param));
+                return _runtime.clients().block(delegate.optionalExternalLongQuery(authHeader, param));
             }
 
             @Override
             public StringAliasExample notNullBody(AuthHeader authHeader, StringAliasExample notNullBody) {
-                return runtime.clients().block(delegate.notNullBody(authHeader, notNullBody));
+                return _runtime.clients().block(delegate.notNullBody(authHeader, notNullBody));
             }
 
             @Override
             public StringAliasExample aliasOne(AuthHeader authHeader, StringAliasExample queryParamName) {
-                return runtime.clients().block(delegate.aliasOne(authHeader, queryParamName));
+                return _runtime.clients().block(delegate.aliasOne(authHeader, queryParamName));
             }
 
             @Override
             public StringAliasExample optionalAliasOne(
                     AuthHeader authHeader, Optional<StringAliasExample> queryParamName) {
-                return runtime.clients().block(delegate.optionalAliasOne(authHeader, queryParamName));
+                return _runtime.clients().block(delegate.optionalAliasOne(authHeader, queryParamName));
             }
 
             @Override
             public NestedStringAliasExample aliasTwo(AuthHeader authHeader, NestedStringAliasExample queryParamName) {
-                return runtime.clients().block(delegate.aliasTwo(authHeader, queryParamName));
+                return _runtime.clients().block(delegate.aliasTwo(authHeader, queryParamName));
             }
 
             @Override
             public StringAliasExample notNullBodyExternalImport(AuthHeader authHeader, StringAliasExample notNullBody) {
-                return runtime.clients().block(delegate.notNullBodyExternalImport(authHeader, notNullBody));
+                return _runtime.clients().block(delegate.notNullBodyExternalImport(authHeader, notNullBody));
             }
 
             @Override
             public Optional<StringAliasExample> optionalBodyExternalImport(
                     AuthHeader authHeader, Optional<StringAliasExample> body) {
-                return runtime.clients().block(delegate.optionalBodyExternalImport(authHeader, body));
+                return _runtime.clients().block(delegate.optionalBodyExternalImport(authHeader, body));
             }
 
             @Override
             public Optional<StringAliasExample> optionalQueryExternalImport(
                     AuthHeader authHeader, Optional<StringAliasExample> query) {
-                return runtime.clients().block(delegate.optionalQueryExternalImport(authHeader, query));
+                return _runtime.clients().block(delegate.optionalQueryExternalImport(authHeader, query));
             }
 
             @Override
             public void noReturn(AuthHeader authHeader) {
-                runtime.clients().block(delegate.noReturn(authHeader));
+                _runtime.clients().block(delegate.noReturn(authHeader));
             }
 
             @Override
             public SimpleEnum enumQuery(AuthHeader authHeader, SimpleEnum queryParamName) {
-                return runtime.clients().block(delegate.enumQuery(authHeader, queryParamName));
+                return _runtime.clients().block(delegate.enumQuery(authHeader, queryParamName));
             }
 
             @Override
             public List<SimpleEnum> enumListQuery(AuthHeader authHeader, List<SimpleEnum> queryParamName) {
-                return runtime.clients().block(delegate.enumListQuery(authHeader, queryParamName));
+                return _runtime.clients().block(delegate.enumListQuery(authHeader, queryParamName));
             }
 
             @Override
             public Optional<SimpleEnum> optionalEnumQuery(AuthHeader authHeader, Optional<SimpleEnum> queryParamName) {
-                return runtime.clients().block(delegate.optionalEnumQuery(authHeader, queryParamName));
+                return _runtime.clients().block(delegate.optionalEnumQuery(authHeader, queryParamName));
             }
 
             @Override
             public SimpleEnum enumHeader(AuthHeader authHeader, SimpleEnum headerParameter) {
-                return runtime.clients().block(delegate.enumHeader(authHeader, headerParameter));
+                return _runtime.clients().block(delegate.enumHeader(authHeader, headerParameter));
             }
 
             @Override
             public Optional<LongAlias> aliasLongEndpoint(AuthHeader authHeader, Optional<LongAlias> input) {
-                return runtime.clients().block(delegate.aliasLongEndpoint(authHeader, input));
+                return _runtime.clients().block(delegate.aliasLongEndpoint(authHeader, input));
             }
 
             @Override
@@ -247,7 +247,7 @@ public interface EteServiceBlocking {
                     Set<StringAliasExample> strings,
                     Set<Long> longs,
                     Set<Integer> ints) {
-                runtime.clients().block(delegate.complexQueryParameters(authHeader, datasetRid, strings, longs, ints));
+                _runtime.clients().block(delegate.complexQueryParameters(authHeader, datasetRid, strings, longs, ints));
             }
         };
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/BlockingGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/BlockingGenerator.java
@@ -30,8 +30,8 @@ import java.util.List;
 import javax.lang.model.element.Modifier;
 
 public final class BlockingGenerator implements StaticFactoryMethodGenerator {
-    private static final String RUNTIME = "runtime";
-    private static final String CHANNEL = "channel";
+    private static final String RUNTIME = "_runtime";
+    private static final String CHANNEL = "_channel";
 
     private final Options options;
     private final ParameterTypeMapper parameterTypes;

--- a/conjure-java-core/src/test/resources/test/api/CookieServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/CookieServiceAsync.java.dialogue
@@ -18,19 +18,19 @@ public interface CookieServiceAsync {
     /**
      * Creates an asynchronous/non-blocking client for a CookieService service.
      */
-    static CookieServiceAsync of(Channel channel, ConjureRuntime runtime) {
+    static CookieServiceAsync of(Channel _channel, ConjureRuntime _runtime) {
         return new CookieServiceAsync() {
-            private final PlainSerDe plainSerDe = runtime.plainSerDe();
+            private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
 
             private final Deserializer<Void> eatCookiesDeserializer =
-                    runtime.bodySerDe().emptyBodyDeserializer();
+                    _runtime.bodySerDe().emptyBodyDeserializer();
 
             @Override
             public ListenableFuture<Void> eatCookies(BearerToken token) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParam("Cookie", "PALANTIR_TOKEN=" + planSerDe.serializeBearerToken(token));
-                return runtime.clients()
-                        .call(channel, DialogueCookieEndpoints.eatCookies, _request.build(), eatCookiesDeserializer);
+                _request.putHeaderParam("Cookie", "PALANTIR_TOKEN=" + _plainSerDe.serializeBearerToken(token));
+                return _runtime.clients()
+                        .call(_channel, DialogueCookieEndpoints.eatCookies, _request.build(), eatCookiesDeserializer);
             }
         };
     }

--- a/conjure-java-core/src/test/resources/test/api/CookieServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/CookieServiceBlocking.java.dialogue
@@ -13,12 +13,12 @@ public interface CookieServiceBlocking {
     /**
      * Creates a synchronous/blocking client for a CookieService service.
      */
-    static CookieServiceBlocking of(Channel channel, ConjureRuntime runtime) {
-        CookieServiceAsync delegate = CookieServiceAsync.of(channel, runtime);
+    static CookieServiceBlocking of(Channel _channel, ConjureRuntime _runtime) {
+        CookieServiceAsync delegate = CookieServiceAsync.of(_channel, _runtime);
         return new CookieServiceBlocking() {
             @Override
             public void eatCookies(BearerToken token) {
-                runtime.clients().block(delegate.eatCookies(token));
+                _runtime.clients().block(delegate.eatCookies(token));
             }
         };
     }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
@@ -109,86 +109,87 @@ public interface TestServiceAsync {
     /**
      * Creates an asynchronous/non-blocking client for a TestService service.
      */
-    static TestServiceAsync of(Channel channel, ConjureRuntime runtime) {
+    static TestServiceAsync of(Channel _channel, ConjureRuntime _runtime) {
         return new TestServiceAsync() {
-            private final PlainSerDe plainSerDe = runtime.plainSerDe();
+            private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
 
             private final Deserializer<Map<String, BackingFileSystem>> getFileSystemsDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Map<String, BackingFileSystem>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Map<String, BackingFileSystem>>() {});
 
             private final Serializer<CreateDatasetRequest> createDatasetSerializer =
-                    runtime.bodySerDe().serializer(new TypeMarker<CreateDatasetRequest>() {});
+                    _runtime.bodySerDe().serializer(new TypeMarker<CreateDatasetRequest>() {});
 
             private final Deserializer<Dataset> createDatasetDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Dataset>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Dataset>() {});
 
             private final Deserializer<Optional<Dataset>> getDatasetDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Optional<Dataset>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Optional<Dataset>>() {});
 
             private final Deserializer<AliasedString> getAliasedStringDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<AliasedString>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<AliasedString>() {});
 
             private final Deserializer<Void> uploadRawDataDeserializer =
-                    runtime.bodySerDe().emptyBodyDeserializer();
+                    _runtime.bodySerDe().emptyBodyDeserializer();
 
             private final Serializer<InputStream> uploadAliasedRawDataSerializer =
-                    runtime.bodySerDe().serializer(new TypeMarker<InputStream>() {});
+                    _runtime.bodySerDe().serializer(new TypeMarker<InputStream>() {});
 
             private final Deserializer<Void> uploadAliasedRawDataDeserializer =
-                    runtime.bodySerDe().emptyBodyDeserializer();
+                    _runtime.bodySerDe().emptyBodyDeserializer();
 
             private final Deserializer<Set<String>> getBranchesDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Set<String>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Set<String>>() {});
 
             private final Deserializer<Set<String>> getBranchesDeprecatedDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Set<String>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Set<String>>() {});
 
             private final Deserializer<Optional<String>> resolveBranchDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {});
 
             private final Deserializer<Optional<String>> testParamDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {});
 
             private final Serializer<String> testQueryParamsSerializer =
-                    runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+                    _runtime.bodySerDe().serializer(new TypeMarker<String>() {});
 
             private final Deserializer<Integer> testQueryParamsDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Integer>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Integer>() {});
 
             private final Serializer<String> testNoResponseQueryParamsSerializer =
-                    runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+                    _runtime.bodySerDe().serializer(new TypeMarker<String>() {});
 
             private final Deserializer<Void> testNoResponseQueryParamsDeserializer =
-                    runtime.bodySerDe().emptyBodyDeserializer();
+                    _runtime.bodySerDe().emptyBodyDeserializer();
 
             private final Deserializer<Boolean> testBooleanDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {});
 
             private final Deserializer<Double> testDoubleDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Double>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Double>() {});
 
             private final Deserializer<Integer> testIntegerDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Integer>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Integer>() {});
 
             private final Serializer<Optional<String>> testPostOptionalSerializer =
-                    runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {});
+                    _runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {});
 
             private final Deserializer<Optional<String>> testPostOptionalDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {});
 
             private final Deserializer<Void> testOptionalIntegerAndDoubleDeserializer =
-                    runtime.bodySerDe().emptyBodyDeserializer();
+                    _runtime.bodySerDe().emptyBodyDeserializer();
 
             private final Deserializer<Void> getForStringsDeserializer =
-                    runtime.bodySerDe().emptyBodyDeserializer();
+                    _runtime.bodySerDe().emptyBodyDeserializer();
 
             @Override
             public ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.getFileSystems,
                                 _request.build(),
                                 getFileSystemsDeserializer);
@@ -198,12 +199,13 @@ public interface TestServiceAsync {
             public ListenableFuture<Dataset> createDataset(
                     AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 _request.body(createDatasetSerializer.serialize(request));
-                _request.putHeaderParams("Test-Header", plainSerDe.serializeString(testHeaderArg));
-                return runtime.clients()
+                _request.putHeaderParams("Test-Header", _plainSerDe.serializeString(testHeaderArg));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.createDataset,
                                 _request.build(),
                                 createDatasetDeserializer);
@@ -213,62 +215,67 @@ public interface TestServiceAsync {
             public ListenableFuture<Optional<Dataset>> getDataset(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
-                return runtime.clients()
-                        .call(channel, DialogueTestEndpoints.getDataset, _request.build(), getDatasetDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
+                        .call(_channel, DialogueTestEndpoints.getDataset, _request.build(), getDatasetDeserializer);
             }
 
             @Override
             public ListenableFuture<InputStream> getRawData(AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.getRawData,
                                 _request.build(),
-                                runtime.bodySerDe().inputStreamDeserializer());
+                                _runtime.bodySerDe().inputStreamDeserializer());
             }
 
             @Override
             public ListenableFuture<InputStream> getAliasedRawData(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.getAliasedRawData,
                                 _request.build(),
-                                runtime.bodySerDe().inputStreamDeserializer());
+                                _runtime.bodySerDe().inputStreamDeserializer());
             }
 
             @Override
             public ListenableFuture<Optional<InputStream>> maybeGetRawData(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.maybeGetRawData,
                                 _request.build(),
-                                runtime.bodySerDe().optionalInputStreamDeserializer());
+                                _runtime.bodySerDe().optionalInputStreamDeserializer());
             }
 
             @Override
             public ListenableFuture<AliasedString> getAliasedString(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.getAliasedString,
                                 _request.build(),
                                 getAliasedStringDeserializer);
@@ -277,11 +284,12 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Void> uploadRawData(AuthHeader authHeader, BinaryRequestBody input) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.body(runtime.bodySerDe().serialize(input));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.body(_runtime.bodySerDe().serialize(input));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.uploadRawData,
                                 _request.build(),
                                 uploadRawDataDeserializer);
@@ -290,11 +298,12 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Void> uploadAliasedRawData(AuthHeader authHeader, BinaryRequestBody input) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.body(runtime.bodySerDe().serialize(input));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.body(_runtime.bodySerDe().serialize(input));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.uploadAliasedRawData,
                                 _request.build(),
                                 uploadAliasedRawDataDeserializer);
@@ -303,21 +312,23 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Set<String>> getBranches(AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
-                return runtime.clients()
-                        .call(channel, DialogueTestEndpoints.getBranches, _request.build(), getBranchesDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
+                        .call(_channel, DialogueTestEndpoints.getBranches, _request.build(), getBranchesDeserializer);
             }
 
             @Override
             public ListenableFuture<Set<String>> getBranchesDeprecated(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.getBranchesDeprecated,
                                 _request.build(),
                                 getBranchesDeprecatedDeserializer);
@@ -327,12 +338,13 @@ public interface TestServiceAsync {
             public ListenableFuture<Optional<String>> resolveBranch(
                     AuthHeader authHeader, ResourceIdentifier datasetRid, String branch) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
-                _request.putPathParams("branch", plainSerDe.serializeString(branch));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                _request.putPathParams("branch", _plainSerDe.serializeString(branch));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.resolveBranch,
                                 _request.build(),
                                 resolveBranchDeserializer);
@@ -341,10 +353,11 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Optional<String>> testParam(AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
-                return runtime.clients()
-                        .call(channel, DialogueTestEndpoints.testParam, _request.build(), testParamDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
+                        .call(_channel, DialogueTestEndpoints.testParam, _request.build(), testParamDeserializer);
             }
 
             @Override
@@ -357,22 +370,23 @@ public interface TestServiceAsync {
                     Optional<ResourceIdentifier> optionalEnd,
                     String query) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 _request.body(testQueryParamsSerializer.serialize(query));
-                _request.putQueryParams("different", plainSerDe.serializeRid(something));
+                _request.putQueryParams("different", _plainSerDe.serializeRid(something));
                 if (optionalMiddle.isPresent()) {
-                    _request.putQueryParams("optionalMiddle", plainSerDe.serializeRid(optionalMiddle.get()));
+                    _request.putQueryParams("optionalMiddle", _plainSerDe.serializeRid(optionalMiddle.get()));
                 }
-                _request.putQueryParams("implicit", plainSerDe.serializeRid(implicit));
+                _request.putQueryParams("implicit", _plainSerDe.serializeRid(implicit));
                 for (String setEndElement : setEnd) {
-                    _request.putQueryParams("setEnd", plainSerDe.serializeString(setEndElement));
+                    _request.putQueryParams("setEnd", _plainSerDe.serializeString(setEndElement));
                 }
                 if (optionalEnd.isPresent()) {
-                    _request.putQueryParams("optionalEnd", plainSerDe.serializeRid(optionalEnd.get()));
+                    _request.putQueryParams("optionalEnd", _plainSerDe.serializeRid(optionalEnd.get()));
                 }
-                return runtime.clients()
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.testQueryParams,
                                 _request.build(),
                                 testQueryParamsDeserializer);
@@ -388,22 +402,23 @@ public interface TestServiceAsync {
                     Optional<ResourceIdentifier> optionalEnd,
                     String query) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 _request.body(testNoResponseQueryParamsSerializer.serialize(query));
-                _request.putQueryParams("different", plainSerDe.serializeRid(something));
+                _request.putQueryParams("different", _plainSerDe.serializeRid(something));
                 if (optionalMiddle.isPresent()) {
-                    _request.putQueryParams("optionalMiddle", plainSerDe.serializeRid(optionalMiddle.get()));
+                    _request.putQueryParams("optionalMiddle", _plainSerDe.serializeRid(optionalMiddle.get()));
                 }
-                _request.putQueryParams("implicit", plainSerDe.serializeRid(implicit));
+                _request.putQueryParams("implicit", _plainSerDe.serializeRid(implicit));
                 for (String setEndElement : setEnd) {
-                    _request.putQueryParams("setEnd", plainSerDe.serializeString(setEndElement));
+                    _request.putQueryParams("setEnd", _plainSerDe.serializeString(setEndElement));
                 }
                 if (optionalEnd.isPresent()) {
-                    _request.putQueryParams("optionalEnd", plainSerDe.serializeRid(optionalEnd.get()));
+                    _request.putQueryParams("optionalEnd", _plainSerDe.serializeRid(optionalEnd.get()));
                 }
-                return runtime.clients()
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.testNoResponseQueryParams,
                                 _request.build(),
                                 testNoResponseQueryParamsDeserializer);
@@ -412,36 +427,40 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Boolean> testBoolean(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
-                        .call(channel, DialogueTestEndpoints.testBoolean, _request.build(), testBooleanDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
+                        .call(_channel, DialogueTestEndpoints.testBoolean, _request.build(), testBooleanDeserializer);
             }
 
             @Override
             public ListenableFuture<Double> testDouble(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
-                        .call(channel, DialogueTestEndpoints.testDouble, _request.build(), testDoubleDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
+                        .call(_channel, DialogueTestEndpoints.testDouble, _request.build(), testDoubleDeserializer);
             }
 
             @Override
             public ListenableFuture<Integer> testInteger(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
-                        .call(channel, DialogueTestEndpoints.testInteger, _request.build(), testIntegerDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
+                        .call(_channel, DialogueTestEndpoints.testInteger, _request.build(), testIntegerDeserializer);
             }
 
             @Override
             public ListenableFuture<Optional<String>> testPostOptional(
                     AuthHeader authHeader, Optional<String> maybeString) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 _request.body(testPostOptionalSerializer.serialize(maybeString));
-                return runtime.clients()
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.testPostOptional,
                                 _request.build(),
                                 testPostOptionalDeserializer);
@@ -451,16 +470,17 @@ public interface TestServiceAsync {
             public ListenableFuture<Void> testOptionalIntegerAndDouble(
                     AuthHeader authHeader, OptionalInt maybeInteger, OptionalDouble maybeDouble) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 if (maybeInteger.isPresent()) {
-                    _request.putQueryParams("maybeInteger", plainSerDe.serializeInteger(maybeInteger.getAsInt()));
+                    _request.putQueryParams("maybeInteger", _plainSerDe.serializeInteger(maybeInteger.getAsInt()));
                 }
                 if (maybeDouble.isPresent()) {
-                    _request.putQueryParams("maybeDouble", plainSerDe.serializeDouble(maybeDouble.getAsDouble()));
+                    _request.putQueryParams("maybeDouble", _plainSerDe.serializeDouble(maybeDouble.getAsDouble()));
                 }
-                return runtime.clients()
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.testOptionalIntegerAndDouble,
                                 _request.build(),
                                 testOptionalIntegerAndDoubleDeserializer);
@@ -470,14 +490,15 @@ public interface TestServiceAsync {
             public ListenableFuture<Void> getForStrings(
                     AuthHeader authHeader, ResourceIdentifier datasetRid, Set<AliasedString> strings) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 for (AliasedString stringsElement : strings) {
-                    _request.putQueryParams("strings", plainSerDe.serializeString(stringsElement.get()));
+                    _request.putQueryParams("strings", _plainSerDe.serializeString(stringsElement.get()));
                 }
-                return runtime.clients()
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.getForStrings,
                                 _request.build(),
                                 getForStringsDeserializer);

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
@@ -109,86 +109,87 @@ public interface TestServiceAsync {
     /**
      * Creates an asynchronous/non-blocking client for a TestService service.
      */
-    static TestServiceAsync of(Channel channel, ConjureRuntime runtime) {
+    static TestServiceAsync of(Channel _channel, ConjureRuntime _runtime) {
         return new TestServiceAsync() {
-            private final PlainSerDe plainSerDe = runtime.plainSerDe();
+            private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
 
             private final Deserializer<Map<String, BackingFileSystem>> getFileSystemsDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Map<String, BackingFileSystem>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Map<String, BackingFileSystem>>() {});
 
             private final Serializer<CreateDatasetRequest> createDatasetSerializer =
-                    runtime.bodySerDe().serializer(new TypeMarker<CreateDatasetRequest>() {});
+                    _runtime.bodySerDe().serializer(new TypeMarker<CreateDatasetRequest>() {});
 
             private final Deserializer<Dataset> createDatasetDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Dataset>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Dataset>() {});
 
             private final Deserializer<Optional<Dataset>> getDatasetDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Optional<Dataset>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Optional<Dataset>>() {});
 
             private final Deserializer<AliasedString> getAliasedStringDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<AliasedString>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<AliasedString>() {});
 
             private final Deserializer<Void> uploadRawDataDeserializer =
-                    runtime.bodySerDe().emptyBodyDeserializer();
+                    _runtime.bodySerDe().emptyBodyDeserializer();
 
             private final Serializer<InputStream> uploadAliasedRawDataSerializer =
-                    runtime.bodySerDe().serializer(new TypeMarker<InputStream>() {});
+                    _runtime.bodySerDe().serializer(new TypeMarker<InputStream>() {});
 
             private final Deserializer<Void> uploadAliasedRawDataDeserializer =
-                    runtime.bodySerDe().emptyBodyDeserializer();
+                    _runtime.bodySerDe().emptyBodyDeserializer();
 
             private final Deserializer<Set<String>> getBranchesDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Set<String>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Set<String>>() {});
 
             private final Deserializer<Set<String>> getBranchesDeprecatedDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Set<String>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Set<String>>() {});
 
             private final Deserializer<Optional<String>> resolveBranchDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {});
 
             private final Deserializer<Optional<String>> testParamDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {});
 
             private final Serializer<String> testQueryParamsSerializer =
-                    runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+                    _runtime.bodySerDe().serializer(new TypeMarker<String>() {});
 
             private final Deserializer<Integer> testQueryParamsDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Integer>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Integer>() {});
 
             private final Serializer<String> testNoResponseQueryParamsSerializer =
-                    runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+                    _runtime.bodySerDe().serializer(new TypeMarker<String>() {});
 
             private final Deserializer<Void> testNoResponseQueryParamsDeserializer =
-                    runtime.bodySerDe().emptyBodyDeserializer();
+                    _runtime.bodySerDe().emptyBodyDeserializer();
 
             private final Deserializer<Boolean> testBooleanDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {});
 
             private final Deserializer<Double> testDoubleDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Double>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Double>() {});
 
             private final Deserializer<Integer> testIntegerDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Integer>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Integer>() {});
 
             private final Serializer<Optional<String>> testPostOptionalSerializer =
-                    runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {});
+                    _runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {});
 
             private final Deserializer<Optional<String>> testPostOptionalDeserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {});
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {});
 
             private final Deserializer<Void> testOptionalIntegerAndDoubleDeserializer =
-                    runtime.bodySerDe().emptyBodyDeserializer();
+                    _runtime.bodySerDe().emptyBodyDeserializer();
 
             private final Deserializer<Void> getForStringsDeserializer =
-                    runtime.bodySerDe().emptyBodyDeserializer();
+                    _runtime.bodySerDe().emptyBodyDeserializer();
 
             @Override
             public ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.getFileSystems,
                                 _request.build(),
                                 getFileSystemsDeserializer);
@@ -198,12 +199,13 @@ public interface TestServiceAsync {
             public ListenableFuture<Dataset> createDataset(
                     AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 _request.body(createDatasetSerializer.serialize(request));
-                _request.putHeaderParams("Test-Header", plainSerDe.serializeString(testHeaderArg));
-                return runtime.clients()
+                _request.putHeaderParams("Test-Header", _plainSerDe.serializeString(testHeaderArg));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.createDataset,
                                 _request.build(),
                                 createDatasetDeserializer);
@@ -213,62 +215,67 @@ public interface TestServiceAsync {
             public ListenableFuture<Optional<Dataset>> getDataset(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
-                return runtime.clients()
-                        .call(channel, DialogueTestEndpoints.getDataset, _request.build(), getDatasetDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
+                        .call(_channel, DialogueTestEndpoints.getDataset, _request.build(), getDatasetDeserializer);
             }
 
             @Override
             public ListenableFuture<InputStream> getRawData(AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.getRawData,
                                 _request.build(),
-                                runtime.bodySerDe().inputStreamDeserializer());
+                                _runtime.bodySerDe().inputStreamDeserializer());
             }
 
             @Override
             public ListenableFuture<InputStream> getAliasedRawData(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.getAliasedRawData,
                                 _request.build(),
-                                runtime.bodySerDe().inputStreamDeserializer());
+                                _runtime.bodySerDe().inputStreamDeserializer());
             }
 
             @Override
             public ListenableFuture<Optional<InputStream>> maybeGetRawData(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.maybeGetRawData,
                                 _request.build(),
-                                runtime.bodySerDe().optionalInputStreamDeserializer());
+                                _runtime.bodySerDe().optionalInputStreamDeserializer());
             }
 
             @Override
             public ListenableFuture<AliasedString> getAliasedString(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.getAliasedString,
                                 _request.build(),
                                 getAliasedStringDeserializer);
@@ -277,11 +284,12 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Void> uploadRawData(AuthHeader authHeader, BinaryRequestBody input) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.body(runtime.bodySerDe().serialize(input));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.body(_runtime.bodySerDe().serialize(input));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.uploadRawData,
                                 _request.build(),
                                 uploadRawDataDeserializer);
@@ -290,11 +298,12 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Void> uploadAliasedRawData(AuthHeader authHeader, BinaryRequestBody input) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.body(runtime.bodySerDe().serialize(input));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.body(_runtime.bodySerDe().serialize(input));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.uploadAliasedRawData,
                                 _request.build(),
                                 uploadAliasedRawDataDeserializer);
@@ -303,21 +312,23 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Set<String>> getBranches(AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
-                return runtime.clients()
-                        .call(channel, DialogueTestEndpoints.getBranches, _request.build(), getBranchesDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
+                        .call(_channel, DialogueTestEndpoints.getBranches, _request.build(), getBranchesDeserializer);
             }
 
             @Override
             public ListenableFuture<Set<String>> getBranchesDeprecated(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.getBranchesDeprecated,
                                 _request.build(),
                                 getBranchesDeprecatedDeserializer);
@@ -327,12 +338,13 @@ public interface TestServiceAsync {
             public ListenableFuture<Optional<String>> resolveBranch(
                     AuthHeader authHeader, ResourceIdentifier datasetRid, String branch) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
-                _request.putPathParams("branch", plainSerDe.serializeString(branch));
-                return runtime.clients()
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                _request.putPathParams("branch", _plainSerDe.serializeString(branch));
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.resolveBranch,
                                 _request.build(),
                                 resolveBranchDeserializer);
@@ -341,10 +353,11 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Optional<String>> testParam(AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
-                return runtime.clients()
-                        .call(channel, DialogueTestEndpoints.testParam, _request.build(), testParamDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
+                        .call(_channel, DialogueTestEndpoints.testParam, _request.build(), testParamDeserializer);
             }
 
             @Override
@@ -357,22 +370,23 @@ public interface TestServiceAsync {
                     Optional<ResourceIdentifier> optionalEnd,
                     String query) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 _request.body(testQueryParamsSerializer.serialize(query));
-                _request.putQueryParams("different", plainSerDe.serializeRid(something));
+                _request.putQueryParams("different", _plainSerDe.serializeRid(something));
                 if (optionalMiddle.isPresent()) {
-                    _request.putQueryParams("optionalMiddle", plainSerDe.serializeRid(optionalMiddle.get()));
+                    _request.putQueryParams("optionalMiddle", _plainSerDe.serializeRid(optionalMiddle.get()));
                 }
-                _request.putQueryParams("implicit", plainSerDe.serializeRid(implicit));
+                _request.putQueryParams("implicit", _plainSerDe.serializeRid(implicit));
                 for (String setEndElement : setEnd) {
-                    _request.putQueryParams("setEnd", plainSerDe.serializeString(setEndElement));
+                    _request.putQueryParams("setEnd", _plainSerDe.serializeString(setEndElement));
                 }
                 if (optionalEnd.isPresent()) {
-                    _request.putQueryParams("optionalEnd", plainSerDe.serializeRid(optionalEnd.get()));
+                    _request.putQueryParams("optionalEnd", _plainSerDe.serializeRid(optionalEnd.get()));
                 }
-                return runtime.clients()
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.testQueryParams,
                                 _request.build(),
                                 testQueryParamsDeserializer);
@@ -388,22 +402,23 @@ public interface TestServiceAsync {
                     Optional<ResourceIdentifier> optionalEnd,
                     String query) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 _request.body(testNoResponseQueryParamsSerializer.serialize(query));
-                _request.putQueryParams("different", plainSerDe.serializeRid(something));
+                _request.putQueryParams("different", _plainSerDe.serializeRid(something));
                 if (optionalMiddle.isPresent()) {
-                    _request.putQueryParams("optionalMiddle", plainSerDe.serializeRid(optionalMiddle.get()));
+                    _request.putQueryParams("optionalMiddle", _plainSerDe.serializeRid(optionalMiddle.get()));
                 }
-                _request.putQueryParams("implicit", plainSerDe.serializeRid(implicit));
+                _request.putQueryParams("implicit", _plainSerDe.serializeRid(implicit));
                 for (String setEndElement : setEnd) {
-                    _request.putQueryParams("setEnd", plainSerDe.serializeString(setEndElement));
+                    _request.putQueryParams("setEnd", _plainSerDe.serializeString(setEndElement));
                 }
                 if (optionalEnd.isPresent()) {
-                    _request.putQueryParams("optionalEnd", plainSerDe.serializeRid(optionalEnd.get()));
+                    _request.putQueryParams("optionalEnd", _plainSerDe.serializeRid(optionalEnd.get()));
                 }
-                return runtime.clients()
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.testNoResponseQueryParams,
                                 _request.build(),
                                 testNoResponseQueryParamsDeserializer);
@@ -412,36 +427,40 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Boolean> testBoolean(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
-                        .call(channel, DialogueTestEndpoints.testBoolean, _request.build(), testBooleanDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
+                        .call(_channel, DialogueTestEndpoints.testBoolean, _request.build(), testBooleanDeserializer);
             }
 
             @Override
             public ListenableFuture<Double> testDouble(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
-                        .call(channel, DialogueTestEndpoints.testDouble, _request.build(), testDoubleDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
+                        .call(_channel, DialogueTestEndpoints.testDouble, _request.build(), testDoubleDeserializer);
             }
 
             @Override
             public ListenableFuture<Integer> testInteger(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                return runtime.clients()
-                        .call(channel, DialogueTestEndpoints.testInteger, _request.build(), testIntegerDeserializer);
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                return _runtime.clients()
+                        .call(_channel, DialogueTestEndpoints.testInteger, _request.build(), testIntegerDeserializer);
             }
 
             @Override
             public ListenableFuture<Optional<String>> testPostOptional(
                     AuthHeader authHeader, Optional<String> maybeString) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 _request.body(testPostOptionalSerializer.serialize(maybeString));
-                return runtime.clients()
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.testPostOptional,
                                 _request.build(),
                                 testPostOptionalDeserializer);
@@ -451,16 +470,17 @@ public interface TestServiceAsync {
             public ListenableFuture<Void> testOptionalIntegerAndDouble(
                     AuthHeader authHeader, OptionalInt maybeInteger, OptionalDouble maybeDouble) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
                 if (maybeInteger.isPresent()) {
-                    _request.putQueryParams("maybeInteger", plainSerDe.serializeInteger(maybeInteger.getAsInt()));
+                    _request.putQueryParams("maybeInteger", _plainSerDe.serializeInteger(maybeInteger.getAsInt()));
                 }
                 if (maybeDouble.isPresent()) {
-                    _request.putQueryParams("maybeDouble", plainSerDe.serializeDouble(maybeDouble.getAsDouble()));
+                    _request.putQueryParams("maybeDouble", _plainSerDe.serializeDouble(maybeDouble.getAsDouble()));
                 }
-                return runtime.clients()
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.testOptionalIntegerAndDouble,
                                 _request.build(),
                                 testOptionalIntegerAndDoubleDeserializer);
@@ -470,14 +490,15 @@ public interface TestServiceAsync {
             public ListenableFuture<Void> getForStrings(
                     AuthHeader authHeader, ResourceIdentifier datasetRid, Set<AliasedString> strings) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams("Authorization", plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
-                _request.putPathParams("datasetRid", plainSerDe.serializeRid(datasetRid));
+                _request.putHeaderParams(
+                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 for (AliasedString stringsElement : strings) {
-                    _request.putQueryParams("strings", plainSerDe.serializeString(stringsElement.get()));
+                    _request.putQueryParams("strings", _plainSerDe.serializeString(stringsElement.get()));
                 }
-                return runtime.clients()
+                return _runtime.clients()
                         .call(
-                                channel,
+                                _channel,
                                 DialogueTestEndpoints.getForStrings,
                                 _request.build(),
                                 getForStringsDeserializer);

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
@@ -97,73 +97,73 @@ public interface TestServiceBlocking {
     /**
      * Creates a synchronous/blocking client for a TestService service.
      */
-    static TestServiceBlocking of(Channel channel, ConjureRuntime runtime) {
-        TestServiceAsync delegate = TestServiceAsync.of(channel, runtime);
+    static TestServiceBlocking of(Channel _channel, ConjureRuntime _runtime) {
+        TestServiceAsync delegate = TestServiceAsync.of(_channel, _runtime);
         return new TestServiceBlocking() {
             @Override
             public Map<String, BackingFileSystem> getFileSystems(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.getFileSystems(authHeader));
+                return _runtime.clients().block(delegate.getFileSystems(authHeader));
             }
 
             @Override
             public Dataset createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request) {
-                return runtime.clients().block(delegate.createDataset(authHeader, testHeaderArg, request));
+                return _runtime.clients().block(delegate.createDataset(authHeader, testHeaderArg, request));
             }
 
             @Override
             public Optional<Dataset> getDataset(AuthHeader authHeader, ResourceIdentifier datasetRid) {
-                return runtime.clients().block(delegate.getDataset(authHeader, datasetRid));
+                return _runtime.clients().block(delegate.getDataset(authHeader, datasetRid));
             }
 
             @Override
             public InputStream getRawData(AuthHeader authHeader, ResourceIdentifier datasetRid) {
-                return runtime.clients().block(delegate.getRawData(authHeader, datasetRid));
+                return _runtime.clients().block(delegate.getRawData(authHeader, datasetRid));
             }
 
             @Override
             public InputStream getAliasedRawData(AuthHeader authHeader, ResourceIdentifier datasetRid) {
-                return runtime.clients().block(delegate.getAliasedRawData(authHeader, datasetRid));
+                return _runtime.clients().block(delegate.getAliasedRawData(authHeader, datasetRid));
             }
 
             @Override
             public Optional<InputStream> maybeGetRawData(AuthHeader authHeader, ResourceIdentifier datasetRid) {
-                return runtime.clients().block(delegate.maybeGetRawData(authHeader, datasetRid));
+                return _runtime.clients().block(delegate.maybeGetRawData(authHeader, datasetRid));
             }
 
             @Override
             public AliasedString getAliasedString(AuthHeader authHeader, ResourceIdentifier datasetRid) {
-                return runtime.clients().block(delegate.getAliasedString(authHeader, datasetRid));
+                return _runtime.clients().block(delegate.getAliasedString(authHeader, datasetRid));
             }
 
             @Override
             public void uploadRawData(AuthHeader authHeader, BinaryRequestBody input) {
-                runtime.clients().block(delegate.uploadRawData(authHeader, input));
+                _runtime.clients().block(delegate.uploadRawData(authHeader, input));
             }
 
             @Override
             public void uploadAliasedRawData(AuthHeader authHeader, BinaryRequestBody input) {
-                runtime.clients().block(delegate.uploadAliasedRawData(authHeader, input));
+                _runtime.clients().block(delegate.uploadAliasedRawData(authHeader, input));
             }
 
             @Override
             public Set<String> getBranches(AuthHeader authHeader, ResourceIdentifier datasetRid) {
-                return runtime.clients().block(delegate.getBranches(authHeader, datasetRid));
+                return _runtime.clients().block(delegate.getBranches(authHeader, datasetRid));
             }
 
             @Override
             @SuppressWarnings("deprecation")
             public Set<String> getBranchesDeprecated(AuthHeader authHeader, ResourceIdentifier datasetRid) {
-                return runtime.clients().block(delegate.getBranchesDeprecated(authHeader, datasetRid));
+                return _runtime.clients().block(delegate.getBranchesDeprecated(authHeader, datasetRid));
             }
 
             @Override
             public Optional<String> resolveBranch(AuthHeader authHeader, ResourceIdentifier datasetRid, String branch) {
-                return runtime.clients().block(delegate.resolveBranch(authHeader, datasetRid, branch));
+                return _runtime.clients().block(delegate.resolveBranch(authHeader, datasetRid, branch));
             }
 
             @Override
             public Optional<String> testParam(AuthHeader authHeader, ResourceIdentifier datasetRid) {
-                return runtime.clients().block(delegate.testParam(authHeader, datasetRid));
+                return _runtime.clients().block(delegate.testParam(authHeader, datasetRid));
             }
 
             @Override
@@ -175,7 +175,7 @@ public interface TestServiceBlocking {
                     Set<String> setEnd,
                     Optional<ResourceIdentifier> optionalEnd,
                     String query) {
-                return runtime.clients()
+                return _runtime.clients()
                         .block(delegate.testQueryParams(
                                 authHeader, something, implicit, optionalMiddle, setEnd, optionalEnd, query));
             }
@@ -189,41 +189,41 @@ public interface TestServiceBlocking {
                     Set<String> setEnd,
                     Optional<ResourceIdentifier> optionalEnd,
                     String query) {
-                runtime.clients()
+                _runtime.clients()
                         .block(delegate.testNoResponseQueryParams(
                                 authHeader, something, implicit, optionalMiddle, setEnd, optionalEnd, query));
             }
 
             @Override
             public boolean testBoolean(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.testBoolean(authHeader));
+                return _runtime.clients().block(delegate.testBoolean(authHeader));
             }
 
             @Override
             public double testDouble(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.testDouble(authHeader));
+                return _runtime.clients().block(delegate.testDouble(authHeader));
             }
 
             @Override
             public int testInteger(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.testInteger(authHeader));
+                return _runtime.clients().block(delegate.testInteger(authHeader));
             }
 
             @Override
             public Optional<String> testPostOptional(AuthHeader authHeader, Optional<String> maybeString) {
-                return runtime.clients().block(delegate.testPostOptional(authHeader, maybeString));
+                return _runtime.clients().block(delegate.testPostOptional(authHeader, maybeString));
             }
 
             @Override
             public void testOptionalIntegerAndDouble(
                     AuthHeader authHeader, OptionalInt maybeInteger, OptionalDouble maybeDouble) {
-                runtime.clients().block(delegate.testOptionalIntegerAndDouble(authHeader, maybeInteger, maybeDouble));
+                _runtime.clients().block(delegate.testOptionalIntegerAndDouble(authHeader, maybeInteger, maybeDouble));
             }
 
             @Override
             public void getForStrings(
                     AuthHeader authHeader, ResourceIdentifier datasetRid, Set<AliasedString> strings) {
-                runtime.clients().block(delegate.getForStrings(authHeader, datasetRid, strings));
+                _runtime.clients().block(delegate.getForStrings(authHeader, datasetRid, strings));
             }
         };
     }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
@@ -97,73 +97,73 @@ public interface TestServiceBlocking {
     /**
      * Creates a synchronous/blocking client for a TestService service.
      */
-    static TestServiceBlocking of(Channel channel, ConjureRuntime runtime) {
-        TestServiceAsync delegate = TestServiceAsync.of(channel, runtime);
+    static TestServiceBlocking of(Channel _channel, ConjureRuntime _runtime) {
+        TestServiceAsync delegate = TestServiceAsync.of(_channel, _runtime);
         return new TestServiceBlocking() {
             @Override
             public Map<String, BackingFileSystem> getFileSystems(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.getFileSystems(authHeader));
+                return _runtime.clients().block(delegate.getFileSystems(authHeader));
             }
 
             @Override
             public Dataset createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request) {
-                return runtime.clients().block(delegate.createDataset(authHeader, testHeaderArg, request));
+                return _runtime.clients().block(delegate.createDataset(authHeader, testHeaderArg, request));
             }
 
             @Override
             public Optional<Dataset> getDataset(AuthHeader authHeader, ResourceIdentifier datasetRid) {
-                return runtime.clients().block(delegate.getDataset(authHeader, datasetRid));
+                return _runtime.clients().block(delegate.getDataset(authHeader, datasetRid));
             }
 
             @Override
             public InputStream getRawData(AuthHeader authHeader, ResourceIdentifier datasetRid) {
-                return runtime.clients().block(delegate.getRawData(authHeader, datasetRid));
+                return _runtime.clients().block(delegate.getRawData(authHeader, datasetRid));
             }
 
             @Override
             public InputStream getAliasedRawData(AuthHeader authHeader, ResourceIdentifier datasetRid) {
-                return runtime.clients().block(delegate.getAliasedRawData(authHeader, datasetRid));
+                return _runtime.clients().block(delegate.getAliasedRawData(authHeader, datasetRid));
             }
 
             @Override
             public Optional<InputStream> maybeGetRawData(AuthHeader authHeader, ResourceIdentifier datasetRid) {
-                return runtime.clients().block(delegate.maybeGetRawData(authHeader, datasetRid));
+                return _runtime.clients().block(delegate.maybeGetRawData(authHeader, datasetRid));
             }
 
             @Override
             public AliasedString getAliasedString(AuthHeader authHeader, ResourceIdentifier datasetRid) {
-                return runtime.clients().block(delegate.getAliasedString(authHeader, datasetRid));
+                return _runtime.clients().block(delegate.getAliasedString(authHeader, datasetRid));
             }
 
             @Override
             public void uploadRawData(AuthHeader authHeader, BinaryRequestBody input) {
-                runtime.clients().block(delegate.uploadRawData(authHeader, input));
+                _runtime.clients().block(delegate.uploadRawData(authHeader, input));
             }
 
             @Override
             public void uploadAliasedRawData(AuthHeader authHeader, BinaryRequestBody input) {
-                runtime.clients().block(delegate.uploadAliasedRawData(authHeader, input));
+                _runtime.clients().block(delegate.uploadAliasedRawData(authHeader, input));
             }
 
             @Override
             public Set<String> getBranches(AuthHeader authHeader, ResourceIdentifier datasetRid) {
-                return runtime.clients().block(delegate.getBranches(authHeader, datasetRid));
+                return _runtime.clients().block(delegate.getBranches(authHeader, datasetRid));
             }
 
             @Override
             @SuppressWarnings("deprecation")
             public Set<String> getBranchesDeprecated(AuthHeader authHeader, ResourceIdentifier datasetRid) {
-                return runtime.clients().block(delegate.getBranchesDeprecated(authHeader, datasetRid));
+                return _runtime.clients().block(delegate.getBranchesDeprecated(authHeader, datasetRid));
             }
 
             @Override
             public Optional<String> resolveBranch(AuthHeader authHeader, ResourceIdentifier datasetRid, String branch) {
-                return runtime.clients().block(delegate.resolveBranch(authHeader, datasetRid, branch));
+                return _runtime.clients().block(delegate.resolveBranch(authHeader, datasetRid, branch));
             }
 
             @Override
             public Optional<String> testParam(AuthHeader authHeader, ResourceIdentifier datasetRid) {
-                return runtime.clients().block(delegate.testParam(authHeader, datasetRid));
+                return _runtime.clients().block(delegate.testParam(authHeader, datasetRid));
             }
 
             @Override
@@ -175,7 +175,7 @@ public interface TestServiceBlocking {
                     Set<String> setEnd,
                     Optional<ResourceIdentifier> optionalEnd,
                     String query) {
-                return runtime.clients()
+                return _runtime.clients()
                         .block(delegate.testQueryParams(
                                 authHeader, something, implicit, optionalMiddle, setEnd, optionalEnd, query));
             }
@@ -189,41 +189,41 @@ public interface TestServiceBlocking {
                     Set<String> setEnd,
                     Optional<ResourceIdentifier> optionalEnd,
                     String query) {
-                runtime.clients()
+                _runtime.clients()
                         .block(delegate.testNoResponseQueryParams(
                                 authHeader, something, implicit, optionalMiddle, setEnd, optionalEnd, query));
             }
 
             @Override
             public boolean testBoolean(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.testBoolean(authHeader));
+                return _runtime.clients().block(delegate.testBoolean(authHeader));
             }
 
             @Override
             public double testDouble(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.testDouble(authHeader));
+                return _runtime.clients().block(delegate.testDouble(authHeader));
             }
 
             @Override
             public int testInteger(AuthHeader authHeader) {
-                return runtime.clients().block(delegate.testInteger(authHeader));
+                return _runtime.clients().block(delegate.testInteger(authHeader));
             }
 
             @Override
             public Optional<String> testPostOptional(AuthHeader authHeader, Optional<String> maybeString) {
-                return runtime.clients().block(delegate.testPostOptional(authHeader, maybeString));
+                return _runtime.clients().block(delegate.testPostOptional(authHeader, maybeString));
             }
 
             @Override
             public void testOptionalIntegerAndDouble(
                     AuthHeader authHeader, OptionalInt maybeInteger, OptionalDouble maybeDouble) {
-                runtime.clients().block(delegate.testOptionalIntegerAndDouble(authHeader, maybeInteger, maybeDouble));
+                _runtime.clients().block(delegate.testOptionalIntegerAndDouble(authHeader, maybeInteger, maybeDouble));
             }
 
             @Override
             public void getForStrings(
                     AuthHeader authHeader, ResourceIdentifier datasetRid, Set<AliasedString> strings) {
-                runtime.clients().block(delegate.getForStrings(authHeader, datasetRid, strings));
+                _runtime.clients().block(delegate.getForStrings(authHeader, datasetRid, strings));
             }
         };
     }


### PR DESCRIPTION
Closes https://github.com/palantir/dialogue/issues/587

## Before this PR
User defined variables could conflict with internal variables

## After this PR
==COMMIT_MSG==
Add prefix to internal variable names to avoid collisions with user variables
==COMMIT_MSG==

## Possible downsides?
N/A

