### PR TITLE
Dialogue ignores markers by design, no need to print 1k lines about it

### DIFF
--- a/changelog/@unreleased/pr-874.v2.yml
+++ b/changelog/@unreleased/pr-874.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix misleading console logging in dialogue code gen
+  links:
+  - https://github.com/palantir/conjure-java/pull/874

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/ParameterTypeMapper.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/ParameterTypeMapper.java
@@ -77,7 +77,7 @@ public final class ParameterTypeMapper {
 
     private Set<AnnotationSpec> markers(List<Type> markers) {
         if (!markers.isEmpty()) {
-            log.warn("conjure-dialogue does not support markers. In particular, it ignores @Safe annotations");
+            log.debug("conjure-dialogue does not support markers. In particular, it ignores @Safe annotations");
         }
         return ImmutableSet.of();
     }


### PR DESCRIPTION
## Before this PR
```
conjure-dialogue does not support markers. In particular, it ignores @Safe annotations
conjure-dialogue does not support markers. In particular, it ignores @Safe annotations
conjure-dialogue does not support markers. In particular, it ignores @Safe annotations
conjure-dialogue does not support markers. In particular, it ignores @Safe annotations
...
```

## After this PR
==COMMIT_MSG==
Dialogue ignores markers by design, it's neither necessary nor helpful to print a warning to the console for ignored markers, especially when there's no identifying information describing the maker or the endpoint where it's defined.
==COMMIT_MSG==

