### PR TITLE
Apply `@Incubating` annotations based on the `incubating` endpoint tag

### DIFF
--- a/changelog/@unreleased/pr-1150.v2.yml
+++ b/changelog/@unreleased/pr-1150.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Apply `@Incubating` annotations based on the `incubating` endpoint
+    tag
+  links:
+  - https://github.com/palantir/conjure-java/pull/1150

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/ConjureAnnotations.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/ConjureAnnotations.java
@@ -16,8 +16,8 @@
 
 package com.palantir.conjure.java;
 
-import com.google.common.annotations.Beta;
 import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.java.lib.internal.Incubating;
 import com.palantir.conjure.spec.Documentation;
 import com.palantir.conjure.spec.EndpointDefinition;
 import com.squareup.javapoet.AnnotationSpec;
@@ -38,9 +38,9 @@ public final class ConjureAnnotations {
                 : ImmutableList.of();
     }
 
-    public static ImmutableList<AnnotationSpec> unstable(EndpointDefinition definition) {
-        if (definition.getTags().contains("unstable")) {
-            return ImmutableList.of(AnnotationSpec.builder(Beta.class).build());
+    public static ImmutableList<AnnotationSpec> incubating(EndpointDefinition definition) {
+        if (definition.getTags().contains("incubating")) {
+            return ImmutableList.of(AnnotationSpec.builder(Incubating.class).build());
         }
         return ImmutableList.of();
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/ConjureAnnotations.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/ConjureAnnotations.java
@@ -16,8 +16,10 @@
 
 package com.palantir.conjure.java;
 
+import com.google.common.annotations.Beta;
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.spec.Documentation;
+import com.palantir.conjure.spec.EndpointDefinition;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import java.util.Optional;
@@ -34,6 +36,13 @@ public final class ConjureAnnotations {
         return deprecation.isPresent()
                 ? ImmutableList.of(AnnotationSpec.builder(Deprecated.class).build())
                 : ImmutableList.of();
+    }
+
+    public static ImmutableList<AnnotationSpec> unstable(EndpointDefinition definition) {
+        if (definition.getTags().contains("unstable")) {
+            return ImmutableList.of(AnnotationSpec.builder(Beta.class).build());
+        }
+        return ImmutableList.of();
     }
 
     private ConjureAnnotations() {}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
@@ -146,6 +146,7 @@ public final class JerseyServiceGenerator extends ServiceGenerator {
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                 .addAnnotation(
                         httpMethodToClassName(endpointDef.getHttpMethod().get().name()))
+                .addAnnotations(ConjureAnnotations.unstable(endpointDef))
                 .addParameters(createServiceMethodParameters(endpointDef, argumentTypeMapper, true))
                 .returns(returnType);
 
@@ -226,6 +227,7 @@ public final class JerseyServiceGenerator extends ServiceGenerator {
                         endpointDef.getEndpointName().get())
                 .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
                 .addAnnotation(Deprecated.class)
+                .addAnnotations(ConjureAnnotations.unstable(endpointDef))
                 .addParameters(IntStream.range(0, sortedParams.size())
                         .filter(i -> !sortedMaybeExtraArgs.get(i).isPresent())
                         .mapToObj(sortedParams::get)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
@@ -146,7 +146,7 @@ public final class JerseyServiceGenerator extends ServiceGenerator {
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                 .addAnnotation(
                         httpMethodToClassName(endpointDef.getHttpMethod().get().name()))
-                .addAnnotations(ConjureAnnotations.unstable(endpointDef))
+                .addAnnotations(ConjureAnnotations.incubating(endpointDef))
                 .addParameters(createServiceMethodParameters(endpointDef, argumentTypeMapper, true))
                 .returns(returnType);
 
@@ -227,7 +227,7 @@ public final class JerseyServiceGenerator extends ServiceGenerator {
                         endpointDef.getEndpointName().get())
                 .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
                 .addAnnotation(Deprecated.class)
-                .addAnnotations(ConjureAnnotations.unstable(endpointDef))
+                .addAnnotations(ConjureAnnotations.incubating(endpointDef))
                 .addParameters(IntStream.range(0, sortedParams.size())
                         .filter(i -> !sortedMaybeExtraArgs.get(i).isPresent())
                         .mapToObj(sortedParams::get)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
@@ -150,7 +150,8 @@ public final class Retrofit2ServiceGenerator extends ServiceGenerator {
                 .addAnnotation(AnnotationSpec.builder(ClassName.get("retrofit2.http", "Headers"))
                         .addMember("value", "$S", "hr-path-template: " + endpointPathWithoutRegex)
                         .addMember("value", "$S", "Accept: " + getReturnMediaType(returnType))
-                        .build());
+                        .build())
+                .addAnnotations(ConjureAnnotations.unstable(endpointDef));
 
         if (returnType.equals(BINARY_RETURN_TYPE) || returnType.equals(OPTIONAL_BINARY_RETURN_TYPE)) {
             methodBuilder.addAnnotation(AnnotationSpec.builder(ClassName.get("retrofit2.http", "Streaming"))
@@ -251,7 +252,8 @@ public final class Retrofit2ServiceGenerator extends ServiceGenerator {
                 .addParameters(IntStream.range(0, sortedParams.size())
                         .filter(i -> !sortedMaybeExtraArgs.get(i).isPresent())
                         .mapToObj(sortedParams::get)
-                        .collect(Collectors.toList()));
+                        .collect(Collectors.toList()))
+                .addAnnotations(ConjureAnnotations.unstable(endpointDef));
 
         endpointDef
                 .getReturns()

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
@@ -151,7 +151,7 @@ public final class Retrofit2ServiceGenerator extends ServiceGenerator {
                         .addMember("value", "$S", "hr-path-template: " + endpointPathWithoutRegex)
                         .addMember("value", "$S", "Accept: " + getReturnMediaType(returnType))
                         .build())
-                .addAnnotations(ConjureAnnotations.unstable(endpointDef));
+                .addAnnotations(ConjureAnnotations.incubating(endpointDef));
 
         if (returnType.equals(BINARY_RETURN_TYPE) || returnType.equals(OPTIONAL_BINARY_RETURN_TYPE)) {
             methodBuilder.addAnnotation(AnnotationSpec.builder(ClassName.get("retrofit2.http", "Streaming"))
@@ -253,7 +253,7 @@ public final class Retrofit2ServiceGenerator extends ServiceGenerator {
                         .filter(i -> !sortedMaybeExtraArgs.get(i).isPresent())
                         .mapToObj(sortedParams::get)
                         .collect(Collectors.toList()))
-                .addAnnotations(ConjureAnnotations.unstable(endpointDef));
+                .addAnnotations(ConjureAnnotations.incubating(endpointDef));
 
         endpointDef
                 .getReturns()

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceInterfaceGenerator.java
@@ -79,7 +79,8 @@ final class UndertowServiceInterfaceGenerator {
                 JavaNameSanitizer.sanitize(endpointDef.getEndpointName().get());
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(methodName)
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-                .addParameters(createServiceMethodParameters(endpointDef, typeMapper));
+                .addParameters(createServiceMethodParameters(endpointDef, typeMapper))
+                .addAnnotations(ConjureAnnotations.unstable(endpointDef));
 
         endpointDef.getDeprecated().ifPresent(deprecatedDocsValue -> methodBuilder.addAnnotation(Deprecated.class));
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceInterfaceGenerator.java
@@ -80,7 +80,7 @@ final class UndertowServiceInterfaceGenerator {
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(methodName)
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                 .addParameters(createServiceMethodParameters(endpointDef, typeMapper))
-                .addAnnotations(ConjureAnnotations.unstable(endpointDef));
+                .addAnnotations(ConjureAnnotations.incubating(endpointDef));
 
         endpointDef.getDeprecated().ifPresent(deprecatedDocsValue -> methodBuilder.addAnnotation(Deprecated.class));
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
@@ -133,7 +133,7 @@ public final class DialogueInterfaceGenerator {
                         endpointDef.getEndpointName().get())
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                 .addParameters(parameterTypes.methodParams(endpointDef))
-                .addAnnotations(ConjureAnnotations.unstable(endpointDef));
+                .addAnnotations(ConjureAnnotations.incubating(endpointDef));
         endpointDef.getMarkers().stream()
                 .filter(marker -> !marker.accept(IsUndertowAsyncMarkerVisitor.INSTANCE))
                 .map(marker -> {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
@@ -132,7 +132,8 @@ public final class DialogueInterfaceGenerator {
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(
                         endpointDef.getEndpointName().get())
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-                .addParameters(parameterTypes.methodParams(endpointDef));
+                .addParameters(parameterTypes.methodParams(endpointDef))
+                .addAnnotations(ConjureAnnotations.unstable(endpointDef));
         endpointDef.getMarkers().stream()
                 .filter(marker -> !marker.accept(IsUndertowAsyncMarkerVisitor.INSTANCE))
                 .map(marker -> {

--- a/conjure-java-core/src/test/resources/example-service.yml
+++ b/conjure-java-core/src/test/resources/example-service.yml
@@ -54,7 +54,9 @@ services:
     endpoints:
       getFileSystems:
         markers:
-          - Nonnull # requires FeatureFlags.DangerousGothamMethodMarkers
+          - Nonnull
+        tags:
+          - unstable
         http: GET /fileSystems
         returns: map<string, BackingFileSystem>
         docs: |

--- a/conjure-java-core/src/test/resources/example-service.yml
+++ b/conjure-java-core/src/test/resources/example-service.yml
@@ -56,7 +56,7 @@ services:
         markers:
           - Nonnull
         tags:
-          - unstable
+          - incubating
         http: GET /fileSystems
         returns: map<string, BackingFileSystem>
         docs: |

--- a/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue
@@ -21,7 +21,7 @@ enum DialogueTestEndpoints implements Endpoint {
         private final PathTemplate pathTemplate =
                 PathTemplate.builder().fixed("catalog").fixed("fileSystems").build();
 
-        private final ImmutableSet<String> tags = ImmutableSet.of("unstable");
+        private final ImmutableSet<String> tags = ImmutableSet.of("incubating");
 
         @Override
         public void renderPath(Map<String, String> params, UrlBuilder url) {

--- a/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue
@@ -1,5 +1,6 @@
 package com.palantir.another;
 
+import com.google.common.collect.ImmutableSet;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.PathTemplate;
@@ -8,6 +9,7 @@ import java.lang.Override;
 import java.lang.String;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueEndpointsGenerator")
@@ -18,6 +20,8 @@ enum DialogueTestEndpoints implements Endpoint {
     getFileSystems {
         private final PathTemplate pathTemplate =
                 PathTemplate.builder().fixed("catalog").fixed("fileSystems").build();
+
+        private final ImmutableSet<String> tags = ImmutableSet.of("unstable");
 
         @Override
         public void renderPath(Map<String, String> params, UrlBuilder url) {
@@ -42,6 +46,11 @@ enum DialogueTestEndpoints implements Endpoint {
         @Override
         public String version() {
             return VERSION;
+        }
+
+        @Override
+        public Set<String> tags() {
+            return tags;
         }
     },
 

--- a/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue.prefix
@@ -21,7 +21,7 @@ enum DialogueTestEndpoints implements Endpoint {
         private final PathTemplate pathTemplate =
                 PathTemplate.builder().fixed("catalog").fixed("fileSystems").build();
 
-        private final ImmutableSet<String> tags = ImmutableSet.of("unstable");
+        private final ImmutableSet<String> tags = ImmutableSet.of("incubating");
 
         @Override
         public void renderPath(Map<String, String> params, UrlBuilder url) {

--- a/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue.prefix
@@ -1,5 +1,6 @@
 package test.prefix.com.palantir.another;
 
+import com.google.common.collect.ImmutableSet;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.HttpMethod;
 import com.palantir.dialogue.PathTemplate;
@@ -8,6 +9,7 @@ import java.lang.Override;
 import java.lang.String;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueEndpointsGenerator")
@@ -18,6 +20,8 @@ enum DialogueTestEndpoints implements Endpoint {
     getFileSystems {
         private final PathTemplate pathTemplate =
                 PathTemplate.builder().fixed("catalog").fixed("fileSystems").build();
+
+        private final ImmutableSet<String> tags = ImmutableSet.of("unstable");
 
         @Override
         public void renderPath(Map<String, String> params, UrlBuilder url) {
@@ -42,6 +46,11 @@ enum DialogueTestEndpoints implements Endpoint {
         @Override
         public String version() {
             return VERSION;
+        }
+
+        @Override
+        public Set<String> tags() {
+            return tags;
         }
     },
 

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
@@ -1,5 +1,6 @@
 package com.palantir.another;
 
+import com.google.common.annotations.Beta;
 import com.palantir.logsafe.Safe;
 import com.palantir.product.AliasedString;
 import com.palantir.product.CreateDatasetRequest;
@@ -40,6 +41,7 @@ public interface TestService {
      * Returns a mapping from file system id to backing file system configuration.
      */
     @GET
+    @Beta
     @Path("catalog/fileSystems")
     Map<String, BackingFileSystem> getFileSystems(@HeaderParam("Authorization") @NotNull AuthHeader authHeader);
 

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
@@ -1,6 +1,6 @@
 package com.palantir.another;
 
-import com.google.common.annotations.Beta;
+import com.palantir.conjure.java.lib.internal.Incubating;
 import com.palantir.logsafe.Safe;
 import com.palantir.product.AliasedString;
 import com.palantir.product.CreateDatasetRequest;
@@ -41,7 +41,7 @@ public interface TestService {
      * Returns a mapping from file system id to backing file system configuration.
      */
     @GET
-    @Beta
+    @Incubating
     @Path("catalog/fileSystems")
     Map<String, BackingFileSystem> getFileSystems(@HeaderParam("Authorization") @NotNull AuthHeader authHeader);
 

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.prefix
@@ -1,5 +1,6 @@
 package test.prefix.com.palantir.another;
 
+import com.google.common.annotations.Beta;
 import com.palantir.logsafe.Safe;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
@@ -39,6 +40,7 @@ public interface TestService {
      * Returns a mapping from file system id to backing file system configuration.
      */
     @GET
+    @Beta
     @Path("catalog/fileSystems")
     Map<String, BackingFileSystem> getFileSystems(@HeaderParam("Authorization") AuthHeader authHeader);
 

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.prefix
@@ -1,6 +1,6 @@
 package test.prefix.com.palantir.another;
 
-import com.google.common.annotations.Beta;
+import com.palantir.conjure.java.lib.internal.Incubating;
 import com.palantir.logsafe.Safe;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
@@ -40,7 +40,7 @@ public interface TestService {
      * Returns a mapping from file system id to backing file system configuration.
      */
     @GET
-    @Beta
+    @Incubating
     @Path("catalog/fileSystems")
     Map<String, BackingFileSystem> getFileSystems(@HeaderParam("Authorization") AuthHeader authHeader);
 

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
@@ -1,5 +1,6 @@
 package com.palantir.another;
 
+import com.google.common.annotations.Beta;
 import com.palantir.logsafe.Safe;
 import com.palantir.product.AliasedString;
 import com.palantir.product.CreateDatasetRequest;
@@ -40,6 +41,7 @@ public interface TestService {
      * Returns a mapping from file system id to backing file system configuration.
      */
     @GET
+    @Beta
     @Path("catalog/fileSystems")
     Map<String, BackingFileSystem> getFileSystems(@HeaderParam("Authorization") @NotNull AuthHeader authHeader);
 

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
@@ -1,6 +1,6 @@
 package com.palantir.another;
 
-import com.google.common.annotations.Beta;
+import com.palantir.conjure.java.lib.internal.Incubating;
 import com.palantir.logsafe.Safe;
 import com.palantir.product.AliasedString;
 import com.palantir.product.CreateDatasetRequest;
@@ -41,7 +41,7 @@ public interface TestService {
      * Returns a mapping from file system id to backing file system configuration.
      */
     @GET
-    @Beta
+    @Incubating
     @Path("catalog/fileSystems")
     Map<String, BackingFileSystem> getFileSystems(@HeaderParam("Authorization") @NotNull AuthHeader authHeader);
 

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
@@ -1,6 +1,6 @@
 package com.palantir.another;
 
-import com.google.common.annotations.Beta;
+import com.palantir.conjure.java.lib.internal.Incubating;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.product.AliasedString;
 import com.palantir.product.CreateDatasetRequest;
@@ -25,7 +25,7 @@ public interface TestService {
      * Returns a mapping from file system id to backing file system configuration.
      * @apiNote {@code GET /catalog/fileSystems}
      */
-    @Beta
+    @Incubating
     Map<String, BackingFileSystem> getFileSystems(AuthHeader authHeader);
 
     /**

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
@@ -1,5 +1,6 @@
 package com.palantir.another;
 
+import com.google.common.annotations.Beta;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.product.AliasedString;
 import com.palantir.product.CreateDatasetRequest;
@@ -24,6 +25,7 @@ public interface TestService {
      * Returns a mapping from file system id to backing file system configuration.
      * @apiNote {@code GET /catalog/fileSystems}
      */
+    @Beta
     Map<String, BackingFileSystem> getFileSystems(AuthHeader authHeader);
 
     /**

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.prefix
@@ -1,5 +1,6 @@
 package test.prefix.com.palantir.another;
 
+import com.google.common.annotations.Beta;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
@@ -24,6 +25,7 @@ public interface TestService {
      * Returns a mapping from file system id to backing file system configuration.
      * @apiNote {@code GET /catalog/fileSystems}
      */
+    @Beta
     Map<String, BackingFileSystem> getFileSystems(AuthHeader authHeader);
 
     /**

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.prefix
@@ -1,6 +1,6 @@
 package test.prefix.com.palantir.another;
 
-import com.google.common.annotations.Beta;
+import com.palantir.conjure.java.lib.internal.Incubating;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
@@ -25,7 +25,7 @@ public interface TestService {
      * Returns a mapping from file system id to backing file system configuration.
      * @apiNote {@code GET /catalog/fileSystems}
      */
-    @Beta
+    @Incubating
     Map<String, BackingFileSystem> getFileSystems(AuthHeader authHeader);
 
     /**

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
@@ -1,7 +1,7 @@
 package com.palantir.another;
 
-import com.google.common.annotations.Beta;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.conjure.java.lib.internal.Incubating;
 import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
@@ -44,7 +44,7 @@ public interface TestServiceAsync {
      * Returns a mapping from file system id to backing file system configuration.
      * @apiNote {@code GET /catalog/fileSystems}
      */
-    @Beta
+    @Incubating
     @Nonnull
     ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(AuthHeader authHeader);
 

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
@@ -1,5 +1,6 @@
 package com.palantir.another;
 
+import com.google.common.annotations.Beta;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.Channel;
@@ -43,6 +44,7 @@ public interface TestServiceAsync {
      * Returns a mapping from file system id to backing file system configuration.
      * @apiNote {@code GET /catalog/fileSystems}
      */
+    @Beta
     @Nonnull
     ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(AuthHeader authHeader);
 

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
@@ -1,5 +1,6 @@
 package test.prefix.com.palantir.another;
 
+import com.google.common.annotations.Beta;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.Channel;
@@ -43,6 +44,7 @@ public interface TestServiceAsync {
      * Returns a mapping from file system id to backing file system configuration.
      * @apiNote {@code GET /catalog/fileSystems}
      */
+    @Beta
     @Nonnull
     ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(AuthHeader authHeader);
 

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
@@ -1,7 +1,7 @@
 package test.prefix.com.palantir.another;
 
-import com.google.common.annotations.Beta;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.conjure.java.lib.internal.Incubating;
 import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
@@ -44,7 +44,7 @@ public interface TestServiceAsync {
      * Returns a mapping from file system id to backing file system configuration.
      * @apiNote {@code GET /catalog/fileSystems}
      */
-    @Beta
+    @Incubating
     @Nonnull
     ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(AuthHeader authHeader);
 

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
@@ -1,5 +1,6 @@
 package com.palantir.another;
 
+import com.google.common.annotations.Beta;
 import com.google.errorprone.annotations.MustBeClosed;
 import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.Channel;
@@ -35,6 +36,7 @@ public interface TestServiceBlocking {
      * Returns a mapping from file system id to backing file system configuration.
      * @apiNote {@code GET /catalog/fileSystems}
      */
+    @Beta
     @Nonnull
     Map<String, BackingFileSystem> getFileSystems(AuthHeader authHeader);
 

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
@@ -1,7 +1,7 @@
 package com.palantir.another;
 
-import com.google.common.annotations.Beta;
 import com.google.errorprone.annotations.MustBeClosed;
+import com.palantir.conjure.java.lib.internal.Incubating;
 import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
@@ -36,7 +36,7 @@ public interface TestServiceBlocking {
      * Returns a mapping from file system id to backing file system configuration.
      * @apiNote {@code GET /catalog/fileSystems}
      */
-    @Beta
+    @Incubating
     @Nonnull
     Map<String, BackingFileSystem> getFileSystems(AuthHeader authHeader);
 

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
@@ -1,7 +1,7 @@
 package test.prefix.com.palantir.another;
 
-import com.google.common.annotations.Beta;
 import com.google.errorprone.annotations.MustBeClosed;
+import com.palantir.conjure.java.lib.internal.Incubating;
 import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
@@ -36,7 +36,7 @@ public interface TestServiceBlocking {
      * Returns a mapping from file system id to backing file system configuration.
      * @apiNote {@code GET /catalog/fileSystems}
      */
-    @Beta
+    @Incubating
     @Nonnull
     Map<String, BackingFileSystem> getFileSystems(AuthHeader authHeader);
 

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
@@ -1,5 +1,6 @@
 package test.prefix.com.palantir.another;
 
+import com.google.common.annotations.Beta;
 import com.google.errorprone.annotations.MustBeClosed;
 import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.Channel;
@@ -35,6 +36,7 @@ public interface TestServiceBlocking {
      * Returns a mapping from file system id to backing file system configuration.
      * @apiNote {@code GET /catalog/fileSystems}
      */
+    @Beta
     @Nonnull
     Map<String, BackingFileSystem> getFileSystems(AuthHeader authHeader);
 

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
@@ -72,7 +72,7 @@ public final class TestServiceEndpoints implements UndertowService {
     }
 
     private static final class GetFileSystemsEndpoint implements HttpHandler, Endpoint {
-        private static final ImmutableSet<String> TAGS = ImmutableSet.of("unstable");
+        private static final ImmutableSet<String> TAGS = ImmutableSet.of("incubating");
 
         private final UndertowRuntime runtime;
 

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
@@ -1,6 +1,7 @@
 package com.palantir.another;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.conjure.java.undertow.lib.Deserializer;
 import com.palantir.conjure.java.undertow.lib.Endpoint;
@@ -71,6 +72,8 @@ public final class TestServiceEndpoints implements UndertowService {
     }
 
     private static final class GetFileSystemsEndpoint implements HttpHandler, Endpoint {
+        private static final ImmutableSet<String> TAGS = ImmutableSet.of("unstable");
+
         private final UndertowRuntime runtime;
 
         private final TestService delegate;
@@ -81,6 +84,11 @@ public final class TestServiceEndpoints implements UndertowService {
             this.runtime = runtime;
             this.delegate = delegate;
             this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Map<String, BackingFileSystem>>() {});
+        }
+
+        @Override
+        public Set<String> tags() {
+            return TAGS;
         }
 
         @Override

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.prefix
@@ -1,6 +1,7 @@
 package test.prefix.com.palantir.another;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.conjure.java.undertow.lib.Deserializer;
 import com.palantir.conjure.java.undertow.lib.Endpoint;
@@ -71,6 +72,8 @@ public final class TestServiceEndpoints implements UndertowService {
     }
 
     private static final class GetFileSystemsEndpoint implements HttpHandler, Endpoint {
+        private static final ImmutableSet<String> TAGS = ImmutableSet.of("unstable");
+
         private final UndertowRuntime runtime;
 
         private final TestService delegate;
@@ -81,6 +84,11 @@ public final class TestServiceEndpoints implements UndertowService {
             this.runtime = runtime;
             this.delegate = delegate;
             this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Map<String, BackingFileSystem>>() {});
+        }
+
+        @Override
+        public Set<String> tags() {
+            return TAGS;
         }
 
         @Override

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.prefix
@@ -72,7 +72,7 @@ public final class TestServiceEndpoints implements UndertowService {
     }
 
     private static final class GetFileSystemsEndpoint implements HttpHandler, Endpoint {
-        private static final ImmutableSet<String> TAGS = ImmutableSet.of("unstable");
+        private static final ImmutableSet<String> TAGS = ImmutableSet.of("incubating");
 
         private final UndertowRuntime runtime;
 

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
@@ -1,7 +1,7 @@
 package com.palantir.another;
 
-import com.google.common.annotations.Beta;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.conjure.java.lib.internal.Incubating;
 import com.palantir.product.AliasedString;
 import com.palantir.product.CreateDatasetRequest;
 import com.palantir.product.datasets.BackingFileSystem;
@@ -36,7 +36,7 @@ public interface TestServiceRetrofit {
      */
     @GET("./catalog/fileSystems")
     @Headers({"hr-path-template: /catalog/fileSystems", "Accept: application/json"})
-    @Beta
+    @Incubating
     ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(@Header("Authorization") AuthHeader authHeader);
 
     /**

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit
@@ -1,5 +1,6 @@
 package com.palantir.another;
 
+import com.google.common.annotations.Beta;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.product.AliasedString;
 import com.palantir.product.CreateDatasetRequest;
@@ -35,6 +36,7 @@ public interface TestServiceRetrofit {
      */
     @GET("./catalog/fileSystems")
     @Headers({"hr-path-template: /catalog/fileSystems", "Accept: application/json"})
+    @Beta
     ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(@Header("Authorization") AuthHeader authHeader);
 
     /**

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit.prefix
@@ -1,5 +1,6 @@
 package test.prefix.com.palantir.another;
 
+import com.google.common.annotations.Beta;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
@@ -35,6 +36,7 @@ public interface TestServiceRetrofit {
      */
     @GET("./catalog/fileSystems")
     @Headers({"hr-path-template: /catalog/fileSystems", "Accept: application/json"})
+    @Beta
     ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(@Header("Authorization") AuthHeader authHeader);
 
     /**

--- a/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceRetrofit.java.retrofit.prefix
@@ -1,7 +1,7 @@
 package test.prefix.com.palantir.another;
 
-import com.google.common.annotations.Beta;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.conjure.java.lib.internal.Incubating;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
 import java.util.Collections;
@@ -36,7 +36,7 @@ public interface TestServiceRetrofit {
      */
     @GET("./catalog/fileSystems")
     @Headers({"hr-path-template: /catalog/fileSystems", "Accept: application/json"})
-    @Beta
+    @Incubating
     ListenableFuture<Map<String, BackingFileSystem>> getFileSystems(@Header("Authorization") AuthHeader authHeader);
 
     /**

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/Incubating.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/Incubating.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.lib.internal;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Signifies that a public API has not yet become stable, and may be subject to change. Projects that cannot quickly
+ * update based on their service dependencies cannot safely use {@link Incubating} APIs.
+ *
+ * This annotation is added to service methods which are tagged with {@code incubating}.
+ * For example:
+ * <pre>{@code
+ * getFileSystems:
+ *   tags:
+ *     - incubating
+ *   http: GET /fileSystems
+ *   returns: map<string, BackingFileSystem>
+ * }</pre>
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.METHOD)
+@Documented
+public @interface Incubating {}


### PR DESCRIPTION
Quick draft of what we discussed, the guava `@Beta` annotation turns invocations yellow in idea based on [UnstableApiUsageInspection.kt#35](https://github.com/JetBrains/intellij-community/blob/5d726bf894d19afe62da7a5b42350e9f021c70fd/jvm/jvm-analysis-impl/src/com/intellij/codeInspection/UnstableApiUsageInspection.kt#L35)

==COMMIT_MSG==
Apply guava `@Beta` annotations based on the `unstable` endpoint tag
==COMMIT_MSG==

Considerations:

1. This implementation uses `unstable`. Would we prefer `incubating`, or something different?
2. This implementation adds the gauva `@Beta` annotation. We can define our own in `conjure-lib` and update our idea configuration to apply it to the UnstableApiUsageInspection list (greater complexity, must work for both idea gradle integration and the idea ipr).