### PR TITLE
Generated dialogue bindings use the package implementation version

### DIFF
--- a/changelog/@unreleased/pr-880.v2.yml
+++ b/changelog/@unreleased/pr-880.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Generated Dialogue Endpoints will use the packages implementation version
+    if present
+  links:
+  - https://github.com/palantir/conjure-java/pull/880

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueCookieEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueCookieEndpoints.java
@@ -7,6 +7,7 @@ import com.palantir.dialogue.UrlBuilder;
 import java.lang.Override;
 import java.lang.String;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueEndpointsGenerator")
@@ -37,9 +38,12 @@ enum DialogueCookieEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(
-                            DialogueCookieEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
-    }
+    };
+
+    private static final String packageVersion = Optional.ofNullable(
+                    DialogueCookieEndpoints.class.getPackage().getImplementationVersion())
+            .orElse("0.0.0");
+    ;
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueCookieEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueCookieEndpoints.java
@@ -37,7 +37,9 @@ enum DialogueCookieEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(
+                            DialogueCookieEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEmptyPathEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEmptyPathEndpoints.java
@@ -36,7 +36,9 @@ enum DialogueEmptyPathEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(
+                            DialogueEmptyPathEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEmptyPathEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEmptyPathEndpoints.java
@@ -7,6 +7,7 @@ import com.palantir.dialogue.UrlBuilder;
 import java.lang.Override;
 import java.lang.String;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueEndpointsGenerator")
@@ -36,9 +37,12 @@ enum DialogueEmptyPathEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(
-                            DialogueEmptyPathEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
-    }
+    };
+
+    private static final String packageVersion = Optional.ofNullable(
+                    DialogueEmptyPathEndpoints.class.getPackage().getImplementationVersion())
+            .orElse("0.0.0");
+    ;
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteBinaryEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteBinaryEndpoints.java
@@ -37,7 +37,9 @@ enum DialogueEteBinaryEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(
+                            DialogueEteBinaryEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -70,7 +72,9 @@ enum DialogueEteBinaryEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(
+                            DialogueEteBinaryEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -103,7 +107,9 @@ enum DialogueEteBinaryEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(
+                            DialogueEteBinaryEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -136,7 +142,9 @@ enum DialogueEteBinaryEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(
+                            DialogueEteBinaryEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteBinaryEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteBinaryEndpoints.java
@@ -7,6 +7,7 @@ import com.palantir.dialogue.UrlBuilder;
 import java.lang.Override;
 import java.lang.String;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueEndpointsGenerator")
@@ -37,9 +38,7 @@ enum DialogueEteBinaryEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(
-                            DialogueEteBinaryEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -72,9 +71,7 @@ enum DialogueEteBinaryEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(
-                            DialogueEteBinaryEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -107,9 +104,7 @@ enum DialogueEteBinaryEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(
-                            DialogueEteBinaryEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -142,9 +137,12 @@ enum DialogueEteBinaryEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(
-                            DialogueEteBinaryEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
-    }
+    };
+
+    private static final String packageVersion = Optional.ofNullable(
+                    DialogueEteBinaryEndpoints.class.getPackage().getImplementationVersion())
+            .orElse("0.0.0");
+    ;
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteEndpoints.java
@@ -7,6 +7,7 @@ import com.palantir.dialogue.UrlBuilder;
 import java.lang.Override;
 import java.lang.String;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueEndpointsGenerator")
@@ -46,8 +47,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -80,8 +80,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -111,8 +110,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -142,8 +140,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -173,8 +170,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -204,8 +200,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -235,8 +230,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -266,8 +260,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -297,8 +290,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -328,8 +320,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -359,8 +350,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -396,8 +386,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -430,8 +419,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -463,8 +451,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -494,8 +481,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -525,8 +511,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -556,8 +541,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -587,8 +571,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -621,8 +604,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -655,8 +637,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -689,8 +670,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -720,8 +700,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -754,8 +733,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -789,8 +767,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -824,8 +801,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -858,8 +834,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -889,8 +864,7 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -924,8 +898,12 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
-    }
+    };
+
+    private static final String packageVersion = Optional.ofNullable(
+                    DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+            .orElse("0.0.0");
+    ;
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteEndpoints.java
@@ -46,7 +46,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -79,7 +80,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -109,7 +111,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -139,7 +142,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -169,7 +173,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -199,7 +204,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -229,7 +235,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -259,7 +266,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -289,7 +297,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -319,7 +328,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -349,7 +359,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -385,7 +396,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -418,7 +430,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -450,7 +463,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -480,7 +494,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -510,7 +525,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -540,7 +556,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -570,7 +587,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -603,7 +621,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -636,7 +655,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -669,7 +689,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -699,7 +720,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -732,7 +754,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -766,7 +789,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -800,7 +824,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -833,7 +858,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -863,7 +889,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -897,7 +924,8 @@ enum DialogueEteEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueEteEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     }
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueServiceGenerator.java
@@ -27,6 +27,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.squareup.javapoet.JavaFile;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -36,9 +37,9 @@ import java.util.stream.Stream;
 public final class DialogueServiceGenerator implements ServiceGenerator {
 
     private final Options options;
-    private final String apiVersion;
+    private final Optional<String> apiVersion;
 
-    public DialogueServiceGenerator(Options options, String apiVersion) {
+    public DialogueServiceGenerator(Options options, Optional<String> apiVersion) {
         this.options = options;
         this.apiVersion = apiVersion;
     }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/DialogueServiceGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/DialogueServiceGeneratorTests.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
@@ -58,7 +59,7 @@ public final class DialogueServiceGeneratorTests extends TestBase {
     void testPrefixedServices() throws IOException {
         ConjureDefinition def = Conjure.parse(ImmutableList.of(new File("src/test/resources/example-service.yml")));
         List<Path> files = new DialogueServiceGenerator(
-                        Options.builder().packagePrefix("test.prefix").build(), "")
+                        Options.builder().packagePrefix("test.prefix").build(), Optional.empty())
                 .emit(def, folder);
         validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".dialogue.prefix");
     }
@@ -70,7 +71,7 @@ public final class DialogueServiceGeneratorTests extends TestBase {
                 new File("src/test/resources/example-types.yml"),
                 new File("src/test/resources/example-service.yml")));
         File src = Files.createDirectory(folder.toPath().resolve("src")).toFile();
-        DialogueServiceGenerator generator = new DialogueServiceGenerator(Options.empty(), "");
+        DialogueServiceGenerator generator = new DialogueServiceGenerator(Options.empty(), Optional.empty());
         generator.emit(conjure, src);
 
         // Generated files contain imports
@@ -84,13 +85,13 @@ public final class DialogueServiceGeneratorTests extends TestBase {
                 new File("src/test/resources/cookie-service.yml"),
                 new File("src/test/resources/ete-service.yml"),
                 new File("src/test/resources/ete-binary.yml")));
-        List<Path> files = new DialogueServiceGenerator(Options.empty(), "").emit(def, folder);
+        List<Path> files = new DialogueServiceGenerator(Options.empty(), Optional.empty()).emit(def, folder);
         validateGeneratorOutput(files, Paths.get("src/integrationInput/java/com/palantir/product"));
     }
 
     private void testServiceGeneration(String conjureFile) throws IOException {
         ConjureDefinition def = Conjure.parse(ImmutableList.of(new File("src/test/resources/" + conjureFile + ".yml")));
-        List<Path> files = new DialogueServiceGenerator(Options.empty(), "").emit(def, folder);
+        List<Path> files = new DialogueServiceGenerator(Options.empty(), Optional.of("0.0.0")).emit(def, folder);
         validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".dialogue");
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/DialogueCookieEndpoints.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/DialogueCookieEndpoints.java.dialogue
@@ -37,7 +37,10 @@ enum DialogueCookieEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
-    }
+    };
+
+    private static final String packageVersion = "0.0.0";
+    ;
 }

--- a/conjure-java-core/src/test/resources/test/api/DialogueCookieEndpoints.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/DialogueCookieEndpoints.java.dialogue
@@ -37,7 +37,7 @@ enum DialogueCookieEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue
@@ -40,7 +40,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -70,7 +70,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -103,7 +103,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -137,7 +137,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -171,7 +171,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -205,7 +205,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -239,7 +239,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -272,7 +272,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -305,7 +305,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -339,7 +339,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -376,7 +376,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -412,7 +412,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -446,7 +446,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -478,7 +478,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -510,7 +510,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -540,7 +540,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -570,7 +570,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -600,7 +600,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -630,7 +630,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -662,7 +662,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     },
 
@@ -696,7 +696,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return "Optional[0.0.0]";
         }
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue
@@ -40,7 +40,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -70,7 +70,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -103,7 +103,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -137,7 +137,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -171,7 +171,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -205,7 +205,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -239,7 +239,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -272,7 +272,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -305,7 +305,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -339,7 +339,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -376,7 +376,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -412,7 +412,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -446,7 +446,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -478,7 +478,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -510,7 +510,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -540,7 +540,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -570,7 +570,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -600,7 +600,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -630,7 +630,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -662,7 +662,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
     },
 
@@ -696,7 +696,10 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "Optional[0.0.0]";
+            return packageVersion;
         }
-    }
+    };
+
+    private static final String packageVersion = "0.0.0";
+    ;
 }

--- a/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue.prefix
@@ -7,6 +7,7 @@ import com.palantir.dialogue.UrlBuilder;
 import java.lang.Override;
 import java.lang.String;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueEndpointsGenerator")
@@ -40,8 +41,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -71,8 +71,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -105,8 +104,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -140,8 +138,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -175,8 +172,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -210,8 +206,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -245,8 +240,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -279,8 +273,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -313,8 +306,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -348,8 +340,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -386,8 +377,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -423,8 +413,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -458,8 +447,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -491,8 +479,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -524,8 +511,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -555,8 +541,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -586,8 +571,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -617,8 +601,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -648,8 +631,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -681,8 +663,7 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
     },
 
@@ -716,8 +697,12 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
-                    .orElse("0.0.0");
+            return packageVersion;
         }
-    }
+    };
+
+    private static final String packageVersion = Optional.ofNullable(
+                    DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+            .orElse("0.0.0");
+    ;
 }

--- a/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue.prefix
@@ -40,7 +40,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -70,7 +71,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -103,7 +105,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -137,7 +140,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -171,7 +175,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -205,7 +210,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -239,7 +245,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -272,7 +279,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -305,7 +313,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -339,7 +348,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -376,7 +386,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -412,7 +423,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -446,7 +458,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -478,7 +491,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -510,7 +524,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -540,7 +555,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -570,7 +586,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -600,7 +617,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -630,7 +648,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -662,7 +681,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     },
 
@@ -696,7 +716,8 @@ enum DialogueTestEndpoints implements Endpoint {
 
         @Override
         public String version() {
-            return "";
+            return Optional.ofNullable(DialogueTestEndpoints.class.getPackage().getImplementationVersion())
+                    .orElse("0.0.0");
         }
     }
 }

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -175,7 +175,9 @@ public final class ConjureJavaCli implements Runnable {
                 ServiceGenerator jerseyGenerator = new JerseyServiceGenerator(config.options());
                 ServiceGenerator retrofitGenerator = new Retrofit2ServiceGenerator(config.options());
                 ServiceGenerator undertowGenerator = new UndertowServiceGenerator(config.options());
-                ServiceGenerator dialogueServiceGenerator = new DialogueServiceGenerator(config.options(), "0.0.0");
+                // TODO(forozco): plumb through API version for local codegen
+                ServiceGenerator dialogueServiceGenerator =
+                        new DialogueServiceGenerator(config.options(), Optional.empty());
 
                 if (config.generateObjects()) {
                     typeGenerator.emit(conjureDefinition, config.outputDirectory());


### PR DESCRIPTION
## Before this PR
All dialogue bindings would have the endpoints specify a version of "0.0.0" which was hard coded into the CLI, making this information pretty much useless for debugging.

## After this PR
==COMMIT_MSG==
Generated Dialogue Endpoints will use the packages implementation version if present
==COMMIT_MSG==

## Possible downsides?
N/A

