### PR TITLE
Dialogue client bindings now have useful toString methods

### DIFF
--- a/changelog/@unreleased/pr-886.v2.yml
+++ b/changelog/@unreleased/pr-886.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Dialogue blocking and async implementations now have a human-readable
+    `toString` method
+  links:
+  - https://github.com/palantir/conjure-java/pull/886

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CookieServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CookieServiceAsync.java
@@ -7,6 +7,9 @@ import com.palantir.dialogue.Deserializer;
 import com.palantir.dialogue.PlainSerDe;
 import com.palantir.dialogue.Request;
 import com.palantir.tokens.auth.BearerToken;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.Void;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
@@ -28,7 +31,7 @@ public interface CookieServiceAsync {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Cookie", "PALANTIR_TOKEN=" + _plainSerDe.serializeBearerToken(token));
                 return _runtime.clients()
-                        .call(_channel, test.api.DialogueCookieEndpoints.eatCookies, _request.build(), eatCookiesDeserializer);
+                        .call(_channel, DialogueCookieEndpoints.eatCookies, _request.build(), eatCookiesDeserializer);
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CookieServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CookieServiceAsync.java
@@ -7,8 +7,6 @@ import com.palantir.dialogue.Deserializer;
 import com.palantir.dialogue.PlainSerDe;
 import com.palantir.dialogue.Request;
 import com.palantir.tokens.auth.BearerToken;
-import java.lang.Override;
-import java.lang.Void;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
@@ -30,7 +28,12 @@ public interface CookieServiceAsync {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Cookie", "PALANTIR_TOKEN=" + _plainSerDe.serializeBearerToken(token));
                 return _runtime.clients()
-                        .call(_channel, DialogueCookieEndpoints.eatCookies, _request.build(), eatCookiesDeserializer);
+                        .call(_channel, test.api.DialogueCookieEndpoints.eatCookies, _request.build(), eatCookiesDeserializer);
+            }
+
+            @Override
+            public String toString() {
+                return "CookieService{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CookieServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CookieServiceAsync.java
@@ -36,7 +36,7 @@ public interface CookieServiceAsync {
 
             @Override
             public String toString() {
-                return "CookieService{channel=" + _channel + ", runtime=" + _runtime + '}';
+                return "CookieServiceBlocking{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CookieServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CookieServiceBlocking.java
@@ -24,7 +24,7 @@ public interface CookieServiceBlocking {
 
             @Override
             public String toString() {
-                return "CookieService{channel=" + _channel + ", runtime=" + _runtime + '}';
+                return "CookieServiceBlocking{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CookieServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CookieServiceBlocking.java
@@ -4,6 +4,7 @@ import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.tokens.auth.BearerToken;
 import java.lang.Override;
+import java.lang.String;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
@@ -19,6 +20,11 @@ public interface CookieServiceBlocking {
             @Override
             public void eatCookies(BearerToken token) {
                 _runtime.clients().block(delegate.eatCookies(token));
+            }
+
+            @Override
+            public String toString() {
+                return "CookieService{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceAsync.java
@@ -9,6 +9,7 @@ import com.palantir.dialogue.Request;
 import com.palantir.dialogue.TypeMarker;
 import java.lang.Boolean;
 import java.lang.Override;
+import java.lang.String;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
@@ -30,6 +31,11 @@ public interface EmptyPathServiceAsync {
                 Request.Builder _request = Request.builder();
                 return _runtime.clients()
                         .call(_channel, DialogueEmptyPathEndpoints.emptyPath, _request.build(), emptyPathDeserializer);
+            }
+
+            @Override
+            public String toString() {
+                return "EmptyPathService{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceAsync.java
@@ -35,7 +35,7 @@ public interface EmptyPathServiceAsync {
 
             @Override
             public String toString() {
-                return "EmptyPathService{channel=" + _channel + ", runtime=" + _runtime + '}';
+                return "EmptyPathServiceBlocking{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceBlocking.java
@@ -3,6 +3,7 @@ package com.palantir.product;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
 import java.lang.Override;
+import java.lang.String;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
@@ -18,6 +19,11 @@ public interface EmptyPathServiceBlocking {
             @Override
             public boolean emptyPath() {
                 return _runtime.clients().block(delegate.emptyPath());
+            }
+
+            @Override
+            public String toString() {
+                return "EmptyPathService{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceBlocking.java
@@ -23,7 +23,7 @@ public interface EmptyPathServiceBlocking {
 
             @Override
             public String toString() {
-                return "EmptyPathService{channel=" + _channel + ", runtime=" + _runtime + '}';
+                return "EmptyPathServiceBlocking{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceAsync.java
@@ -9,6 +9,7 @@ import com.palantir.dialogue.Request;
 import com.palantir.tokens.auth.AuthHeader;
 import java.io.InputStream;
 import java.lang.Override;
+import java.lang.String;
 import java.util.Optional;
 import javax.annotation.Generated;
 
@@ -80,6 +81,11 @@ public interface EteBinaryServiceAsync {
                                 DialogueEteBinaryEndpoints.getBinaryFailure,
                                 _request.build(),
                                 _runtime.bodySerDe().inputStreamDeserializer());
+            }
+
+            @Override
+            public String toString() {
+                return "EteBinaryService{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceAsync.java
@@ -85,7 +85,7 @@ public interface EteBinaryServiceAsync {
 
             @Override
             public String toString() {
-                return "EteBinaryService{channel=" + _channel + ", runtime=" + _runtime + '}';
+                return "EteBinaryServiceBlocking{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceBlocking.java
@@ -51,7 +51,7 @@ public interface EteBinaryServiceBlocking {
 
             @Override
             public String toString() {
-                return "EteBinaryService{channel=" + _channel + ", runtime=" + _runtime + '}';
+                return "EteBinaryServiceBlocking{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceBlocking.java
@@ -6,6 +6,7 @@ import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.tokens.auth.AuthHeader;
 import java.io.InputStream;
 import java.lang.Override;
+import java.lang.String;
 import java.util.Optional;
 import javax.annotation.Generated;
 
@@ -46,6 +47,11 @@ public interface EteBinaryServiceBlocking {
             @Override
             public InputStream getBinaryFailure(AuthHeader authHeader, int numBytes) {
                 return _runtime.clients().block(delegate.getBinaryFailure(authHeader, numBytes));
+            }
+
+            @Override
+            public String toString() {
+                return "EteBinaryService{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceAsync.java
@@ -539,6 +539,11 @@ public interface EteServiceAsync {
                                 _request.build(),
                                 complexQueryParametersDeserializer);
             }
+
+            @Override
+            public String toString() {
+                return "EteService{channel=" + _channel + ", runtime=" + _runtime + '}';
+            }
         };
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceAsync.java
@@ -542,7 +542,7 @@ public interface EteServiceAsync {
 
             @Override
             public String toString() {
-                return "EteService{channel=" + _channel + ", runtime=" + _runtime + '}';
+                return "EteServiceBlocking{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceBlocking.java
@@ -252,7 +252,7 @@ public interface EteServiceBlocking {
 
             @Override
             public String toString() {
-                return "EteService{channel=" + _channel + ", runtime=" + _runtime + '}';
+                return "EteServiceBlocking{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceBlocking.java
@@ -249,6 +249,11 @@ public interface EteServiceBlocking {
                     Set<Integer> ints) {
                 _runtime.clients().block(delegate.complexQueryParameters(authHeader, datasetRid, strings, longs, ints));
             }
+
+            @Override
+            public String toString() {
+                return "EteService{channel=" + _channel + ", runtime=" + _runtime + '}';
+            }
         };
     }
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/AsyncGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/AsyncGenerator.java
@@ -107,7 +107,7 @@ public final class AsyncGenerator implements StaticFactoryMethodGenerator {
             impl.addMethod(asyncClientImpl(def, endpoint));
         });
 
-        impl.addMethod(BlockingGenerator.toStringMethod(def));
+        impl.addMethod(BlockingGenerator.toStringMethod(Names.blockingClassName(def, options)));
 
         MethodSpec asyncImpl = MethodSpec.methodBuilder("of")
                 .addModifiers(Modifier.STATIC, Modifier.PUBLIC)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/AsyncGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/AsyncGenerator.java
@@ -107,6 +107,8 @@ public final class AsyncGenerator implements StaticFactoryMethodGenerator {
             impl.addMethod(asyncClientImpl(def, endpoint));
         });
 
+        impl.addMethod(BlockingGenerator.toStringMethod(def));
+
         MethodSpec asyncImpl = MethodSpec.methodBuilder("of")
                 .addModifiers(Modifier.STATIC, Modifier.PUBLIC)
                 .addJavadoc(

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/BlockingGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/BlockingGenerator.java
@@ -49,6 +49,8 @@ public final class BlockingGenerator implements StaticFactoryMethodGenerator {
                 TypeSpec.anonymousClassBuilder("").addSuperinterface(Names.blockingClassName(def, options));
         def.getEndpoints().forEach(endpoint -> impl.addMethod(blockingClientImpl(endpoint)));
 
+        impl.addMethod(toStringMethod(def));
+
         MethodSpec blockingImpl = MethodSpec.methodBuilder("of")
                 .addModifiers(Modifier.STATIC, Modifier.PUBLIC)
                 .addJavadoc(
@@ -66,6 +68,17 @@ public final class BlockingGenerator implements StaticFactoryMethodGenerator {
                 .addCode(CodeBlock.builder().add("return $L;", impl.build()).build())
                 .build();
         return blockingImpl;
+    }
+
+    static MethodSpec toStringMethod(ServiceDefinition def) {
+        return MethodSpec.methodBuilder("toString")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(String.class)
+                .addAnnotation(Override.class)
+                .addCode(
+                        "return \"$L{channel=\" + _channel + \", runtime=\" + _runtime + '}';",
+                        def.getServiceName().getName())
+                .build();
     }
 
     private MethodSpec blockingClientImpl(EndpointDefinition def) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/BlockingGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/BlockingGenerator.java
@@ -22,6 +22,7 @@ import com.palantir.conjure.spec.ServiceDefinition;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
 import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
@@ -49,7 +50,7 @@ public final class BlockingGenerator implements StaticFactoryMethodGenerator {
                 TypeSpec.anonymousClassBuilder("").addSuperinterface(Names.blockingClassName(def, options));
         def.getEndpoints().forEach(endpoint -> impl.addMethod(blockingClientImpl(endpoint)));
 
-        impl.addMethod(toStringMethod(def));
+        impl.addMethod(toStringMethod(Names.blockingClassName(def, options)));
 
         MethodSpec blockingImpl = MethodSpec.methodBuilder("of")
                 .addModifiers(Modifier.STATIC, Modifier.PUBLIC)
@@ -70,14 +71,12 @@ public final class BlockingGenerator implements StaticFactoryMethodGenerator {
         return blockingImpl;
     }
 
-    static MethodSpec toStringMethod(ServiceDefinition def) {
+    static MethodSpec toStringMethod(ClassName className) {
         return MethodSpec.methodBuilder("toString")
                 .addModifiers(Modifier.PUBLIC)
                 .returns(String.class)
                 .addAnnotation(Override.class)
-                .addCode(
-                        "return \"$L{channel=\" + _channel + \", runtime=\" + _runtime + '}';",
-                        def.getServiceName().getName())
+                .addCode("return \"$L{channel=\" + _channel + \", runtime=\" + _runtime + '}';", className.simpleName())
                 .build();
     }
 

--- a/conjure-java-core/src/test/resources/test/api/CookieServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/CookieServiceAsync.java.dialogue
@@ -8,6 +8,7 @@ import com.palantir.dialogue.PlainSerDe;
 import com.palantir.dialogue.Request;
 import com.palantir.tokens.auth.BearerToken;
 import java.lang.Override;
+import java.lang.String;
 import java.lang.Void;
 import javax.annotation.Generated;
 
@@ -31,6 +32,11 @@ public interface CookieServiceAsync {
                 _request.putHeaderParams("Cookie", "PALANTIR_TOKEN=" + _plainSerDe.serializeBearerToken(token));
                 return _runtime.clients()
                         .call(_channel, DialogueCookieEndpoints.eatCookies, _request.build(), eatCookiesDeserializer);
+            }
+
+            @Override
+            public String toString() {
+                return "CookieService{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/test/resources/test/api/CookieServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/CookieServiceAsync.java.dialogue
@@ -36,7 +36,7 @@ public interface CookieServiceAsync {
 
             @Override
             public String toString() {
-                return "CookieService{channel=" + _channel + ", runtime=" + _runtime + '}';
+                return "CookieServiceBlocking{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/test/resources/test/api/CookieServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/CookieServiceBlocking.java.dialogue
@@ -24,7 +24,7 @@ public interface CookieServiceBlocking {
 
             @Override
             public String toString() {
-                return "CookieService{channel=" + _channel + ", runtime=" + _runtime + '}';
+                return "CookieServiceBlocking{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/test/resources/test/api/CookieServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/CookieServiceBlocking.java.dialogue
@@ -4,6 +4,7 @@ import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.tokens.auth.BearerToken;
 import java.lang.Override;
+import java.lang.String;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
@@ -19,6 +20,11 @@ public interface CookieServiceBlocking {
             @Override
             public void eatCookies(BearerToken token) {
                 _runtime.clients().block(delegate.eatCookies(token));
+            }
+
+            @Override
+            public String toString() {
+                return "CookieService{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
@@ -485,7 +485,7 @@ public interface TestServiceAsync {
 
             @Override
             public String toString() {
-                return "TestService{channel=" + _channel + ", runtime=" + _runtime + '}';
+                return "TestServiceBlocking{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
@@ -482,6 +482,11 @@ public interface TestServiceAsync {
                                 _request.build(),
                                 getForStringsDeserializer);
             }
+
+            @Override
+            public String toString() {
+                return "TestService{channel=" + _channel + ", runtime=" + _runtime + '}';
+            }
         };
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
@@ -485,7 +485,7 @@ public interface TestServiceAsync {
 
             @Override
             public String toString() {
-                return "TestService{channel=" + _channel + ", runtime=" + _runtime + '}';
+                return "TestServiceBlocking{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
@@ -482,6 +482,11 @@ public interface TestServiceAsync {
                                 _request.build(),
                                 getForStringsDeserializer);
             }
+
+            @Override
+            public String toString() {
+                return "TestService{channel=" + _channel + ", runtime=" + _runtime + '}';
+            }
         };
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
@@ -228,7 +228,7 @@ public interface TestServiceBlocking {
 
             @Override
             public String toString() {
-                return "TestService{channel=" + _channel + ", runtime=" + _runtime + '}';
+                return "TestServiceBlocking{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
@@ -225,6 +225,11 @@ public interface TestServiceBlocking {
                     AuthHeader authHeader, ResourceIdentifier datasetRid, Set<AliasedString> strings) {
                 _runtime.clients().block(delegate.getForStrings(authHeader, datasetRid, strings));
             }
+
+            @Override
+            public String toString() {
+                return "TestService{channel=" + _channel + ", runtime=" + _runtime + '}';
+            }
         };
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
@@ -228,7 +228,7 @@ public interface TestServiceBlocking {
 
             @Override
             public String toString() {
-                return "TestService{channel=" + _channel + ", runtime=" + _runtime + '}';
+                return "TestServiceBlocking{channel=" + _channel + ", runtime=" + _runtime + '}';
             }
         };
     }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
@@ -225,6 +225,11 @@ public interface TestServiceBlocking {
                     AuthHeader authHeader, ResourceIdentifier datasetRid, Set<AliasedString> strings) {
                 _runtime.clients().block(delegate.getForStrings(authHeader, datasetRid, strings));
             }
+
+            @Override
+            public String toString() {
+                return "TestService{channel=" + _channel + ", runtime=" + _runtime + '}';
+            }
         };
     }
 }


### PR DESCRIPTION
## Before this PR

Currently a dialogue client has a toString that looks something like this:

```
com.palantir.dialogue.example.SampleServiceBlocking$1@5c080ef3
```

This is a little annoying because it's hard to eyeball whether internals are actually being re-used or now.

## After this PR
==COMMIT_MSG==
Dialogue blocking and async implementations now have a human-readable `toString` method
==COMMIT_MSG==

## Possible downsides?
- this could make it slightly harder to distinguish if you have tons and tons of clients (as previously you'd be able to see the `5c080ef3` change each time.)

