### PR TITLE
Undertow Endpoints provide tags when defined

### DIFF
--- a/changelog/@unreleased/pr-1145.v2.yml
+++ b/changelog/@unreleased/pr-1145.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Undertow Endpoints provide tags when defined
+  links:
+  - https://github.com/palantir/conjure-java/pull/1145

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AsyncRequestProcessingTestServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AsyncRequestProcessingTestServiceEndpoints.java
@@ -1,5 +1,6 @@
 package com.palantir.product;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.conjure.java.undertow.lib.Endpoint;
@@ -14,8 +15,6 @@ import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import io.undertow.util.StatusCodes;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
@@ -37,12 +36,12 @@ public final class AsyncRequestProcessingTestServiceEndpoints implements Underto
 
     @Override
     public List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return Collections.unmodifiableList(Arrays.asList(
+        return ImmutableList.of(
                 new DelayEndpoint(runtime, delegate),
                 new ThrowsInHandlerEndpoint(runtime, delegate),
                 new FailedFutureEndpoint(runtime, delegate),
                 new BinaryEndpoint(runtime, delegate),
-                new FutureTraceIdEndpoint(runtime, delegate)));
+                new FutureTraceIdEndpoint(runtime, delegate));
     }
 
     private static final class DelayEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<String> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceEndpoints.java
@@ -1,5 +1,6 @@
 package com.palantir.product;
 
+import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.undertow.lib.Endpoint;
 import com.palantir.conjure.java.undertow.lib.Serializer;
 import com.palantir.conjure.java.undertow.lib.TypeMarker;
@@ -10,8 +11,6 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Generated;
 
@@ -29,7 +28,7 @@ public final class EmptyPathServiceEndpoints implements UndertowService {
 
     @Override
     public List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return Collections.unmodifiableList(Arrays.asList(new EmptyPathEndpoint(runtime, delegate)));
+        return ImmutableList.of(new EmptyPathEndpoint(runtime, delegate));
     }
 
     private static final class EmptyPathEndpoint implements HttpHandler, Endpoint {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceEndpoints.java
@@ -1,5 +1,6 @@
 package com.palantir.product;
 
+import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.conjure.java.undertow.lib.Endpoint;
 import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
@@ -12,8 +13,6 @@ import io.undertow.util.Methods;
 import io.undertow.util.StatusCodes;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
@@ -34,13 +33,13 @@ public final class EteBinaryServiceEndpoints implements UndertowService {
 
     @Override
     public List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return Collections.unmodifiableList(Arrays.asList(
+        return ImmutableList.of(
                 new PostBinaryEndpoint(runtime, delegate),
                 new PostBinaryThrowsEndpoint(runtime, delegate),
                 new GetOptionalBinaryPresentEndpoint(runtime, delegate),
                 new GetOptionalBinaryEmptyEndpoint(runtime, delegate),
                 new GetBinaryFailureEndpoint(runtime, delegate),
-                new GetAliasedEndpoint(runtime, delegate)));
+                new GetAliasedEndpoint(runtime, delegate));
     }
 
     private static final class PostBinaryEndpoint implements HttpHandler, Endpoint {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
@@ -22,8 +22,6 @@ import io.undertow.util.PathTemplateMatch;
 import io.undertow.util.StatusCodes;
 import java.io.IOException;
 import java.time.OffsetDateTime;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +43,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
     @Override
     public List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return Collections.unmodifiableList(Arrays.asList(
+        return ImmutableList.of(
                 new StringEndpoint(runtime, delegate),
                 new IntegerEndpoint(runtime, delegate),
                 new Double_Endpoint(runtime, delegate),
@@ -75,7 +73,7 @@ public final class EteServiceEndpoints implements UndertowService {
                 new AliasLongEndpointEndpoint(runtime, delegate),
                 new ComplexQueryParametersEndpoint(runtime, delegate),
                 new ReceiveListOfOptionalsEndpoint(runtime, delegate),
-                new ReceiveSetOfOptionalsEndpoint(runtime, delegate)));
+                new ReceiveSetOfOptionalsEndpoint(runtime, delegate));
     }
 
     private static final class StringEndpoint implements HttpHandler, Endpoint {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
@@ -79,7 +79,7 @@ public final class EteServiceEndpoints implements UndertowService {
     }
 
     private static final class StringEndpoint implements HttpHandler, Endpoint {
-        private static final List<String> TAGS = Collections.unmodifiableList(Arrays.asList("bar", "foo"));
+        private static final ImmutableList<String> TAGS = ImmutableList.of("bar", "foo");
 
         private final UndertowRuntime runtime;
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
@@ -77,7 +77,7 @@ public final class EteServiceEndpoints implements UndertowService {
     }
 
     private static final class StringEndpoint implements HttpHandler, Endpoint {
-        private static final ImmutableList<String> TAGS = ImmutableList.of("bar", "foo");
+        private static final ImmutableSet<String> TAGS = ImmutableSet.of("bar", "foo");
 
         private final UndertowRuntime runtime;
 
@@ -92,7 +92,7 @@ public final class EteServiceEndpoints implements UndertowService {
         }
 
         @Override
-        public List<String> tags() {
+        public Set<String> tags() {
             return TAGS;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
@@ -79,6 +79,8 @@ public final class EteServiceEndpoints implements UndertowService {
     }
 
     private static final class StringEndpoint implements HttpHandler, Endpoint {
+        private static final List<String> TAGS = Collections.unmodifiableList(Arrays.asList("bar", "foo"));
+
         private final UndertowRuntime runtime;
 
         private final UndertowEteService delegate;
@@ -89,6 +91,11 @@ public final class EteServiceEndpoints implements UndertowService {
             this.runtime = runtime;
             this.delegate = delegate;
             this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+        }
+
+        @Override
+        public List<String> tags() {
+            return TAGS;
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/NameCollisionServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/NameCollisionServiceEndpoints.java
@@ -1,5 +1,6 @@
 package com.palantir.product;
 
+import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.undertow.lib.Deserializer;
 import com.palantir.conjure.java.undertow.lib.Endpoint;
 import com.palantir.conjure.java.undertow.lib.Serializer;
@@ -14,8 +15,6 @@ import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import io.undertow.util.PathTemplateMatch;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +34,7 @@ public final class NameCollisionServiceEndpoints implements UndertowService {
 
     @Override
     public List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return Collections.unmodifiableList(Arrays.asList(new IntEndpoint(runtime, delegate)));
+        return ImmutableList.of(new IntEndpoint(runtime, delegate));
     }
 
     private static final class IntEndpoint implements HttpHandler, Endpoint {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -357,13 +357,12 @@ final class UndertowServiceHandlerGenerator {
             CodeBlock arrayValues = CodeBlock.join(
                     Collections2.transform(endpointDefinition.getTags(), value -> CodeBlock.of("$S", value)), ", ");
             endpointBuilder.addField(FieldSpec.builder(
-                            ParameterizedTypeName.get(List.class, String.class),
+                            ParameterizedTypeName.get(ImmutableList.class, String.class),
                             "TAGS",
                             Modifier.PRIVATE,
                             Modifier.STATIC,
                             Modifier.FINAL)
-                    .initializer(CodeBlock.of(
-                            "$T.unmodifiableList($T.asList(" + arrayValues + "))", Collections.class, Arrays.class))
+                    .initializer(CodeBlock.of("$T.of($L)", ImmutableList.class, arrayValues))
                     .build());
             endpointBuilder.addMethod(MethodSpec.methodBuilder("tags")
                     .addModifiers(Modifier.PUBLIC)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -78,9 +78,7 @@ import io.undertow.util.StatusCodes;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
@@ -172,11 +170,7 @@ final class UndertowServiceHandlerGenerator {
                         .addModifiers(Modifier.PUBLIC)
                         .addParameter(UndertowRuntime.class, RUNTIME_VAR_NAME)
                         .returns(ParameterizedTypeName.get(List.class, Endpoint.class))
-                        .addStatement(
-                                "return $1T.unmodifiableList($2T.asList($3L))",
-                                Collections.class,
-                                Arrays.class,
-                                endpointBlock)
+                        .addStatement("return $1T.of($2L)", ImmutableList.class, endpointBlock)
                         .build())
                 .addTypes(Lists.transform(
                         serviceDefinition.getEndpoints(),

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.services;
 
+import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -240,6 +241,8 @@ final class UndertowServiceHandlerGenerator {
                 .addField(FieldSpec.builder(serviceClass, DELEGATE_VAR_NAME, Modifier.PRIVATE, Modifier.FINAL)
                         .build());
 
+        addTags(endpointDefinition, endpointBuilder);
+
         getBodyParamTypeArgument(endpointDefinition.getArgs())
                 .map(ArgumentDefinition::getType)
                 // Filter out binary data
@@ -347,6 +350,28 @@ final class UndertowServiceHandlerGenerator {
                         .build()));
 
         return endpointBuilder.build();
+    }
+
+    private static void addTags(EndpointDefinition endpointDefinition, TypeSpec.Builder endpointBuilder) {
+        if (!endpointDefinition.getTags().isEmpty()) {
+            CodeBlock arrayValues = CodeBlock.join(
+                    Collections2.transform(endpointDefinition.getTags(), value -> CodeBlock.of("$S", value)), ", ");
+            endpointBuilder.addField(FieldSpec.builder(
+                            ParameterizedTypeName.get(List.class, String.class),
+                            "TAGS",
+                            Modifier.PRIVATE,
+                            Modifier.STATIC,
+                            Modifier.FINAL)
+                    .initializer(CodeBlock.of(
+                            "$T.unmodifiableList($T.asList(" + arrayValues + "))", Collections.class, Arrays.class))
+                    .build());
+            endpointBuilder.addMethod(MethodSpec.methodBuilder("tags")
+                    .addModifiers(Modifier.PUBLIC)
+                    .addAnnotation(Override.class)
+                    .returns(ParameterizedTypeName.get(List.class, String.class))
+                    .addStatement("return TAGS")
+                    .build());
+        }
     }
 
     private static final ClassName LIST_NAME = ClassName.get(List.class);

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -351,17 +351,17 @@ final class UndertowServiceHandlerGenerator {
             CodeBlock arrayValues = CodeBlock.join(
                     Collections2.transform(endpointDefinition.getTags(), value -> CodeBlock.of("$S", value)), ", ");
             endpointBuilder.addField(FieldSpec.builder(
-                            ParameterizedTypeName.get(ImmutableList.class, String.class),
+                            ParameterizedTypeName.get(ImmutableSet.class, String.class),
                             "TAGS",
                             Modifier.PRIVATE,
                             Modifier.STATIC,
                             Modifier.FINAL)
-                    .initializer(CodeBlock.of("$T.of($L)", ImmutableList.class, arrayValues))
+                    .initializer(CodeBlock.of("$T.of($L)", ImmutableSet.class, arrayValues))
                     .build());
             endpointBuilder.addMethod(MethodSpec.methodBuilder("tags")
                     .addModifiers(Modifier.PUBLIC)
                     .addAnnotation(Override.class)
-                    .returns(ParameterizedTypeName.get(List.class, String.class))
+                    .returns(ParameterizedTypeName.get(Set.class, String.class))
                     .addStatement("return TAGS")
                     .build());
         }

--- a/conjure-java-core/src/test/resources/ete-service.yml
+++ b/conjure-java-core/src/test/resources/ete-service.yml
@@ -43,6 +43,9 @@ services:
       string:
         http: GET /string
         returns: string
+        tags:
+          - foo
+          - bar
         docs: |
           foo bar baz.
 

--- a/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow
@@ -83,6 +83,8 @@ public final class AsyncMarkersEndpoints implements UndertowService {
     }
 
     private static final class AsyncTagEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<String> {
+        private static final List<String> TAGS = Collections.unmodifiableList(Arrays.asList("server-async"));
+
         private final UndertowRuntime runtime;
 
         private final AsyncMarkers delegate;
@@ -93,6 +95,11 @@ public final class AsyncMarkersEndpoints implements UndertowService {
             this.runtime = runtime;
             this.delegate = delegate;
             this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+        }
+
+        @Override
+        public List<String> tags() {
+            return TAGS;
         }
 
         @Override

--- a/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow
@@ -13,8 +13,6 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Generated;
 
@@ -32,10 +30,10 @@ public final class AsyncMarkersEndpoints implements UndertowService {
 
     @Override
     public List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return Collections.unmodifiableList(Arrays.asList(
+        return ImmutableList.of(
                 new AsyncMarkerEndpoint(runtime, delegate),
                 new AsyncTagEndpoint(runtime, delegate),
-                new SyncEndpoint(runtime, delegate)));
+                new SyncEndpoint(runtime, delegate));
     }
 
     private static final class AsyncMarkerEndpoint implements HttpHandler, Endpoint {

--- a/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow
@@ -1,5 +1,6 @@
 package test.api;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.conjure.java.undertow.lib.Endpoint;
 import com.palantir.conjure.java.undertow.lib.ReturnValueWriter;
@@ -83,7 +84,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
     }
 
     private static final class AsyncTagEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<String> {
-        private static final List<String> TAGS = Collections.unmodifiableList(Arrays.asList("server-async"));
+        private static final ImmutableList<String> TAGS = ImmutableList.of("server-async");
 
         private final UndertowRuntime runtime;
 

--- a/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow
@@ -1,6 +1,7 @@
 package test.api;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.conjure.java.undertow.lib.Endpoint;
 import com.palantir.conjure.java.undertow.lib.ReturnValueWriter;
@@ -14,6 +15,7 @@ import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceHandlerGenerator")
@@ -82,7 +84,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
     }
 
     private static final class AsyncTagEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<String> {
-        private static final ImmutableList<String> TAGS = ImmutableList.of("server-async");
+        private static final ImmutableSet<String> TAGS = ImmutableSet.of("server-async");
 
         private final UndertowRuntime runtime;
 
@@ -97,7 +99,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
         }
 
         @Override
-        public List<String> tags() {
+        public Set<String> tags() {
             return TAGS;
         }
 

--- a/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow.async
+++ b/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow.async
@@ -1,6 +1,7 @@
 package test.api;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.conjure.java.undertow.lib.Endpoint;
 import com.palantir.conjure.java.undertow.lib.ReturnValueWriter;
@@ -14,6 +15,7 @@ import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.UndertowServiceHandlerGenerator")
@@ -87,7 +89,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
     }
 
     private static final class AsyncTagEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<String> {
-        private static final ImmutableList<String> TAGS = ImmutableList.of("server-async");
+        private static final ImmutableSet<String> TAGS = ImmutableSet.of("server-async");
 
         private final UndertowRuntime runtime;
 
@@ -102,7 +104,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
         }
 
         @Override
-        public List<String> tags() {
+        public Set<String> tags() {
             return TAGS;
         }
 

--- a/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow.async
+++ b/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow.async
@@ -1,5 +1,6 @@
 package test.api;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.conjure.java.undertow.lib.Endpoint;
 import com.palantir.conjure.java.undertow.lib.ReturnValueWriter;
@@ -88,7 +89,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
     }
 
     private static final class AsyncTagEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<String> {
-        private static final List<String> TAGS = Collections.unmodifiableList(Arrays.asList("server-async"));
+        private static final ImmutableList<String> TAGS = ImmutableList.of("server-async");
 
         private final UndertowRuntime runtime;
 

--- a/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow.async
+++ b/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow.async
@@ -13,8 +13,6 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Generated;
 
@@ -32,10 +30,10 @@ public final class AsyncMarkersEndpoints implements UndertowService {
 
     @Override
     public List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return Collections.unmodifiableList(Arrays.asList(
+        return ImmutableList.of(
                 new AsyncMarkerEndpoint(runtime, delegate),
                 new AsyncTagEndpoint(runtime, delegate),
-                new SyncEndpoint(runtime, delegate)));
+                new SyncEndpoint(runtime, delegate));
     }
 
     private static final class AsyncMarkerEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<String> {

--- a/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow.async
+++ b/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow.async
@@ -88,6 +88,8 @@ public final class AsyncMarkersEndpoints implements UndertowService {
     }
 
     private static final class AsyncTagEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<String> {
+        private static final List<String> TAGS = Collections.unmodifiableList(Arrays.asList("server-async"));
+
         private final UndertowRuntime runtime;
 
         private final AsyncMarkers delegate;
@@ -98,6 +100,11 @@ public final class AsyncMarkersEndpoints implements UndertowService {
             this.runtime = runtime;
             this.delegate = delegate;
             this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+        }
+
+        @Override
+        public List<String> tags() {
+            return TAGS;
         }
 
         @Override

--- a/conjure-java-core/src/test/resources/test/api/CookieServiceEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/CookieServiceEndpoints.java.undertow
@@ -1,5 +1,6 @@
 package test.api;
 
+import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.undertow.lib.Endpoint;
 import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
 import com.palantir.conjure.java.undertow.lib.UndertowService;
@@ -10,8 +11,6 @@ import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import io.undertow.util.StatusCodes;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Generated;
 
@@ -29,7 +28,7 @@ public final class CookieServiceEndpoints implements UndertowService {
 
     @Override
     public List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return Collections.unmodifiableList(Arrays.asList(new EatCookiesEndpoint(runtime, delegate)));
+        return ImmutableList.of(new EatCookiesEndpoint(runtime, delegate));
     }
 
     private static final class EatCookiesEndpoint implements HttpHandler, Endpoint {

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
@@ -1,5 +1,6 @@
 package com.palantir.another;
 
+import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.conjure.java.undertow.lib.Deserializer;
 import com.palantir.conjure.java.undertow.lib.Endpoint;
@@ -22,8 +23,6 @@ import io.undertow.util.PathTemplateMatch;
 import io.undertow.util.StatusCodes;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
@@ -47,7 +46,7 @@ public final class TestServiceEndpoints implements UndertowService {
 
     @Override
     public List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return Collections.unmodifiableList(Arrays.asList(
+        return ImmutableList.of(
                 new GetFileSystemsEndpoint(runtime, delegate),
                 new CreateDatasetEndpoint(runtime, delegate),
                 new GetDatasetEndpoint(runtime, delegate),
@@ -68,7 +67,7 @@ public final class TestServiceEndpoints implements UndertowService {
                 new TestIntegerEndpoint(runtime, delegate),
                 new TestPostOptionalEndpoint(runtime, delegate),
                 new TestOptionalIntegerAndDoubleEndpoint(runtime, delegate),
-                new GetForStringsEndpoint(runtime, delegate)));
+                new GetForStringsEndpoint(runtime, delegate));
     }
 
     private static final class GetFileSystemsEndpoint implements HttpHandler, Endpoint {

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.binary
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.binary
@@ -1,5 +1,6 @@
 package test.api;
 
+import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.conjure.java.undertow.lib.Endpoint;
 import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
@@ -9,8 +10,6 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Generated;
 
@@ -28,7 +27,7 @@ public final class TestServiceEndpoints implements UndertowService {
 
     @Override
     public List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return Collections.unmodifiableList(Arrays.asList(new GetBinaryEndpoint(runtime, delegate)));
+        return ImmutableList.of(new GetBinaryEndpoint(runtime, delegate));
     }
 
     private static final class GetBinaryEndpoint implements HttpHandler, Endpoint {

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.prefix
@@ -1,5 +1,6 @@
 package test.prefix.com.palantir.another;
 
+import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.conjure.java.undertow.lib.Deserializer;
 import com.palantir.conjure.java.undertow.lib.Endpoint;
@@ -18,8 +19,6 @@ import io.undertow.util.PathTemplateMatch;
 import io.undertow.util.StatusCodes;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
@@ -47,7 +46,7 @@ public final class TestServiceEndpoints implements UndertowService {
 
     @Override
     public List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return Collections.unmodifiableList(Arrays.asList(
+        return ImmutableList.of(
                 new GetFileSystemsEndpoint(runtime, delegate),
                 new CreateDatasetEndpoint(runtime, delegate),
                 new GetDatasetEndpoint(runtime, delegate),
@@ -68,7 +67,7 @@ public final class TestServiceEndpoints implements UndertowService {
                 new TestIntegerEndpoint(runtime, delegate),
                 new TestPostOptionalEndpoint(runtime, delegate),
                 new TestOptionalIntegerAndDoubleEndpoint(runtime, delegate),
-                new GetForStringsEndpoint(runtime, delegate)));
+                new GetForStringsEndpoint(runtime, delegate));
     }
 
     private static final class GetFileSystemsEndpoint implements HttpHandler, Endpoint {

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/Endpoint.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/Endpoint.java
@@ -16,10 +16,13 @@
 
 package com.palantir.conjure.java.undertow.lib;
 
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.palantir.logsafe.Preconditions;
 import io.undertow.server.HttpHandler;
 import io.undertow.util.HttpString;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -60,6 +63,11 @@ public interface Endpoint {
         return Optional.empty();
     }
 
+    /** Endpoint tags corresponding to the endpoint definition. */
+    default List<String> tags() {
+        return Collections.emptyList();
+    }
+
     static Builder builder() {
         return new Builder();
     }
@@ -74,6 +82,7 @@ public interface Endpoint {
         private String serviceName;
         private String name;
         private Optional<String> deprecated = Optional.empty();
+        private ImmutableList<String> tags = ImmutableList.of();
 
         @CanIgnoreReturnValue
         public Builder method(HttpString value) {
@@ -112,6 +121,12 @@ public interface Endpoint {
         }
 
         @CanIgnoreReturnValue
+        public Builder tags(Iterable<String> value) {
+            tags = ImmutableList.copyOf(Preconditions.checkNotNull(value, "tags are required"));
+            return this;
+        }
+
+        @CanIgnoreReturnValue
         public Builder from(Endpoint endpoint) {
             method = endpoint.method();
             template = endpoint.template();
@@ -119,6 +134,7 @@ public interface Endpoint {
             serviceName = endpoint.serviceName();
             name = endpoint.name();
             deprecated = endpoint.deprecated();
+            tags = ImmutableList.copyOf(endpoint.tags());
             return this;
         }
 
@@ -158,6 +174,11 @@ public interface Endpoint {
                 @Override
                 public Optional<String> deprecated() {
                     return deprecated;
+                }
+
+                @Override
+                public List<String> tags() {
+                    return tags;
                 }
             };
         }

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/Endpoint.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/Endpoint.java
@@ -16,14 +16,14 @@
 
 package com.palantir.conjure.java.undertow.lib;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.palantir.logsafe.Preconditions;
 import io.undertow.server.HttpHandler;
 import io.undertow.util.HttpString;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * An {@link Endpoint} represents a single rpc method. End points provide a location, tuple of {@link Endpoint#method()}
@@ -64,8 +64,8 @@ public interface Endpoint {
     }
 
     /** Endpoint tags corresponding to the endpoint definition. */
-    default List<String> tags() {
-        return Collections.emptyList();
+    default Set<String> tags() {
+        return Collections.emptySet();
     }
 
     static Builder builder() {
@@ -82,7 +82,7 @@ public interface Endpoint {
         private String serviceName;
         private String name;
         private Optional<String> deprecated = Optional.empty();
-        private ImmutableList<String> tags = ImmutableList.of();
+        private ImmutableSet<String> tags = ImmutableSet.of();
 
         @CanIgnoreReturnValue
         public Builder method(HttpString value) {
@@ -122,7 +122,7 @@ public interface Endpoint {
 
         @CanIgnoreReturnValue
         public Builder tags(Iterable<String> value) {
-            tags = ImmutableList.copyOf(Preconditions.checkNotNull(value, "tags are required"));
+            tags = ImmutableSet.copyOf(Preconditions.checkNotNull(value, "tags are required"));
             return this;
         }
 
@@ -134,7 +134,7 @@ public interface Endpoint {
             serviceName = endpoint.serviceName();
             name = endpoint.name();
             deprecated = endpoint.deprecated();
-            tags = ImmutableList.copyOf(endpoint.tags());
+            tags = ImmutableSet.copyOf(endpoint.tags());
             return this;
         }
 
@@ -177,7 +177,7 @@ public interface Endpoint {
                 }
 
                 @Override
-                public List<String> tags() {
+                public Set<String> tags() {
                     return tags;
                 }
             };


### PR DESCRIPTION
## Before this PR
No way to discover tag information while registering endpoints.

==COMMIT_MSG==
Undertow Endpoints provide tags when defined
==COMMIT_MSG==

This opens the door for prototyping work outside of the conjure-java project, for example to allow individual endpoints to opt into rate limiting based on a shared key for all endpoints of a similar type.
