### PR TITLE
Annotate enums with error-prone Immutable

### DIFF
--- a/changelog/@unreleased/pr-1086.v2.yml
+++ b/changelog/@unreleased/pr-1086.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: The java classes for conjure enums are now annotated with `@com.google.errorprone.annotations.Immutable`,
+    which ensures that if they're used inside hand-rolled enums, Google's [ImmutableEnumChecker](https://errorprone.info/bugpattern/ImmutableEnumChecker)
+    won't complain.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1086

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -2,6 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.errorprone.annotations.Immutable;
 import com.palantir.logsafe.Preconditions;
 import java.util.Arrays;
 import java.util.Collections;
@@ -23,6 +24,7 @@ import javax.annotation.Nonnull;
  * There is no method to access all instantiations of this class, since they cannot be known at compile time.
  */
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
+@Immutable
 public final class EnumExample {
     public static final EnumExample ONE = new EnumExample(Value.ONE, "ONE");
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
@@ -2,6 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.errorprone.annotations.Immutable;
 import com.palantir.logsafe.Preconditions;
 import java.util.Arrays;
 import java.util.Collections;
@@ -21,6 +22,7 @@ import javax.annotation.Nonnull;
  * There is no method to access all instantiations of this class, since they cannot be known at compile time.
  */
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
+@Immutable
 public final class SimpleEnum {
     public static final SimpleEnum VALUE = new SimpleEnum(Value.VALUE, "VALUE");
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
@@ -2,6 +2,7 @@ package test.prefix.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.errorprone.annotations.Immutable;
 import com.palantir.logsafe.Preconditions;
 import java.util.Arrays;
 import java.util.Collections;
@@ -23,6 +24,7 @@ import javax.annotation.Nonnull;
  * There is no method to access all instantiations of this class, since they cannot be known at compile time.
  */
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
+@Immutable
 public final class EnumExample {
     public static final EnumExample ONE = new EnumExample(Value.ONE, "ONE");
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
@@ -2,6 +2,7 @@ package test.prefix.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.errorprone.annotations.Immutable;
 import com.palantir.logsafe.Preconditions;
 import java.util.Arrays;
 import java.util.Collections;
@@ -21,6 +22,7 @@ import javax.annotation.Nonnull;
  * There is no method to access all instantiations of this class, since they cannot be known at compile time.
  */
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
+@Immutable
 public final class SimpleEnum {
     public static final SimpleEnum VALUE = new SimpleEnum(Value.VALUE, "VALUE");
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.errorprone.annotations.Immutable;
 import com.palantir.conjure.java.ConjureAnnotations;
 import com.palantir.conjure.java.Options;
 import com.palantir.conjure.java.util.Javadoc;
@@ -74,6 +75,7 @@ public final class EnumGenerator {
             EnumDefinition typeDef, ClassName thisClass, ClassName enumClass, ClassName visitorClass) {
         TypeSpec.Builder wrapper = TypeSpec.classBuilder(typeDef.getTypeName().getName())
                 .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(EnumGenerator.class))
+                .addAnnotation(Immutable.class)
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                 .addType(createEnum(enumClass, typeDef.getValues(), true))
                 .addType(createVisitor(visitorClass, typeDef.getValues()))


### PR DESCRIPTION
## Before this PR

fixes https://github.com/palantir/conjure/issues/700

## After this PR
==COMMIT_MSG==
The java classes for conjure enums are now annotated with `@com.google.errorprone.annotations.Immutable`, which ensures that if they're used inside hand-rolled enums, Google's [ImmutableEnumChecker](https://errorprone.info/bugpattern/ImmutableEnumChecker) won't complain.
==COMMIT_MSG==

We already have the necessary jar on the `conjure-lib` classpath, so this should be literally zero downside... https://github.com/palantir/conjure-java/blob/5130885768f0a147e7a69dfd29e3ef06cfb8a138/conjure-lib/build.gradle#L27

Only open question is should we just do this for beans/unions too??

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

