### PR TITLE
Dialogue blocking clients require binary responses to be closed

### DIFF
--- a/changelog/@unreleased/pr-892.v2.yml
+++ b/changelog/@unreleased/pr-892.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Dialogue blocking clients require binary responses to be closed using
+    error-prone annotations
+  links:
+  - https://github.com/palantir/conjure-java/pull/892

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceBlocking.java
@@ -1,5 +1,6 @@
 package com.palantir.product;
 
+import com.google.errorprone.annotations.MustBeClosed;
 import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
@@ -30,6 +31,7 @@ public interface EteBinaryServiceBlocking {
         EteBinaryServiceAsync delegate = EteBinaryServiceAsync.of(_channel, _runtime);
         return new EteBinaryServiceBlocking() {
             @Override
+            @MustBeClosed
             public InputStream postBinary(AuthHeader authHeader, BinaryRequestBody body) {
                 return _runtime.clients().block(delegate.postBinary(authHeader, body));
             }
@@ -45,6 +47,7 @@ public interface EteBinaryServiceBlocking {
             }
 
             @Override
+            @MustBeClosed
             public InputStream getBinaryFailure(AuthHeader authHeader, int numBytes) {
                 return _runtime.clients().block(delegate.getBinaryFailure(authHeader, numBytes));
             }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceBlocking.java
@@ -1,5 +1,6 @@
 package com.palantir.product;
 
+import com.google.errorprone.annotations.MustBeClosed;
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
@@ -153,6 +154,7 @@ public interface EteServiceBlocking {
             }
 
             @Override
+            @MustBeClosed
             public InputStream binary(AuthHeader authHeader) {
                 return _runtime.clients().block(delegate.binary(authHeader));
             }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/BlockingGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/BlockingGenerator.java
@@ -20,7 +20,6 @@ import com.google.errorprone.annotations.MustBeClosed;
 import com.palantir.conjure.java.Options;
 import com.palantir.conjure.spec.EndpointDefinition;
 import com.palantir.conjure.spec.ServiceDefinition;
-import com.palantir.conjure.visitor.TypeVisitor;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
 import com.squareup.javapoet.AnnotationSpec;
@@ -28,7 +27,9 @@ import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
+import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
+import java.io.InputStream;
 import java.util.List;
 import javax.lang.model.element.Modifier;
 
@@ -96,11 +97,12 @@ public final class BlockingGenerator implements StaticFactoryMethodGenerator {
                     .build());
         }
 
-        if (def.getReturns().map(type -> type.accept(TypeVisitor.IS_BINARY)).orElse(false)) {
+        TypeName returnType = returnTypes.baseType(def.getReturns());
+        methodBuilder.returns(returnType);
+
+        if (TypeName.get(InputStream.class).equals(returnType)) {
             methodBuilder.addAnnotation(MustBeClosed.class);
         }
-
-        methodBuilder.returns(returnTypes.baseType(def.getReturns()));
 
         CodeBlock argList =
                 params.stream().map(argDef -> CodeBlock.of("$L", argDef.name)).collect(CodeBlock.joining(", "));

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/BlockingGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/BlockingGenerator.java
@@ -16,9 +16,11 @@
 
 package com.palantir.conjure.java.services.dialogue;
 
+import com.google.errorprone.annotations.MustBeClosed;
 import com.palantir.conjure.java.Options;
 import com.palantir.conjure.spec.EndpointDefinition;
 import com.palantir.conjure.spec.ServiceDefinition;
+import com.palantir.conjure.visitor.TypeVisitor;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
 import com.squareup.javapoet.AnnotationSpec;
@@ -92,6 +94,10 @@ public final class BlockingGenerator implements StaticFactoryMethodGenerator {
             methodBuilder.addAnnotation(AnnotationSpec.builder(SuppressWarnings.class)
                     .addMember("value", "$S", "deprecation")
                     .build());
+        }
+
+        if (def.getReturns().map(type -> type.accept(TypeVisitor.IS_BINARY)).orElse(false)) {
+            methodBuilder.addAnnotation(MustBeClosed.class);
         }
 
         methodBuilder.returns(returnTypes.baseType(def.getReturns()));

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
@@ -123,6 +123,7 @@ public interface TestServiceBlocking {
             }
 
             @Override
+            @MustBeClosed
             public InputStream getAliasedRawData(AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 return _runtime.clients().block(delegate.getAliasedRawData(authHeader, datasetRid));
             }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
@@ -1,5 +1,6 @@
 package com.palantir.another;
 
+import com.google.errorprone.annotations.MustBeClosed;
 import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
@@ -116,6 +117,7 @@ public interface TestServiceBlocking {
             }
 
             @Override
+            @MustBeClosed
             public InputStream getRawData(AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 return _runtime.clients().block(delegate.getRawData(authHeader, datasetRid));
             }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
@@ -123,6 +123,7 @@ public interface TestServiceBlocking {
             }
 
             @Override
+            @MustBeClosed
             public InputStream getAliasedRawData(AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 return _runtime.clients().block(delegate.getAliasedRawData(authHeader, datasetRid));
             }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
@@ -1,5 +1,6 @@
 package test.prefix.com.palantir.another;
 
+import com.google.errorprone.annotations.MustBeClosed;
 import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
@@ -116,6 +117,7 @@ public interface TestServiceBlocking {
             }
 
             @Override
+            @MustBeClosed
             public InputStream getRawData(AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 return _runtime.clients().block(delegate.getRawData(authHeader, datasetRid));
             }

--- a/conjure-lib/build.gradle
+++ b/conjure-lib/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     compile 'com.palantir.conjure.java.api:errors'
     compile 'jakarta.annotation:jakarta.annotation-api'
     compile 'jakarta.ws.rs:jakarta.ws.rs-api'
+    compile 'com.google.errorprone:error_prone_annotations'
 
     testCompile 'org.assertj:assertj-core'
     testCompile 'org.mockito:mockito-core'


### PR DESCRIPTION
## Before this PR
Easy to leak resources.

## After this PR
==COMMIT_MSG==
Dialogue blocking clients require binary responses to be closed using error-prone annotations
==COMMIT_MSG==

## Possible downsides?
This adds an error-prone annotation dependency to conjure-lib.
