### PR TITLE
Generated objects memoized hash code is not volatile

### DIFF
--- a/changelog/@unreleased/pr-1038.v2.yml
+++ b/changelog/@unreleased/pr-1038.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Generated objects memoized hash code is not volatile
+  links:
+  - https://github.com/palantir/conjure-java/pull/1038

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
@@ -33,7 +33,7 @@ public final class AliasAsMapKeyExample {
 
     private final Map<UuidAliasExample, ManyFieldExample> uuids;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private AliasAsMapKeyExample(
             Map<StringAliasExample, ManyFieldExample> strings,

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
@@ -21,7 +21,7 @@ import javax.annotation.Nonnull;
 public final class AnyMapExample {
     private final Map<String, Object> items;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private AnyMapExample(Map<String, Object> items) {
         validateFields(items);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
@@ -23,7 +23,7 @@ public final class CovariantListExample {
 
     private final List<ExampleExternalReference> externalItems;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private CovariantListExample(List<Object> items, List<ExampleExternalReference> externalItems) {
         validateFields(items, externalItems);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
@@ -23,7 +23,7 @@ public final class CovariantOptionalExample {
 
     private final Optional<Set<StringAliasExample>> setItem;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private CovariantOptionalExample(Optional<Object> item, Optional<Set<StringAliasExample>> setItem) {
         validateFields(item, setItem);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
@@ -18,7 +18,7 @@ import javax.annotation.Nonnull;
 public final class DateTimeExample {
     private final OffsetDateTime datetime;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private DateTimeExample(OffsetDateTime datetime) {
         validateFields(datetime);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -26,7 +26,7 @@ public final class ExternalLongExample {
 
     private final List<Long> listExternalLong;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private ExternalLongExample(long externalLong, Optional<Long> optionalExternalLong, List<Long> listExternalLong) {
         validateFields(optionalExternalLong, listExternalLong);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
@@ -31,7 +31,7 @@ public final class ListExample {
 
     private final List<List<String>> nestedItems;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private ListExample(
             List<String> items,

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -39,7 +39,7 @@ public final class ManyFieldExample {
 
     private final StringAliasExample alias;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private ManyFieldExample(
             String string,

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
@@ -26,7 +26,7 @@ public final class MapExample {
 
     private final Map<String, OptionalAlias> aliasOptionalItems;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private MapExample(
             Map<String, String> items,

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
@@ -37,7 +37,7 @@ public final class PrimitiveOptionalsExample {
 
     private final Optional<UUID> uuid;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private PrimitiveOptionalsExample(
             OptionalDouble num,

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -27,7 +27,7 @@ public final class ReservedKeyExample {
 
     private final int result;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private ReservedKeyExample(
             String package_,

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
@@ -24,7 +24,7 @@ public final class SetExample {
 
     private final Set<Double> doubleItems;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private SetExample(Set<String> items, Set<Double> doubleItems) {
         validateFields(items, doubleItems);

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AliasAsMapKeyExample.java
@@ -34,7 +34,7 @@ public final class AliasAsMapKeyExample {
 
     private final Map<UuidAliasExample, ManyFieldExample> uuids;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private AliasAsMapKeyExample(
             Map<StringAliasExample, ManyFieldExample> strings,

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyMapExample.java
@@ -22,7 +22,7 @@ import javax.annotation.Nonnull;
 public final class AnyMapExample {
     private final Map<String, Object> items;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private AnyMapExample(Map<String, Object> items) {
         validateFields(items);

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
@@ -24,7 +24,7 @@ public final class CovariantListExample {
 
     private final List<ExampleExternalReference> externalItems;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private CovariantListExample(List<Object> items, List<ExampleExternalReference> externalItems) {
         validateFields(items, externalItems);

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantOptionalExample.java
@@ -24,7 +24,7 @@ public final class CovariantOptionalExample {
 
     private final Optional<Set<StringAliasExample>> setItem;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private CovariantOptionalExample(Optional<Object> item, Optional<Set<StringAliasExample>> setItem) {
         validateFields(item, setItem);

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeExample.java
@@ -19,7 +19,7 @@ import javax.annotation.Nonnull;
 public final class DateTimeExample {
     private final OffsetDateTime datetime;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private DateTimeExample(OffsetDateTime datetime) {
         validateFields(datetime);

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
@@ -27,7 +27,7 @@ public final class ExternalLongExample {
 
     private final List<Long> listExternalLong;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private ExternalLongExample(long externalLong, Optional<Long> optionalExternalLong, List<Long> listExternalLong) {
         validateFields(optionalExternalLong, listExternalLong);

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListExample.java
@@ -32,7 +32,7 @@ public final class ListExample {
 
     private final List<List<String>> nestedItems;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private ListExample(
             List<String> items,

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
@@ -40,7 +40,7 @@ public final class ManyFieldExample {
 
     private final StringAliasExample alias;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private ManyFieldExample(
             String string,

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapExample.java
@@ -27,7 +27,7 @@ public final class MapExample {
 
     private final Map<String, OptionalAlias> aliasOptionalItems;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private MapExample(
             Map<String, String> items,

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
@@ -38,7 +38,7 @@ public final class PrimitiveOptionalsExample {
 
     private final Optional<UUID> uuid;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private PrimitiveOptionalsExample(
             OptionalDouble num,

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReservedKeyExample.java
@@ -28,7 +28,7 @@ public final class ReservedKeyExample {
 
     private final int result;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private ReservedKeyExample(
             String package_,

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetExample.java
@@ -25,7 +25,7 @@ public final class SetExample {
 
     private final Set<Double> doubleItems;
 
-    private volatile int memoizedHashCode;
+    private int memoizedHashCode;
 
     private SetExample(Set<String> items, Set<Double> doubleItems) {
         validateFields(items, doubleItems);

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/MethodSpecs.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/MethodSpecs.java
@@ -89,8 +89,7 @@ public final class MethodSpecs {
     }
 
     public static void addCachedHashCode(TypeSpec.Builder typeBuilder, Collection<FieldSpec> fields) {
-        FieldSpec.Builder hashFieldSpec =
-                FieldSpec.builder(TypeName.INT, "memoizedHashCode", Modifier.PRIVATE, Modifier.VOLATILE);
+        FieldSpec.Builder hashFieldSpec = FieldSpec.builder(TypeName.INT, "memoizedHashCode", Modifier.PRIVATE);
         typeBuilder.addField(hashFieldSpec.build());
 
         typeBuilder.addMethod(MethodSpec.methodBuilder("hashCode")


### PR DESCRIPTION
The Java memory model does not allow word tearing and we don't
expect concurrent hashing across threads. In cases where that
occurs there is already a race that allows multiple computations,
which are relatively inexpensive.

See [String.java](https://github.com/openjdk/jdk/blob/1f63603288670e6a01ae52930fc7daeec5b15ffc/src/java.base/share/classes/java/lang/String.java#L164-L165) for a similar example. Note that they use a second field to track whether the hash code result was zero to prevent adversarial inputs from producing poor performance (denial of service), which isn't important in our case.

## After this PR
==COMMIT_MSG==
Generated objects memoized hash code is not volatile
==COMMIT_MSG==

