### PR TITLE
add environment variable to control formatting

### DIFF
--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/Goethe.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/Goethe.java
@@ -49,12 +49,16 @@ public final class Goethe {
             Path outputFile = getFilePath(file, baseDir);
             StringBuilder code = new StringBuilder();
             file.writeTo(code);
-
             CharSink sink = com.google.common.io.Files.asCharSink(outputFile.toFile(), StandardCharsets.UTF_8);
-            try {
-                JAVA_FORMATTER.formatSource(CharSource.wrap(code), sink);
-            } catch (FormatterException e) {
-                throw new RuntimeException(generateMessage(file, code.toString(), e.diagnostics()), e);
+            boolean noFormat = Boolean.parseBoolean(System.getenv("CONJURE_JAVA_NO_FORMAT"));
+            if (noFormat) {
+                sink.write(code);
+            } else {
+                try {
+                    JAVA_FORMATTER.formatSource(CharSource.wrap(code), sink);
+                } catch (FormatterException e) {
+                    throw new RuntimeException(generateMessage(file, code.toString(), e.diagnostics()), e);
+                }
             }
             return outputFile;
         } catch (IOException e) {


### PR DESCRIPTION
to avoid formatting, set CONJURE_JAVA_NO_FORMAT=true

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
There was no way to control whether or not formatting was allowed.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
add environment variable to control formatting
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
No downsides. I'm not sure this is the best way to implement this, but we don't want it to run in CI.
