### PR TITLE
Undertow Endpoints provide tags when defined

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
@@ -79,6 +79,8 @@ public final class EteServiceEndpoints implements UndertowService {
     }
 
     private static final class StringEndpoint implements HttpHandler, Endpoint {
+        private static final List<String> TAGS = Collections.unmodifiableList(Arrays.asList("bar", "foo"));
+
         private final UndertowRuntime runtime;
 
         private final UndertowEteService delegate;
@@ -89,6 +91,11 @@ public final class EteServiceEndpoints implements UndertowService {
             this.runtime = runtime;
             this.delegate = delegate;
             this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+        }
+
+        @Override
+        public List<String> tags() {
+            return TAGS;
         }
 
         @Override

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowTypeFunctions.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowTypeFunctions.java
@@ -28,9 +28,10 @@ import com.squareup.javapoet.ParameterizedTypeName;
 final class UndertowTypeFunctions {
 
     /**
-     * Asynchronous-processing capable endpoints are generated if either of the following are true.
+     * Asynchronous-processing capable endpoints are generated if any of the following are true.
      *
      * <ul>
+     *   <li>The {@link EndpointDefinition} is {@link EndpointDefinition#getTags() tagged} with {@code server-async}
      *   <li>The {@link Options#undertowListenableFutures()} is set
      *   <li>Experimental: Both {@link Options#experimentalUndertowAsyncMarkers()} is set and
      *       {@link EndpointDefinition#getMarkers()} contains an imported annotation with name
@@ -42,7 +43,8 @@ final class UndertowTypeFunctions {
         return options.undertowListenableFutures()
                 || (options.experimentalUndertowAsyncMarkers()
                         && endpoint.getMarkers().stream()
-                                .anyMatch(marker -> marker.accept(IsUndertowAsyncMarkerVisitor.INSTANCE)));
+                                .anyMatch(marker -> marker.accept(IsUndertowAsyncMarkerVisitor.INSTANCE)))
+                || endpoint.getTags().contains("server-async");
     }
 
     static ParameterizedTypeName getAsyncReturnType(EndpointDefinition endpoint, TypeMapper mapper, Options flags) {

--- a/conjure-java-core/src/test/resources/ete-service.yml
+++ b/conjure-java-core/src/test/resources/ete-service.yml
@@ -43,6 +43,9 @@ services:
       string:
         http: GET /string
         returns: string
+        tags:
+          - foo
+          - bar
         docs: |
           foo bar baz.
 

--- a/conjure-java-core/src/test/resources/test/api/AsyncMarkers.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/AsyncMarkers.java.undertow
@@ -1,13 +1,19 @@
 package test.api;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
 public interface AsyncMarkers {
     /**
-     * @apiNote {@code GET /async}
+     * @apiNote {@code GET /async/marker}
      */
-    String async();
+    String asyncMarker();
+
+    /**
+     * @apiNote {@code GET /async/tag}
+     */
+    ListenableFuture<String> asyncTag();
 
     /**
      * @apiNote {@code GET /sync}

--- a/conjure-java-core/src/test/resources/test/api/AsyncMarkers.java.undertow.async
+++ b/conjure-java-core/src/test/resources/test/api/AsyncMarkers.java.undertow.async
@@ -6,9 +6,14 @@ import javax.annotation.Generated;
 @Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
 public interface AsyncMarkers {
     /**
-     * @apiNote {@code GET /async}
+     * @apiNote {@code GET /async/marker}
      */
-    ListenableFuture<String> async();
+    ListenableFuture<String> asyncMarker();
+
+    /**
+     * @apiNote {@code GET /async/tag}
+     */
+    ListenableFuture<String> asyncTag();
 
     /**
      * @apiNote {@code GET /sync}

--- a/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow
@@ -1,6 +1,8 @@
 package test.api;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.ReturnValueWriter;
 import com.palantir.conjure.java.undertow.lib.Serializer;
 import com.palantir.conjure.java.undertow.lib.TypeMarker;
 import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
@@ -29,18 +31,20 @@ public final class AsyncMarkersEndpoints implements UndertowService {
 
     @Override
     public List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return Collections.unmodifiableList(
-                Arrays.asList(new AsyncEndpoint(runtime, delegate), new SyncEndpoint(runtime, delegate)));
+        return Collections.unmodifiableList(Arrays.asList(
+                new AsyncMarkerEndpoint(runtime, delegate),
+                new AsyncTagEndpoint(runtime, delegate),
+                new SyncEndpoint(runtime, delegate)));
     }
 
-    private static final class AsyncEndpoint implements HttpHandler, Endpoint {
+    private static final class AsyncMarkerEndpoint implements HttpHandler, Endpoint {
         private final UndertowRuntime runtime;
 
         private final AsyncMarkers delegate;
 
         private final Serializer<String> serializer;
 
-        AsyncEndpoint(UndertowRuntime runtime, AsyncMarkers delegate) {
+        AsyncMarkerEndpoint(UndertowRuntime runtime, AsyncMarkers delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
             this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
@@ -48,7 +52,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            String result = delegate.async();
+            String result = delegate.asyncMarker();
             serializer.serialize(result, exchange);
         }
 
@@ -59,7 +63,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
 
         @Override
         public String template() {
-            return "/async";
+            return "/async/marker";
         }
 
         @Override
@@ -69,7 +73,64 @@ public final class AsyncMarkersEndpoints implements UndertowService {
 
         @Override
         public String name() {
-            return "async";
+            return "asyncMarker";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class AsyncTagEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<String> {
+        private static final List<String> TAGS = Collections.unmodifiableList(Arrays.asList("server-async"));
+
+        private final UndertowRuntime runtime;
+
+        private final AsyncMarkers delegate;
+
+        private final Serializer<String> serializer;
+
+        AsyncTagEndpoint(UndertowRuntime runtime, AsyncMarkers delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+        }
+
+        @Override
+        public List<String> tags() {
+            return TAGS;
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            ListenableFuture<String> result = delegate.asyncTag();
+            runtime.async().register(result, this, exchange);
+        }
+
+        @Override
+        public void write(String result, HttpServerExchange exchange) throws IOException {
+            serializer.serialize(result, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/async/tag";
+        }
+
+        @Override
+        public String serviceName() {
+            return "AsyncMarkers";
+        }
+
+        @Override
+        public String name() {
+            return "asyncTag";
         }
 
         @Override

--- a/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow.async
+++ b/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow.async
@@ -31,18 +31,20 @@ public final class AsyncMarkersEndpoints implements UndertowService {
 
     @Override
     public List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return Collections.unmodifiableList(
-                Arrays.asList(new AsyncEndpoint(runtime, delegate), new SyncEndpoint(runtime, delegate)));
+        return Collections.unmodifiableList(Arrays.asList(
+                new AsyncMarkerEndpoint(runtime, delegate),
+                new AsyncTagEndpoint(runtime, delegate),
+                new SyncEndpoint(runtime, delegate)));
     }
 
-    private static final class AsyncEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<String> {
+    private static final class AsyncMarkerEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<String> {
         private final UndertowRuntime runtime;
 
         private final AsyncMarkers delegate;
 
         private final Serializer<String> serializer;
 
-        AsyncEndpoint(UndertowRuntime runtime, AsyncMarkers delegate) {
+        AsyncMarkerEndpoint(UndertowRuntime runtime, AsyncMarkers delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
             this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
@@ -50,7 +52,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            ListenableFuture<String> result = delegate.async();
+            ListenableFuture<String> result = delegate.asyncMarker();
             runtime.async().register(result, this, exchange);
         }
 
@@ -66,7 +68,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
 
         @Override
         public String template() {
-            return "/async";
+            return "/async/marker";
         }
 
         @Override
@@ -76,7 +78,64 @@ public final class AsyncMarkersEndpoints implements UndertowService {
 
         @Override
         public String name() {
-            return "async";
+            return "asyncMarker";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class AsyncTagEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<String> {
+        private static final List<String> TAGS = Collections.unmodifiableList(Arrays.asList("server-async"));
+
+        private final UndertowRuntime runtime;
+
+        private final AsyncMarkers delegate;
+
+        private final Serializer<String> serializer;
+
+        AsyncTagEndpoint(UndertowRuntime runtime, AsyncMarkers delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+        }
+
+        @Override
+        public List<String> tags() {
+            return TAGS;
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            ListenableFuture<String> result = delegate.asyncTag();
+            runtime.async().register(result, this, exchange);
+        }
+
+        @Override
+        public void write(String result, HttpServerExchange exchange) throws IOException {
+            serializer.serialize(result, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/async/tag";
+        }
+
+        @Override
+        public String serviceName() {
+            return "AsyncMarkers";
+        }
+
+        @Override
+        public String name() {
+            return "asyncTag";
         }
 
         @Override

--- a/conjure-java-core/src/test/resources/undertow-async-endpoint.yml
+++ b/conjure-java-core/src/test/resources/undertow-async-endpoint.yml
@@ -11,11 +11,16 @@ services:
     package: test.api
     name: Async Endpoint Test
     endpoints:
-      async:
-        http: GET /async
+      asyncMarker:
+        http: GET /async/marker
         returns: string
         markers:
           - Async
+      asyncTag:
+        http: GET /async/tag
+        returns: string
+        tags:
+          - server-async
       sync:
         http: GET /sync
         returns: string

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/Endpoint.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/Endpoint.java
@@ -16,10 +16,13 @@
 
 package com.palantir.conjure.java.undertow.lib;
 
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.palantir.logsafe.Preconditions;
 import io.undertow.server.HttpHandler;
 import io.undertow.util.HttpString;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -60,6 +63,11 @@ public interface Endpoint {
         return Optional.empty();
     }
 
+    /** Endpoint tags corresponding to the endpoint definition. */
+    default List<String> tags() {
+        return Collections.emptyList();
+    }
+
     static Builder builder() {
         return new Builder();
     }
@@ -74,6 +82,7 @@ public interface Endpoint {
         private String serviceName;
         private String name;
         private Optional<String> deprecated = Optional.empty();
+        private ImmutableList<String> tags = ImmutableList.of();
 
         @CanIgnoreReturnValue
         public Builder method(HttpString value) {
@@ -112,6 +121,12 @@ public interface Endpoint {
         }
 
         @CanIgnoreReturnValue
+        public Builder tags(Iterable<String> value) {
+            tags = ImmutableList.copyOf(Preconditions.checkNotNull(value, "tags are required"));
+            return this;
+        }
+
+        @CanIgnoreReturnValue
         public Builder from(Endpoint endpoint) {
             method = endpoint.method();
             template = endpoint.template();
@@ -119,6 +134,7 @@ public interface Endpoint {
             serviceName = endpoint.serviceName();
             name = endpoint.name();
             deprecated = endpoint.deprecated();
+            tags = ImmutableList.copyOf(endpoint.tags());
             return this;
         }
 
@@ -158,6 +174,11 @@ public interface Endpoint {
                 @Override
                 public Optional<String> deprecated() {
                     return deprecated;
+                }
+
+                @Override
+                public List<String> tags() {
+                    return tags;
                 }
             };
         }

--- a/readme.md
+++ b/readme.md
@@ -239,8 +239,17 @@ implemented synchronously by replacing `return object` with `return Futures.imme
 Asynchronous request processing decouples the HTTP request lifecycle from server task threads, allowing you to replace
 waiting on shared resources with callbacks, reducing the number of required threads.
 
-This feature is enabled using:
+This feature is enabled on individual endpoints using the `server-async` endpoint tag:
 
+```yaml
+getEvents:
+  http: GET /events
+  returns: list<Event>
+  tags:
+    - server-async
+```
+
+Or for all endpoints using the `undertowListenableFutures` generator flag:
 ```groovy
 conjure {
     java {


### PR DESCRIPTION
==COMMIT_MSG==
Undertow Endpoints provide tags when defined
==COMMIT_MSG==

These can allow us to set up more specific rate limiting based on the definition using simple filters around registration.
Unclear if we would want to do something similar with parameter tags.