### PR TITLE
Dialogue async services toString uses the correct class name

### DIFF
--- a/changelog/@unreleased/pr-1092.v2.yml
+++ b/changelog/@unreleased/pr-1092.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Dialogue async service toString uses the correct class name
+  links:
+  - https://github.com/palantir/conjure-java/pull/1092

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CookieServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CookieServiceAsync.java
@@ -44,8 +44,8 @@ public interface CookieServiceAsync {
 
             @Override
             public String toString() {
-                return "CookieServiceBlocking{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime="
-                        + _runtime + '}';
+                return "CookieServiceAsync{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime=" + _runtime
+                        + '}';
             }
         };
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceAsync.java
@@ -43,7 +43,7 @@ public interface EmptyPathServiceAsync {
 
             @Override
             public String toString() {
-                return "EmptyPathServiceBlocking{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime="
+                return "EmptyPathServiceAsync{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime="
                         + _runtime + '}';
             }
         };

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceAsync.java
@@ -128,7 +128,7 @@ public interface EteBinaryServiceAsync {
 
             @Override
             public String toString() {
-                return "EteBinaryServiceBlocking{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime="
+                return "EteBinaryServiceAsync{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime="
                         + _runtime + '}';
             }
         };

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceAsync.java
@@ -694,7 +694,7 @@ public interface EteServiceAsync {
 
             @Override
             public String toString() {
-                return "EteServiceBlocking{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime=" + _runtime
+                return "EteServiceAsync{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime=" + _runtime
                         + '}';
             }
         };

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/AsyncGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/AsyncGenerator.java
@@ -107,7 +107,7 @@ public final class AsyncGenerator implements StaticFactoryMethodGenerator {
             impl.addMethod(asyncClientImpl(def, endpoint));
         });
 
-        impl.addMethod(BlockingGenerator.toStringMethod(Names.blockingClassName(def, options)));
+        impl.addMethod(BlockingGenerator.toStringMethod(Names.asyncClassName(def, options)));
 
         MethodSpec asyncImpl = MethodSpec.methodBuilder("of")
                 .addModifiers(Modifier.STATIC, Modifier.PUBLIC)

--- a/conjure-java-core/src/test/resources/test/api/CookieServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/CookieServiceAsync.java.dialogue
@@ -44,8 +44,8 @@ public interface CookieServiceAsync {
 
             @Override
             public String toString() {
-                return "CookieServiceBlocking{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime="
-                        + _runtime + '}';
+                return "CookieServiceAsync{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime=" + _runtime
+                        + '}';
             }
         };
     }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
@@ -552,8 +552,8 @@ public interface TestServiceAsync {
 
             @Override
             public String toString() {
-                return "TestServiceBlocking{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime="
-                        + _runtime + '}';
+                return "TestServiceAsync{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime=" + _runtime
+                        + '}';
             }
         };
     }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
@@ -552,8 +552,8 @@ public interface TestServiceAsync {
 
             @Override
             public String toString() {
-                return "TestServiceBlocking{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime="
-                        + _runtime + '}';
+                return "TestServiceAsync{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime=" + _runtime
+                        + '}';
             }
         };
     }


### PR DESCRIPTION
==COMMIT_MSG==
Dialogue async service toString uses the correct class name
==COMMIT_MSG==

