### PR TITLE
fix #1050: Undertow endpoints disallow request body collections with null values

### DIFF
--- a/changelog/@unreleased/pr-1051.v2.yml
+++ b/changelog/@unreleased/pr-1051.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Undertow endpoints disallow request body collections with null values
+    when `--nonNullCollections` is set
+  links:
+  - https://github.com/palantir/conjure-java/pull/1051

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteEndpoints.java
@@ -899,5 +899,71 @@ enum DialogueEteEndpoints implements Endpoint {
         public String version() {
             return "1.2.3";
         }
+    },
+
+    receiveListOfOptionals {
+        private final PathTemplate pathTemplate = PathTemplate.builder()
+                .fixed("base")
+                .fixed("list")
+                .fixed("optionals")
+                .build();
+
+        @Override
+        public void renderPath(Map<String, String> params, UrlBuilder url) {
+            pathTemplate.fill(params, url);
+        }
+
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.PUT;
+        }
+
+        @Override
+        public String serviceName() {
+            return "EteService";
+        }
+
+        @Override
+        public String endpointName() {
+            return "receiveListOfOptionals";
+        }
+
+        @Override
+        public String version() {
+            return "1.2.3";
+        }
+    },
+
+    receiveSetOfOptionals {
+        private final PathTemplate pathTemplate = PathTemplate.builder()
+                .fixed("base")
+                .fixed("set")
+                .fixed("optionals")
+                .build();
+
+        @Override
+        public void renderPath(Map<String, String> params, UrlBuilder url) {
+            pathTemplate.fill(params, url);
+        }
+
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.PUT;
+        }
+
+        @Override
+        public String serviceName() {
+            return "EteService";
+        }
+
+        @Override
+        public String endpointName() {
+            return "receiveSetOfOptionals";
+        }
+
+        @Override
+        public String version() {
+            return "1.2.3";
+        }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
@@ -15,6 +15,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -182,6 +183,16 @@ public interface EteService {
             @QueryParam("strings") Set<StringAliasExample> strings,
             @QueryParam("longs") Set<Long> longs,
             @QueryParam("ints") Set<Integer> ints);
+
+    @PUT
+    @Path("base/list/optionals")
+    void receiveListOfOptionals(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader, @NotNull List<Optional<String>> value);
+
+    @PUT
+    @Path("base/set/optionals")
+    void receiveSetOfOptionals(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader, @NotNull Set<Optional<String>> value);
 
     @Deprecated
     default Optional<Long> optionalExternalLongQuery(AuthHeader authHeader) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceAsync.java
@@ -193,6 +193,16 @@ public interface EteServiceAsync {
             Set<Integer> ints);
 
     /**
+     * @apiNote {@code PUT /base/list/optionals}
+     */
+    ListenableFuture<Void> receiveListOfOptionals(AuthHeader authHeader, List<Optional<String>> value);
+
+    /**
+     * @apiNote {@code PUT /base/set/optionals}
+     */
+    ListenableFuture<Void> receiveSetOfOptionals(AuthHeader authHeader, Set<Optional<String>> value);
+
+    /**
      * Creates an asynchronous/non-blocking client for a EteService service.
      */
     static EteServiceAsync of(EndpointChannelFactory _endpointChannelFactory, ConjureRuntime _runtime) {
@@ -367,6 +377,24 @@ public interface EteServiceAsync {
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.complexQueryParameters);
 
             private final Deserializer<Void> complexQueryParametersDeserializer =
+                    _runtime.bodySerDe().emptyBodyDeserializer();
+
+            private final Serializer<List<Optional<String>>> receiveListOfOptionalsSerializer =
+                    _runtime.bodySerDe().serializer(new TypeMarker<List<Optional<String>>>() {});
+
+            private final EndpointChannel receiveListOfOptionalsChannel =
+                    _endpointChannelFactory.endpoint(DialogueEteEndpoints.receiveListOfOptionals);
+
+            private final Deserializer<Void> receiveListOfOptionalsDeserializer =
+                    _runtime.bodySerDe().emptyBodyDeserializer();
+
+            private final Serializer<Set<Optional<String>>> receiveSetOfOptionalsSerializer =
+                    _runtime.bodySerDe().serializer(new TypeMarker<Set<Optional<String>>>() {});
+
+            private final EndpointChannel receiveSetOfOptionalsChannel =
+                    _endpointChannelFactory.endpoint(DialogueEteEndpoints.receiveSetOfOptionals);
+
+            private final Deserializer<Void> receiveSetOfOptionalsDeserializer =
                     _runtime.bodySerDe().emptyBodyDeserializer();
 
             @Override
@@ -644,6 +672,24 @@ public interface EteServiceAsync {
                 }
                 return _runtime.clients()
                         .call(complexQueryParametersChannel, _request.build(), complexQueryParametersDeserializer);
+            }
+
+            @Override
+            public ListenableFuture<Void> receiveListOfOptionals(AuthHeader authHeader, List<Optional<String>> value) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.body(receiveListOfOptionalsSerializer.serialize(value));
+                return _runtime.clients()
+                        .call(receiveListOfOptionalsChannel, _request.build(), receiveListOfOptionalsDeserializer);
+            }
+
+            @Override
+            public ListenableFuture<Void> receiveSetOfOptionals(AuthHeader authHeader, Set<Optional<String>> value) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.body(receiveSetOfOptionalsSerializer.serialize(value));
+                return _runtime.clients()
+                        .call(receiveSetOfOptionalsChannel, _request.build(), receiveSetOfOptionalsDeserializer);
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceBlocking.java
@@ -180,6 +180,16 @@ public interface EteServiceBlocking {
             Set<Integer> ints);
 
     /**
+     * @apiNote {@code PUT /base/list/optionals}
+     */
+    void receiveListOfOptionals(AuthHeader authHeader, List<Optional<String>> value);
+
+    /**
+     * @apiNote {@code PUT /base/set/optionals}
+     */
+    void receiveSetOfOptionals(AuthHeader authHeader, Set<Optional<String>> value);
+
+    /**
      * Creates a synchronous/blocking client for a EteService service.
      */
     static EteServiceBlocking of(EndpointChannelFactory _endpointChannelFactory, ConjureRuntime _runtime) {
@@ -331,6 +341,16 @@ public interface EteServiceBlocking {
                     Set<Long> longs,
                     Set<Integer> ints) {
                 _runtime.clients().block(delegate.complexQueryParameters(authHeader, datasetRid, strings, longs, ints));
+            }
+
+            @Override
+            public void receiveListOfOptionals(AuthHeader authHeader, List<Optional<String>> value) {
+                _runtime.clients().block(delegate.receiveListOfOptionals(authHeader, value));
+            }
+
+            @Override
+            public void receiveSetOfOptionals(AuthHeader authHeader, Set<Optional<String>> value) {
+                _runtime.clients().block(delegate.receiveSetOfOptionals(authHeader, value));
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
@@ -71,7 +71,9 @@ public final class EteServiceEndpoints implements UndertowService {
                 new OptionalEnumQueryEndpoint(runtime, delegate),
                 new EnumHeaderEndpoint(runtime, delegate),
                 new AliasLongEndpointEndpoint(runtime, delegate),
-                new ComplexQueryParametersEndpoint(runtime, delegate)));
+                new ComplexQueryParametersEndpoint(runtime, delegate),
+                new ReceiveListOfOptionalsEndpoint(runtime, delegate),
+                new ReceiveSetOfOptionalsEndpoint(runtime, delegate)));
     }
 
     private static final class StringEndpoint implements HttpHandler, Endpoint {
@@ -1433,6 +1435,100 @@ public final class EteServiceEndpoints implements UndertowService {
         @Override
         public String name() {
             return "complexQueryParameters";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class ReceiveListOfOptionalsEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final UndertowEteService delegate;
+
+        private final Deserializer<List<Optional<String>>> deserializer;
+
+        ReceiveListOfOptionalsEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<List<Optional<String>>>() {});
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            List<Optional<String>> value = deserializer.deserialize(exchange);
+            delegate.receiveListOfOptionals(authHeader, value);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.PUT;
+        }
+
+        @Override
+        public String template() {
+            return "/base/list/optionals";
+        }
+
+        @Override
+        public String serviceName() {
+            return "EteService";
+        }
+
+        @Override
+        public String name() {
+            return "receiveListOfOptionals";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class ReceiveSetOfOptionalsEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final UndertowEteService delegate;
+
+        private final Deserializer<Set<Optional<String>>> deserializer;
+
+        ReceiveSetOfOptionalsEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Set<Optional<String>>>() {});
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            Set<Optional<String>> value = deserializer.deserialize(exchange);
+            delegate.receiveSetOfOptionals(authHeader, value);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.PUT;
+        }
+
+        @Override
+        public String template() {
+            return "/base/set/optionals";
+        }
+
+        @Override
+        public String serviceName() {
+            return "EteService";
+        }
+
+        @Override
+        public String name() {
+            return "receiveSetOfOptionals";
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
@@ -1,5 +1,7 @@
 package com.palantir.product;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.conjure.java.undertow.lib.Deserializer;
@@ -1448,12 +1450,12 @@ public final class EteServiceEndpoints implements UndertowService {
 
         private final UndertowEteService delegate;
 
-        private final Deserializer<List<Optional<String>>> deserializer;
+        private final Deserializer<ImmutableList<Optional<String>>> deserializer;
 
         ReceiveListOfOptionalsEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<List<Optional<String>>>() {});
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<ImmutableList<Optional<String>>>() {});
         }
 
         @Override
@@ -1495,12 +1497,12 @@ public final class EteServiceEndpoints implements UndertowService {
 
         private final UndertowEteService delegate;
 
-        private final Deserializer<Set<Optional<String>>> deserializer;
+        private final Deserializer<ImmutableSet<Optional<String>>> deserializer;
 
         ReceiveSetOfOptionalsEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Set<Optional<String>>>() {});
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<ImmutableSet<Optional<String>>>() {});
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
@@ -17,6 +17,7 @@ import retrofit2.http.GET;
 import retrofit2.http.Header;
 import retrofit2.http.Headers;
 import retrofit2.http.POST;
+import retrofit2.http.PUT;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 import retrofit2.http.Streaming;
@@ -172,6 +173,16 @@ public interface EteServiceRetrofit {
             @Query("strings") Set<StringAliasExample> strings,
             @Query("longs") Set<Long> longs,
             @Query("ints") Set<Integer> ints);
+
+    @PUT("./base/list/optionals")
+    @Headers({"hr-path-template: /base/list/optionals", "Accept: application/json"})
+    ListenableFuture<Void> receiveListOfOptionals(
+            @Header("Authorization") AuthHeader authHeader, @Body List<Optional<String>> value);
+
+    @PUT("./base/set/optionals")
+    @Headers({"hr-path-template: /base/set/optionals", "Accept: application/json"})
+    ListenableFuture<Void> receiveSetOfOptionals(
+            @Header("Authorization") AuthHeader authHeader, @Body Set<Optional<String>> value);
 
     @Deprecated
     default ListenableFuture<Optional<Long>> optionalExternalLongQuery(@Header("Authorization") AuthHeader authHeader) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
@@ -167,4 +167,14 @@ public interface UndertowEteService {
             Set<StringAliasExample> strings,
             Set<Long> longs,
             Set<Integer> ints);
+
+    /**
+     * @apiNote {@code PUT /base/list/optionals}
+     */
+    void receiveListOfOptionals(AuthHeader authHeader, List<Optional<String>> value);
+
+    /**
+     * @apiNote {@code PUT /base/set/optionals}
+     */
+    void receiveSetOfOptionals(AuthHeader authHeader, Set<Optional<String>> value);
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
@@ -94,6 +94,15 @@ public interface Options {
         return false;
     }
 
+    /**
+     * Instructs the service generator to use top-level collections that fail to deserialize collections with null
+     * values.
+     */
+    @Value.Default
+    default boolean nonNullTopLevelCollectionValues() {
+        return false;
+    }
+
     Optional<String> packagePrefix();
 
     Optional<String> apiVersion();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
@@ -100,7 +100,7 @@ public interface Options {
      */
     @Value.Default
     default boolean nonNullTopLevelCollectionValues() {
-        return false;
+        return nonNullCollections();
     }
 
     Optional<String> packagePrefix();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -350,7 +350,7 @@ final class UndertowServiceHandlerGenerator {
     private TypeName immutableCollection(TypeName input) {
         // Note that only the outermost collection is considered for replacement to avoid
         // generic type incompatibilities.
-        if (options.nonNullCollections() && input instanceof ParameterizedTypeName) {
+        if (options.nonNullTopLevelCollectionValues() && input instanceof ParameterizedTypeName) {
             ParameterizedTypeName parameterized = (ParameterizedTypeName) input;
             if (LIST_NAME.equals(parameterized.rawType)) {
                 return ParameterizedTypeName.get(

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -348,6 +348,8 @@ final class UndertowServiceHandlerGenerator {
     private static final ClassName IMMUTABLE_SET_NAME = ClassName.get(ImmutableSet.class);
 
     private TypeName immutableCollection(TypeName input) {
+        // Note that only the outermost collection is considered for replacement to avoid
+        // generic type incompatibilities.
         if (options.nonNullCollections() && input instanceof ParameterizedTypeName) {
             ParameterizedTypeName parameterized = (ParameterizedTypeName) input;
             if (LIST_NAME.equals(parameterized.rawType)) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.services;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -79,6 +80,7 @@ import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
@@ -241,6 +243,7 @@ final class UndertowServiceHandlerGenerator {
                 .flatMap(type -> type.accept(TypeVisitor.IS_BINARY) ? Optional.empty() : Optional.of(type))
                 .map(typeMapper::getClassName)
                 .map(TypeName::box)
+                .map(this::immutableCollection)
                 .ifPresent(typeName -> {
                     TypeName type = ParameterizedTypeName.get(ClassName.get(Deserializer.class), typeName);
                     endpointBuilder.addField(
@@ -337,6 +340,26 @@ final class UndertowServiceHandlerGenerator {
                         .build()));
 
         return endpointBuilder.build();
+    }
+
+    private static final ClassName LIST_NAME = ClassName.get(List.class);
+    private static final ClassName IMMUTABLE_LIST_NAME = ClassName.get(ImmutableList.class);
+    private static final ClassName SET_NAME = ClassName.get(Set.class);
+    private static final ClassName IMMUTABLE_SET_NAME = ClassName.get(ImmutableSet.class);
+
+    private TypeName immutableCollection(TypeName input) {
+        if (options.nonNullCollections() && input instanceof ParameterizedTypeName) {
+            ParameterizedTypeName parameterized = (ParameterizedTypeName) input;
+            if (LIST_NAME.equals(parameterized.rawType)) {
+                return ParameterizedTypeName.get(
+                        IMMUTABLE_LIST_NAME, parameterized.typeArguments.toArray(new TypeName[0]));
+            } else if (SET_NAME.equals(parameterized.rawType)) {
+                return ParameterizedTypeName.get(
+                        IMMUTABLE_SET_NAME, parameterized.typeArguments.toArray(new TypeName[0]));
+            }
+        }
+
+        return input;
     }
 
     private static final String PATH_PARAMS_VAR_NAME = "pathParams";

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/EteResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/EteResource.java
@@ -187,5 +187,11 @@ public class EteResource implements EteService {
         // nop
     }
 
+    @Override
+    public void receiveListOfOptionals(AuthHeader _authHeader, List<Optional<String>> _value) {}
+
+    @Override
+    public void receiveSetOfOptionals(AuthHeader _authHeader, Set<Optional<String>> _value) {}
+
     interface Streaming extends StreamingOutput, BinaryResponseBody {}
 }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -511,7 +511,10 @@ public final class UndertowServiceEteTest extends TestBase {
     public static void beforeClass() throws IOException {
         ConjureDefinition def = Conjure.parse(ImmutableList.of(
                 new File("src/test/resources/ete-service.yml"), new File("src/test/resources/ete-binary.yml")));
-        Options options = Options.builder().undertowServicePrefix(true).build();
+        Options options = Options.builder()
+                .undertowServicePrefix(true)
+                .nonNullCollections(true)
+                .build();
         List<Path> files = ImmutableList.<Path>builder()
                 .addAll(new UndertowServiceGenerator(options).emit(def, folder))
                 .addAll(new ObjectGenerator(options).emit(def, folder))

--- a/conjure-java-core/src/test/resources/ete-service.yml
+++ b/conjure-java-core/src/test/resources/ete-service.yml
@@ -223,3 +223,13 @@ services:
           ints:
             type: set<integer>
             param-type: query
+
+      receiveListOfOptionals:
+        http: PUT /list/optionals
+        args:
+          value: list<optional<string>>
+
+      receiveSetOfOptionals:
+        http: PUT /set/optionals
+        args:
+          value: set<optional<string>>

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -139,6 +139,14 @@ public final class ConjureJavaCli implements Runnable {
                 description = "Generate POJOs that by default will fail to deserialize collections with null values")
         private boolean nonNullCollections;
 
+        @CommandLine.Option(
+                names = "--nonNullTopLevelCollectionValues",
+                defaultValue = "false",
+                description = "Generate services that by default will fail to deserialize top-level collections with "
+                        + "null values. This option is always enabled when --nonNullCollections is used, this option "
+                        + "exists to allow consumers which cannot use the broader flag yet.")
+        private boolean nonNullTopLevelCollectionValues;
+
         @Beta
         @CommandLine.Option(
                 names = "--experimentalUndertowAsyncMarkers",
@@ -223,6 +231,7 @@ public final class ConjureJavaCli implements Runnable {
                             .experimentalUndertowAsyncMarkers(experimentalUndertowAsyncMarkers)
                             .strictObjects(strictObjects)
                             .nonNullCollections(nonNullCollections)
+                            .nonNullTopLevelCollectionValues(nonNullCollections || nonNullTopLevelCollectionValues)
                             .packagePrefix(Optional.ofNullable(packagePrefix))
                             .apiVersion(Optional.ofNullable(apiVersion))
                             .build())

--- a/conjure-java/src/test/java/com/palantir/conjure/java/cli/ConjureJavaCliTest.java
+++ b/conjure-java/src/test/java/com/palantir/conjure/java/cli/ConjureJavaCliTest.java
@@ -51,8 +51,11 @@ public final class ConjureJavaCliTest {
                 .outputDirectory(tempDir)
                 .generateObjects(true)
                 .build();
-        ConjureJavaCli.GenerateCommand cmd =
-                new CommandLine(new ConjureJavaCli()).parse(args).get(1).getCommand();
+        ConjureJavaCli.GenerateCommand cmd = new CommandLine(new ConjureJavaCli())
+                .parseArgs(args)
+                .asCommandLineList()
+                .get(1)
+                .getCommand();
         assertThat(cmd.getConfiguration()).isEqualTo(expectedConfiguration);
     }
 
@@ -78,8 +81,33 @@ public final class ConjureJavaCliTest {
                         .useImmutableBytes(true)
                         .build())
                 .build();
-        ConjureJavaCli.GenerateCommand cmd =
-                new CommandLine(new ConjureJavaCli()).parse(args).get(1).getCommand();
+        ConjureJavaCli.GenerateCommand cmd = new CommandLine(new ConjureJavaCli())
+                .parseArgs(args)
+                .asCommandLineList()
+                .get(1)
+                .getCommand();
+        assertThat(cmd.getConfiguration()).isEqualTo(expectedConfiguration);
+    }
+
+    @Test
+    public void nonNullCollectionsImpliesTopLevelNonNullValues() {
+        String[] args = {
+            "generate", targetFile.getAbsolutePath(), tempDir.getAbsolutePath(), "--objects", "--nonNullCollections"
+        };
+        CliConfiguration expectedConfiguration = CliConfiguration.builder()
+                .input(targetFile)
+                .outputDirectory(tempDir)
+                .generateObjects(true)
+                .options(Options.builder()
+                        .nonNullCollections(true)
+                        .nonNullTopLevelCollectionValues(true)
+                        .build())
+                .build();
+        ConjureJavaCli.GenerateCommand cmd = new CommandLine(new ConjureJavaCli())
+                .parseArgs(args)
+                .asCommandLineList()
+                .get(1)
+                .getCommand();
         assertThat(cmd.getConfiguration()).isEqualTo(expectedConfiguration);
     }
 


### PR DESCRIPTION
==COMMIT_MSG==
Undertow endpoints disallow request body collections with null values when `--nonNullCollections` is set
==COMMIT_MSG==

## Possible downsides?
Some consumers may rely on collections including null values.

