### PR TITLE
Conjure types avoid jackson heuristics and ambiguity around JsonCreator

### DIFF
--- a/changelog/@unreleased/pr-1155.v2.yml
+++ b/changelog/@unreleased/pr-1155.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Conjure types avoid jackson heuristics and ambiguity using `@JsonCreator`.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1155

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryAliasExample.java
@@ -36,7 +36,7 @@ public final class BinaryAliasExample {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static BinaryAliasExample of(@Nonnull ByteBuffer value) {
         return new BinaryAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasOptionalDoubleAliasedBinaryResult.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasOptionalDoubleAliasedBinaryResult.java
@@ -41,7 +41,7 @@ public final class AliasOptionalDoubleAliasedBinaryResult {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static AliasOptionalDoubleAliasedBinaryResult of(@Nonnull Optional<DoubleAliasedBinaryResult> value) {
         return new AliasOptionalDoubleAliasedBinaryResult(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedBinaryResult.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedBinaryResult.java
@@ -36,7 +36,7 @@ public final class AliasedBinaryResult {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static AliasedBinaryResult of(@Nonnull ByteBuffer value) {
         return new AliasedBinaryResult(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenAliasExample.java
@@ -41,7 +41,7 @@ public final class BearerTokenAliasExample {
         return of(BearerToken.valueOf(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static BearerTokenAliasExample of(@Nonnull BearerToken value) {
         return new BearerTokenAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasExample.java
@@ -36,7 +36,7 @@ public final class BinaryAliasExample {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static BinaryAliasExample of(@Nonnull Bytes value) {
         return new BinaryAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasOne.java
@@ -35,7 +35,7 @@ public final class BinaryAliasOne {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static BinaryAliasOne of(@Nonnull Bytes value) {
         return new BinaryAliasOne(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasTwo.java
@@ -34,7 +34,7 @@ public final class BinaryAliasTwo {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static BinaryAliasTwo of(@Nonnull BinaryAliasOne value) {
         return new BinaryAliasTwo(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanAliasExample.java
@@ -37,7 +37,7 @@ public final class BooleanAliasExample {
         return of(Boolean.parseBoolean(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static BooleanAliasExample of(boolean value) {
         return new BooleanAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeAliasExample.java
@@ -40,7 +40,7 @@ public final class DateTimeAliasExample {
         return of(OffsetDateTime.parse(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static DateTimeAliasExample of(@Nonnull OffsetDateTime value) {
         return new DateTimeAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
@@ -40,23 +40,23 @@ public final class DoubleAliasExample {
         return of(Double.parseDouble(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static DoubleAliasExample of(double value) {
         return new DoubleAliasExample(value);
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static DoubleAliasExample of(long value) {
         long safeValue = SafeLong.of(value).longValue();
         return new DoubleAliasExample((double) safeValue);
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static DoubleAliasExample of(int value) {
         return new DoubleAliasExample((double) value);
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static DoubleAliasExample of(String value) {
         switch (value) {
             case "NaN":

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasedBinaryResult.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasedBinaryResult.java
@@ -36,7 +36,7 @@ public final class DoubleAliasedBinaryResult {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static DoubleAliasedBinaryResult of(@Nonnull AliasedBinaryResult value) {
         return new DoubleAliasedBinaryResult(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyObjectExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyObjectExample.java
@@ -16,7 +16,7 @@ public final class EmptyObjectExample {
         return "EmptyObjectExample{}";
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static EmptyObjectExample of() {
         return INSTANCE;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
@@ -19,7 +19,7 @@ import javax.annotation.Nonnull;
 public final class EmptyUnionTypeExample {
     private final Base value;
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     private EmptyUnionTypeExample(Base value) {
         this.value = value;
     }
@@ -107,7 +107,7 @@ public final class EmptyUnionTypeExample {
 
         private final Map<String, Object> value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private UnknownWrapper(@JsonProperty("type") String type) {
             this(type, new HashMap<String, Object>());
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -73,7 +73,7 @@ public final class EnumExample {
         return this.string.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     @SuppressWarnings("deprecation")
     public static EnumExample valueOf(@Nonnull String value) {
         Preconditions.checkNotNull(value, "value cannot be null");

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasExample.java
@@ -39,7 +39,7 @@ public final class ExternalLongAliasExample {
         return of(Long.valueOf(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static ExternalLongAliasExample of(long value) {
         return new ExternalLongAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasOne.java
@@ -38,7 +38,7 @@ public final class ExternalLongAliasOne {
         return of(Long.valueOf(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static ExternalLongAliasOne of(long value) {
         return new ExternalLongAliasOne(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasTwo.java
@@ -39,7 +39,7 @@ public final class ExternalLongAliasTwo {
         return of(ExternalLongAliasOne.valueOf(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static ExternalLongAliasTwo of(@Nonnull ExternalLongAliasOne value) {
         return new ExternalLongAliasTwo(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalStringAliasExample.java
@@ -36,7 +36,7 @@ public final class ExternalStringAliasExample {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static ExternalStringAliasExample of(@Nonnull String value) {
         return new ExternalStringAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerAliasExample.java
@@ -37,7 +37,7 @@ public final class IntegerAliasExample {
         return of(Integer.parseInt(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static IntegerAliasExample of(int value) {
         return new IntegerAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/LongAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/LongAlias.java
@@ -37,7 +37,7 @@ public final class LongAlias {
         return of(Long.valueOf(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static LongAlias of(long value) {
         return new LongAlias(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapAliasExample.java
@@ -36,7 +36,7 @@ public final class MapAliasExample {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static MapAliasExample of(@Nonnull Map<String, Object> value) {
         return new MapAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/NestedStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/NestedStringAliasExample.java
@@ -40,7 +40,7 @@ public final class NestedStringAliasExample {
         return of(StringAliasExample.valueOf(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static NestedStringAliasExample of(@Nonnull StringAliasExample value) {
         return new NestedStringAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAlias.java
@@ -39,7 +39,7 @@ public final class OptionalAlias {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static OptionalAlias of(@Nonnull Optional<String> value) {
         return new OptionalAlias(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReferenceAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReferenceAliasExample.java
@@ -35,7 +35,7 @@ public final class ReferenceAliasExample {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static ReferenceAliasExample of(@Nonnull AnyExample value) {
         return new ReferenceAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RidAliasExample.java
@@ -40,7 +40,7 @@ public final class RidAliasExample {
         return of(ResourceIdentifier.valueOf(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static RidAliasExample of(@Nonnull ResourceIdentifier value) {
         return new RidAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongAliasExample.java
@@ -40,7 +40,7 @@ public final class SafeLongAliasExample {
         return of(SafeLong.valueOf(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static SafeLongAliasExample of(@Nonnull SafeLong value) {
         return new SafeLongAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
@@ -57,7 +57,7 @@ public final class SimpleEnum {
         return this.string.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static SimpleEnum valueOf(@Nonnull String value) {
         Preconditions.checkNotNull(value, "value cannot be null");
         String upperCasedValue = value.toUpperCase(Locale.ROOT);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -22,7 +22,7 @@ import javax.annotation.Nonnull;
 public final class SingleUnion {
     private final Base value;
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     private SingleUnion(Base value) {
         this.value = value;
     }
@@ -130,7 +130,7 @@ public final class SingleUnion {
     private static final class FooWrapper implements Base {
         private final String value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private FooWrapper(@JsonSetter("foo") @Nonnull String value) {
             Preconditions.checkNotNull(value, "foo cannot be null");
             this.value = value;
@@ -176,7 +176,7 @@ public final class SingleUnion {
 
         private final Map<String, Object> value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private UnknownWrapper(@JsonProperty("type") String type) {
             this(type, new HashMap<String, Object>());
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasExample.java
@@ -39,7 +39,7 @@ public final class StringAliasExample {
         return of(value);
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static StringAliasExample of(@Nonnull String value) {
         return new StringAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasOne.java
@@ -38,7 +38,7 @@ public final class StringAliasOne {
         return of(value);
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static StringAliasOne of(@Nonnull String value) {
         return new StringAliasOne(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasThree.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasThree.java
@@ -35,7 +35,7 @@ public final class StringAliasThree {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static StringAliasThree of(@Nonnull StringAliasTwo value) {
         return new StringAliasThree(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasTwo.java
@@ -39,7 +39,7 @@ public final class StringAliasTwo {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static StringAliasTwo of(@Nonnull Optional<StringAliasOne> value) {
         return new StringAliasTwo(value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -23,7 +23,7 @@ import javax.annotation.Nonnull;
 public final class Union {
     private final Base value;
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     private Union(Base value) {
         this.value = value;
     }
@@ -207,7 +207,7 @@ public final class Union {
     private static final class FooWrapper implements Base {
         private final String value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private FooWrapper(@JsonSetter("foo") @Nonnull String value) {
             Preconditions.checkNotNull(value, "foo cannot be null");
             this.value = value;
@@ -247,7 +247,7 @@ public final class Union {
     private static final class BarWrapper implements Base {
         private final int value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private BarWrapper(@JsonSetter("bar") @Nonnull int value) {
             Preconditions.checkNotNull(value, "bar cannot be null");
             this.value = value;
@@ -288,7 +288,7 @@ public final class Union {
     private static final class BazWrapper implements Base {
         private final long value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private BazWrapper(@JsonSetter("baz") @Nonnull long value) {
             Preconditions.checkNotNull(value, "baz cannot be null");
             this.value = value;
@@ -335,7 +335,7 @@ public final class Union {
 
         private final Map<String, Object> value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private UnknownWrapper(@JsonProperty("type") String type) {
             this(type, new HashMap<String, Object>());
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -30,7 +30,7 @@ import javax.annotation.Nonnull;
 public final class UnionTypeExample {
     private final Base value;
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     private UnionTypeExample(Base value) {
         this.value = value;
     }
@@ -448,7 +448,7 @@ public final class UnionTypeExample {
     private static final class StringExampleWrapper implements Base {
         private final StringExample value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private StringExampleWrapper(@JsonSetter("stringExample") @Nonnull StringExample value) {
             Preconditions.checkNotNull(value, "stringExample cannot be null");
             this.value = value;
@@ -488,7 +488,7 @@ public final class UnionTypeExample {
     private static final class SetWrapper implements Base {
         private final Set<String> value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private SetWrapper(@JsonSetter(value = "set", nulls = Nulls.AS_EMPTY) @Nonnull Set<String> value) {
             Preconditions.checkNotNull(value, "set cannot be null");
             this.value = value;
@@ -528,7 +528,7 @@ public final class UnionTypeExample {
     private static final class ThisFieldIsAnIntegerWrapper implements Base {
         private final int value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private ThisFieldIsAnIntegerWrapper(@JsonSetter("thisFieldIsAnInteger") @Nonnull int value) {
             Preconditions.checkNotNull(value, "thisFieldIsAnInteger cannot be null");
             this.value = value;
@@ -569,7 +569,7 @@ public final class UnionTypeExample {
     private static final class AlsoAnIntegerWrapper implements Base {
         private final int value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private AlsoAnIntegerWrapper(@JsonSetter("alsoAnInteger") @Nonnull int value) {
             Preconditions.checkNotNull(value, "alsoAnInteger cannot be null");
             this.value = value;
@@ -609,7 +609,7 @@ public final class UnionTypeExample {
     private static final class IfWrapper implements Base {
         private final int value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private IfWrapper(@JsonSetter("if") @Nonnull int value) {
             Preconditions.checkNotNull(value, "if cannot be null");
             this.value = value;
@@ -649,7 +649,7 @@ public final class UnionTypeExample {
     private static final class NewWrapper implements Base {
         private final int value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private NewWrapper(@JsonSetter("new") @Nonnull int value) {
             Preconditions.checkNotNull(value, "new cannot be null");
             this.value = value;
@@ -689,7 +689,7 @@ public final class UnionTypeExample {
     private static final class InterfaceWrapper implements Base {
         private final int value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private InterfaceWrapper(@JsonSetter("interface") @Nonnull int value) {
             Preconditions.checkNotNull(value, "interface cannot be null");
             this.value = value;
@@ -729,7 +729,7 @@ public final class UnionTypeExample {
     private static final class CompletedWrapper implements Base {
         private final int value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private CompletedWrapper(@JsonSetter("completed") @Nonnull int value) {
             Preconditions.checkNotNull(value, "completed cannot be null");
             this.value = value;
@@ -769,7 +769,7 @@ public final class UnionTypeExample {
     private static final class Unknown_Wrapper implements Base {
         private final int value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private Unknown_Wrapper(@JsonSetter("unknown") @Nonnull int value) {
             Preconditions.checkNotNull(value, "unknown_ cannot be null");
             this.value = value;
@@ -809,7 +809,7 @@ public final class UnionTypeExample {
     private static final class OptionalWrapper implements Base {
         private final Optional<String> value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private OptionalWrapper(@JsonSetter("optional") @Nonnull Optional<String> value) {
             Preconditions.checkNotNull(value, "optional cannot be null");
             this.value = value;
@@ -849,7 +849,7 @@ public final class UnionTypeExample {
     private static final class ListWrapper implements Base {
         private final List<String> value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private ListWrapper(@JsonSetter(value = "list", nulls = Nulls.AS_EMPTY) @Nonnull List<String> value) {
             Preconditions.checkNotNull(value, "list cannot be null");
             this.value = value;
@@ -889,7 +889,7 @@ public final class UnionTypeExample {
     private static final class MapWrapper implements Base {
         private final Map<String, String> value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private MapWrapper(@JsonSetter(value = "map", nulls = Nulls.AS_EMPTY) @Nonnull Map<String, String> value) {
             Preconditions.checkNotNull(value, "map cannot be null");
             this.value = value;
@@ -935,7 +935,7 @@ public final class UnionTypeExample {
 
         private final Map<String, Object> value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private UnknownWrapper(@JsonProperty("type") String type) {
             this(type, new HashMap<String, Object>());
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
@@ -22,7 +22,7 @@ import javax.annotation.Nonnull;
 public final class UnionWithUnknownString {
     private final Base value;
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     private UnionWithUnknownString(Base value) {
         this.value = value;
     }
@@ -130,7 +130,7 @@ public final class UnionWithUnknownString {
     private static final class Unknown_Wrapper implements Base {
         private final String value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private Unknown_Wrapper(@JsonSetter("unknown") @Nonnull String value) {
             Preconditions.checkNotNull(value, "unknown_ cannot be null");
             this.value = value;
@@ -176,7 +176,7 @@ public final class UnionWithUnknownString {
 
         private final Map<String, Object> value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private UnknownWrapper(@JsonProperty("type") String type) {
             this(type, new HashMap<String, Object>());
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidAliasExample.java
@@ -40,7 +40,7 @@ public final class UuidAliasExample {
         return of(UUID.fromString(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static UuidAliasExample of(@Nonnull UUID value) {
         return new UuidAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BearerTokenAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BearerTokenAliasExample.java
@@ -41,7 +41,7 @@ public final class BearerTokenAliasExample {
         return of(BearerToken.valueOf(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static BearerTokenAliasExample of(@Nonnull BearerToken value) {
         return new BearerTokenAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasExample.java
@@ -36,7 +36,7 @@ public final class BinaryAliasExample {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static BinaryAliasExample of(@Nonnull ByteBuffer value) {
         return new BinaryAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasOne.java
@@ -35,7 +35,7 @@ public final class BinaryAliasOne {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static BinaryAliasOne of(@Nonnull ByteBuffer value) {
         return new BinaryAliasOne(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasTwo.java
@@ -34,7 +34,7 @@ public final class BinaryAliasTwo {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static BinaryAliasTwo of(@Nonnull BinaryAliasOne value) {
         return new BinaryAliasTwo(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BooleanAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BooleanAliasExample.java
@@ -37,7 +37,7 @@ public final class BooleanAliasExample {
         return of(Boolean.parseBoolean(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static BooleanAliasExample of(boolean value) {
         return new BooleanAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeAliasExample.java
@@ -40,7 +40,7 @@ public final class DateTimeAliasExample {
         return of(OffsetDateTime.parse(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static DateTimeAliasExample of(@Nonnull OffsetDateTime value) {
         return new DateTimeAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleAliasExample.java
@@ -40,23 +40,23 @@ public final class DoubleAliasExample {
         return of(Double.parseDouble(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static DoubleAliasExample of(double value) {
         return new DoubleAliasExample(value);
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static DoubleAliasExample of(long value) {
         long safeValue = SafeLong.of(value).longValue();
         return new DoubleAliasExample((double) safeValue);
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static DoubleAliasExample of(int value) {
         return new DoubleAliasExample((double) value);
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static DoubleAliasExample of(String value) {
         switch (value) {
             case "NaN":

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyObjectExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyObjectExample.java
@@ -16,7 +16,7 @@ public final class EmptyObjectExample {
         return "EmptyObjectExample{}";
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static EmptyObjectExample of() {
         return INSTANCE;
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
@@ -19,7 +19,7 @@ import javax.annotation.Nonnull;
 public final class EmptyUnionTypeExample {
     private final Base value;
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     private EmptyUnionTypeExample(Base value) {
         this.value = value;
     }
@@ -107,7 +107,7 @@ public final class EmptyUnionTypeExample {
 
         private final Map<String, Object> value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private UnknownWrapper(@JsonProperty("type") String type) {
             this(type, new HashMap<String, Object>());
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
@@ -73,7 +73,7 @@ public final class EnumExample {
         return this.string.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     @SuppressWarnings("deprecation")
     public static EnumExample valueOf(@Nonnull String value) {
         Preconditions.checkNotNull(value, "value cannot be null");

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasExample.java
@@ -39,7 +39,7 @@ public final class ExternalLongAliasExample {
         return of(Long.valueOf(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static ExternalLongAliasExample of(long value) {
         return new ExternalLongAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasOne.java
@@ -38,7 +38,7 @@ public final class ExternalLongAliasOne {
         return of(Long.valueOf(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static ExternalLongAliasOne of(long value) {
         return new ExternalLongAliasOne(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasTwo.java
@@ -39,7 +39,7 @@ public final class ExternalLongAliasTwo {
         return of(ExternalLongAliasOne.valueOf(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static ExternalLongAliasTwo of(@Nonnull ExternalLongAliasOne value) {
         return new ExternalLongAliasTwo(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalStringAliasExample.java
@@ -36,7 +36,7 @@ public final class ExternalStringAliasExample {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static ExternalStringAliasExample of(@Nonnull String value) {
         return new ExternalStringAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/IntegerAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/IntegerAliasExample.java
@@ -37,7 +37,7 @@ public final class IntegerAliasExample {
         return of(Integer.parseInt(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static IntegerAliasExample of(int value) {
         return new IntegerAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapAliasExample.java
@@ -36,7 +36,7 @@ public final class MapAliasExample {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static MapAliasExample of(@Nonnull Map<String, Object> value) {
         return new MapAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/NestedStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/NestedStringAliasExample.java
@@ -40,7 +40,7 @@ public final class NestedStringAliasExample {
         return of(StringAliasExample.valueOf(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static NestedStringAliasExample of(@Nonnull StringAliasExample value) {
         return new NestedStringAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAlias.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAlias.java
@@ -39,7 +39,7 @@ public final class OptionalAlias {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static OptionalAlias of(@Nonnull Optional<String> value) {
         return new OptionalAlias(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReferenceAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReferenceAliasExample.java
@@ -35,7 +35,7 @@ public final class ReferenceAliasExample {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static ReferenceAliasExample of(@Nonnull AnyExample value) {
         return new ReferenceAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RidAliasExample.java
@@ -40,7 +40,7 @@ public final class RidAliasExample {
         return of(ResourceIdentifier.valueOf(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static RidAliasExample of(@Nonnull ResourceIdentifier value) {
         return new RidAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeLongAliasExample.java
@@ -40,7 +40,7 @@ public final class SafeLongAliasExample {
         return of(SafeLong.valueOf(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static SafeLongAliasExample of(@Nonnull SafeLong value) {
         return new SafeLongAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
@@ -57,7 +57,7 @@ public final class SimpleEnum {
         return this.string.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static SimpleEnum valueOf(@Nonnull String value) {
         Preconditions.checkNotNull(value, "value cannot be null");
         String upperCasedValue = value.toUpperCase(Locale.ROOT);

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
@@ -22,7 +22,7 @@ import javax.annotation.Nonnull;
 public final class SingleUnion {
     private final Base value;
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     private SingleUnion(Base value) {
         this.value = value;
     }
@@ -130,7 +130,7 @@ public final class SingleUnion {
     private static final class FooWrapper implements Base {
         private final String value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private FooWrapper(@JsonSetter("foo") @Nonnull String value) {
             Preconditions.checkNotNull(value, "foo cannot be null");
             this.value = value;
@@ -176,7 +176,7 @@ public final class SingleUnion {
 
         private final Map<String, Object> value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private UnknownWrapper(@JsonProperty("type") String type) {
             this(type, new HashMap<String, Object>());
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasExample.java
@@ -39,7 +39,7 @@ public final class StringAliasExample {
         return of(value);
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static StringAliasExample of(@Nonnull String value) {
         return new StringAliasExample(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasOne.java
@@ -38,7 +38,7 @@ public final class StringAliasOne {
         return of(value);
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static StringAliasOne of(@Nonnull String value) {
         return new StringAliasOne(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasThree.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasThree.java
@@ -35,7 +35,7 @@ public final class StringAliasThree {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static StringAliasThree of(@Nonnull StringAliasTwo value) {
         return new StringAliasThree(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasTwo.java
@@ -39,7 +39,7 @@ public final class StringAliasTwo {
         return value.hashCode();
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static StringAliasTwo of(@Nonnull Optional<StringAliasOne> value) {
         return new StringAliasTwo(value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
@@ -23,7 +23,7 @@ import javax.annotation.Nonnull;
 public final class Union {
     private final Base value;
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     private Union(Base value) {
         this.value = value;
     }
@@ -207,7 +207,7 @@ public final class Union {
     private static final class FooWrapper implements Base {
         private final String value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private FooWrapper(@JsonSetter("foo") @Nonnull String value) {
             Preconditions.checkNotNull(value, "foo cannot be null");
             this.value = value;
@@ -247,7 +247,7 @@ public final class Union {
     private static final class BarWrapper implements Base {
         private final int value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private BarWrapper(@JsonSetter("bar") @Nonnull int value) {
             Preconditions.checkNotNull(value, "bar cannot be null");
             this.value = value;
@@ -288,7 +288,7 @@ public final class Union {
     private static final class BazWrapper implements Base {
         private final long value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private BazWrapper(@JsonSetter("baz") @Nonnull long value) {
             Preconditions.checkNotNull(value, "baz cannot be null");
             this.value = value;
@@ -335,7 +335,7 @@ public final class Union {
 
         private final Map<String, Object> value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private UnknownWrapper(@JsonProperty("type") String type) {
             this(type, new HashMap<String, Object>());
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -30,7 +30,7 @@ import javax.annotation.Nonnull;
 public final class UnionTypeExample {
     private final Base value;
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     private UnionTypeExample(Base value) {
         this.value = value;
     }
@@ -448,7 +448,7 @@ public final class UnionTypeExample {
     private static final class StringExampleWrapper implements Base {
         private final StringExample value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private StringExampleWrapper(@JsonSetter("stringExample") @Nonnull StringExample value) {
             Preconditions.checkNotNull(value, "stringExample cannot be null");
             this.value = value;
@@ -488,7 +488,7 @@ public final class UnionTypeExample {
     private static final class SetWrapper implements Base {
         private final Set<String> value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private SetWrapper(@JsonSetter(value = "set", nulls = Nulls.AS_EMPTY) @Nonnull Set<String> value) {
             Preconditions.checkNotNull(value, "set cannot be null");
             this.value = value;
@@ -528,7 +528,7 @@ public final class UnionTypeExample {
     private static final class ThisFieldIsAnIntegerWrapper implements Base {
         private final int value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private ThisFieldIsAnIntegerWrapper(@JsonSetter("thisFieldIsAnInteger") @Nonnull int value) {
             Preconditions.checkNotNull(value, "thisFieldIsAnInteger cannot be null");
             this.value = value;
@@ -569,7 +569,7 @@ public final class UnionTypeExample {
     private static final class AlsoAnIntegerWrapper implements Base {
         private final int value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private AlsoAnIntegerWrapper(@JsonSetter("alsoAnInteger") @Nonnull int value) {
             Preconditions.checkNotNull(value, "alsoAnInteger cannot be null");
             this.value = value;
@@ -609,7 +609,7 @@ public final class UnionTypeExample {
     private static final class IfWrapper implements Base {
         private final int value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private IfWrapper(@JsonSetter("if") @Nonnull int value) {
             Preconditions.checkNotNull(value, "if cannot be null");
             this.value = value;
@@ -649,7 +649,7 @@ public final class UnionTypeExample {
     private static final class NewWrapper implements Base {
         private final int value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private NewWrapper(@JsonSetter("new") @Nonnull int value) {
             Preconditions.checkNotNull(value, "new cannot be null");
             this.value = value;
@@ -689,7 +689,7 @@ public final class UnionTypeExample {
     private static final class InterfaceWrapper implements Base {
         private final int value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private InterfaceWrapper(@JsonSetter("interface") @Nonnull int value) {
             Preconditions.checkNotNull(value, "interface cannot be null");
             this.value = value;
@@ -729,7 +729,7 @@ public final class UnionTypeExample {
     private static final class CompletedWrapper implements Base {
         private final int value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private CompletedWrapper(@JsonSetter("completed") @Nonnull int value) {
             Preconditions.checkNotNull(value, "completed cannot be null");
             this.value = value;
@@ -769,7 +769,7 @@ public final class UnionTypeExample {
     private static final class Unknown_Wrapper implements Base {
         private final int value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private Unknown_Wrapper(@JsonSetter("unknown") @Nonnull int value) {
             Preconditions.checkNotNull(value, "unknown_ cannot be null");
             this.value = value;
@@ -809,7 +809,7 @@ public final class UnionTypeExample {
     private static final class OptionalWrapper implements Base {
         private final Optional<String> value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private OptionalWrapper(@JsonSetter("optional") @Nonnull Optional<String> value) {
             Preconditions.checkNotNull(value, "optional cannot be null");
             this.value = value;
@@ -849,7 +849,7 @@ public final class UnionTypeExample {
     private static final class ListWrapper implements Base {
         private final List<String> value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private ListWrapper(@JsonSetter(value = "list", nulls = Nulls.AS_EMPTY) @Nonnull List<String> value) {
             Preconditions.checkNotNull(value, "list cannot be null");
             this.value = value;
@@ -889,7 +889,7 @@ public final class UnionTypeExample {
     private static final class MapWrapper implements Base {
         private final Map<String, String> value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private MapWrapper(@JsonSetter(value = "map", nulls = Nulls.AS_EMPTY) @Nonnull Map<String, String> value) {
             Preconditions.checkNotNull(value, "map cannot be null");
             this.value = value;
@@ -935,7 +935,7 @@ public final class UnionTypeExample {
 
         private final Map<String, Object> value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private UnknownWrapper(@JsonProperty("type") String type) {
             this(type, new HashMap<String, Object>());
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
@@ -22,7 +22,7 @@ import javax.annotation.Nonnull;
 public final class UnionWithUnknownString {
     private final Base value;
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     private UnionWithUnknownString(Base value) {
         this.value = value;
     }
@@ -130,7 +130,7 @@ public final class UnionWithUnknownString {
     private static final class Unknown_Wrapper implements Base {
         private final String value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private Unknown_Wrapper(@JsonSetter("unknown") @Nonnull String value) {
             Preconditions.checkNotNull(value, "unknown_ cannot be null");
             this.value = value;
@@ -176,7 +176,7 @@ public final class UnionWithUnknownString {
 
         private final Map<String, Object> value;
 
-        @JsonCreator
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         private UnknownWrapper(@JsonProperty("type") String type) {
             this(type, new HashMap<String, Object>());
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UuidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UuidAliasExample.java
@@ -40,7 +40,7 @@ public final class UuidAliasExample {
         return of(UUID.fromString(value));
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static UuidAliasExample of(@Nonnull UUID value) {
         return new UuidAliasExample(value);
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/ConjureAnnotations.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/ConjureAnnotations.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.lib.internal.Incubating;
 import com.palantir.conjure.spec.Documentation;
@@ -26,6 +27,17 @@ import java.util.Optional;
 
 public final class ConjureAnnotations {
 
+    private static final ImmutableList<AnnotationSpec> DEPRECATED =
+            ImmutableList.of(AnnotationSpec.builder(Deprecated.class).build());
+    private static final ImmutableList<AnnotationSpec> INCUBATING =
+            ImmutableList.of(AnnotationSpec.builder(Incubating.class).build());
+    private static final AnnotationSpec DELEGATING_JSON_CREATOR = AnnotationSpec.builder(JsonCreator.class)
+            .addMember("mode", "$T.DELEGATING", JsonCreator.Mode.class)
+            .build();
+    private static final AnnotationSpec PROPERTIES_JSON_CREATOR = AnnotationSpec.builder(JsonCreator.class)
+            .addMember("mode", "$T.PROPERTIES", JsonCreator.Mode.class)
+            .build();
+
     public static AnnotationSpec getConjureGeneratedAnnotation(Class<?> clazz) {
         return AnnotationSpec.builder(ClassName.get("javax.annotation", "Generated"))
                 .addMember("value", "$S", clazz.getCanonicalName())
@@ -33,16 +45,22 @@ public final class ConjureAnnotations {
     }
 
     public static ImmutableList<AnnotationSpec> deprecation(Optional<Documentation> deprecation) {
-        return deprecation.isPresent()
-                ? ImmutableList.of(AnnotationSpec.builder(Deprecated.class).build())
-                : ImmutableList.of();
+        return deprecation.isPresent() ? DEPRECATED : ImmutableList.of();
     }
 
     public static ImmutableList<AnnotationSpec> incubating(EndpointDefinition definition) {
         if (definition.getTags().contains("incubating")) {
-            return ImmutableList.of(AnnotationSpec.builder(Incubating.class).build());
+            return INCUBATING;
         }
         return ImmutableList.of();
+    }
+
+    public static AnnotationSpec delegatingJsonCreator() {
+        return DELEGATING_JSON_CREATOR;
+    }
+
+    public static AnnotationSpec propertiesJsonCreator() {
+        return PROPERTIES_JSON_CREATOR;
     }
 
     private ConjureAnnotations() {}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -108,7 +108,7 @@ public final class AliasGenerator {
 
         spec.addMethod(MethodSpec.methodBuilder("of")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .addAnnotation(JsonCreator.class)
+                .addAnnotation(ConjureAnnotations.delegatingJsonCreator())
                 .addParameter(Parameters.nonnullParameter(aliasTypeName, "value"))
                 .returns(thisClass)
                 .addStatement("return new $T(value)", thisClass)
@@ -131,7 +131,7 @@ public final class AliasGenerator {
 
             spec.addMethod(MethodSpec.methodBuilder("of")
                     .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                    .addAnnotation(JsonCreator.class)
+                    .addAnnotation(ConjureAnnotations.delegatingJsonCreator())
                     .addParameter(TypeName.LONG, "value")
                     .returns(thisClass)
                     .addCode(longCastCodeBlock)
@@ -139,7 +139,7 @@ public final class AliasGenerator {
 
             spec.addMethod(MethodSpec.methodBuilder("of")
                     .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                    .addAnnotation(JsonCreator.class)
+                    .addAnnotation(ConjureAnnotations.delegatingJsonCreator())
                     .addParameter(TypeName.INT, "value")
                     .returns(thisClass)
                     .addCode(intCastCodeBlock)
@@ -170,7 +170,7 @@ public final class AliasGenerator {
 
             spec.addMethod(MethodSpec.methodBuilder("of")
                     .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                    .addAnnotation(JsonCreator.class)
+                    .addAnnotation(ConjureAnnotations.delegatingJsonCreator())
                     .addParameter(ClassName.get(String.class), "value")
                     .returns(thisClass)
                     .addCode(doubleFromStringCodeBlock)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.java.types;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -254,7 +253,8 @@ public final class BeanGenerator {
                 .returns(objectClass);
 
         if (fields.isEmpty()) {
-            builder.addAnnotation(JsonCreator.class).addCode("return $L;", SINGLETON_INSTANCE_NAME);
+            builder.addAnnotation(ConjureAnnotations.delegatingJsonCreator())
+                    .addCode("return $L;", SINGLETON_INSTANCE_NAME);
         } else {
             builder.addCode("return builder()");
             for (FieldSpec spec : fields) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.java.types;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableList;
@@ -149,7 +148,7 @@ public final class EnumGenerator {
         } else {
             enumBuilder.addMethod(MethodSpec.methodBuilder("fromString")
                     .addJavadoc("$L", "Preferred, case-insensitive constructor for string-to-enum conversion.\n")
-                    .addAnnotation(JsonCreator.class)
+                    .addAnnotation(ConjureAnnotations.delegatingJsonCreator())
                     .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                     .addParameter(ClassName.get(String.class), "value")
                     .addStatement("return $T.valueOf(value.toUpperCase($T.ROOT))", enumClass, Locale.class)
@@ -258,7 +257,7 @@ public final class EnumGenerator {
         return MethodSpec.methodBuilder("valueOf")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .returns(thisClass)
-                .addAnnotation(JsonCreator.class)
+                .addAnnotation(ConjureAnnotations.delegatingJsonCreator())
                 .addAnnotations(
                         anyDeprecatedValues
                                 ? ImmutableList.of(AnnotationSpec.builder(SuppressWarnings.class)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -18,7 +18,6 @@ package com.palantir.conjure.java.types;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -126,7 +125,7 @@ public final class UnionGenerator {
     private static MethodSpec generateConstructor(ClassName baseClass) {
         return MethodSpec.constructorBuilder()
                 .addModifiers(Modifier.PRIVATE)
-                .addAnnotation(AnnotationSpec.builder(JsonCreator.class).build())
+                .addAnnotation(ConjureAnnotations.delegatingJsonCreator())
                 .addParameter(baseClass, VALUE_FIELD_NAME)
                 // no null check because this constructor is private and is only called by nice factory methods
                 .addStatement("this.$1L = $1L", VALUE_FIELD_NAME)
@@ -539,8 +538,7 @@ public final class UnionGenerator {
                             .addFields(fields)
                             .addMethod(MethodSpec.constructorBuilder()
                                     .addModifiers(Modifier.PRIVATE)
-                                    .addAnnotation(AnnotationSpec.builder(JsonCreator.class)
-                                            .build())
+                                    .addAnnotation(ConjureAnnotations.propertiesJsonCreator())
                                     .addParameter(ParameterSpec.builder(memberType, VALUE_FIELD_NAME)
                                             .addAnnotation(wrapperConstructorParameterAnnotation(memberTypeDef))
                                             .addAnnotation(Nonnull.class)
@@ -622,7 +620,7 @@ public final class UnionGenerator {
                 .addFields(fields)
                 .addMethod(MethodSpec.constructorBuilder()
                         .addModifiers(Modifier.PRIVATE)
-                        .addAnnotation(AnnotationSpec.builder(JsonCreator.class).build())
+                        .addAnnotation(ConjureAnnotations.propertiesJsonCreator())
                         .addParameter(annotatedTypeParameter)
                         .addStatement("this($N, new $T())", typeParameter, genericHashMapType)
                         .build())


### PR DESCRIPTION
## Before this PR
JsonCreator may attempt to use properties rather than delegation.
No reason to do additional heuristic work, and we certainly don't
want unexpected inputs to be deserialized successfully.


## After this PR
==COMMIT_MSG==
Conjure types avoid Jackson heuristics and ambiguity around JsonCreator
==COMMIT_MSG==

## Possible downsides?
Reference an additional jackson class from generated code.

