### PR TITLE
SafeExchangeCompletionListener also catches failures from `next.proceed()`

### DIFF
--- a/changelog/@unreleased/pr-999.v2.yml
+++ b/changelog/@unreleased/pr-999.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: SafeExchangeCompletionListener also catches failures from `next.proceed()`
+  links:
+  - https://github.com/palantir/conjure-java/pull/999

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/SafeExchangeCompletionListener.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/SafeExchangeCompletionListener.java
@@ -47,7 +47,11 @@ public final class SafeExchangeCompletionListener implements ExchangeCompletionL
         } catch (RuntimeException | Error e) {
             log.error("ExchangeCompletionListener threw an exception", e);
         } finally {
-            nextListener.proceed();
+            try {
+                nextListener.proceed();
+            } catch (RuntimeException | Error e) {
+                log.error("NextListener.proceed threw an exception", e);
+            }
         }
     }
 }

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/SafeExchangeCompletionListenerTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/SafeExchangeCompletionListenerTest.java
@@ -68,4 +68,14 @@ public class SafeExchangeCompletionListenerTest {
         Mockito.verify(nextListener).proceed();
         Mockito.verifyNoMoreInteractions(nextListener, action);
     }
+
+    @Test
+    public void test_proceedThrowsRuntimeException() {
+        Mockito.doThrow(new SafeIllegalArgumentException()).when(nextListener).proceed();
+        ExchangeCompletionListener listener = SafeExchangeCompletionListener.of(action);
+        listener.exchangeEvent(exchange, nextListener);
+        Mockito.verify(action).accept(exchange);
+        Mockito.verify(nextListener).proceed();
+        Mockito.verifyNoMoreInteractions(nextListener, action);
+    }
 }


### PR DESCRIPTION
==COMMIT_MSG==
SafeExchangeCompletionListener also catches failures from `next.proceed()`
==COMMIT_MSG==

