### PR TITLE
Conjure-undertow failures are exposed via an attachment

### DIFF
--- a/changelog/@unreleased/pr-982.v2.yml
+++ b/changelog/@unreleased/pr-982.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Conjure-undertow failures are exposed via an attachment
+  links:
+  - https://github.com/palantir/conjure-java/pull/982

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Attachments.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Attachments.java
@@ -25,5 +25,7 @@ public final class Attachments {
     public static final AttachmentKey<Optional<UnverifiedJsonWebToken>> UNVERIFIED_JWT =
             AttachmentKey.create(Optional.class);
 
+    public static final AttachmentKey<Throwable> FAILURE = AttachmentKey.create(Throwable.class);
+
     private Attachments() {}
 }


### PR DESCRIPTION
This allows us to report rich metrics across sync and async
request processing endpoints.

==COMMIT_MSG==
Conjure-undertow failures are exposed via an attachment
==COMMIT_MSG==

