### PR TITLE
publish conjure-java jar

### DIFF
--- a/changelog/@unreleased/pr-1112.v2.yml
+++ b/changelog/@unreleased/pr-1112.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: The `conjure-java` CLI is now published as a jar so that it can be invoked in process by custom gradle plugins. Note that gradle-conjure does not use this approach to ensure that classpaths remain isolated and that the conjure-java generator can be upgraded independently from the gradle-conjure plugin itself.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1112

--- a/conjure-java/build.gradle
+++ b/conjure-java/build.gradle
@@ -15,6 +15,7 @@
  */
 
 apply from: "$rootDir/gradle/publish-dist.gradle"
+apply from: "$rootDir/gradle/publish-jar.gradle"
 
 mainClassName = 'com.palantir.conjure.java.cli.ConjureJavaCli'
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
conjure-java was only published as a dist so it could be used as a cli.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Publish conjure-java as a jar so that it can be invoked in process in gradle so it does not unnecessarily consume extra resources.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
No downsides
