### PR TITLE
improvement: dialogue interfaces ignore undertow async marker

### DIFF
--- a/changelog/@unreleased/pr-1034.v2.yml
+++ b/changelog/@unreleased/pr-1034.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue interfaces ignore undertow async marker
+  links:
+  - https://github.com/palantir/conjure-java/pull/1034

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/IsUndertowAsyncMarkerVisitor.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/IsUndertowAsyncMarkerVisitor.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.services;
+
+import com.google.common.annotations.Beta;
+import com.palantir.conjure.java.visitor.DefaultTypeVisitor;
+import com.palantir.conjure.spec.ExternalReference;
+
+@Beta
+public final class IsUndertowAsyncMarkerVisitor extends DefaultTypeVisitor<Boolean> {
+    public static final IsUndertowAsyncMarkerVisitor INSTANCE = new IsUndertowAsyncMarkerVisitor();
+
+    @Override
+    public Boolean visitExternal(ExternalReference value) {
+        return "Async".equals(value.getExternalReference().getName());
+    }
+
+    @Override
+    public Boolean visitDefault() {
+        return false;
+    }
+}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowTypeFunctions.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowTypeFunctions.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.java.services;
 
-import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -234,21 +233,6 @@ final class UndertowTypeFunctions {
                         .map(mapper::getClassName)
                         .orElseGet(() -> ClassName.get(Void.class))
                         .box());
-    }
-
-    @Beta
-    private static final class IsUndertowAsyncMarkerVisitor extends DefaultTypeVisitor<Boolean> {
-        static final IsUndertowAsyncMarkerVisitor INSTANCE = new IsUndertowAsyncMarkerVisitor();
-
-        @Override
-        public Boolean visitExternal(ExternalReference value) {
-            return "Async".equals(value.getExternalReference().getName());
-        }
-
-        @Override
-        public Boolean visitDefault() {
-            return false;
-        }
     }
 
     private UndertowTypeFunctions() {}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
@@ -132,7 +132,7 @@ public final class DialogueInterfaceGenerator {
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                 .addParameters(parameterTypes.methodParams(endpointDef));
         endpointDef.getMarkers().stream()
-                .filter(marker -> marker.accept(IsUndertowAsyncMarkerVisitor.INSTANCE))
+                .filter(marker -> !marker.accept(IsUndertowAsyncMarkerVisitor.INSTANCE))
                 .map(marker -> {
                     Preconditions.checkState(
                             marker.accept(TypeVisitor.IS_REFERENCE),


### PR DESCRIPTION
## Before this PR
We would generate dialogue interfaces with a non-existant annotation if users chose to use the experimentalUndertowAsyncMarker

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Dialogue interfaces ignore undertow async marker
==COMMIT_MSG==

## Possible downsides?
N/A

