### PR TITLE
Generate endpoint markers as annotations on Dialogue interfaces

### DIFF
--- a/changelog/@unreleased/pr-921.v2.yml
+++ b/changelog/@unreleased/pr-921.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Generate endpoint markers as annotations on Dialogue interfaces
+  links:
+  - https://github.com/palantir/conjure-java/pull/921

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
@@ -30,6 +30,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.Set;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 /**
  * A Markdown description of the service.
@@ -39,6 +40,7 @@ public interface TestServiceAsync {
     /**
      * Returns a mapping from file system id to backing file system configuration.
      */
+    @Nonnull
     ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(AuthHeader authHeader);
 
     ListenableFuture<Dataset> createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request);

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
@@ -26,6 +26,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.Set;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 import test.prefix.com.palantir.product.AliasedString;
 import test.prefix.com.palantir.product.CreateDatasetRequest;
 import test.prefix.com.palantir.product.datasets.BackingFileSystem;
@@ -39,6 +40,7 @@ public interface TestServiceAsync {
     /**
      * Returns a mapping from file system id to backing file system configuration.
      */
+    @Nonnull
     ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(AuthHeader authHeader);
 
     ListenableFuture<Dataset> createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request);

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
@@ -21,6 +21,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.Set;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 
 /**
  * A Markdown description of the service.
@@ -30,6 +31,7 @@ public interface TestServiceBlocking {
     /**
      * Returns a mapping from file system id to backing file system configuration.
      */
+    @Nonnull
     Map<String, BackingFileSystem> getFileSystems(AuthHeader authHeader);
 
     Dataset createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request);

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
@@ -17,6 +17,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.Set;
 import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 import test.prefix.com.palantir.product.AliasedString;
 import test.prefix.com.palantir.product.CreateDatasetRequest;
 import test.prefix.com.palantir.product.datasets.BackingFileSystem;
@@ -30,6 +31,7 @@ public interface TestServiceBlocking {
     /**
      * Returns a mapping from file system id to backing file system configuration.
      */
+    @Nonnull
     Map<String, BackingFileSystem> getFileSystems(AuthHeader authHeader);
 
     Dataset createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request);


### PR DESCRIPTION
## Before this PR
We would completely ignore endpoint markers in Dialogue generated interfaces. Ideally we would replace markers with a more universal structure that every language can take care of. Doing so would require making changes to the IR which we currently do not have the bandwidth to do, so in lieu of first class support we mirror other implementations and add markers as annotations.

cc @akroy 

## After this PR
==COMMIT_MSG==
Generate endpoint markers as annotations on Dialogue interfaces
==COMMIT_MSG==

## Possible downsides?
Further couples us to endpoint markers which long term we would like to remove.

