### PR TITLE
Add backcompat stubs for optional header params

### DIFF
--- a/changelog/@unreleased/pr-967.v2.yml
+++ b/changelog/@unreleased/pr-967.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: When optional header params are added, Retrofit and Jersey generated
+    code now includes deprecated methods without these headers - similar to those
+    generated when optional query params are added.
+  links:
+  - https://github.com/palantir/conjure-java/pull/967

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
@@ -186,9 +186,14 @@ public final class JerseyServiceGenerator implements ServiceGenerator {
     /** Provides a linear expansion of optional query arguments to improve Java back-compat. */
     private List<MethodSpec> generateCompatibilityBackfillServiceMethods(
             EndpointDefinition endpointDef, TypeMapper returnTypeMapper, TypeMapper argumentTypeMapper) {
+        List<ArgumentDefinition> headerArgs = new ArrayList<>();
         List<ArgumentDefinition> queryArgs = new ArrayList<>();
 
         for (ArgumentDefinition arg : endpointDef.getArgs()) {
+            if (arg.getParamType().accept(ParameterTypeVisitor.IS_HEADER)
+                    && arg.getType().accept(DefaultableTypeVisitor.INSTANCE)) {
+                headerArgs.add(arg);
+            }
             if (arg.getParamType().accept(ParameterTypeVisitor.IS_QUERY)
                     && arg.getType().accept(DefaultableTypeVisitor.INSTANCE)) {
                 queryArgs.add(arg);
@@ -196,9 +201,17 @@ public final class JerseyServiceGenerator implements ServiceGenerator {
         }
 
         List<MethodSpec> alternateMethods = new ArrayList<>();
-        for (int i = 0; i < queryArgs.size(); i++) {
-            alternateMethods.add(createCompatibilityBackfillMethod(
-                    endpointDef, returnTypeMapper, argumentTypeMapper, queryArgs.subList(i, queryArgs.size())));
+        for (int j = 0; j <= headerArgs.size(); j++) {
+            for (int i = 0; i <= queryArgs.size(); i++) {
+                List<ArgumentDefinition> extraHeaderArgs = headerArgs.subList(j, headerArgs.size());
+                List<ArgumentDefinition> extraQueryArgs = queryArgs.subList(i, queryArgs.size());
+                List<ArgumentDefinition> extraArgs = new ArrayList<>(extraHeaderArgs);
+                extraArgs.addAll(extraQueryArgs);
+                if (!extraArgs.isEmpty()) {
+                    alternateMethods.add(createCompatibilityBackfillMethod(
+                            endpointDef, returnTypeMapper, argumentTypeMapper, extraArgs));
+                }
+            }
         }
 
         return alternateMethods;

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
@@ -19,7 +19,6 @@ package com.palantir.conjure.java.services;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.palantir.conjure.java.ConjureAnnotations;
 import com.palantir.conjure.java.Options;
 import com.palantir.conjure.java.types.DefaultClassNameVisitor;
@@ -221,7 +220,7 @@ public final class Retrofit2ServiceGenerator implements ServiceGenerator {
             for (int i = 0; i <= queryArgs.size(); i++) {
                 List<ArgumentDefinition> extraHeaderArgs = headerArgs.subList(j, headerArgs.size());
                 List<ArgumentDefinition> extraQueryArgs = queryArgs.subList(i, queryArgs.size());
-                List<ArgumentDefinition> extraArgs = Lists.newArrayList(extraHeaderArgs);
+                List<ArgumentDefinition> extraArgs = new ArrayList<>(extraHeaderArgs);
                 extraArgs.addAll(extraQueryArgs);
                 if (!extraArgs.isEmpty()) {
                     alternateMethods.add(createCompatibilityBackfillMethod(

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/TestBase.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/TestBase.java
@@ -56,7 +56,7 @@ public abstract class TestBase {
                 Files.deleteIfExists(output);
                 Files.copy(file, output);
             }
-            assertThat(readFromFile(file)).isEqualTo(readFromFile(output));
+            assertThat(readFromFile(file)).describedAs(output.toString()).isEqualTo(readFromFile(output));
         }
     }
 }

--- a/conjure-java-core/src/test/resources/example-service.yml
+++ b/conjure-java-core/src/test/resources/example-service.yml
@@ -224,6 +224,21 @@ services:
             type: optional<rid>
             param-type: query
 
+      testOptionalHeaderParam:
+        http: POST /test-optional-header-param
+        args:
+          query: string
+          maybeHeader:
+            type: optional<string>
+            param-type: header
+            param-id: MaybeHeader
+          implicit:
+            type: rid
+            param-type: query
+          maybeQuery:
+            type: optional<rid>
+            param-type: query
+
       testBoolean:
         http: GET /boolean
         returns: boolean

--- a/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue
@@ -515,6 +515,38 @@ enum DialogueTestEndpoints implements Endpoint {
         }
     },
 
+    testOptionalHeaderParam {
+        private final PathTemplate pathTemplate = PathTemplate.builder()
+                .fixed("catalog")
+                .fixed("test-optional-header-param")
+                .build();
+
+        @Override
+        public void renderPath(Map<String, String> params, UrlBuilder url) {
+            pathTemplate.fill(params, url);
+        }
+
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.POST;
+        }
+
+        @Override
+        public String serviceName() {
+            return "TestService";
+        }
+
+        @Override
+        public String endpointName() {
+            return "testOptionalHeaderParam";
+        }
+
+        @Override
+        public String version() {
+            return VERSION;
+        }
+    },
+
     testBoolean {
         private final PathTemplate pathTemplate =
                 PathTemplate.builder().fixed("catalog").fixed("boolean").build();

--- a/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue.prefix
@@ -515,6 +515,38 @@ enum DialogueTestEndpoints implements Endpoint {
         }
     },
 
+    testOptionalHeaderParam {
+        private final PathTemplate pathTemplate = PathTemplate.builder()
+                .fixed("catalog")
+                .fixed("test-optional-header-param")
+                .build();
+
+        @Override
+        public void renderPath(Map<String, String> params, UrlBuilder url) {
+            pathTemplate.fill(params, url);
+        }
+
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.POST;
+        }
+
+        @Override
+        public String serviceName() {
+            return "TestService";
+        }
+
+        @Override
+        public String endpointName() {
+            return "testOptionalHeaderParam";
+        }
+
+        @Override
+        public String version() {
+            return VERSION;
+        }
+    },
+
     testBoolean {
         private final PathTemplate pathTemplate =
                 PathTemplate.builder().fixed("catalog").fixed("boolean").build();

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
@@ -150,6 +150,15 @@ public interface TestService {
             @QueryParam("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
             @NotNull String query);
 
+    @POST
+    @Path("catalog/test-optional-header-param")
+    void testOptionalHeaderParam(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @HeaderParam("MaybeHeader") Optional<String> maybeHeader,
+            @QueryParam("implicit") ResourceIdentifier implicit,
+            @QueryParam("maybeQuery") Optional<ResourceIdentifier> maybeQuery,
+            @NotNull String query);
+
     @GET
     @Path("catalog/boolean")
     boolean testBoolean(@HeaderParam("Authorization") @NotNull AuthHeader authHeader);
@@ -237,6 +246,23 @@ public interface TestService {
             Set<String> setEnd,
             String query) {
         testNoResponseQueryParams(authHeader, something, implicit, optionalMiddle, setEnd, Optional.empty(), query);
+    }
+
+    @Deprecated
+    default void testOptionalHeaderParam(AuthHeader authHeader, ResourceIdentifier implicit, String query) {
+        testOptionalHeaderParam(authHeader, Optional.empty(), implicit, Optional.empty(), query);
+    }
+
+    @Deprecated
+    default void testOptionalHeaderParam(
+            AuthHeader authHeader, ResourceIdentifier implicit, Optional<ResourceIdentifier> maybeQuery, String query) {
+        testOptionalHeaderParam(authHeader, Optional.empty(), implicit, maybeQuery, query);
+    }
+
+    @Deprecated
+    default void testOptionalHeaderParam(
+            AuthHeader authHeader, Optional<String> maybeHeader, ResourceIdentifier implicit, String query) {
+        testOptionalHeaderParam(authHeader, maybeHeader, implicit, Optional.empty(), query);
     }
 
     @Deprecated

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.prefix
@@ -148,6 +148,15 @@ public interface TestService {
             @QueryParam("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
             String query);
 
+    @POST
+    @Path("catalog/test-optional-header-param")
+    void testOptionalHeaderParam(
+            @HeaderParam("Authorization") AuthHeader authHeader,
+            @HeaderParam("MaybeHeader") Optional<String> maybeHeader,
+            @QueryParam("implicit") ResourceIdentifier implicit,
+            @QueryParam("maybeQuery") Optional<ResourceIdentifier> maybeQuery,
+            String query);
+
     @GET
     @Path("catalog/boolean")
     boolean testBoolean(@HeaderParam("Authorization") AuthHeader authHeader);
@@ -235,6 +244,23 @@ public interface TestService {
             Set<String> setEnd,
             String query) {
         testNoResponseQueryParams(authHeader, something, implicit, optionalMiddle, setEnd, Optional.empty(), query);
+    }
+
+    @Deprecated
+    default void testOptionalHeaderParam(AuthHeader authHeader, ResourceIdentifier implicit, String query) {
+        testOptionalHeaderParam(authHeader, Optional.empty(), implicit, Optional.empty(), query);
+    }
+
+    @Deprecated
+    default void testOptionalHeaderParam(
+            AuthHeader authHeader, ResourceIdentifier implicit, Optional<ResourceIdentifier> maybeQuery, String query) {
+        testOptionalHeaderParam(authHeader, Optional.empty(), implicit, maybeQuery, query);
+    }
+
+    @Deprecated
+    default void testOptionalHeaderParam(
+            AuthHeader authHeader, Optional<String> maybeHeader, ResourceIdentifier implicit, String query) {
+        testOptionalHeaderParam(authHeader, maybeHeader, implicit, Optional.empty(), query);
     }
 
     @Deprecated

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
@@ -150,6 +150,15 @@ public interface TestService {
             @QueryParam("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
             @NotNull String query);
 
+    @POST
+    @Path("catalog/test-optional-header-param")
+    void testOptionalHeaderParam(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @HeaderParam("MaybeHeader") Optional<String> maybeHeader,
+            @QueryParam("implicit") ResourceIdentifier implicit,
+            @QueryParam("maybeQuery") Optional<ResourceIdentifier> maybeQuery,
+            @NotNull String query);
+
     @GET
     @Path("catalog/boolean")
     boolean testBoolean(@HeaderParam("Authorization") @NotNull AuthHeader authHeader);
@@ -237,6 +246,23 @@ public interface TestService {
             Set<String> setEnd,
             String query) {
         testNoResponseQueryParams(authHeader, something, implicit, optionalMiddle, setEnd, Optional.empty(), query);
+    }
+
+    @Deprecated
+    default void testOptionalHeaderParam(AuthHeader authHeader, ResourceIdentifier implicit, String query) {
+        testOptionalHeaderParam(authHeader, Optional.empty(), implicit, Optional.empty(), query);
+    }
+
+    @Deprecated
+    default void testOptionalHeaderParam(
+            AuthHeader authHeader, ResourceIdentifier implicit, Optional<ResourceIdentifier> maybeQuery, String query) {
+        testOptionalHeaderParam(authHeader, Optional.empty(), implicit, maybeQuery, query);
+    }
+
+    @Deprecated
+    default void testOptionalHeaderParam(
+            AuthHeader authHeader, Optional<String> maybeHeader, ResourceIdentifier implicit, String query) {
+        testOptionalHeaderParam(authHeader, maybeHeader, implicit, Optional.empty(), query);
     }
 
     @Deprecated

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
@@ -77,6 +77,13 @@ public interface TestService {
             Optional<ResourceIdentifier> optionalEnd,
             String query);
 
+    void testOptionalHeaderParam(
+            AuthHeader authHeader,
+            Optional<String> maybeHeader,
+            ResourceIdentifier implicit,
+            Optional<ResourceIdentifier> maybeQuery,
+            String query);
+
     boolean testBoolean(AuthHeader authHeader);
 
     double testDouble(AuthHeader authHeader);

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.prefix
@@ -77,6 +77,13 @@ public interface TestService {
             Optional<ResourceIdentifier> optionalEnd,
             String query);
 
+    void testOptionalHeaderParam(
+            AuthHeader authHeader,
+            Optional<String> maybeHeader,
+            ResourceIdentifier implicit,
+            Optional<ResourceIdentifier> maybeQuery,
+            String query);
+
     boolean testBoolean(AuthHeader authHeader);
 
     double testDouble(AuthHeader authHeader);

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
@@ -95,6 +95,13 @@ public interface TestServiceAsync {
             Optional<ResourceIdentifier> optionalEnd,
             String query);
 
+    ListenableFuture<Void> testOptionalHeaderParam(
+            AuthHeader authHeader,
+            Optional<String> maybeHeader,
+            ResourceIdentifier implicit,
+            Optional<ResourceIdentifier> maybeQuery,
+            String query);
+
     ListenableFuture<Boolean> testBoolean(AuthHeader authHeader);
 
     ListenableFuture<Double> testDouble(AuthHeader authHeader);
@@ -207,6 +214,15 @@ public interface TestServiceAsync {
                     _runtime.clients().bind(_channel, DialogueTestEndpoints.testNoResponseQueryParams);
 
             private final Deserializer<Void> testNoResponseQueryParamsDeserializer =
+                    _runtime.bodySerDe().emptyBodyDeserializer();
+
+            private final Serializer<String> testOptionalHeaderParamSerializer =
+                    _runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+
+            private final EndpointChannel testOptionalHeaderParamChannel =
+                    _runtime.clients().bind(_channel, DialogueTestEndpoints.testOptionalHeaderParam);
+
+            private final Deserializer<Void> testOptionalHeaderParamDeserializer =
                     _runtime.bodySerDe().emptyBodyDeserializer();
 
             private final EndpointChannel testBooleanChannel =
@@ -428,6 +444,27 @@ public interface TestServiceAsync {
                                 testNoResponseQueryParamsChannel,
                                 _request.build(),
                                 testNoResponseQueryParamsDeserializer);
+            }
+
+            @Override
+            public ListenableFuture<Void> testOptionalHeaderParam(
+                    AuthHeader authHeader,
+                    Optional<String> maybeHeader,
+                    ResourceIdentifier implicit,
+                    Optional<ResourceIdentifier> maybeQuery,
+                    String query) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.body(testOptionalHeaderParamSerializer.serialize(query));
+                if (maybeHeader.isPresent()) {
+                    _request.putHeaderParams("MaybeHeader", _plainSerDe.serializeString(maybeHeader.get()));
+                }
+                _request.putQueryParams("implicit", _plainSerDe.serializeRid(implicit));
+                if (maybeQuery.isPresent()) {
+                    _request.putQueryParams("maybeQuery", _plainSerDe.serializeRid(maybeQuery.get()));
+                }
+                return _runtime.clients()
+                        .call(testOptionalHeaderParamChannel, _request.build(), testOptionalHeaderParamDeserializer);
             }
 
             @Override

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
@@ -95,6 +95,13 @@ public interface TestServiceAsync {
             Optional<ResourceIdentifier> optionalEnd,
             String query);
 
+    ListenableFuture<Void> testOptionalHeaderParam(
+            AuthHeader authHeader,
+            Optional<String> maybeHeader,
+            ResourceIdentifier implicit,
+            Optional<ResourceIdentifier> maybeQuery,
+            String query);
+
     ListenableFuture<Boolean> testBoolean(AuthHeader authHeader);
 
     ListenableFuture<Double> testDouble(AuthHeader authHeader);
@@ -207,6 +214,15 @@ public interface TestServiceAsync {
                     _runtime.clients().bind(_channel, DialogueTestEndpoints.testNoResponseQueryParams);
 
             private final Deserializer<Void> testNoResponseQueryParamsDeserializer =
+                    _runtime.bodySerDe().emptyBodyDeserializer();
+
+            private final Serializer<String> testOptionalHeaderParamSerializer =
+                    _runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+
+            private final EndpointChannel testOptionalHeaderParamChannel =
+                    _runtime.clients().bind(_channel, DialogueTestEndpoints.testOptionalHeaderParam);
+
+            private final Deserializer<Void> testOptionalHeaderParamDeserializer =
                     _runtime.bodySerDe().emptyBodyDeserializer();
 
             private final EndpointChannel testBooleanChannel =
@@ -428,6 +444,27 @@ public interface TestServiceAsync {
                                 testNoResponseQueryParamsChannel,
                                 _request.build(),
                                 testNoResponseQueryParamsDeserializer);
+            }
+
+            @Override
+            public ListenableFuture<Void> testOptionalHeaderParam(
+                    AuthHeader authHeader,
+                    Optional<String> maybeHeader,
+                    ResourceIdentifier implicit,
+                    Optional<ResourceIdentifier> maybeQuery,
+                    String query) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.body(testOptionalHeaderParamSerializer.serialize(query));
+                if (maybeHeader.isPresent()) {
+                    _request.putHeaderParams("MaybeHeader", _plainSerDe.serializeString(maybeHeader.get()));
+                }
+                _request.putQueryParams("implicit", _plainSerDe.serializeRid(implicit));
+                if (maybeQuery.isPresent()) {
+                    _request.putQueryParams("maybeQuery", _plainSerDe.serializeRid(maybeQuery.get()));
+                }
+                return _runtime.clients()
+                        .call(testOptionalHeaderParamChannel, _request.build(), testOptionalHeaderParamDeserializer);
             }
 
             @Override

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
@@ -85,6 +85,13 @@ public interface TestServiceBlocking {
             Optional<ResourceIdentifier> optionalEnd,
             String query);
 
+    void testOptionalHeaderParam(
+            AuthHeader authHeader,
+            Optional<String> maybeHeader,
+            ResourceIdentifier implicit,
+            Optional<ResourceIdentifier> maybeQuery,
+            String query);
+
     boolean testBoolean(AuthHeader authHeader);
 
     double testDouble(AuthHeader authHeader);
@@ -197,6 +204,17 @@ public interface TestServiceBlocking {
                 _runtime.clients()
                         .block(delegate.testNoResponseQueryParams(
                                 authHeader, something, implicit, optionalMiddle, setEnd, optionalEnd, query));
+            }
+
+            @Override
+            public void testOptionalHeaderParam(
+                    AuthHeader authHeader,
+                    Optional<String> maybeHeader,
+                    ResourceIdentifier implicit,
+                    Optional<ResourceIdentifier> maybeQuery,
+                    String query) {
+                _runtime.clients()
+                        .block(delegate.testOptionalHeaderParam(authHeader, maybeHeader, implicit, maybeQuery, query));
             }
 
             @Override

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
@@ -85,6 +85,13 @@ public interface TestServiceBlocking {
             Optional<ResourceIdentifier> optionalEnd,
             String query);
 
+    void testOptionalHeaderParam(
+            AuthHeader authHeader,
+            Optional<String> maybeHeader,
+            ResourceIdentifier implicit,
+            Optional<ResourceIdentifier> maybeQuery,
+            String query);
+
     boolean testBoolean(AuthHeader authHeader);
 
     double testDouble(AuthHeader authHeader);
@@ -197,6 +204,17 @@ public interface TestServiceBlocking {
                 _runtime.clients()
                         .block(delegate.testNoResponseQueryParams(
                                 authHeader, something, implicit, optionalMiddle, setEnd, optionalEnd, query));
+            }
+
+            @Override
+            public void testOptionalHeaderParam(
+                    AuthHeader authHeader,
+                    Optional<String> maybeHeader,
+                    ResourceIdentifier implicit,
+                    Optional<ResourceIdentifier> maybeQuery,
+                    String query) {
+                _runtime.clients()
+                        .block(delegate.testOptionalHeaderParam(authHeader, maybeHeader, implicit, maybeQuery, query));
             }
 
             @Override

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
@@ -64,6 +64,7 @@ public final class TestServiceEndpoints implements UndertowService {
                 new TestParamEndpoint(runtime, delegate),
                 new TestQueryParamsEndpoint(runtime, delegate),
                 new TestNoResponseQueryParamsEndpoint(runtime, delegate),
+                new TestOptionalHeaderParamEndpoint(runtime, delegate),
                 new TestBooleanEndpoint(runtime, delegate),
                 new TestDoubleEndpoint(runtime, delegate),
                 new TestIntegerEndpoint(runtime, delegate),
@@ -839,6 +840,60 @@ public final class TestServiceEndpoints implements UndertowService {
         @Override
         public String name() {
             return "testNoResponseQueryParams";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class TestOptionalHeaderParamEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final TestService delegate;
+
+        private final Deserializer<String> deserializer;
+
+        TestOptionalHeaderParamEndpoint(UndertowRuntime runtime, TestService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {});
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            String query = deserializer.deserialize(exchange);
+            HeaderMap headerParams = exchange.getRequestHeaders();
+            Optional<String> maybeHeader =
+                    runtime.plainSerDe().deserializeOptionalString(headerParams.get("MaybeHeader"));
+            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            ResourceIdentifier implicit = runtime.plainSerDe().deserializeRid(queryParams.get("implicit"));
+            Optional<ResourceIdentifier> maybeQuery =
+                    runtime.plainSerDe().deserializeOptionalRid(queryParams.get("maybeQuery"));
+            delegate.testOptionalHeaderParam(authHeader, maybeHeader, implicit, maybeQuery, query);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/catalog/test-optional-header-param";
+        }
+
+        @Override
+        public String serviceName() {
+            return "TestService";
+        }
+
+        @Override
+        public String name() {
+            return "testOptionalHeaderParam";
         }
 
         @Override

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.prefix
@@ -64,6 +64,7 @@ public final class TestServiceEndpoints implements UndertowService {
                 new TestParamEndpoint(runtime, delegate),
                 new TestQueryParamsEndpoint(runtime, delegate),
                 new TestNoResponseQueryParamsEndpoint(runtime, delegate),
+                new TestOptionalHeaderParamEndpoint(runtime, delegate),
                 new TestBooleanEndpoint(runtime, delegate),
                 new TestDoubleEndpoint(runtime, delegate),
                 new TestIntegerEndpoint(runtime, delegate),
@@ -839,6 +840,60 @@ public final class TestServiceEndpoints implements UndertowService {
         @Override
         public String name() {
             return "testNoResponseQueryParams";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class TestOptionalHeaderParamEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final TestService delegate;
+
+        private final Deserializer<String> deserializer;
+
+        TestOptionalHeaderParamEndpoint(UndertowRuntime runtime, TestService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {});
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            String query = deserializer.deserialize(exchange);
+            HeaderMap headerParams = exchange.getRequestHeaders();
+            Optional<String> maybeHeader =
+                    runtime.plainSerDe().deserializeOptionalString(headerParams.get("MaybeHeader"));
+            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            ResourceIdentifier implicit = runtime.plainSerDe().deserializeRid(queryParams.get("implicit"));
+            Optional<ResourceIdentifier> maybeQuery =
+                    runtime.plainSerDe().deserializeOptionalRid(queryParams.get("maybeQuery"));
+            delegate.testOptionalHeaderParam(authHeader, maybeHeader, implicit, maybeQuery, query);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/catalog/test-optional-header-param";
+        }
+
+        @Override
+        public String serviceName() {
+            return "TestService";
+        }
+
+        @Override
+        public String name() {
+            return "testOptionalHeaderParam";
         }
 
         @Override

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
@@ -135,6 +135,15 @@ public interface TestServiceRetrofit {
             @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
             @Body String query);
 
+    @POST("./catalog/test-optional-header-param")
+    @Headers({"hr-path-template: /catalog/test-optional-header-param", "Accept: application/json"})
+    ListenableFuture<Void> testOptionalHeaderParam(
+            @Header("Authorization") AuthHeader authHeader,
+            @Header("MaybeHeader") Optional<String> maybeHeader,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Query("maybeQuery") Optional<ResourceIdentifier> maybeQuery,
+            @Body String query);
+
     @GET("./catalog/boolean")
     @Headers({"hr-path-template: /catalog/boolean", "Accept: application/json"})
     ListenableFuture<Boolean> testBoolean(@Header("Authorization") AuthHeader authHeader);
@@ -228,6 +237,32 @@ public interface TestServiceRetrofit {
             @Query("setEnd") Set<String> setEnd,
             @Body String query) {
         testNoResponseQueryParams(authHeader, something, implicit, optionalMiddle, setEnd, Optional.empty(), query);
+    }
+
+    @Deprecated
+    default void testOptionalHeaderParam(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Body String query) {
+        testOptionalHeaderParam(authHeader, Optional.empty(), implicit, Optional.empty(), query);
+    }
+
+    @Deprecated
+    default void testOptionalHeaderParam(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Query("maybeQuery") Optional<ResourceIdentifier> maybeQuery,
+            @Body String query) {
+        testOptionalHeaderParam(authHeader, Optional.empty(), implicit, maybeQuery, query);
+    }
+
+    @Deprecated
+    default void testOptionalHeaderParam(
+            @Header("Authorization") AuthHeader authHeader,
+            @Header("MaybeHeader") Optional<String> maybeHeader,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Body String query) {
+        testOptionalHeaderParam(authHeader, maybeHeader, implicit, Optional.empty(), query);
     }
 
     @Deprecated

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit.prefix
@@ -135,6 +135,15 @@ public interface TestServiceRetrofit {
             @Query("optionalEnd") Optional<ResourceIdentifier> optionalEnd,
             @Body String query);
 
+    @POST("./catalog/test-optional-header-param")
+    @Headers({"hr-path-template: /catalog/test-optional-header-param", "Accept: application/json"})
+    ListenableFuture<Void> testOptionalHeaderParam(
+            @Header("Authorization") AuthHeader authHeader,
+            @Header("MaybeHeader") Optional<String> maybeHeader,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Query("maybeQuery") Optional<ResourceIdentifier> maybeQuery,
+            @Body String query);
+
     @GET("./catalog/boolean")
     @Headers({"hr-path-template: /catalog/boolean", "Accept: application/json"})
     ListenableFuture<Boolean> testBoolean(@Header("Authorization") AuthHeader authHeader);
@@ -228,6 +237,32 @@ public interface TestServiceRetrofit {
             @Query("setEnd") Set<String> setEnd,
             @Body String query) {
         testNoResponseQueryParams(authHeader, something, implicit, optionalMiddle, setEnd, Optional.empty(), query);
+    }
+
+    @Deprecated
+    default void testOptionalHeaderParam(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Body String query) {
+        testOptionalHeaderParam(authHeader, Optional.empty(), implicit, Optional.empty(), query);
+    }
+
+    @Deprecated
+    default void testOptionalHeaderParam(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Query("maybeQuery") Optional<ResourceIdentifier> maybeQuery,
+            @Body String query) {
+        testOptionalHeaderParam(authHeader, Optional.empty(), implicit, maybeQuery, query);
+    }
+
+    @Deprecated
+    default void testOptionalHeaderParam(
+            @Header("Authorization") AuthHeader authHeader,
+            @Header("MaybeHeader") Optional<String> maybeHeader,
+            @Query("implicit") ResourceIdentifier implicit,
+            @Body String query) {
+        testOptionalHeaderParam(authHeader, maybeHeader, implicit, Optional.empty(), query);
     }
 
     @Deprecated


### PR DESCRIPTION
## Before this PR
Similar to #960 - when an optional Header param is added to a method, no `@Deprecated` method without the header param is generated. This results in dev breaks, requiring any consumers to add either `Optional.empty()` or the header, as in [this commit](https://github.palantir.build/foundry/foundry/pull/6202/commits/7d3bd7819dcabed470afdfb32e70d24e53afdbbd).

## After this PR
==COMMIT_MSG==
When optional header params are added, Retrofit and Jersey generated code now includes deprecated methods without these headers - similar to those generated when optional query params are added.
==COMMIT_MSG==

## Possible downsides?
Still not added for Dialogue - may split this into another PR.

