### PR TITLE
Fix Dialogue Endpoint javadoc rendering with javapoet escape chars

### DIFF
--- a/changelog/@unreleased/pr-974.v2.yml
+++ b/changelog/@unreleased/pr-974.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix Dialogue Endpoint javadoc rendering with javapoet escape chars
+  links:
+  - https://github.com/palantir/conjure-java/pull/974

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueEndpointsGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueEndpointsGenerator.java
@@ -79,7 +79,7 @@ final class DialogueEndpointsGenerator {
 
     private static TypeSpec endpointField(EndpointDefinition def, String serviceName, Optional<String> apiVersion) {
         TypeSpec.Builder builder = TypeSpec.anonymousClassBuilder("");
-        def.getDocs().map(Javadoc::render).ifPresent(builder::addJavadoc);
+        def.getDocs().ifPresent(docs -> builder.addJavadoc("$L", Javadoc.render(docs)));
 
         return builder.addField(FieldSpec.builder(
                                 TypeName.get(PathTemplate.class), "pathTemplate", Modifier.PRIVATE, Modifier.FINAL)

--- a/conjure-java-core/src/test/resources/example-service.yml
+++ b/conjure-java-core/src/test/resources/example-service.yml
@@ -71,6 +71,7 @@ services:
             markers:
               - Safe
         returns: Dataset
+        docs: foo $bar
 
       getDataset:
         http: GET /datasets/{datasetRid}

--- a/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue
@@ -45,6 +45,9 @@ enum DialogueTestEndpoints implements Endpoint {
         }
     },
 
+    /**
+     * foo $bar
+     */
     createDataset {
         private final PathTemplate pathTemplate =
                 PathTemplate.builder().fixed("catalog").fixed("datasets").build();

--- a/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue.prefix
@@ -45,6 +45,9 @@ enum DialogueTestEndpoints implements Endpoint {
         }
     },
 
+    /**
+     * foo $bar
+     */
     createDataset {
         private final PathTemplate pathTemplate =
                 PathTemplate.builder().fixed("catalog").fixed("datasets").build();

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
@@ -44,6 +44,9 @@ public interface TestService {
     @Path("catalog/fileSystems")
     Map<String, BackingFileSystem> getFileSystems(@HeaderParam("Authorization") @NotNull AuthHeader authHeader);
 
+    /**
+     * foo $bar
+     */
     @POST
     @Path("catalog/datasets")
     Dataset createDataset(

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.prefix
@@ -43,6 +43,9 @@ public interface TestService {
     @Path("catalog/fileSystems")
     Map<String, BackingFileSystem> getFileSystems(@HeaderParam("Authorization") AuthHeader authHeader);
 
+    /**
+     * foo $bar
+     */
     @POST
     @Path("catalog/datasets")
     Dataset createDataset(

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
@@ -44,6 +44,9 @@ public interface TestService {
     @Path("catalog/fileSystems")
     Map<String, BackingFileSystem> getFileSystems(@HeaderParam("Authorization") @NotNull AuthHeader authHeader);
 
+    /**
+     * foo $bar
+     */
     @POST
     @Path("catalog/datasets")
     Dataset createDataset(

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
@@ -26,6 +26,9 @@ public interface TestService {
      */
     Map<String, BackingFileSystem> getFileSystems(AuthHeader authHeader);
 
+    /**
+     * foo $bar
+     */
     Dataset createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request);
 
     Optional<Dataset> getDataset(AuthHeader authHeader, ResourceIdentifier datasetRid);

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.prefix
@@ -26,6 +26,9 @@ public interface TestService {
      */
     Map<String, BackingFileSystem> getFileSystems(AuthHeader authHeader);
 
+    /**
+     * foo $bar
+     */
     Dataset createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request);
 
     Optional<Dataset> getDataset(AuthHeader authHeader, ResourceIdentifier datasetRid);

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
@@ -43,6 +43,9 @@ public interface TestServiceAsync {
     @Nonnull
     ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(AuthHeader authHeader);
 
+    /**
+     * foo $bar
+     */
     ListenableFuture<Dataset> createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request);
 
     ListenableFuture<Optional<Dataset>> getDataset(AuthHeader authHeader, ResourceIdentifier datasetRid);

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
@@ -43,6 +43,9 @@ public interface TestServiceAsync {
     @Nonnull
     ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(AuthHeader authHeader);
 
+    /**
+     * foo $bar
+     */
     ListenableFuture<Dataset> createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request);
 
     ListenableFuture<Optional<Dataset>> getDataset(AuthHeader authHeader, ResourceIdentifier datasetRid);

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
@@ -34,6 +34,9 @@ public interface TestServiceBlocking {
     @Nonnull
     Map<String, BackingFileSystem> getFileSystems(AuthHeader authHeader);
 
+    /**
+     * foo $bar
+     */
     Dataset createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request);
 
     Optional<Dataset> getDataset(AuthHeader authHeader, ResourceIdentifier datasetRid);

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
@@ -34,6 +34,9 @@ public interface TestServiceBlocking {
     @Nonnull
     Map<String, BackingFileSystem> getFileSystems(AuthHeader authHeader);
 
+    /**
+     * foo $bar
+     */
     Dataset createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request);
 
     Optional<Dataset> getDataset(AuthHeader authHeader, ResourceIdentifier datasetRid);

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
@@ -38,6 +38,9 @@ public interface TestServiceRetrofit {
     @Headers({"hr-path-template: /catalog/fileSystems", "Accept: application/json"})
     ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(@Header("Authorization") AuthHeader authHeader);
 
+    /**
+     * foo $bar
+     */
     @POST("./catalog/datasets")
     @Headers({"hr-path-template: /catalog/datasets", "Accept: application/json"})
     ListenableFuture<Dataset> createDataset(

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit.prefix
@@ -38,6 +38,9 @@ public interface TestServiceRetrofit {
     @Headers({"hr-path-template: /catalog/fileSystems", "Accept: application/json"})
     ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(@Header("Authorization") AuthHeader authHeader);
 
+    /**
+     * foo $bar
+     */
     @POST("./catalog/datasets")
     @Headers({"hr-path-template: /catalog/datasets", "Accept: application/json"})
     ListenableFuture<Dataset> createDataset(


### PR DESCRIPTION
## Before this PR
boom: https://github.com/palantir/conjure-java/issues/901#issuecomment-648786171

## After this PR
==COMMIT_MSG==
Fix Dialogue Endpoint javadoc rendering with javapoet escape chars
==COMMIT_MSG==

## Possible downsides?
none, matches other places we add javadoc