### PR TITLE
Fix compilation failure when union types are called `completed`

### DIFF
--- a/changelog/@unreleased/pr-893.v2.yml
+++ b/changelog/@unreleased/pr-893.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix compilation failure when union types are called `completed`
+  links:
+  - https://github.com/palantir/conjure-java/pull/893

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
@@ -64,11 +64,11 @@ public final class EmptyUnionTypeExample {
     }
 
     private static final class VisitorBuilder<T>
-            implements UnknownStageVisitorBuilder<T>, CompletedStageVisitorBuilder<T> {
+            implements UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
         private Function<String, T> unknownVisitor;
 
         @Override
-        public CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -87,10 +87,10 @@ public final class EmptyUnionTypeExample {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
     }
 
-    public interface CompletedStageVisitorBuilder<T> {
+    public interface Completed_StageVisitorBuilder<T> {
         Visitor<T> build();
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -74,7 +74,7 @@ public final class SingleUnion {
     }
 
     private static final class VisitorBuilder<T>
-            implements FooStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, CompletedStageVisitorBuilder<T> {
+            implements FooStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
         private Function<String, T> fooVisitor;
 
         private Function<String, T> unknownVisitor;
@@ -87,7 +87,7 @@ public final class SingleUnion {
         }
 
         @Override
-        public CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -116,10 +116,10 @@ public final class SingleUnion {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
     }
 
-    public interface CompletedStageVisitorBuilder<T> {
+    public interface Completed_StageVisitorBuilder<T> {
         Visitor<T> build();
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -114,7 +114,7 @@ public final class Union {
                     BazStageVisitorBuilder<T>,
                     FooStageVisitorBuilder<T>,
                     UnknownStageVisitorBuilder<T>,
-                    CompletedStageVisitorBuilder<T> {
+                    Completed_StageVisitorBuilder<T> {
         private IntFunction<T> barVisitor;
 
         private Function<Long, T> bazVisitor;
@@ -145,7 +145,7 @@ public final class Union {
         }
 
         @Override
-        public CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -194,10 +194,10 @@ public final class Union {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
     }
 
-    public interface CompletedStageVisitorBuilder<T> {
+    public interface Completed_StageVisitorBuilder<T> {
         Visitor<T> build();
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
@@ -64,11 +64,11 @@ public final class EmptyUnionTypeExample {
     }
 
     private static final class VisitorBuilder<T>
-            implements UnknownStageVisitorBuilder<T>, CompletedStageVisitorBuilder<T> {
+            implements UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
         private Function<String, T> unknownVisitor;
 
         @Override
-        public CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -87,10 +87,10 @@ public final class EmptyUnionTypeExample {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
     }
 
-    public interface CompletedStageVisitorBuilder<T> {
+    public interface Completed_StageVisitorBuilder<T> {
         Visitor<T> build();
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
@@ -74,7 +74,7 @@ public final class SingleUnion {
     }
 
     private static final class VisitorBuilder<T>
-            implements FooStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, CompletedStageVisitorBuilder<T> {
+            implements FooStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
         private Function<String, T> fooVisitor;
 
         private Function<String, T> unknownVisitor;
@@ -87,7 +87,7 @@ public final class SingleUnion {
         }
 
         @Override
-        public CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -116,10 +116,10 @@ public final class SingleUnion {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
     }
 
-    public interface CompletedStageVisitorBuilder<T> {
+    public interface Completed_StageVisitorBuilder<T> {
         Visitor<T> build();
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
@@ -114,7 +114,7 @@ public final class Union {
                     BazStageVisitorBuilder<T>,
                     FooStageVisitorBuilder<T>,
                     UnknownStageVisitorBuilder<T>,
-                    CompletedStageVisitorBuilder<T> {
+                    Completed_StageVisitorBuilder<T> {
         private IntFunction<T> barVisitor;
 
         private Function<Long, T> bazVisitor;
@@ -145,7 +145,7 @@ public final class Union {
         }
 
         @Override
-        public CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -194,10 +194,10 @@ public final class Union {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
     }
 
-    public interface CompletedStageVisitorBuilder<T> {
+    public interface Completed_StageVisitorBuilder<T> {
         Visitor<T> build();
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -68,7 +68,7 @@ public final class UnionGenerator {
     private static final String VALUE_FIELD_NAME = "value";
     private static final String UNKNOWN_WRAPPER_CLASS_NAME = "UnknownWrapper";
     private static final String VISIT_UNKNOWN_METHOD_NAME = "visitUnknown";
-    private static final String COMPLETED = "completed";
+    private static final String COMPLETED = "completed_";
     private static final TypeVariableName TYPE_VARIABLE = TypeVariableName.get("T");
 
     // If the member type is not known, a String containing the name of the unknown type is used.

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -468,6 +468,11 @@ public final class WireFormatTests {
         }
 
         @Override
+        public Integer visitCompleted(int value) {
+            return value;
+        }
+
+        @Override
         public Integer visitIf(int value) {
             return value;
         }

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -176,6 +176,7 @@ types:
           if: integer # some 'bad' member names!
           new: integer
           interface: integer
+          completed: integer
       EmptyUnionTypeExample:
         union: {}
       EmptyObjectExample:


### PR DESCRIPTION
## Before this PR
Compilation failures.

## After this PR
==COMMIT_MSG==
Fix compilation failure when union types are called `completed`
==COMMIT_MSG==

