### PR TITLE
Dialogue clients no longer hard-code "0.0.0" (optional --apiVersion param)

### DIFF
--- a/changelog/@unreleased/pr-879.v2.yml
+++ b/changelog/@unreleased/pr-879.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Generated dialogue clients now use the jar's Implementation-Version
+    instead of a hard-coded "0.0.0". This can be overridden using the `--apiVersion`
+    flag if necessary (e.g. for local codegen).
+  links:
+  - https://github.com/palantir/conjure-java/pull/879

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueCookieEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueCookieEndpoints.java
@@ -37,7 +37,7 @@ enum DialogueCookieEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEmptyPathEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEmptyPathEndpoints.java
@@ -36,7 +36,7 @@ enum DialogueEmptyPathEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteBinaryEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteBinaryEndpoints.java
@@ -37,7 +37,7 @@ enum DialogueEteBinaryEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -70,7 +70,7 @@ enum DialogueEteBinaryEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -103,7 +103,7 @@ enum DialogueEteBinaryEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -136,7 +136,7 @@ enum DialogueEteBinaryEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteEndpoints.java
@@ -46,7 +46,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -79,7 +79,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -109,7 +109,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -139,7 +139,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -169,7 +169,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -199,7 +199,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -229,7 +229,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -259,7 +259,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -289,7 +289,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -319,7 +319,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -349,7 +349,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -385,7 +385,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -418,7 +418,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -450,7 +450,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -480,7 +480,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -510,7 +510,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -540,7 +540,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -570,7 +570,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -603,7 +603,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -636,7 +636,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -669,7 +669,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -699,7 +699,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -732,7 +732,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -766,7 +766,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -800,7 +800,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -833,7 +833,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -863,7 +863,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     },
 
@@ -897,7 +897,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "1.2.3";
         }
     }
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
@@ -96,6 +96,8 @@ public interface Options {
 
     Optional<String> packagePrefix();
 
+    Optional<String> apiVersion();
+
     class Builder extends ImmutableOptions.Builder {}
 
     static Builder builder() {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueServiceGenerator.java
@@ -36,16 +36,14 @@ import java.util.stream.Stream;
 public final class DialogueServiceGenerator implements ServiceGenerator {
 
     private final Options options;
-    private final String apiVersion;
 
-    public DialogueServiceGenerator(Options options, String apiVersion) {
+    public DialogueServiceGenerator(Options options) {
         this.options = options;
-        this.apiVersion = apiVersion;
     }
 
     @Override
     public Set<JavaFile> generate(ConjureDefinition conjureDefinition) {
-        DialogueEndpointsGenerator endpoints = new DialogueEndpointsGenerator(options, apiVersion);
+        DialogueEndpointsGenerator endpoints = new DialogueEndpointsGenerator(options);
 
         TypeMapper parameterTypes = new TypeMapper(
                 conjureDefinition.getTypes(),

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/DialogueServiceGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/DialogueServiceGeneratorTests.java
@@ -58,7 +58,7 @@ public final class DialogueServiceGeneratorTests extends TestBase {
     void testPrefixedServices() throws IOException {
         ConjureDefinition def = Conjure.parse(ImmutableList.of(new File("src/test/resources/example-service.yml")));
         List<Path> files = new DialogueServiceGenerator(
-                        Options.builder().packagePrefix("test.prefix").build(), "")
+                        Options.builder().packagePrefix("test.prefix").build())
                 .emit(def, folder);
         validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".dialogue.prefix");
     }
@@ -70,7 +70,7 @@ public final class DialogueServiceGeneratorTests extends TestBase {
                 new File("src/test/resources/example-types.yml"),
                 new File("src/test/resources/example-service.yml")));
         File src = Files.createDirectory(folder.toPath().resolve("src")).toFile();
-        DialogueServiceGenerator generator = new DialogueServiceGenerator(Options.empty(), "");
+        DialogueServiceGenerator generator = new DialogueServiceGenerator(Options.empty());
         generator.emit(conjure, src);
 
         // Generated files contain imports
@@ -84,13 +84,15 @@ public final class DialogueServiceGeneratorTests extends TestBase {
                 new File("src/test/resources/cookie-service.yml"),
                 new File("src/test/resources/ete-service.yml"),
                 new File("src/test/resources/ete-binary.yml")));
-        List<Path> files = new DialogueServiceGenerator(Options.empty(), "").emit(def, folder);
+        List<Path> files = new DialogueServiceGenerator(
+                        Options.builder().apiVersion("1.2.3").build())
+                .emit(def, folder);
         validateGeneratorOutput(files, Paths.get("src/integrationInput/java/com/palantir/product"));
     }
 
     private void testServiceGeneration(String conjureFile) throws IOException {
         ConjureDefinition def = Conjure.parse(ImmutableList.of(new File("src/test/resources/" + conjureFile + ".yml")));
-        List<Path> files = new DialogueServiceGenerator(Options.empty(), "").emit(def, folder);
+        List<Path> files = new DialogueServiceGenerator(Options.empty()).emit(def, folder);
         validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".dialogue");
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/DialogueCookieEndpoints.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/DialogueCookieEndpoints.java.dialogue
@@ -7,6 +7,7 @@ import com.palantir.dialogue.UrlBuilder;
 import java.lang.Override;
 import java.lang.String;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueEndpointsGenerator")
@@ -37,7 +38,11 @@ enum DialogueCookieEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
-    }
+    };
+
+    private static final String VERSION = Optional.ofNullable(
+                    DialogueCookieEndpoints.class.getPackage().getImplementationVersion())
+            .orElse("0.0.0");
 }

--- a/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue
@@ -7,6 +7,7 @@ import com.palantir.dialogue.UrlBuilder;
 import java.lang.Override;
 import java.lang.String;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueEndpointsGenerator")
@@ -40,7 +41,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -70,7 +71,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -103,7 +104,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -137,7 +138,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -171,7 +172,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -205,7 +206,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -239,7 +240,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -272,7 +273,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -305,7 +306,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -339,7 +340,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -376,7 +377,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -412,7 +413,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -446,7 +447,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -478,7 +479,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -510,7 +511,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -540,7 +541,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -570,7 +571,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -600,7 +601,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -630,7 +631,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -662,7 +663,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -696,7 +697,11 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
-    }
+    };
+
+    private static final String VERSION = Optional.ofNullable(
+                    DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+            .orElse("0.0.0");
 }

--- a/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue.prefix
@@ -7,6 +7,7 @@ import com.palantir.dialogue.UrlBuilder;
 import java.lang.Override;
 import java.lang.String;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueEndpointsGenerator")
@@ -40,7 +41,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -70,7 +71,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -103,7 +104,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -137,7 +138,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -171,7 +172,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -205,7 +206,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -239,7 +240,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -272,7 +273,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -305,7 +306,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -339,7 +340,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -376,7 +377,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -412,7 +413,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -446,7 +447,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -478,7 +479,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -510,7 +511,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -540,7 +541,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -570,7 +571,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -600,7 +601,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -630,7 +631,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -662,7 +663,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
     },
 
@@ -696,7 +697,11 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return VERSION;
         }
-    }
+    };
+
+    private static final String VERSION = Optional.ofNullable(
+                    DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+            .orElse("0.0.0");
 }

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/CliConfiguration.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/CliConfiguration.java
@@ -19,7 +19,6 @@ package com.palantir.conjure.java.cli;
 import com.palantir.conjure.java.Options;
 import com.palantir.logsafe.Preconditions;
 import java.io.File;
-import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -52,9 +51,6 @@ public interface CliConfiguration {
     default boolean generateDialogue() {
         return false;
     }
-
-    @Value.Default
-    default Optional<String> apiVersion() { return Optional.empty(); }
 
     @Value.Default
     default Options options() {

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/CliConfiguration.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/CliConfiguration.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.cli;
 import com.palantir.conjure.java.Options;
 import com.palantir.logsafe.Preconditions;
 import java.io.File;
+import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -51,6 +52,9 @@ public interface CliConfiguration {
     default boolean generateDialogue() {
         return false;
     }
+
+    @Value.Default
+    default Optional<String> apiVersion() { return Optional.empty(); }
 
     @Value.Default
     default Options options() {

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -157,9 +157,10 @@ public final class ConjureJavaCli implements Runnable {
         @Nullable
         private String packagePrefix;
 
-        @CommandLine.Option(names = "--apiVersion", description = "A optional version number (e.g. '1.2.3') to be "
-                + "embedded in the generated Java code. If omitted, the version will be read from the Jar Manifest's "
-                + "Implementation-Version.")
+        @CommandLine.Option(
+                names = "--apiVersion",
+                description = "A optional version number (e.g. '1.2.3') to be embedded in the generated Java code. If"
+                        + " omitted, the version will be read from the Jar Manifest's Implementation-Version.")
         @Nullable
         private String apiVersion;
 

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -157,6 +157,12 @@ public final class ConjureJavaCli implements Runnable {
         @Nullable
         private String packagePrefix;
 
+        @CommandLine.Option(names = "--apiVersion", description = "A optional version number (e.g. '1.2.3') to be "
+                + "embedded in the generated Java code. If omitted, the version will be read from the Jar Manifest's "
+                + "Implementation-Version.")
+        @Nullable
+        private String apiVersion;
+
         @SuppressWarnings("unused")
         @CommandLine.Unmatched
         private List<String> unmatchedOptions;
@@ -175,7 +181,7 @@ public final class ConjureJavaCli implements Runnable {
                 ServiceGenerator jerseyGenerator = new JerseyServiceGenerator(config.options());
                 ServiceGenerator retrofitGenerator = new Retrofit2ServiceGenerator(config.options());
                 ServiceGenerator undertowGenerator = new UndertowServiceGenerator(config.options());
-                ServiceGenerator dialogueServiceGenerator = new DialogueServiceGenerator(config.options(), "0.0.0");
+                ServiceGenerator dialogueServiceGenerator = new DialogueServiceGenerator(config.options());
 
                 if (config.generateObjects()) {
                     typeGenerator.emit(conjureDefinition, config.outputDirectory());
@@ -217,6 +223,7 @@ public final class ConjureJavaCli implements Runnable {
                             .strictObjects(strictObjects)
                             .nonNullCollections(nonNullCollections)
                             .packagePrefix(Optional.ofNullable(packagePrefix))
+                            .apiVersion(Optional.ofNullable(apiVersion))
                             .build())
                     .build();
         }


### PR DESCRIPTION
## Before this PR

Right now, every request made by a dialogue client has a user agent like `... FooServiceBlocking/0.0.0 ...`. This is suboptimal (and a regression from c-j-r) because server authors/operators can no longer assess how up-to-date their callers are.

## After this PR
==COMMIT_MSG==
When generating dialogue clients, conjure-java now allows users to specify an `--apiVersion` flag.
==COMMIT_MSG==

This exists to support the local codegen workflow, where you explicitly _don't_ want to just use the `Foo.class.getPackage().getImplementationVersion()`.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

