### PR TITLE
Tweak double equality around NaN, negative zero

### DIFF
--- a/changelog/@unreleased/pr-1018.v2.yml
+++ b/changelog/@unreleased/pr-1018.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: |-
+    Conjure types involving `double` now have more sane behaviour:
+    - for negative zero: `0.0d` is no longer considered equal to `-0.0d` (previously it was)
+    - `NaN` values produced in different ways are now considered to be equal (e.g. `Math.sqrt(-1)` and `0d/0d`)
+  links:
+  - https://github.com/palantir/conjure-java/pull/1018

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
@@ -26,7 +26,9 @@ public final class DoubleAliasExample {
     @Override
     public boolean equals(Object other) {
         return this == other
-                || (other instanceof DoubleAliasExample && this.value == ((DoubleAliasExample) other).value);
+                || (other instanceof DoubleAliasExample
+                        && Double.doubleToLongBits(this.value)
+                                == Double.doubleToLongBits(((DoubleAliasExample) other).value));
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
@@ -29,7 +29,7 @@ public final class DoubleExample {
     }
 
     private boolean equalTo(DoubleExample other) {
-        return this.doubleValue == other.doubleValue;
+        return Double.doubleToLongBits(this.doubleValue) == Double.doubleToLongBits(other.doubleValue);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -136,7 +136,7 @@ public final class ManyFieldExample {
     private boolean equalTo(ManyFieldExample other) {
         return this.string.equals(other.string)
                 && this.integer == other.integer
-                && this.doubleValue == other.doubleValue
+                && Double.doubleToLongBits(this.doubleValue) == Double.doubleToLongBits(other.doubleValue)
                 && this.optionalItem.equals(other.optionalItem)
                 && this.items.equals(other.items)
                 && this.set.equals(other.set)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleAliasExample.java
@@ -26,7 +26,9 @@ public final class DoubleAliasExample {
     @Override
     public boolean equals(Object other) {
         return this == other
-                || (other instanceof DoubleAliasExample && this.value == ((DoubleAliasExample) other).value);
+                || (other instanceof DoubleAliasExample
+                        && Double.doubleToLongBits(this.value)
+                                == Double.doubleToLongBits(((DoubleAliasExample) other).value));
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleExample.java
@@ -30,7 +30,7 @@ public final class DoubleExample {
     }
 
     private boolean equalTo(DoubleExample other) {
-        return this.doubleValue == other.doubleValue;
+        return Double.doubleToLongBits(this.doubleValue) == Double.doubleToLongBits(other.doubleValue);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
@@ -137,7 +137,7 @@ public final class ManyFieldExample {
     private boolean equalTo(ManyFieldExample other) {
         return this.string.equals(other.string)
                 && this.integer == other.integer
-                && this.doubleValue == other.doubleValue
+                && Double.doubleToLongBits(this.doubleValue) == Double.doubleToLongBits(other.doubleValue)
                 && this.optionalItem.equals(other.optionalItem)
                 && this.items.equals(other.items)
                 && this.set.equals(other.set)

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -75,6 +75,16 @@ public final class WireFormatTests {
     }
 
     @Test
+    public void double_alias_should_deserialize_negative_zero() throws IOException {
+        DoubleAliasExample conjureType = mapper.readValue("-0.0", DoubleAliasExample.class);
+        assertThat(conjureType).hasToString("-0.0");
+        assertThat(conjureType).isEqualTo(DoubleAliasExample.of(-0.0d));
+        assertThat(conjureType)
+                .describedAs("Java is weird: == gets this wrong, but .equals gets it right")
+                .isNotEqualTo(DoubleAliasExample.of(0.0d));
+    }
+
+    @Test
     public void double_alias_should_deserialize_infinity() throws IOException {
         assertThat(mapper.readValue("\"Infinity\"", DoubleAliasExample.class).get())
                 .isEqualTo(Double.POSITIVE_INFINITY);


### PR DESCRIPTION
## Before this PR

@padamowicz raised a question in #dev-foundry-infra about doubles, and it was noted that in [RFC 005](https://palantir.github.io/conjure/#/docs/rfc/005-handling-double-nan-and-infinity), we acknowledged that:

> java has inconsistent behaviour here between unboxed and boxed variants - we want the boxed behaviour.

```
// Java handles zero equality differently for unboxed and boxed values!
System.out.println(0.0d == -0.0d); // prints 'true'
System.out.println(new Double(0.0d).equals(new Double(-0.0d))); // prints 'false'
```

However our beans and aliases still use the surprising `==`, NOT the more sane boxed behaviour.

## After this PR
==COMMIT_MSG==
Conjure types involving `double` now have more sane behaviour:
- for negative zero: `0.0d` is no longer considered equal to `-0.0d` (previously it was)
- `NaN` values produced in different ways are now considered to be equal (e.g. `Math.sqrt(-1)` and `0d/0d`)

==COMMIT_MSG==

Open question
 - ~do we need to do this for the hashcode too?~ Edit: no, seems like Double.hashCode does the right thing already:
```java
    public static int hashCode(double value) {
        long bits = doubleToLongBits(value);
        return (int)(bits ^ (bits >>> 32));
    }
```
 - do we need to major rev for this?

(Just in case you're interested:

```
        double d1 = 0.0d / 0.0d;
        double d2 = Math.sqrt(-1);
        System.out.println(d1 + " " + Double.doubleToRawLongBits(d1) + " " + Double.doubleToLongBits(d1));
        System.out.println(d2 + " " + Double.doubleToRawLongBits(d2) + " " + Double.doubleToLongBits(d2));
```
Prints:
```
NaN 9221120237041090560 9221120237041090560
NaN -2251799813685248 9221120237041090560
```

## Possible downsides?


