### PR TITLE
cache hashcode in bytes

### DIFF
--- a/changelog/@unreleased/pr-1132.v2.yml
+++ b/changelog/@unreleased/pr-1132.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: cache hashcode in Bytes
+  links:
+  - https://github.com/palantir/conjure-java/pull/1132

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/Bytes.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/Bytes.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 @JsonDeserialize(using = Bytes.Deserializer.class)
 public final class Bytes {
     private final byte[] safe;
+    private int hashCode;
 
     /** Constructs a new {@link Bytes} assuming the provided array is not held by any other class. */
     private Bytes(byte[] array) {
@@ -70,7 +71,10 @@ public final class Bytes {
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(safe);
+        if (hashCode == 0) {
+            hashCode = Arrays.hashCode(safe);
+        }
+        return hashCode;
     }
 
     @Override

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/Bytes.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/Bytes.java
@@ -71,10 +71,13 @@ public final class Bytes {
 
     @Override
     public int hashCode() {
-        if (hashCode == 0) {
-            hashCode = Arrays.hashCode(safe);
+        // same implementation as java.lang.String except Arrays.hashCode(new byte[0]) == 1 so no length check.
+        int hash = hashCode;
+        if (hash == 0) {
+            hash = Arrays.hashCode(safe);
+            hashCode = hash;
         }
-        return hashCode;
+        return hash;
     }
 
     @Override


### PR DESCRIPTION
## Before this PR

bytes implements hashcode, but each call will rehash, meaning that performance in a hashmap is dependent on the size of the array. This is incongruent with Conjure generated types.

## After this PR

Performance of bytes in hash map is more predictable

## Possible downsides?

Expected no downside. Cost of arrays.hashcode is expected to be far more expensive than the branch. Uses same hashCode pattern as String.
