### PR TITLE
conjure-undertow drains request bytes prior to writing responses

### DIFF
--- a/changelog/@unreleased/pr-1022.v2.yml
+++ b/changelog/@unreleased/pr-1022.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: conjure-undertow drains request bytes prior to writing responses
+  links:
+  - https://github.com/palantir/conjure-java/pull/1022

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteBinaryEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteBinaryEndpoints.java
@@ -41,6 +41,36 @@ enum DialogueEteBinaryEndpoints implements Endpoint {
         }
     },
 
+    postBinaryThrows {
+        private final PathTemplate pathTemplate =
+                PathTemplate.builder().fixed("binary").fixed("throws").build();
+
+        @Override
+        public void renderPath(Map<String, String> params, UrlBuilder url) {
+            pathTemplate.fill(params, url);
+        }
+
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.POST;
+        }
+
+        @Override
+        public String serviceName() {
+            return "EteBinaryService";
+        }
+
+        @Override
+        public String endpointName() {
+            return "postBinaryThrows";
+        }
+
+        @Override
+        public String version() {
+            return "1.2.3";
+        }
+    },
+
     getOptionalBinaryPresent {
         private final PathTemplate pathTemplate = PathTemplate.builder()
                 .fixed("binary")

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryService.java
@@ -26,6 +26,15 @@ public interface EteBinaryService {
     @Consumes(MediaType.APPLICATION_OCTET_STREAM)
     StreamingOutput postBinary(@HeaderParam("Authorization") @NotNull AuthHeader authHeader, @NotNull InputStream body);
 
+    @POST
+    @Path("binary/throws")
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    @Consumes(MediaType.APPLICATION_OCTET_STREAM)
+    StreamingOutput postBinaryThrows(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @QueryParam("bytesToRead") int bytesToRead,
+            @NotNull InputStream body);
+
     @GET
     @Path("binary/optional/present")
     @Produces(MediaType.APPLICATION_OCTET_STREAM)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceAsync.java
@@ -24,6 +24,11 @@ public interface EteBinaryServiceAsync {
     ListenableFuture<InputStream> postBinary(AuthHeader authHeader, BinaryRequestBody body);
 
     /**
+     * @apiNote {@code POST /binary/throws}
+     */
+    ListenableFuture<InputStream> postBinaryThrows(AuthHeader authHeader, int bytesToRead, BinaryRequestBody body);
+
+    /**
      * @apiNote {@code GET /binary/optional/present}
      */
     ListenableFuture<Optional<InputStream>> getOptionalBinaryPresent(AuthHeader authHeader);
@@ -49,6 +54,9 @@ public interface EteBinaryServiceAsync {
             private final EndpointChannel postBinaryChannel =
                     _endpointChannelFactory.endpoint(DialogueEteBinaryEndpoints.postBinary);
 
+            private final EndpointChannel postBinaryThrowsChannel =
+                    _endpointChannelFactory.endpoint(DialogueEteBinaryEndpoints.postBinaryThrows);
+
             private final EndpointChannel getOptionalBinaryPresentChannel =
                     _endpointChannelFactory.endpoint(DialogueEteBinaryEndpoints.getOptionalBinaryPresent);
 
@@ -66,6 +74,20 @@ public interface EteBinaryServiceAsync {
                 return _runtime.clients()
                         .call(
                                 postBinaryChannel,
+                                _request.build(),
+                                _runtime.bodySerDe().inputStreamDeserializer());
+            }
+
+            @Override
+            public ListenableFuture<InputStream> postBinaryThrows(
+                    AuthHeader authHeader, int bytesToRead, BinaryRequestBody body) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.body(_runtime.bodySerDe().serialize(body));
+                _request.putQueryParams("bytesToRead", _plainSerDe.serializeInteger(bytesToRead));
+                return _runtime.clients()
+                        .call(
+                                postBinaryThrowsChannel,
                                 _request.build(),
                                 _runtime.bodySerDe().inputStreamDeserializer());
             }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceBlocking.java
@@ -22,6 +22,11 @@ public interface EteBinaryServiceBlocking {
     InputStream postBinary(AuthHeader authHeader, BinaryRequestBody body);
 
     /**
+     * @apiNote {@code POST /binary/throws}
+     */
+    InputStream postBinaryThrows(AuthHeader authHeader, int bytesToRead, BinaryRequestBody body);
+
+    /**
      * @apiNote {@code GET /binary/optional/present}
      */
     Optional<InputStream> getOptionalBinaryPresent(AuthHeader authHeader);
@@ -47,6 +52,12 @@ public interface EteBinaryServiceBlocking {
             @MustBeClosed
             public InputStream postBinary(AuthHeader authHeader, BinaryRequestBody body) {
                 return _runtime.clients().block(delegate.postBinary(authHeader, body));
+            }
+
+            @Override
+            @MustBeClosed
+            public InputStream postBinaryThrows(AuthHeader authHeader, int bytesToRead, BinaryRequestBody body) {
+                return _runtime.clients().block(delegate.postBinaryThrows(authHeader, bytesToRead, body));
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceRetrofit.java
@@ -21,6 +21,14 @@ public interface EteBinaryServiceRetrofit {
     @Streaming
     ListenableFuture<ResponseBody> postBinary(@Header("Authorization") AuthHeader authHeader, @Body RequestBody body);
 
+    @POST("./binary/throws")
+    @Headers({"hr-path-template: /binary/throws", "Accept: application/octet-stream"})
+    @Streaming
+    ListenableFuture<ResponseBody> postBinaryThrows(
+            @Header("Authorization") AuthHeader authHeader,
+            @Query("bytesToRead") int bytesToRead,
+            @Body RequestBody body);
+
     @GET("./binary/optional/present")
     @Headers({"hr-path-template: /binary/optional/present", "Accept: application/octet-stream"})
     @Streaming

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteBinaryService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteBinaryService.java
@@ -14,6 +14,11 @@ public interface UndertowEteBinaryService {
     BinaryResponseBody postBinary(AuthHeader authHeader, InputStream body);
 
     /**
+     * @apiNote {@code POST /binary/throws}
+     */
+    BinaryResponseBody postBinaryThrows(AuthHeader authHeader, int bytesToRead, InputStream body);
+
+    /**
      * @apiNote {@code GET /binary/optional/present}
      */
     Optional<BinaryResponseBody> getOptionalBinaryPresent(AuthHeader authHeader);

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/EteBinaryResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/EteBinaryResource.java
@@ -43,7 +43,7 @@ final class EteBinaryResource implements EteBinaryService {
             @NotNull AuthHeader authHeader, int bytesToRead, @NotNull InputStream body) {
         if (bytesToRead > 0) {
             try {
-                ByteStreams.copy(ByteStreams.limit(body, bytesToRead), ByteStreams.nullOutputStream());
+                ByteStreams.exhaust(ByteStreams.limit(body, bytesToRead));
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/EteBinaryResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/EteBinaryResource.java
@@ -16,20 +16,40 @@
 
 package com.palantir.conjure.java;
 
+import com.google.common.base.Strings;
 import com.google.common.io.ByteStreams;
+import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.ServiceException;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.product.EteBinaryService;
 import com.palantir.tokens.auth.AuthHeader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.Random;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.StreamingOutput;
 
 final class EteBinaryResource implements EteBinaryService {
     @Override
     public StreamingOutput postBinary(AuthHeader _authHeader, InputStream body) {
         return output -> output.write(ByteStreams.toByteArray(body));
+    }
+
+    @Override
+    public StreamingOutput postBinaryThrows(
+            @NotNull AuthHeader authHeader, int bytesToRead, @NotNull InputStream body) {
+        if (bytesToRead > 0) {
+            try {
+                ByteStreams.copy(ByteStreams.limit(body, bytesToRead), ByteStreams.nullOutputStream());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        throw new ServiceException(
+                ErrorType.INVALID_ARGUMENT, SafeArg.of("large", Strings.repeat("Hello, World!", 1024 * 1024)));
     }
 
     @Override

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowBinaryResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowBinaryResource.java
@@ -43,7 +43,7 @@ final class UndertowBinaryResource implements UndertowEteBinaryService {
             @NotNull AuthHeader authHeader, int bytesToRead, @NotNull InputStream body) {
         if (bytesToRead > 0) {
             try {
-                ByteStreams.copy(ByteStreams.limit(body, bytesToRead), ByteStreams.nullOutputStream());
+                ByteStreams.exhaust(ByteStreams.limit(body, bytesToRead));
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/conjure-java-core/src/test/resources/ete-binary.yml
+++ b/conjure-java-core/src/test/resources/ete-binary.yml
@@ -10,6 +10,14 @@ services:
         args:
           body: binary
         returns: binary
+      postBinaryThrows:
+        http: POST /throws
+        args:
+          body: binary
+          bytesToRead:
+            param-type: query
+            type: integer
+        returns: binary
       getOptionalBinaryPresent:
         http: GET /optional/present
         returns: optional<binary>


### PR DESCRIPTION
Note that we already effectively provide this behavior when the
response is sufficiently small (fits into some combination of the
web server and system buffers) where the request is drained after
the response has been sent. This change allows us to provide the
same behavior in the presence of large responses.

==COMMIT_MSG==
conjure-undertow drains request bytes prior to writing responses
==COMMIT_MSG==

