### PR TITLE
Expose framework exception

### DIFF
--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/FrameworkException.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/FrameworkException.java
@@ -25,7 +25,7 @@ import io.undertow.util.StatusCodes;
 import java.util.List;
 
 /** Internal type to signal a conjure protocol-level failure with a specific response code. */
-final class FrameworkException extends RuntimeException implements SafeLoggable {
+public final class FrameworkException extends RuntimeException implements SafeLoggable {
 
     private static final ErrorType UNPROCESSABLE_ENTITY =
             ErrorType.create(ErrorType.Code.INVALID_ARGUMENT, "Conjure:UnprocessableEntity");


### PR DESCRIPTION
## Before this PR
We had defined a `FrameworkException` to work around `ServiceException` only supporting status codes defined in the Conjure wire spec. `FrameworkException` was package private preventing our server library from properly handling these exceptions.

## After this PR
==COMMIT_MSG==
Change `FrameworkException`'s visibility to public
==COMMIT_MSG==

## Possible downsides?
This doesn't solve underlying grossness of having two similar but slightly different structured exceptions. Ideally we would unify on a single type which supports arbitrary status codes. We would still expect consistency across the Conjure ecosystem since the language and code-gen would limit you to Spec's status codes

