### PR TITLE
improve union visitor generation

### DIFF
--- a/changelog/@unreleased/pr-949.v2.yml
+++ b/changelog/@unreleased/pr-949.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Improve generated union classes to avoid instanceof checks.
+  links:
+  - https://github.com/palantir/conjure-java/pull/949

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
@@ -30,10 +30,7 @@ public final class EmptyUnionTypeExample {
     }
 
     public <T> T accept(Visitor<T> visitor) {
-        if (value instanceof UnknownWrapper) {
-            return visitor.visitUnknown(((UnknownWrapper) value).getType());
-        }
-        throw new IllegalStateException(String.format("Could not identify type %s", value.getClass()));
+        return value.accept(visitor);
     }
 
     @Override
@@ -96,7 +93,9 @@ public final class EmptyUnionTypeExample {
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true, defaultImpl = UnknownWrapper.class)
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private interface Base {}
+    private interface Base {
+        <T> T accept(Visitor<T> visitor);
+    }
 
     @JsonTypeInfo(
             use = JsonTypeInfo.Id.NAME,
@@ -133,6 +132,11 @@ public final class EmptyUnionTypeExample {
         @JsonAnySetter
         private void put(String key, Object val) {
             value.put(key, val);
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitUnknown(type);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -72,26 +72,7 @@ public final class UnionTypeExample {
     }
 
     public <T> T accept(Visitor<T> visitor) {
-        if (value instanceof StringExampleWrapper) {
-            return visitor.visitStringExample(((StringExampleWrapper) value).value);
-        } else if (value instanceof SetWrapper) {
-            return visitor.visitSet(((SetWrapper) value).value);
-        } else if (value instanceof ThisFieldIsAnIntegerWrapper) {
-            return visitor.visitThisFieldIsAnInteger(((ThisFieldIsAnIntegerWrapper) value).value);
-        } else if (value instanceof AlsoAnIntegerWrapper) {
-            return visitor.visitAlsoAnInteger(((AlsoAnIntegerWrapper) value).value);
-        } else if (value instanceof IfWrapper) {
-            return visitor.visitIf(((IfWrapper) value).value);
-        } else if (value instanceof NewWrapper) {
-            return visitor.visitNew(((NewWrapper) value).value);
-        } else if (value instanceof InterfaceWrapper) {
-            return visitor.visitInterface(((InterfaceWrapper) value).value);
-        } else if (value instanceof CompletedWrapper) {
-            return visitor.visitCompleted(((CompletedWrapper) value).value);
-        } else if (value instanceof UnknownWrapper) {
-            return visitor.visitUnknown(((UnknownWrapper) value).getType());
-        }
-        throw new IllegalStateException(String.format("Could not identify type %s", value.getClass()));
+        return value.accept(visitor);
     }
 
     @Override
@@ -346,7 +327,9 @@ public final class UnionTypeExample {
         @JsonSubTypes.Type(CompletedWrapper.class)
     })
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private interface Base {}
+    private interface Base {
+        <T> T accept(Visitor<T> visitor);
+    }
 
     @JsonTypeName("stringExample")
     private static final class StringExampleWrapper implements Base {
@@ -361,6 +344,11 @@ public final class UnionTypeExample {
         @JsonProperty("stringExample")
         private StringExample getValue() {
             return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitStringExample(value);
         }
 
         @Override
@@ -399,6 +387,11 @@ public final class UnionTypeExample {
         }
 
         @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitSet(value);
+        }
+
+        @Override
         public boolean equals(Object other) {
             return this == other || (other instanceof SetWrapper && equalTo((SetWrapper) other));
         }
@@ -431,6 +424,11 @@ public final class UnionTypeExample {
         @JsonProperty("thisFieldIsAnInteger")
         private int getValue() {
             return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitThisFieldIsAnInteger(value);
         }
 
         @Override
@@ -470,6 +468,11 @@ public final class UnionTypeExample {
         }
 
         @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitAlsoAnInteger(value);
+        }
+
+        @Override
         public boolean equals(Object other) {
             return this == other || (other instanceof AlsoAnIntegerWrapper && equalTo((AlsoAnIntegerWrapper) other));
         }
@@ -502,6 +505,11 @@ public final class UnionTypeExample {
         @JsonProperty("if")
         private int getValue() {
             return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitIf(value);
         }
 
         @Override
@@ -540,6 +548,11 @@ public final class UnionTypeExample {
         }
 
         @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitNew(value);
+        }
+
+        @Override
         public boolean equals(Object other) {
             return this == other || (other instanceof NewWrapper && equalTo((NewWrapper) other));
         }
@@ -575,6 +588,11 @@ public final class UnionTypeExample {
         }
 
         @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitInterface(value);
+        }
+
+        @Override
         public boolean equals(Object other) {
             return this == other || (other instanceof InterfaceWrapper && equalTo((InterfaceWrapper) other));
         }
@@ -607,6 +625,11 @@ public final class UnionTypeExample {
         @JsonProperty("completed")
         private int getValue() {
             return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitCompleted(value);
         }
 
         @Override
@@ -664,6 +687,11 @@ public final class UnionTypeExample {
         @JsonAnySetter
         private void put(String key, Object val) {
             value.put(key, val);
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitUnknown(type);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
@@ -30,10 +30,7 @@ public final class EmptyUnionTypeExample {
     }
 
     public <T> T accept(Visitor<T> visitor) {
-        if (value instanceof UnknownWrapper) {
-            return visitor.visitUnknown(((UnknownWrapper) value).getType());
-        }
-        throw new IllegalStateException(String.format("Could not identify type %s", value.getClass()));
+        return value.accept(visitor);
     }
 
     @Override
@@ -96,7 +93,9 @@ public final class EmptyUnionTypeExample {
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true, defaultImpl = UnknownWrapper.class)
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private interface Base {}
+    private interface Base {
+        <T> T accept(Visitor<T> visitor);
+    }
 
     @JsonTypeInfo(
             use = JsonTypeInfo.Id.NAME,
@@ -133,6 +132,11 @@ public final class EmptyUnionTypeExample {
         @JsonAnySetter
         private void put(String key, Object val) {
             value.put(key, val);
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitUnknown(type);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -72,26 +72,7 @@ public final class UnionTypeExample {
     }
 
     public <T> T accept(Visitor<T> visitor) {
-        if (value instanceof StringExampleWrapper) {
-            return visitor.visitStringExample(((StringExampleWrapper) value).value);
-        } else if (value instanceof SetWrapper) {
-            return visitor.visitSet(((SetWrapper) value).value);
-        } else if (value instanceof ThisFieldIsAnIntegerWrapper) {
-            return visitor.visitThisFieldIsAnInteger(((ThisFieldIsAnIntegerWrapper) value).value);
-        } else if (value instanceof AlsoAnIntegerWrapper) {
-            return visitor.visitAlsoAnInteger(((AlsoAnIntegerWrapper) value).value);
-        } else if (value instanceof IfWrapper) {
-            return visitor.visitIf(((IfWrapper) value).value);
-        } else if (value instanceof NewWrapper) {
-            return visitor.visitNew(((NewWrapper) value).value);
-        } else if (value instanceof InterfaceWrapper) {
-            return visitor.visitInterface(((InterfaceWrapper) value).value);
-        } else if (value instanceof CompletedWrapper) {
-            return visitor.visitCompleted(((CompletedWrapper) value).value);
-        } else if (value instanceof UnknownWrapper) {
-            return visitor.visitUnknown(((UnknownWrapper) value).getType());
-        }
-        throw new IllegalStateException(String.format("Could not identify type %s", value.getClass()));
+        return value.accept(visitor);
     }
 
     @Override
@@ -346,7 +327,9 @@ public final class UnionTypeExample {
         @JsonSubTypes.Type(CompletedWrapper.class)
     })
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private interface Base {}
+    private interface Base {
+        <T> T accept(Visitor<T> visitor);
+    }
 
     @JsonTypeName("stringExample")
     private static final class StringExampleWrapper implements Base {
@@ -361,6 +344,11 @@ public final class UnionTypeExample {
         @JsonProperty("stringExample")
         private StringExample getValue() {
             return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitStringExample(value);
         }
 
         @Override
@@ -399,6 +387,11 @@ public final class UnionTypeExample {
         }
 
         @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitSet(value);
+        }
+
+        @Override
         public boolean equals(Object other) {
             return this == other || (other instanceof SetWrapper && equalTo((SetWrapper) other));
         }
@@ -431,6 +424,11 @@ public final class UnionTypeExample {
         @JsonProperty("thisFieldIsAnInteger")
         private int getValue() {
             return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitThisFieldIsAnInteger(value);
         }
 
         @Override
@@ -470,6 +468,11 @@ public final class UnionTypeExample {
         }
 
         @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitAlsoAnInteger(value);
+        }
+
+        @Override
         public boolean equals(Object other) {
             return this == other || (other instanceof AlsoAnIntegerWrapper && equalTo((AlsoAnIntegerWrapper) other));
         }
@@ -502,6 +505,11 @@ public final class UnionTypeExample {
         @JsonProperty("if")
         private int getValue() {
             return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitIf(value);
         }
 
         @Override
@@ -540,6 +548,11 @@ public final class UnionTypeExample {
         }
 
         @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitNew(value);
+        }
+
+        @Override
         public boolean equals(Object other) {
             return this == other || (other instanceof NewWrapper && equalTo((NewWrapper) other));
         }
@@ -575,6 +588,11 @@ public final class UnionTypeExample {
         }
 
         @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitInterface(value);
+        }
+
+        @Override
         public boolean equals(Object other) {
             return this == other || (other instanceof InterfaceWrapper && equalTo((InterfaceWrapper) other));
         }
@@ -607,6 +625,11 @@ public final class UnionTypeExample {
         @JsonProperty("completed")
         private int getValue() {
             return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitCompleted(value);
         }
 
         @Override
@@ -664,6 +687,11 @@ public final class UnionTypeExample {
         @JsonAnySetter
         private void put(String key, Object val) {
             value.put(key, val);
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitUnknown(type);
         }
 
         @Override


### PR DESCRIPTION
## Before this PR
The Union accept method is not very efficient because it checks the value type for being an instance of each possible value wrapper. This is up to N instanceof checks where N is the number of distinct union value types.

## After this PR
The logic of which visitor method to call is delegated to each ValueWrapper class. The efficiency of calling the accept method on unions will now be the same no matter how many distinct value types there are.

==COMMIT_MSG==
Improves the union generator to avoid relying on instanceof checks to
pick the correct visit method. This makes using visitors with union
types more efficient when there are many possible value types, as it
avoids repeated checks for each possible value type.
==COMMIT_MSG==

## Possible downsides?

Introduces asymmetry between the way unions and enums are implemented. We might want to add a similar fix for enums, as they have the exact same problem when using visitors with many values.
