### PR TITLE
Fix dialogue auth header serialization

### DIFF
--- a/changelog/@unreleased/pr-860.v2.yml
+++ b/changelog/@unreleased/pr-860.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix dialogue auth header serialization by providing the expected `Bearer
+    ` prefix.
+  links:
+  - https://github.com/palantir/conjure-java/pull/860

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceAsync.java
@@ -35,8 +35,7 @@ public interface EteBinaryServiceAsync {
             @Override
             public ListenableFuture<InputStream> postBinary(AuthHeader authHeader, BinaryRequestBody body) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.body(_runtime.bodySerDe().serialize(body));
                 return _runtime.clients()
                         .call(
@@ -49,8 +48,7 @@ public interface EteBinaryServiceAsync {
             @Override
             public ListenableFuture<Optional<InputStream>> getOptionalBinaryPresent(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(
                                 _channel,
@@ -62,8 +60,7 @@ public interface EteBinaryServiceAsync {
             @Override
             public ListenableFuture<Optional<InputStream>> getOptionalBinaryEmpty(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(
                                 _channel,
@@ -75,8 +72,7 @@ public interface EteBinaryServiceAsync {
             @Override
             public ListenableFuture<InputStream> getBinaryFailure(AuthHeader authHeader, int numBytes) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putQueryParams("numBytes", _plainSerDe.serializeInteger(numBytes));
                 return _runtime.clients()
                         .call(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceAsync.java
@@ -211,8 +211,7 @@ public interface EteServiceAsync {
             @Override
             public ListenableFuture<String> string(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(_channel, DialogueEteEndpoints.string, _request.build(), stringDeserializer);
             }
@@ -220,8 +219,7 @@ public interface EteServiceAsync {
             @Override
             public ListenableFuture<Integer> integer(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(_channel, DialogueEteEndpoints.integer, _request.build(), integerDeserializer);
             }
@@ -229,8 +227,7 @@ public interface EteServiceAsync {
             @Override
             public ListenableFuture<Double> double_(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(_channel, DialogueEteEndpoints.double_, _request.build(), double_Deserializer);
             }
@@ -238,8 +235,7 @@ public interface EteServiceAsync {
             @Override
             public ListenableFuture<Boolean> boolean_(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(_channel, DialogueEteEndpoints.boolean_, _request.build(), boolean_Deserializer);
             }
@@ -247,8 +243,7 @@ public interface EteServiceAsync {
             @Override
             public ListenableFuture<SafeLong> safelong(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(_channel, DialogueEteEndpoints.safelong, _request.build(), safelongDeserializer);
             }
@@ -256,16 +251,14 @@ public interface EteServiceAsync {
             @Override
             public ListenableFuture<ResourceIdentifier> rid(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients().call(_channel, DialogueEteEndpoints.rid, _request.build(), ridDeserializer);
             }
 
             @Override
             public ListenableFuture<BearerToken> bearertoken(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(_channel, DialogueEteEndpoints.bearertoken, _request.build(), bearertokenDeserializer);
             }
@@ -273,8 +266,7 @@ public interface EteServiceAsync {
             @Override
             public ListenableFuture<Optional<String>> optionalString(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(
                                 _channel,
@@ -286,8 +278,7 @@ public interface EteServiceAsync {
             @Override
             public ListenableFuture<Optional<String>> optionalEmpty(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(
                                 _channel,
@@ -299,8 +290,7 @@ public interface EteServiceAsync {
             @Override
             public ListenableFuture<OffsetDateTime> datetime(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(_channel, DialogueEteEndpoints.datetime, _request.build(), datetimeDeserializer);
             }
@@ -308,8 +298,7 @@ public interface EteServiceAsync {
             @Override
             public ListenableFuture<InputStream> binary(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(
                                 _channel,
@@ -321,8 +310,7 @@ public interface EteServiceAsync {
             @Override
             public ListenableFuture<String> path(AuthHeader authHeader, String param) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("param", _plainSerDe.serializeString(param));
                 return _runtime.clients().call(_channel, DialogueEteEndpoints.path, _request.build(), pathDeserializer);
             }
@@ -330,8 +318,7 @@ public interface EteServiceAsync {
             @Override
             public ListenableFuture<Long> externalLongPath(AuthHeader authHeader, long param) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("param", Objects.toString(param));
                 return _runtime.clients()
                         .call(
@@ -345,8 +332,7 @@ public interface EteServiceAsync {
             public ListenableFuture<Optional<Long>> optionalExternalLongQuery(
                     AuthHeader authHeader, Optional<Long> param) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 if (param.isPresent()) {
                     _request.putQueryParams("param", Objects.toString(param.get()));
                 }
@@ -362,8 +348,7 @@ public interface EteServiceAsync {
             public ListenableFuture<StringAliasExample> notNullBody(
                     AuthHeader authHeader, StringAliasExample notNullBody) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.body(notNullBodySerializer.serialize(notNullBody));
                 return _runtime.clients()
                         .call(_channel, DialogueEteEndpoints.notNullBody, _request.build(), notNullBodyDeserializer);
@@ -373,8 +358,7 @@ public interface EteServiceAsync {
             public ListenableFuture<StringAliasExample> aliasOne(
                     AuthHeader authHeader, StringAliasExample queryParamName) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putQueryParams("queryParamName", _plainSerDe.serializeString(queryParamName.get()));
                 return _runtime.clients()
                         .call(_channel, DialogueEteEndpoints.aliasOne, _request.build(), aliasOneDeserializer);
@@ -384,8 +368,7 @@ public interface EteServiceAsync {
             public ListenableFuture<StringAliasExample> optionalAliasOne(
                     AuthHeader authHeader, Optional<StringAliasExample> queryParamName) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 if (queryParamName.isPresent()) {
                     _request.putQueryParams(
                             "queryParamName",
@@ -403,8 +386,7 @@ public interface EteServiceAsync {
             public ListenableFuture<NestedStringAliasExample> aliasTwo(
                     AuthHeader authHeader, NestedStringAliasExample queryParamName) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putQueryParams(
                         "queryParamName",
                         _plainSerDe.serializeString(queryParamName.get().get()));
@@ -416,8 +398,7 @@ public interface EteServiceAsync {
             public ListenableFuture<StringAliasExample> notNullBodyExternalImport(
                     AuthHeader authHeader, StringAliasExample notNullBody) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.body(notNullBodyExternalImportSerializer.serialize(notNullBody));
                 return _runtime.clients()
                         .call(
@@ -431,8 +412,7 @@ public interface EteServiceAsync {
             public ListenableFuture<Optional<StringAliasExample>> optionalBodyExternalImport(
                     AuthHeader authHeader, Optional<StringAliasExample> body) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.body(optionalBodyExternalImportSerializer.serialize(body));
                 return _runtime.clients()
                         .call(
@@ -446,8 +426,7 @@ public interface EteServiceAsync {
             public ListenableFuture<Optional<StringAliasExample>> optionalQueryExternalImport(
                     AuthHeader authHeader, Optional<StringAliasExample> query) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 if (query.isPresent()) {
                     _request.putQueryParams("query", Objects.toString(query.get()));
                 }
@@ -462,8 +441,7 @@ public interface EteServiceAsync {
             @Override
             public ListenableFuture<Void> noReturn(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(_channel, DialogueEteEndpoints.noReturn, _request.build(), noReturnDeserializer);
             }
@@ -471,8 +449,7 @@ public interface EteServiceAsync {
             @Override
             public ListenableFuture<SimpleEnum> enumQuery(AuthHeader authHeader, SimpleEnum queryParamName) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putQueryParams("queryParamName", Objects.toString(queryParamName));
                 return _runtime.clients()
                         .call(_channel, DialogueEteEndpoints.enumQuery, _request.build(), enumQueryDeserializer);
@@ -482,8 +459,7 @@ public interface EteServiceAsync {
             public ListenableFuture<List<SimpleEnum>> enumListQuery(
                     AuthHeader authHeader, List<SimpleEnum> queryParamName) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 for (SimpleEnum queryParamNameElement : queryParamName) {
                     _request.putQueryParams("queryParamName", Objects.toString(queryParamNameElement));
                 }
@@ -499,8 +475,7 @@ public interface EteServiceAsync {
             public ListenableFuture<Optional<SimpleEnum>> optionalEnumQuery(
                     AuthHeader authHeader, Optional<SimpleEnum> queryParamName) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 if (queryParamName.isPresent()) {
                     _request.putQueryParams("queryParamName", Objects.toString(queryParamName.get()));
                 }
@@ -515,8 +490,7 @@ public interface EteServiceAsync {
             @Override
             public ListenableFuture<SimpleEnum> enumHeader(AuthHeader authHeader, SimpleEnum headerParameter) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putHeaderParams("Custom-Header", Objects.toString(headerParameter));
                 return _runtime.clients()
                         .call(_channel, DialogueEteEndpoints.enumHeader, _request.build(), enumHeaderDeserializer);
@@ -526,8 +500,7 @@ public interface EteServiceAsync {
             public ListenableFuture<Optional<LongAlias>> aliasLongEndpoint(
                     AuthHeader authHeader, Optional<LongAlias> input) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 if (input.isPresent()) {
                     _request.putQueryParams(
                             "input", Objects.toString(input.get().get()));
@@ -548,8 +521,7 @@ public interface EteServiceAsync {
                     Set<Long> longs,
                     Set<Integer> ints) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 for (StringAliasExample stringsElement : strings) {
                     _request.putQueryParams("strings", _plainSerDe.serializeString(stringsElement.get()));

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/AsyncGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/AsyncGenerator.java
@@ -348,10 +348,9 @@ public final class AsyncGenerator implements StaticFactoryMethodGenerator {
             @Override
             public CodeBlock visitHeader(HeaderAuthType value) {
                 return CodeBlock.of(
-                        "$L.putHeaderParams($S, $L.serializeBearerToken($L.getBearerToken()));",
+                        "$L.putHeaderParams($S, $L.toString());",
                         REQUEST,
                         Auth.AUTH_HEADER_NAME,
-                        PLAIN_SER_DE,
                         Auth.AUTH_HEADER_PARAM_NAME);
             }
 

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
@@ -185,8 +185,7 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(
                                 _channel,
@@ -199,8 +198,7 @@ public interface TestServiceAsync {
             public ListenableFuture<Dataset> createDataset(
                     AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.body(createDatasetSerializer.serialize(request));
                 _request.putHeaderParams("Test-Header", _plainSerDe.serializeString(testHeaderArg));
                 return _runtime.clients()
@@ -215,8 +213,7 @@ public interface TestServiceAsync {
             public ListenableFuture<Optional<Dataset>> getDataset(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 return _runtime.clients()
                         .call(_channel, DialogueTestEndpoints.getDataset, _request.build(), getDatasetDeserializer);
@@ -225,8 +222,7 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<InputStream> getRawData(AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 return _runtime.clients()
                         .call(
@@ -240,8 +236,7 @@ public interface TestServiceAsync {
             public ListenableFuture<InputStream> getAliasedRawData(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 return _runtime.clients()
                         .call(
@@ -255,8 +250,7 @@ public interface TestServiceAsync {
             public ListenableFuture<Optional<InputStream>> maybeGetRawData(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 return _runtime.clients()
                         .call(
@@ -270,8 +264,7 @@ public interface TestServiceAsync {
             public ListenableFuture<AliasedString> getAliasedString(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 return _runtime.clients()
                         .call(
@@ -284,8 +277,7 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Void> uploadRawData(AuthHeader authHeader, BinaryRequestBody input) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.body(_runtime.bodySerDe().serialize(input));
                 return _runtime.clients()
                         .call(
@@ -298,8 +290,7 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Void> uploadAliasedRawData(AuthHeader authHeader, BinaryRequestBody input) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.body(_runtime.bodySerDe().serialize(input));
                 return _runtime.clients()
                         .call(
@@ -312,8 +303,7 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Set<String>> getBranches(AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 return _runtime.clients()
                         .call(_channel, DialogueTestEndpoints.getBranches, _request.build(), getBranchesDeserializer);
@@ -323,8 +313,7 @@ public interface TestServiceAsync {
             public ListenableFuture<Set<String>> getBranchesDeprecated(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 return _runtime.clients()
                         .call(
@@ -338,8 +327,7 @@ public interface TestServiceAsync {
             public ListenableFuture<Optional<String>> resolveBranch(
                     AuthHeader authHeader, ResourceIdentifier datasetRid, String branch) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 _request.putPathParams("branch", _plainSerDe.serializeString(branch));
                 return _runtime.clients()
@@ -353,8 +341,7 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Optional<String>> testParam(AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 return _runtime.clients()
                         .call(_channel, DialogueTestEndpoints.testParam, _request.build(), testParamDeserializer);
@@ -370,8 +357,7 @@ public interface TestServiceAsync {
                     Optional<ResourceIdentifier> optionalEnd,
                     String query) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.body(testQueryParamsSerializer.serialize(query));
                 _request.putQueryParams("different", _plainSerDe.serializeRid(something));
                 if (optionalMiddle.isPresent()) {
@@ -402,8 +388,7 @@ public interface TestServiceAsync {
                     Optional<ResourceIdentifier> optionalEnd,
                     String query) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.body(testNoResponseQueryParamsSerializer.serialize(query));
                 _request.putQueryParams("different", _plainSerDe.serializeRid(something));
                 if (optionalMiddle.isPresent()) {
@@ -427,8 +412,7 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Boolean> testBoolean(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(_channel, DialogueTestEndpoints.testBoolean, _request.build(), testBooleanDeserializer);
             }
@@ -436,8 +420,7 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Double> testDouble(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(_channel, DialogueTestEndpoints.testDouble, _request.build(), testDoubleDeserializer);
             }
@@ -445,8 +428,7 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Integer> testInteger(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(_channel, DialogueTestEndpoints.testInteger, _request.build(), testIntegerDeserializer);
             }
@@ -455,8 +437,7 @@ public interface TestServiceAsync {
             public ListenableFuture<Optional<String>> testPostOptional(
                     AuthHeader authHeader, Optional<String> maybeString) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.body(testPostOptionalSerializer.serialize(maybeString));
                 return _runtime.clients()
                         .call(
@@ -470,8 +451,7 @@ public interface TestServiceAsync {
             public ListenableFuture<Void> testOptionalIntegerAndDouble(
                     AuthHeader authHeader, OptionalInt maybeInteger, OptionalDouble maybeDouble) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 if (maybeInteger.isPresent()) {
                     _request.putQueryParams("maybeInteger", _plainSerDe.serializeInteger(maybeInteger.getAsInt()));
                 }
@@ -490,8 +470,7 @@ public interface TestServiceAsync {
             public ListenableFuture<Void> getForStrings(
                     AuthHeader authHeader, ResourceIdentifier datasetRid, Set<AliasedString> strings) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 for (AliasedString stringsElement : strings) {
                     _request.putQueryParams("strings", _plainSerDe.serializeString(stringsElement.get()));

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
@@ -185,8 +185,7 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(
                                 _channel,
@@ -199,8 +198,7 @@ public interface TestServiceAsync {
             public ListenableFuture<Dataset> createDataset(
                     AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.body(createDatasetSerializer.serialize(request));
                 _request.putHeaderParams("Test-Header", _plainSerDe.serializeString(testHeaderArg));
                 return _runtime.clients()
@@ -215,8 +213,7 @@ public interface TestServiceAsync {
             public ListenableFuture<Optional<Dataset>> getDataset(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 return _runtime.clients()
                         .call(_channel, DialogueTestEndpoints.getDataset, _request.build(), getDatasetDeserializer);
@@ -225,8 +222,7 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<InputStream> getRawData(AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 return _runtime.clients()
                         .call(
@@ -240,8 +236,7 @@ public interface TestServiceAsync {
             public ListenableFuture<InputStream> getAliasedRawData(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 return _runtime.clients()
                         .call(
@@ -255,8 +250,7 @@ public interface TestServiceAsync {
             public ListenableFuture<Optional<InputStream>> maybeGetRawData(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 return _runtime.clients()
                         .call(
@@ -270,8 +264,7 @@ public interface TestServiceAsync {
             public ListenableFuture<AliasedString> getAliasedString(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 return _runtime.clients()
                         .call(
@@ -284,8 +277,7 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Void> uploadRawData(AuthHeader authHeader, BinaryRequestBody input) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.body(_runtime.bodySerDe().serialize(input));
                 return _runtime.clients()
                         .call(
@@ -298,8 +290,7 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Void> uploadAliasedRawData(AuthHeader authHeader, BinaryRequestBody input) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.body(_runtime.bodySerDe().serialize(input));
                 return _runtime.clients()
                         .call(
@@ -312,8 +303,7 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Set<String>> getBranches(AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 return _runtime.clients()
                         .call(_channel, DialogueTestEndpoints.getBranches, _request.build(), getBranchesDeserializer);
@@ -323,8 +313,7 @@ public interface TestServiceAsync {
             public ListenableFuture<Set<String>> getBranchesDeprecated(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 return _runtime.clients()
                         .call(
@@ -338,8 +327,7 @@ public interface TestServiceAsync {
             public ListenableFuture<Optional<String>> resolveBranch(
                     AuthHeader authHeader, ResourceIdentifier datasetRid, String branch) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 _request.putPathParams("branch", _plainSerDe.serializeString(branch));
                 return _runtime.clients()
@@ -353,8 +341,7 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Optional<String>> testParam(AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 return _runtime.clients()
                         .call(_channel, DialogueTestEndpoints.testParam, _request.build(), testParamDeserializer);
@@ -370,8 +357,7 @@ public interface TestServiceAsync {
                     Optional<ResourceIdentifier> optionalEnd,
                     String query) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.body(testQueryParamsSerializer.serialize(query));
                 _request.putQueryParams("different", _plainSerDe.serializeRid(something));
                 if (optionalMiddle.isPresent()) {
@@ -402,8 +388,7 @@ public interface TestServiceAsync {
                     Optional<ResourceIdentifier> optionalEnd,
                     String query) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.body(testNoResponseQueryParamsSerializer.serialize(query));
                 _request.putQueryParams("different", _plainSerDe.serializeRid(something));
                 if (optionalMiddle.isPresent()) {
@@ -427,8 +412,7 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Boolean> testBoolean(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(_channel, DialogueTestEndpoints.testBoolean, _request.build(), testBooleanDeserializer);
             }
@@ -436,8 +420,7 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Double> testDouble(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(_channel, DialogueTestEndpoints.testDouble, _request.build(), testDoubleDeserializer);
             }
@@ -445,8 +428,7 @@ public interface TestServiceAsync {
             @Override
             public ListenableFuture<Integer> testInteger(AuthHeader authHeader) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 return _runtime.clients()
                         .call(_channel, DialogueTestEndpoints.testInteger, _request.build(), testIntegerDeserializer);
             }
@@ -455,8 +437,7 @@ public interface TestServiceAsync {
             public ListenableFuture<Optional<String>> testPostOptional(
                     AuthHeader authHeader, Optional<String> maybeString) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.body(testPostOptionalSerializer.serialize(maybeString));
                 return _runtime.clients()
                         .call(
@@ -470,8 +451,7 @@ public interface TestServiceAsync {
             public ListenableFuture<Void> testOptionalIntegerAndDouble(
                     AuthHeader authHeader, OptionalInt maybeInteger, OptionalDouble maybeDouble) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 if (maybeInteger.isPresent()) {
                     _request.putQueryParams("maybeInteger", _plainSerDe.serializeInteger(maybeInteger.getAsInt()));
                 }
@@ -490,8 +470,7 @@ public interface TestServiceAsync {
             public ListenableFuture<Void> getForStrings(
                     AuthHeader authHeader, ResourceIdentifier datasetRid, Set<AliasedString> strings) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParams(
-                        "Authorization", _plainSerDe.serializeBearerToken(authHeader.getBearerToken()));
+                _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 for (AliasedString stringsElement : strings) {
                     _request.putQueryParams("strings", _plainSerDe.serializeString(stringsElement.get()));


### PR DESCRIPTION
This provides the expected `Bearer ` prefix. Note that this does
not use the plainSerDe methods, instead relying on the AuthHeader
toString implementation.

## After this PR
==COMMIT_MSG==
Fix dialogue auth header serialization by providing the expected `Bearer ` prefix.
==COMMIT_MSG==

