### PR TITLE
Revert generated undertow service interfaces extend UndertowService now

### DIFF
--- a/changelog/@unreleased/pr-993.v2.yml
+++ b/changelog/@unreleased/pr-993.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Revert generated undertow service interfaces extend UndertowService
+    now
+  links:
+  - https://github.com/palantir/conjure-java/pull/993

--- a/changelog/@unreleased/pr-993.v2.yml
+++ b/changelog/@unreleased/pr-993.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: fix
+fix:
   description: Revert generated undertow service interfaces extend UndertowService
     now
   links:

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowAsyncRequestProcessingTestService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowAsyncRequestProcessingTestService.java
@@ -2,16 +2,12 @@ package com.palantir.product;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
-import com.palantir.conjure.java.undertow.lib.Endpoint;
-import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
-import com.palantir.conjure.java.undertow.lib.UndertowService;
-import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
-public interface UndertowAsyncRequestProcessingTestService extends UndertowService {
+public interface UndertowAsyncRequestProcessingTestService {
     /**
      * @apiNote {@code GET /async/delay}
      */
@@ -36,9 +32,4 @@ public interface UndertowAsyncRequestProcessingTestService extends UndertowServi
      * @apiNote {@code GET /async/future-trace}
      */
     ListenableFuture<Object> futureTraceId(OptionalInt delayMillis);
-
-    @Override
-    default List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return AsyncRequestProcessingTestServiceEndpoints.of(this).endpoints(runtime);
-    }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEmptyPathService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEmptyPathService.java
@@ -1,20 +1,11 @@
 package com.palantir.product;
 
-import com.palantir.conjure.java.undertow.lib.Endpoint;
-import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
-import com.palantir.conjure.java.undertow.lib.UndertowService;
-import java.util.List;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
-public interface UndertowEmptyPathService extends UndertowService {
+public interface UndertowEmptyPathService {
     /**
      * @apiNote {@code GET /}
      */
     boolean emptyPath();
-
-    @Override
-    default List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return EmptyPathServiceEndpoints.of(this).endpoints(runtime);
-    }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteBinaryService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteBinaryService.java
@@ -1,17 +1,13 @@
 package com.palantir.product;
 
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
-import com.palantir.conjure.java.undertow.lib.Endpoint;
-import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
-import com.palantir.conjure.java.undertow.lib.UndertowService;
 import com.palantir.tokens.auth.AuthHeader;
 import java.io.InputStream;
-import java.util.List;
 import java.util.Optional;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
-public interface UndertowEteBinaryService extends UndertowService {
+public interface UndertowEteBinaryService {
     /**
      * @apiNote {@code POST /binary}
      */
@@ -32,9 +28,4 @@ public interface UndertowEteBinaryService extends UndertowService {
      * @apiNote {@code GET /binary/failure}
      */
     BinaryResponseBody getBinaryFailure(AuthHeader authHeader, int numBytes);
-
-    @Override
-    default List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return EteBinaryServiceEndpoints.of(this).endpoints(runtime);
-    }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
@@ -2,9 +2,6 @@ package com.palantir.product;
 
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
-import com.palantir.conjure.java.undertow.lib.Endpoint;
-import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
-import com.palantir.conjure.java.undertow.lib.UndertowService;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
@@ -15,7 +12,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
-public interface UndertowEteService extends UndertowService {
+public interface UndertowEteService {
     /**
      * foo bar baz.
      * <h2>Very Important Documentation</h2>
@@ -170,9 +167,4 @@ public interface UndertowEteService extends UndertowService {
             Set<StringAliasExample> strings,
             Set<Long> longs,
             Set<Integer> ints);
-
-    @Override
-    default List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return EteServiceEndpoints.of(this).endpoints(runtime);
-    }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowNameCollisionService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowNameCollisionService.java
@@ -1,14 +1,10 @@
 package com.palantir.product;
 
-import com.palantir.conjure.java.undertow.lib.Endpoint;
-import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
-import com.palantir.conjure.java.undertow.lib.UndertowService;
 import com.palantir.tokens.auth.AuthHeader;
-import java.util.List;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
-public interface UndertowNameCollisionService extends UndertowService {
+public interface UndertowNameCollisionService {
     /**
      * @apiNote {@code POST /{runtime}}
      */
@@ -21,9 +17,4 @@ public interface UndertowNameCollisionService extends UndertowService {
             String delegate,
             String result,
             String deserializer);
-
-    @Override
-    default List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return NameCollisionServiceEndpoints.of(this).endpoints(runtime);
-    }
 }

--- a/conjure-java-core/src/test/resources/test/api/AsyncMarkers.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/AsyncMarkers.java.undertow
@@ -1,13 +1,9 @@
 package test.api;
 
-import com.palantir.conjure.java.undertow.lib.Endpoint;
-import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
-import com.palantir.conjure.java.undertow.lib.UndertowService;
-import java.util.List;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
-public interface AsyncMarkers extends UndertowService {
+public interface AsyncMarkers {
     /**
      * @apiNote {@code GET /async}
      */
@@ -17,9 +13,4 @@ public interface AsyncMarkers extends UndertowService {
      * @apiNote {@code GET /sync}
      */
     String sync();
-
-    @Override
-    default List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return AsyncMarkersEndpoints.of(this).endpoints(runtime);
-    }
 }

--- a/conjure-java-core/src/test/resources/test/api/AsyncMarkers.java.undertow.async
+++ b/conjure-java-core/src/test/resources/test/api/AsyncMarkers.java.undertow.async
@@ -1,14 +1,10 @@
 package test.api;
 
 import com.google.common.util.concurrent.ListenableFuture;
-import com.palantir.conjure.java.undertow.lib.Endpoint;
-import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
-import com.palantir.conjure.java.undertow.lib.UndertowService;
-import java.util.List;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
-public interface AsyncMarkers extends UndertowService {
+public interface AsyncMarkers {
     /**
      * @apiNote {@code GET /async}
      */
@@ -18,9 +14,4 @@ public interface AsyncMarkers extends UndertowService {
      * @apiNote {@code GET /sync}
      */
     String sync();
-
-    @Override
-    default List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return AsyncMarkersEndpoints.of(this).endpoints(runtime);
-    }
 }

--- a/conjure-java-core/src/test/resources/test/api/CookieService.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/CookieService.java.undertow
@@ -1,21 +1,12 @@
 package test.api;
 
-import com.palantir.conjure.java.undertow.lib.Endpoint;
-import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
-import com.palantir.conjure.java.undertow.lib.UndertowService;
 import com.palantir.tokens.auth.BearerToken;
-import java.util.List;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
-public interface CookieService extends UndertowService {
+public interface CookieService {
     /**
      * @apiNote {@code GET /cookies}
      */
     void eatCookies(BearerToken cookieToken);
-
-    @Override
-    default List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return CookieServiceEndpoints.of(this).endpoints(runtime);
-    }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
@@ -1,9 +1,6 @@
 package com.palantir.another;
 
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
-import com.palantir.conjure.java.undertow.lib.Endpoint;
-import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
-import com.palantir.conjure.java.undertow.lib.UndertowService;
 import com.palantir.product.AliasedString;
 import com.palantir.product.CreateDatasetRequest;
 import com.palantir.product.NestedAliasedBinary;
@@ -12,7 +9,6 @@ import com.palantir.product.datasets.Dataset;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
 import java.io.InputStream;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -24,7 +20,7 @@ import javax.annotation.Generated;
  * A Markdown description of the service.
  */
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
-public interface TestService extends UndertowService {
+public interface TestService {
     /**
      * Returns a mapping from file system id to backing file system configuration.
      * @apiNote {@code GET /catalog/fileSystems}
@@ -150,9 +146,4 @@ public interface TestService extends UndertowService {
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/strings}
      */
     void getForStrings(AuthHeader authHeader, ResourceIdentifier datasetRid, Set<AliasedString> strings);
-
-    @Override
-    default List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return TestServiceEndpoints.of(this).endpoints(runtime);
-    }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.binary
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.binary
@@ -1,21 +1,12 @@
 package test.api;
 
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
-import com.palantir.conjure.java.undertow.lib.Endpoint;
-import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
-import com.palantir.conjure.java.undertow.lib.UndertowService;
-import java.util.List;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
-public interface TestService extends UndertowService {
+public interface TestService {
     /**
      * @apiNote {@code GET /}
      */
     BinaryResponseBody getBinary();
-
-    @Override
-    default List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return TestServiceEndpoints.of(this).endpoints(runtime);
-    }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.prefix
@@ -1,13 +1,9 @@
 package test.prefix.com.palantir.another;
 
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
-import com.palantir.conjure.java.undertow.lib.Endpoint;
-import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
-import com.palantir.conjure.java.undertow.lib.UndertowService;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
 import java.io.InputStream;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -24,7 +20,7 @@ import test.prefix.com.palantir.product.datasets.Dataset;
  * A Markdown description of the service.
  */
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
-public interface TestService extends UndertowService {
+public interface TestService {
     /**
      * Returns a mapping from file system id to backing file system configuration.
      * @apiNote {@code GET /catalog/fileSystems}
@@ -150,9 +146,4 @@ public interface TestService extends UndertowService {
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/strings}
      */
     void getForStrings(AuthHeader authHeader, ResourceIdentifier datasetRid, Set<AliasedString> strings);
-
-    @Override
-    default List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return TestServiceEndpoints.of(this).endpoints(runtime);
-    }
 }

--- a/conjure-java-server-verifier/src/test/java/com/palantir/conjure/java/verification/server/AutoDeserializeTest.java
+++ b/conjure-java-server-verifier/src/test/java/com/palantir/conjure/java/verification/server/AutoDeserializeTest.java
@@ -52,12 +52,8 @@ public final class AutoDeserializeTest {
             Resources.getResource("config.yml").getPath());
 
     @RegisterExtension
-    public static final UndertowServerUnderTestExtension undertowServerUnderTestWithWrapper =
-            new UndertowServerUnderTestExtension(true);
-
-    @RegisterExtension
-    public static final UndertowServerUnderTestExtension undertowServerUnderTestWithoutWrapper =
-            new UndertowServerUnderTestExtension(false);
+    public static final UndertowServerUnderTestExtension undertowServerUnderTest =
+            new UndertowServerUnderTestExtension();
 
     @RegisterExtension
     public static final VerificationClientExtension VERIFICATION_CLIENT_EXTENSION = new VerificationClientExtension();
@@ -99,16 +95,8 @@ public final class AutoDeserializeTest {
     }
 
     @AutoDeserializeTestCases
-    public void runUndertowWithEndpointsWrapperTestCase(
-            EndpointName endpointName, int index, boolean shouldSucceed, String jsonString) {
-        runTestCase(endpointName, index, shouldSucceed, jsonString, undertowServerUnderTestWithWrapper.getLocalPort());
-    }
-
-    @AutoDeserializeTestCases
-    public void runUndertowWithoutEndpointsWrapperTestCase(
-            EndpointName endpointName, int index, boolean shouldSucceed, String jsonString) {
-        runTestCase(
-                endpointName, index, shouldSucceed, jsonString, undertowServerUnderTestWithoutWrapper.getLocalPort());
+    public void runUndertowTestCase(EndpointName endpointName, int index, boolean shouldSucceed, String jsonString) {
+        runTestCase(endpointName, index, shouldSucceed, jsonString, undertowServerUnderTest.getLocalPort());
     }
 
     public void runTestCase(EndpointName endpointName, int index, boolean shouldSucceed, String jsonString, int port) {

--- a/conjure-java-server-verifier/src/test/java/com/palantir/conjure/java/verification/server/undertest/EchoResourceInvocationHandler.java
+++ b/conjure-java-server-verifier/src/test/java/com/palantir/conjure/java/verification/server/undertest/EchoResourceInvocationHandler.java
@@ -19,11 +19,6 @@ package com.palantir.conjure.java.verification.server.undertest;
 import com.google.common.base.Preconditions;
 import com.google.common.reflect.AbstractInvocationHandler;
 import com.palantir.conjure.java.com.palantir.conjure.verification.client.AutoDeserializeService;
-import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeRuntimeException;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 
@@ -32,25 +27,9 @@ import java.lang.reflect.Method;
  * parameter.
  */
 final class EchoResourceInvocationHandler extends AbstractInvocationHandler {
-
     @Override
-    protected Object handleInvocation(Object proxy, Method method, Object[] args) throws Throwable {
-        if (method.isDefault()) {
-            return getMethodHandle(method).bindTo(proxy).invokeWithArguments(args);
-        }
+    protected Object handleInvocation(Object _proxy, Method method, Object[] args) {
         Preconditions.checkArgument(args.length == 1, "Expected single argument. Method: %s", method);
         return com.palantir.logsafe.Preconditions.checkNotNull(args[0], "Null values are not allowed");
-    }
-
-    private static MethodHandle getMethodHandle(Method method) {
-        Class<?> declaringClass = method.getDeclaringClass();
-        try {
-            Constructor<MethodHandles.Lookup> constructor =
-                    MethodHandles.Lookup.class.getDeclaredConstructor(Class.class);
-            constructor.setAccessible(true);
-            return constructor.newInstance(declaringClass).unreflectSpecial(method, declaringClass);
-        } catch (ReflectiveOperationException e) {
-            throw new SafeRuntimeException("Failed to find method handle", e, SafeArg.of("method", method));
-        }
     }
 }

--- a/conjure-java-server-verifier/src/test/java/com/palantir/conjure/java/verification/server/undertest/UndertowServerUnderTestExtension.java
+++ b/conjure-java-server-verifier/src/test/java/com/palantir/conjure/java/verification/server/undertest/UndertowServerUnderTestExtension.java
@@ -33,16 +33,13 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 public final class UndertowServerUnderTestExtension implements BeforeAllCallback, AfterAllCallback {
 
-    private final boolean useEndpointsWrapper;
     private Undertow server;
-
-    public UndertowServerUnderTestExtension(boolean useEndpointsWrapper) {
-        this.useEndpointsWrapper = useEndpointsWrapper;
-    }
 
     @Override
     public void beforeAll(ExtensionContext _context) {
-        UndertowService service = getAutoDeserializeService();
+        UndertowAutoDeserializeService autoDeserialize =
+                Reflection.newProxy(UndertowAutoDeserializeService.class, new EchoResourceInvocationHandler());
+        UndertowService service = AutoDeserializeServiceEndpoints.of(autoDeserialize);
 
         HttpHandler handler = ConjureHandler.builder()
                 .addAllEndpoints(
@@ -67,14 +64,5 @@ public final class UndertowServerUnderTestExtension implements BeforeAllCallback
         return ((InetSocketAddress)
                         Iterables.getOnlyElement(server.getListenerInfo()).getAddress())
                 .getPort();
-    }
-
-    private UndertowService getAutoDeserializeService() {
-        UndertowAutoDeserializeService autoDeserialize =
-                Reflection.newProxy(UndertowAutoDeserializeService.class, new EchoResourceInvocationHandler());
-        if (useEndpointsWrapper) {
-            return AutoDeserializeServiceEndpoints.of(autoDeserialize);
-        }
-        return autoDeserialize;
     }
 }


### PR DESCRIPTION
## After this PR

Revert https://github.com/palantir/conjure-java/pull/975.

There are some risky edge cases we did not consider in the initial PR:

* Services implementing both UndertowService interfaces and Jersey interfaces need to cast when registering their service `server.api((Object) service)` as it won't register the jersey service otherwise.
* Changing `server.api(FooEndpoints.of(Proxy.wrap(impl)))` to `server.api(Proxy.wrap(impl))` would ignore the proxy.

==COMMIT_MSG==
Revert generated undertow service interfaces extend UndertowService now
==COMMIT_MSG==