### PR TITLE
Fix for large values w/ double alias

### DIFF
--- a/changelog/@unreleased/pr-1006.v2.yml
+++ b/changelog/@unreleased/pr-1006.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix for bug with alias'd doubles with whole numbers larger than 2^31
+  links:
+  - https://github.com/palantir/conjure-java/pull/1006

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
@@ -2,6 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.conjure.java.lib.SafeLong;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -44,7 +45,8 @@ public final class DoubleAliasExample {
 
     @JsonCreator
     public static DoubleAliasExample of(long value) {
-        return new DoubleAliasExample((double) value);
+        long safeValue = SafeLong.of(value).longValue();
+        return new DoubleAliasExample((double) safeValue);
     }
 
     @JsonCreator

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
@@ -43,12 +43,12 @@ public final class DoubleAliasExample {
     }
 
     @JsonCreator
-    public static DoubleAliasExample of(int value) {
+    public static DoubleAliasExample of(long value) {
         return new DoubleAliasExample((double) value);
     }
 
     @JsonCreator
-    public static DoubleAliasExample of(long value) {
+    public static DoubleAliasExample of(int value) {
         return new DoubleAliasExample((double) value);
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
@@ -48,6 +48,11 @@ public final class DoubleAliasExample {
     }
 
     @JsonCreator
+    public static DoubleAliasExample of(long value) {
+        return new DoubleAliasExample((double) value);
+    }
+
+    @JsonCreator
     public static DoubleAliasExample of(String value) {
         switch (value) {
             case "NaN":

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleAliasExample.java
@@ -2,6 +2,7 @@ package test.prefix.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.conjure.java.lib.SafeLong;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -44,7 +45,8 @@ public final class DoubleAliasExample {
 
     @JsonCreator
     public static DoubleAliasExample of(long value) {
-        return new DoubleAliasExample((double) value);
+        long safeValue = SafeLong.of(value).longValue();
+        return new DoubleAliasExample((double) safeValue);
     }
 
     @JsonCreator

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleAliasExample.java
@@ -43,6 +43,11 @@ public final class DoubleAliasExample {
     }
 
     @JsonCreator
+    public static DoubleAliasExample of(long value) {
+        return new DoubleAliasExample((double) value);
+    }
+
+    @JsonCreator
     public static DoubleAliasExample of(int value) {
         return new DoubleAliasExample((double) value);
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -127,6 +127,14 @@ public final class AliasGenerator {
             spec.addMethod(MethodSpec.methodBuilder("of")
                     .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                     .addAnnotation(JsonCreator.class)
+                    .addParameter(TypeName.LONG, "value")
+                    .returns(thisClass)
+                    .addCode(codeBlock)
+                    .build());
+
+            spec.addMethod(MethodSpec.methodBuilder("of")
+                    .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                    .addAnnotation(JsonCreator.class)
                     .addParameter(TypeName.INT, "value")
                     .returns(thisClass)
                     .addCode(codeBlock)

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/AliasTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/AliasTests.java
@@ -19,13 +19,18 @@ package com.palantir.conjure.java.types;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.logsafe.exceptions.SafeNullPointerException;
+import com.palantir.product.DoubleAliasExample;
 import com.palantir.product.ExternalLongAliasOne;
 import com.palantir.product.ExternalLongAliasTwo;
 import com.palantir.product.UuidAliasExample;
 import org.junit.jupiter.api.Test;
 
 public class AliasTests {
+    private static final ObjectMapper TEST_MAPPER = ObjectMappers.newServerObjectMapper();
 
     @Test
     public void testNullValueSafeLoggable() {
@@ -42,5 +47,19 @@ public class AliasTests {
     @Test
     public void testValueOf_externalNested() {
         assertThat(ExternalLongAliasTwo.valueOf("3")).isEqualTo(ExternalLongAliasTwo.of(ExternalLongAliasOne.of(3L)));
+    }
+
+    @Test
+    public void testValueOf_largeDouble_double() throws JsonProcessingException {
+        // Doesn't fit in an int, but does fit comfortably in a double
+        assertThat(TEST_MAPPER.readValue("9667500000.0", DoubleAliasExample.class))
+                .isEqualTo(DoubleAliasExample.of(9667500000.0));
+    }
+
+    @Test
+    public void testValueOf_largeDouble_long() throws JsonProcessingException {
+        // Doesn't fit in an int, but does fit comfortably in a double; looks like a long
+        assertThat(TEST_MAPPER.readValue("9667500000", DoubleAliasExample.class))
+                .isEqualTo(DoubleAliasExample.of(9667500000.0));
     }
 }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/AliasTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/AliasTests.java
@@ -50,6 +50,13 @@ public class AliasTests {
     }
 
     @Test
+    public void testValueOf_largeDouble_lossyDouble() throws JsonProcessingException {
+        // So large it doesn't fit in a double; jackson silently drops precision
+        assertThat(TEST_MAPPER.readValue("9007199254740992.234", DoubleAliasExample.class))
+                .isEqualTo(DoubleAliasExample.of(9007199254740992.0));
+    }
+
+    @Test
     public void testValueOf_largeDouble_double() throws JsonProcessingException {
         // Doesn't fit in an int, but does fit comfortably in a double
         assertThat(TEST_MAPPER.readValue("9667500000.0", DoubleAliasExample.class))


### PR DESCRIPTION
## Before this PR

For a conjure alias of double, whole numbers larger than 2^31 would fail to deserialize (see `testValueOf_largeDouble_long`). This is because there was a `@JsonCreator` for int and one for double, but not for long.

Relevant internal tickets: PDS-126734, PDS-126642

## After this PR
==COMMIT_MSG==
Fix for bug with alias'd doubles with whole numbers larger than 2^31
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

