### PR TITLE
fix #901: Properly escape object documentation strings

### DIFF
--- a/changelog/@unreleased/pr-919.v2.yml
+++ b/changelog/@unreleased/pr-919.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Properly escape object documentation strings
+  links:
+  - https://github.com/palantir/conjure-java/pull/919

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -94,7 +94,7 @@ public final class ManyFieldExample {
     }
 
     /**
-     * docs for items field
+     * docs for items field with exciting character$ used by javapoet.
      */
     @JsonProperty("items")
     public List<String> getItems() {
@@ -287,7 +287,7 @@ public final class ManyFieldExample {
         }
 
         /**
-         * docs for items field
+         * docs for items field with exciting character$ used by javapoet.
          */
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Iterable<String> items) {
@@ -297,7 +297,7 @@ public final class ManyFieldExample {
         }
 
         /**
-         * docs for items field
+         * docs for items field with exciting character$ used by javapoet.
          */
         public Builder addAllItems(@Nonnull Iterable<String> items) {
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
@@ -305,7 +305,7 @@ public final class ManyFieldExample {
         }
 
         /**
-         * docs for items field
+         * docs for items field with exciting character$ used by javapoet.
          */
         public Builder items(String items) {
             this.items.add(items);

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
@@ -95,7 +95,7 @@ public final class ManyFieldExample {
     }
 
     /**
-     * docs for items field
+     * docs for items field with exciting character$ used by javapoet.
      */
     @JsonProperty("items")
     public List<String> getItems() {
@@ -289,7 +289,7 @@ public final class ManyFieldExample {
         }
 
         /**
-         * docs for items field
+         * docs for items field with exciting character$ used by javapoet.
          */
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<String> items) {
@@ -299,7 +299,7 @@ public final class ManyFieldExample {
         }
 
         /**
-         * docs for items field
+         * docs for items field with exciting character$ used by javapoet.
          */
         public Builder addAllItems(@Nonnull Iterable<String> items) {
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
@@ -307,7 +307,7 @@ public final class ManyFieldExample {
         }
 
         /**
-         * docs for items field
+         * docs for items field with exciting character$ used by javapoet.
          */
         public Builder items(String items) {
             this.items.add(items);

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -278,7 +278,8 @@ public final class BeanBuilderGenerator {
         boolean shouldClearFirst = false;
         return MethodSpec.methodBuilder(prefix + StringUtils.capitalize(field.name))
                 .addJavadoc(Javadoc.render(definition.getDocs(), definition.getDeprecated())
-                        .orElse(""))
+                        .map(rendered -> CodeBlock.of("$L", rendered))
+                        .orElseGet(() -> CodeBlock.builder().build()))
                 .addAnnotations(ConjureAnnotations.deprecation(definition.getDeprecated()))
                 .addModifiers(Modifier.PUBLIC)
                 .returns(builderClass)
@@ -490,7 +491,8 @@ public final class BeanBuilderGenerator {
         FieldDefinition definition = enriched.conjureDef();
         return MethodSpec.methodBuilder(enriched.poetSpec().name)
                 .addJavadoc(Javadoc.render(definition.getDocs(), definition.getDeprecated())
-                        .orElse(""))
+                        .map(rendered -> CodeBlock.of("$L", rendered))
+                        .orElseGet(() -> CodeBlock.builder().build()))
                 .addAnnotations(ConjureAnnotations.deprecation(definition.getDeprecated()))
                 .addModifiers(Modifier.PUBLIC)
                 .returns(builderClass);

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -277,7 +277,8 @@ public final class UnionGenerator {
                             .addJavadoc(Javadoc.render(
                                             entry.getKey().getDocs(),
                                             entry.getKey().getDeprecated())
-                                    .orElse(""))
+                                    .map(rendered -> CodeBlock.of("$L", rendered))
+                                    .orElseGet(() -> CodeBlock.builder().build()))
                             .addAnnotations(ConjureAnnotations.deprecation(
                                     entry.getKey().getDeprecated()))
                             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -153,7 +153,7 @@ types:
             docs: docs for optionalItem field
           items:
             type: list<string>
-            docs: docs for items field
+            docs: docs for items field with exciting character$ used by javapoet.
           set:
             type: set<string>
             docs: docs for set field


### PR DESCRIPTION
==COMMIT_MSG==
Properly escape object documentation strings
==COMMIT_MSG==

