### PR TITLE
Fix Dialogue cookie auth

### DIFF
--- a/changelog/@unreleased/pr-861.v2.yml
+++ b/changelog/@unreleased/pr-861.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Dialogue generates valid code for services with cookie auth
+  links:
+  - https://github.com/palantir/conjure-java/pull/861

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/AsyncGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/AsyncGenerator.java
@@ -357,7 +357,7 @@ public final class AsyncGenerator implements StaticFactoryMethodGenerator {
             @Override
             public CodeBlock visitCookie(CookieAuthType value) {
                 return CodeBlock.of(
-                        "$L.putHeaderParam($S, \"$L=\" + $L.serializeBearerToken($L));",
+                        "$L.putHeaderParams($S, \"$L=\" + $L.serializeBearerToken($L));",
                         REQUEST,
                         "Cookie",
                         value.getCookieName(),

--- a/conjure-java-core/src/test/resources/test/api/CookieServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/CookieServiceAsync.java.dialogue
@@ -28,7 +28,7 @@ public interface CookieServiceAsync {
             @Override
             public ListenableFuture<Void> eatCookies(BearerToken token) {
                 Request.Builder _request = Request.builder();
-                _request.putHeaderParam("Cookie", "PALANTIR_TOKEN=" + _plainSerDe.serializeBearerToken(token));
+                _request.putHeaderParams("Cookie", "PALANTIR_TOKEN=" + _plainSerDe.serializeBearerToken(token));
                 return _runtime.clients()
                         .call(_channel, DialogueCookieEndpoints.eatCookies, _request.build(), eatCookiesDeserializer);
             }


### PR DESCRIPTION
## Before this PR
We would generate code that wouldn't compile for services with cookie auth

## After this PR
==COMMIT_MSG==
Dialogue generates valid code for services with cookie auth
==COMMIT_MSG==

## Possible downsides?
N/A

