### PR TITLE
fix #573: Unions with type `unknown` compile as expected

### DIFF
--- a/changelog/@unreleased/pr-1103.v2.yml
+++ b/changelog/@unreleased/pr-1103.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Unions with type `unknown` compile as expected
+  links:
+  - https://github.com/palantir/conjure-java/pull/1103

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -71,6 +71,10 @@ public final class UnionTypeExample {
         return new UnionTypeExample(new CompletedWrapper(value));
     }
 
+    public static UnionTypeExample unknown_(int value) {
+        return new UnionTypeExample(new Unknown_Wrapper(value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }
@@ -114,6 +118,8 @@ public final class UnionTypeExample {
 
         T visitCompleted(int value);
 
+        T visitUnknown_(int value);
+
         T visitUnknown(String unknownType);
 
         static <T> AlsoAnIntegerStageVisitorBuilder<T> builder() {
@@ -130,6 +136,7 @@ public final class UnionTypeExample {
                     SetStageVisitorBuilder<T>,
                     StringExampleStageVisitorBuilder<T>,
                     ThisFieldIsAnIntegerStageVisitorBuilder<T>,
+                    Unknown_StageVisitorBuilder<T>,
                     UnknownStageVisitorBuilder<T>,
                     Completed_StageVisitorBuilder<T> {
         private IntFunction<T> alsoAnIntegerVisitor;
@@ -147,6 +154,8 @@ public final class UnionTypeExample {
         private Function<StringExample, T> stringExampleVisitor;
 
         private IntFunction<T> thisFieldIsAnIntegerVisitor;
+
+        private IntFunction<T> unknown_Visitor;
 
         private Function<String, T> unknownVisitor;
 
@@ -201,9 +210,17 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public UnknownStageVisitorBuilder<T> thisFieldIsAnInteger(@Nonnull IntFunction<T> thisFieldIsAnIntegerVisitor) {
+        public Unknown_StageVisitorBuilder<T> thisFieldIsAnInteger(
+                @Nonnull IntFunction<T> thisFieldIsAnIntegerVisitor) {
             Preconditions.checkNotNull(thisFieldIsAnIntegerVisitor, "thisFieldIsAnIntegerVisitor cannot be null");
             this.thisFieldIsAnIntegerVisitor = thisFieldIsAnIntegerVisitor;
+            return this;
+        }
+
+        @Override
+        public UnknownStageVisitorBuilder<T> unknown_(@Nonnull IntFunction<T> unknown_Visitor) {
+            Preconditions.checkNotNull(unknown_Visitor, "unknown_Visitor cannot be null");
+            this.unknown_Visitor = unknown_Visitor;
             return this;
         }
 
@@ -224,6 +241,7 @@ public final class UnionTypeExample {
             final Function<Set<String>, T> setVisitor = this.setVisitor;
             final Function<StringExample, T> stringExampleVisitor = this.stringExampleVisitor;
             final IntFunction<T> thisFieldIsAnIntegerVisitor = this.thisFieldIsAnIntegerVisitor;
+            final IntFunction<T> unknown_Visitor = this.unknown_Visitor;
             final Function<String, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
@@ -267,6 +285,11 @@ public final class UnionTypeExample {
                 }
 
                 @Override
+                public T visitUnknown_(int value) {
+                    return unknown_Visitor.apply(value);
+                }
+
+                @Override
                 public T visitUnknown(String value) {
                     return unknownVisitor.apply(value);
                 }
@@ -304,7 +327,11 @@ public final class UnionTypeExample {
     }
 
     public interface ThisFieldIsAnIntegerStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> thisFieldIsAnInteger(@Nonnull IntFunction<T> thisFieldIsAnIntegerVisitor);
+        Unknown_StageVisitorBuilder<T> thisFieldIsAnInteger(@Nonnull IntFunction<T> thisFieldIsAnIntegerVisitor);
+    }
+
+    public interface Unknown_StageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> unknown_(@Nonnull IntFunction<T> unknown_Visitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {
@@ -324,7 +351,8 @@ public final class UnionTypeExample {
         @JsonSubTypes.Type(IfWrapper.class),
         @JsonSubTypes.Type(NewWrapper.class),
         @JsonSubTypes.Type(InterfaceWrapper.class),
-        @JsonSubTypes.Type(CompletedWrapper.class)
+        @JsonSubTypes.Type(CompletedWrapper.class),
+        @JsonSubTypes.Type(Unknown_Wrapper.class)
     })
     @JsonIgnoreProperties(ignoreUnknown = true)
     private interface Base {
@@ -649,6 +677,46 @@ public final class UnionTypeExample {
         @Override
         public String toString() {
             return "CompletedWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("unknown")
+    private static final class Unknown_Wrapper implements Base {
+        private final int value;
+
+        @JsonCreator
+        private Unknown_Wrapper(@JsonProperty("unknown") @Nonnull int value) {
+            Preconditions.checkNotNull(value, "unknown_ cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty("unknown")
+        private int getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitUnknown_(value);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof Unknown_Wrapper && equalTo((Unknown_Wrapper) other));
+        }
+
+        private boolean equalTo(Unknown_Wrapper other) {
+            return this.value == other.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return Integer.hashCode(this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "Unknown_Wrapper{value: " + value + '}';
         }
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
@@ -1,0 +1,229 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import javax.annotation.Generated;
+import javax.annotation.Nonnull;
+
+@Generated("com.palantir.conjure.java.types.UnionGenerator")
+public final class UnionWithUnknownString {
+    private final Base value;
+
+    @JsonCreator
+    private UnionWithUnknownString(Base value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    private Base getValue() {
+        return value;
+    }
+
+    public static UnionWithUnknownString unknown_(String value) {
+        return new UnionWithUnknownString(new Unknown_Wrapper(value));
+    }
+
+    public <T> T accept(Visitor<T> visitor) {
+        return value.accept(visitor);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other || (other instanceof UnionWithUnknownString && equalTo((UnionWithUnknownString) other));
+    }
+
+    private boolean equalTo(UnionWithUnknownString other) {
+        return this.value.equals(other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.value);
+    }
+
+    @Override
+    public String toString() {
+        return "UnionWithUnknownString{value: " + value + '}';
+    }
+
+    public interface Visitor<T> {
+        T visitUnknown_(String value);
+
+        T visitUnknown(String unknownType);
+
+        static <T> Unknown_StageVisitorBuilder<T> builder() {
+            return new VisitorBuilder<T>();
+        }
+    }
+
+    private static final class VisitorBuilder<T>
+            implements Unknown_StageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
+        private Function<String, T> unknown_Visitor;
+
+        private Function<String, T> unknownVisitor;
+
+        @Override
+        public UnknownStageVisitorBuilder<T> unknown_(@Nonnull Function<String, T> unknown_Visitor) {
+            Preconditions.checkNotNull(unknown_Visitor, "unknown_Visitor cannot be null");
+            this.unknown_Visitor = unknown_Visitor;
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
+            Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
+            this.unknownVisitor = unknownVisitor;
+            return this;
+        }
+
+        @Override
+        public Visitor<T> build() {
+            final Function<String, T> unknown_Visitor = this.unknown_Visitor;
+            final Function<String, T> unknownVisitor = this.unknownVisitor;
+            return new Visitor<T>() {
+                @Override
+                public T visitUnknown_(String value) {
+                    return unknown_Visitor.apply(value);
+                }
+
+                @Override
+                public T visitUnknown(String value) {
+                    return unknownVisitor.apply(value);
+                }
+            };
+        }
+    }
+
+    public interface Unknown_StageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> unknown_(@Nonnull Function<String, T> unknown_Visitor);
+    }
+
+    public interface UnknownStageVisitorBuilder<T> {
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+    }
+
+    public interface Completed_StageVisitorBuilder<T> {
+        Visitor<T> build();
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true, defaultImpl = UnknownWrapper.class)
+    @JsonSubTypes(@JsonSubTypes.Type(Unknown_Wrapper.class))
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private interface Base {
+        <T> T accept(Visitor<T> visitor);
+    }
+
+    @JsonTypeName("unknown")
+    private static final class Unknown_Wrapper implements Base {
+        private final String value;
+
+        @JsonCreator
+        private Unknown_Wrapper(@JsonProperty("unknown") @Nonnull String value) {
+            Preconditions.checkNotNull(value, "unknown_ cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty("unknown")
+        private String getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitUnknown_(value);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof Unknown_Wrapper && equalTo((Unknown_Wrapper) other));
+        }
+
+        private boolean equalTo(Unknown_Wrapper other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "Unknown_Wrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeInfo(
+            use = JsonTypeInfo.Id.NAME,
+            include = JsonTypeInfo.As.EXISTING_PROPERTY,
+            property = "type",
+            visible = true)
+    private static final class UnknownWrapper implements Base {
+        private final String type;
+
+        private final Map<String, Object> value;
+
+        @JsonCreator
+        private UnknownWrapper(@JsonProperty("type") String type) {
+            this(type, new HashMap<String, Object>());
+        }
+
+        private UnknownWrapper(@Nonnull String type, @Nonnull Map<String, Object> value) {
+            Preconditions.checkNotNull(type, "type cannot be null");
+            Preconditions.checkNotNull(value, "value cannot be null");
+            this.type = type;
+            this.value = value;
+        }
+
+        @JsonProperty
+        private String getType() {
+            return type;
+        }
+
+        @JsonAnyGetter
+        private Map<String, Object> getValue() {
+            return value;
+        }
+
+        @JsonAnySetter
+        private void put(String key, Object val) {
+            value.put(key, val);
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitUnknown(type);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof UnknownWrapper && equalTo((UnknownWrapper) other));
+        }
+
+        private boolean equalTo(UnknownWrapper other) {
+            return this.type.equals(other.type) && this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.type, this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "UnknownWrapper{type: " + type + ", value: " + value + '}';
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -71,6 +71,10 @@ public final class UnionTypeExample {
         return new UnionTypeExample(new CompletedWrapper(value));
     }
 
+    public static UnionTypeExample unknown_(int value) {
+        return new UnionTypeExample(new Unknown_Wrapper(value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }
@@ -114,6 +118,8 @@ public final class UnionTypeExample {
 
         T visitCompleted(int value);
 
+        T visitUnknown_(int value);
+
         T visitUnknown(String unknownType);
 
         static <T> AlsoAnIntegerStageVisitorBuilder<T> builder() {
@@ -130,6 +136,7 @@ public final class UnionTypeExample {
                     SetStageVisitorBuilder<T>,
                     StringExampleStageVisitorBuilder<T>,
                     ThisFieldIsAnIntegerStageVisitorBuilder<T>,
+                    Unknown_StageVisitorBuilder<T>,
                     UnknownStageVisitorBuilder<T>,
                     Completed_StageVisitorBuilder<T> {
         private IntFunction<T> alsoAnIntegerVisitor;
@@ -147,6 +154,8 @@ public final class UnionTypeExample {
         private Function<StringExample, T> stringExampleVisitor;
 
         private IntFunction<T> thisFieldIsAnIntegerVisitor;
+
+        private IntFunction<T> unknown_Visitor;
 
         private Function<String, T> unknownVisitor;
 
@@ -201,9 +210,17 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public UnknownStageVisitorBuilder<T> thisFieldIsAnInteger(@Nonnull IntFunction<T> thisFieldIsAnIntegerVisitor) {
+        public Unknown_StageVisitorBuilder<T> thisFieldIsAnInteger(
+                @Nonnull IntFunction<T> thisFieldIsAnIntegerVisitor) {
             Preconditions.checkNotNull(thisFieldIsAnIntegerVisitor, "thisFieldIsAnIntegerVisitor cannot be null");
             this.thisFieldIsAnIntegerVisitor = thisFieldIsAnIntegerVisitor;
+            return this;
+        }
+
+        @Override
+        public UnknownStageVisitorBuilder<T> unknown_(@Nonnull IntFunction<T> unknown_Visitor) {
+            Preconditions.checkNotNull(unknown_Visitor, "unknown_Visitor cannot be null");
+            this.unknown_Visitor = unknown_Visitor;
             return this;
         }
 
@@ -224,6 +241,7 @@ public final class UnionTypeExample {
             final Function<Set<String>, T> setVisitor = this.setVisitor;
             final Function<StringExample, T> stringExampleVisitor = this.stringExampleVisitor;
             final IntFunction<T> thisFieldIsAnIntegerVisitor = this.thisFieldIsAnIntegerVisitor;
+            final IntFunction<T> unknown_Visitor = this.unknown_Visitor;
             final Function<String, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
@@ -267,6 +285,11 @@ public final class UnionTypeExample {
                 }
 
                 @Override
+                public T visitUnknown_(int value) {
+                    return unknown_Visitor.apply(value);
+                }
+
+                @Override
                 public T visitUnknown(String value) {
                     return unknownVisitor.apply(value);
                 }
@@ -304,7 +327,11 @@ public final class UnionTypeExample {
     }
 
     public interface ThisFieldIsAnIntegerStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> thisFieldIsAnInteger(@Nonnull IntFunction<T> thisFieldIsAnIntegerVisitor);
+        Unknown_StageVisitorBuilder<T> thisFieldIsAnInteger(@Nonnull IntFunction<T> thisFieldIsAnIntegerVisitor);
+    }
+
+    public interface Unknown_StageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> unknown_(@Nonnull IntFunction<T> unknown_Visitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {
@@ -324,7 +351,8 @@ public final class UnionTypeExample {
         @JsonSubTypes.Type(IfWrapper.class),
         @JsonSubTypes.Type(NewWrapper.class),
         @JsonSubTypes.Type(InterfaceWrapper.class),
-        @JsonSubTypes.Type(CompletedWrapper.class)
+        @JsonSubTypes.Type(CompletedWrapper.class),
+        @JsonSubTypes.Type(Unknown_Wrapper.class)
     })
     @JsonIgnoreProperties(ignoreUnknown = true)
     private interface Base {
@@ -649,6 +677,46 @@ public final class UnionTypeExample {
         @Override
         public String toString() {
             return "CompletedWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("unknown")
+    private static final class Unknown_Wrapper implements Base {
+        private final int value;
+
+        @JsonCreator
+        private Unknown_Wrapper(@JsonProperty("unknown") @Nonnull int value) {
+            Preconditions.checkNotNull(value, "unknown_ cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty("unknown")
+        private int getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitUnknown_(value);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof Unknown_Wrapper && equalTo((Unknown_Wrapper) other));
+        }
+
+        private boolean equalTo(Unknown_Wrapper other) {
+            return this.value == other.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return Integer.hashCode(this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "Unknown_Wrapper{value: " + value + '}';
         }
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
@@ -1,0 +1,229 @@
+package test.prefix.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import javax.annotation.Generated;
+import javax.annotation.Nonnull;
+
+@Generated("com.palantir.conjure.java.types.UnionGenerator")
+public final class UnionWithUnknownString {
+    private final Base value;
+
+    @JsonCreator
+    private UnionWithUnknownString(Base value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    private Base getValue() {
+        return value;
+    }
+
+    public static UnionWithUnknownString unknown_(String value) {
+        return new UnionWithUnknownString(new Unknown_Wrapper(value));
+    }
+
+    public <T> T accept(Visitor<T> visitor) {
+        return value.accept(visitor);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other || (other instanceof UnionWithUnknownString && equalTo((UnionWithUnknownString) other));
+    }
+
+    private boolean equalTo(UnionWithUnknownString other) {
+        return this.value.equals(other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.value);
+    }
+
+    @Override
+    public String toString() {
+        return "UnionWithUnknownString{value: " + value + '}';
+    }
+
+    public interface Visitor<T> {
+        T visitUnknown_(String value);
+
+        T visitUnknown(String unknownType);
+
+        static <T> Unknown_StageVisitorBuilder<T> builder() {
+            return new VisitorBuilder<T>();
+        }
+    }
+
+    private static final class VisitorBuilder<T>
+            implements Unknown_StageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
+        private Function<String, T> unknown_Visitor;
+
+        private Function<String, T> unknownVisitor;
+
+        @Override
+        public UnknownStageVisitorBuilder<T> unknown_(@Nonnull Function<String, T> unknown_Visitor) {
+            Preconditions.checkNotNull(unknown_Visitor, "unknown_Visitor cannot be null");
+            this.unknown_Visitor = unknown_Visitor;
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
+            Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
+            this.unknownVisitor = unknownVisitor;
+            return this;
+        }
+
+        @Override
+        public Visitor<T> build() {
+            final Function<String, T> unknown_Visitor = this.unknown_Visitor;
+            final Function<String, T> unknownVisitor = this.unknownVisitor;
+            return new Visitor<T>() {
+                @Override
+                public T visitUnknown_(String value) {
+                    return unknown_Visitor.apply(value);
+                }
+
+                @Override
+                public T visitUnknown(String value) {
+                    return unknownVisitor.apply(value);
+                }
+            };
+        }
+    }
+
+    public interface Unknown_StageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> unknown_(@Nonnull Function<String, T> unknown_Visitor);
+    }
+
+    public interface UnknownStageVisitorBuilder<T> {
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+    }
+
+    public interface Completed_StageVisitorBuilder<T> {
+        Visitor<T> build();
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true, defaultImpl = UnknownWrapper.class)
+    @JsonSubTypes(@JsonSubTypes.Type(Unknown_Wrapper.class))
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private interface Base {
+        <T> T accept(Visitor<T> visitor);
+    }
+
+    @JsonTypeName("unknown")
+    private static final class Unknown_Wrapper implements Base {
+        private final String value;
+
+        @JsonCreator
+        private Unknown_Wrapper(@JsonProperty("unknown") @Nonnull String value) {
+            Preconditions.checkNotNull(value, "unknown_ cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty("unknown")
+        private String getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitUnknown_(value);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof Unknown_Wrapper && equalTo((Unknown_Wrapper) other));
+        }
+
+        private boolean equalTo(Unknown_Wrapper other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "Unknown_Wrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeInfo(
+            use = JsonTypeInfo.Id.NAME,
+            include = JsonTypeInfo.As.EXISTING_PROPERTY,
+            property = "type",
+            visible = true)
+    private static final class UnknownWrapper implements Base {
+        private final String type;
+
+        private final Map<String, Object> value;
+
+        @JsonCreator
+        private UnknownWrapper(@JsonProperty("type") String type) {
+            this(type, new HashMap<String, Object>());
+        }
+
+        private UnknownWrapper(@Nonnull String type, @Nonnull Map<String, Object> value) {
+            Preconditions.checkNotNull(type, "type cannot be null");
+            Preconditions.checkNotNull(value, "value cannot be null");
+            this.type = type;
+            this.value = value;
+        }
+
+        @JsonProperty
+        private String getType() {
+            return type;
+        }
+
+        @JsonAnyGetter
+        private Map<String, Object> getValue() {
+            return value;
+        }
+
+        @JsonAnySetter
+        private void put(String key, Object val) {
+            value.put(key, val);
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitUnknown(type);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof UnknownWrapper && equalTo((UnknownWrapper) other));
+        }
+
+        private boolean equalTo(UnknownWrapper other) {
+            return this.type.equals(other.type) && this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.type, this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "UnknownWrapper{type: " + type + ", value: " + value + '}';
+        }
+    }
+}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/JavaNameSanitizer.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/JavaNameSanitizer.java
@@ -34,7 +34,13 @@ public final class JavaNameSanitizer {
 
     /** Sanitizes the given {@link FieldName} for use as a java specifier. */
     public static String sanitize(FieldName fieldName) {
-        String identifier = CaseConverter.toCase(fieldName.get(), CaseConverter.Case.LOWER_CAMEL_CASE);
+        String identifier = null;
+        try {
+            identifier = CaseConverter.toCase(fieldName.get(), CaseConverter.Case.LOWER_CAMEL_CASE);
+        } catch (IllegalArgumentException e) {
+            identifier =
+                    CaseConverter.Case.LOWER_CAMEL_CASE.convertTo(fieldName.get(), CaseConverter.Case.LOWER_CAMEL_CASE);
+        }
         return sanitizeFieldName(identifier);
     }
 

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -316,10 +316,18 @@ public final class WireFormatTests {
 
     @Test
     public void testUnionType_unknownType() throws Exception {
-        String serializedUnionTypeUnknown = "{\"type\":\"unknown\",\"value\":5}";
+        String serializedUnionTypeUnknown = "{\"type\":\"notknown\",\"notknown\":5}";
         UnionTypeExample unionTypeUnknown = mapper.readValue(serializedUnionTypeUnknown, UnionTypeExample.class);
         assertThat(mapper.writeValueAsString(unionTypeUnknown)).isEqualTo(serializedUnionTypeUnknown);
         assertThat(unionTypeUnknown.accept(new TestVisitor())).isZero();
+    }
+
+    @Test
+    public void testUnionType_knownUnknown() throws Exception {
+        String serializedUnionTypeUnknown = "{\"type\":\"unknown\",\"unknown\":5}";
+        UnionTypeExample unionTypeUnknown = mapper.readValue(serializedUnionTypeUnknown, UnionTypeExample.class);
+        assertThat(mapper.writeValueAsString(unionTypeUnknown)).isEqualTo(serializedUnionTypeUnknown);
+        assertThat(unionTypeUnknown.accept(new TestVisitor())).isEqualTo(5);
     }
 
     @Test
@@ -479,6 +487,11 @@ public final class WireFormatTests {
 
         @Override
         public Integer visitCompleted(int value) {
+            return value;
+        }
+
+        @Override
+        public Integer visitUnknown_(int value) {
             return value;
         }
 

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -177,6 +177,10 @@ types:
           new: integer
           interface: integer
           completed: integer
+          unknown: integer
+      UnionWithUnknownString:
+        union:
+          unknown: string
       EmptyUnionTypeExample:
         union: {}
       EmptyObjectExample:


### PR DESCRIPTION
Note that this approach avoids renaming the standard unknown
visitor builder stage so that we don't cause unnecessary abi
breaks on consumers.

==COMMIT_MSG==
Unions with type `unknown` compile as expected
==COMMIT_MSG==
