### PR TITLE
Support alias of wrapper null coercion

### DIFF
--- a/changelog/@unreleased/pr-1156.v2.yml
+++ b/changelog/@unreleased/pr-1156.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Support alias of wrapper null coercion
+  links:
+  - https://github.com/palantir/conjure-java/pull/1156

--- a/conjure-java-client-verifier/src/test/resources/ignored-test-cases.yml
+++ b/conjure-java-client-verifier/src/test/resources/ignored-test-cases.yml
@@ -69,6 +69,7 @@ client:
 
     receiveMapBearerTokenAliasExample:
       - 'null'
+      - '{}'
 
     receiveMapBinaryAliasExample:
       - "{}"
@@ -77,24 +78,32 @@ client:
 
     receiveMapBooleanAliasExample:
       - 'null'
+      - '{}'
     receiveMapDateTimeAliasExample:
       - 'null'
+      - '{}'
     receiveMapDoubleAliasExample:
       - '{"10": true, "10e0": false}'
       - '{"10": true, "10.0": false}'
       - 'null'
+      - '{}'
     receiveMapIntegerAliasExample:
      - 'null'
     receiveMapRidAliasExample:
       - 'null'
+      - '{}'
     receiveMapSafeLongAliasExample:
       - 'null'
+      - '{}'
     receiveMapStringAliasExample:
       - 'null'
+      - '{}'
     receiveMapUuidAliasExample:
       - 'null'
+      - '{}'
     receiveMapEnumExampleAlias:
       - 'null'
+      - '{}'
     receiveEnumExample:
       - '"!!!"'
       - '"one-hundred"' # https://github.com/palantir/conjure-java/issues/134
@@ -102,76 +111,100 @@ client:
     receiveListAnyAliasExample:
       - '[null]'
       - 'null'
+      - '{}'
 
     receiveSetAnyAliasExample:
       - '[null]'
       - 'null'
+      - '{}'
 
     receiveListBearerTokenAliasExample:
       - 'null'
+      - '{}'
 
     receiveListBinaryAliasExample:
       - 'null'
+      - '{}'
 
     receiveListBooleanAliasExample:
       - 'null'
+      - '{}'
 
     receiveListDateTimeAliasExample:
       - 'null'
+      - '{}'
 
     receiveListDoubleAliasExample:
       - 'null'
+      - '{}'
 
     receiveListIntegerAliasExample:
       - 'null'
+      - '{}'
 
     receiveListRidAliasExample:
       - 'null'
+      - '{}'
 
     receiveListSafeLongAliasExample:
       - 'null'
+      - '{}'
 
     receiveListStringAliasExample:
       - 'null'
+      - '{}'
 
     receiveListUuidAliasExample:
       - 'null'
+      - '{}'
 
     receiveListOptionalAnyAliasExample:
       - 'null'
+      - '{}'
 
     receiveSetBearerTokenAliasExample:
       - 'null'
+      - '{}'
 
     receiveSetBinaryAliasExample:
       - 'null'
+      - '{}'
 
     receiveSetBooleanAliasExample:
       - 'null'
+      - '{}'
 
     receiveSetDateTimeAliasExample:
       - 'null'
+      - '{}'
 
     receiveSetDoubleAliasExample:
       - 'null'
+      - '{}'
 
     receiveSetIntegerAliasExample:
       - 'null'
+      - '{}'
 
     receiveSetRidAliasExample:
       - 'null'
+      - '{}'
 
     receiveSetSafeLongAliasExample:
       - 'null'
+      - '{}'
 
     receiveSetStringAliasExample:
       - 'null'
+      - '{}'
 
     receiveSetUuidAliasExample:
       - 'null'
+      - '{}'
 
     receiveSetOptionalAnyAliasExample:
       - 'null'
+      - '{}'
 
   singleHeaderService:
     headerOptionalString:

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasExample.java
@@ -34,7 +34,7 @@ public final class ExternalLongAliasExample {
         return Long.hashCode(value);
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static ExternalLongAliasExample valueOf(String value) {
         return of(Long.valueOf(value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasOne.java
@@ -33,7 +33,7 @@ public final class ExternalLongAliasOne {
         return Long.hashCode(value);
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static ExternalLongAliasOne valueOf(String value) {
         return of(Long.valueOf(value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListAlias.java
@@ -4,24 +4,24 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.Collections;
-import java.util.Map;
+import java.util.List;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
-public final class MapAliasExample {
-    private final Map<String, Object> value;
+public final class ListAlias {
+    private final List<String> value;
 
-    private MapAliasExample(@Nonnull Map<String, Object> value) {
+    private ListAlias(@Nonnull List<String> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
-    private MapAliasExample() {
-        this(Collections.emptyMap());
+    private ListAlias() {
+        this(Collections.emptyList());
     }
 
     @JsonValue
-    public Map<String, Object> get() {
+    public List<String> get() {
         return value;
     }
 
@@ -32,8 +32,7 @@ public final class MapAliasExample {
 
     @Override
     public boolean equals(Object other) {
-        return this == other
-                || (other instanceof MapAliasExample && this.value.equals(((MapAliasExample) other).value));
+        return this == other || (other instanceof ListAlias && this.value.equals(((ListAlias) other).value));
     }
 
     @Override
@@ -42,7 +41,7 @@ public final class MapAliasExample {
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static MapAliasExample of(@Nonnull Map<String, Object> value) {
-        return new MapAliasExample(value);
+    public static ListAlias of(@Nonnull List<String> value) {
+        return new ListAlias(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/LongAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/LongAlias.java
@@ -32,7 +32,7 @@ public final class LongAlias {
         return Long.hashCode(value);
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static LongAlias valueOf(String value) {
         return of(Long.valueOf(value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetAlias.java
@@ -4,24 +4,24 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.Collections;
-import java.util.Map;
+import java.util.Set;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
-public final class MapAliasExample {
-    private final Map<String, Object> value;
+public final class SetAlias {
+    private final Set<String> value;
 
-    private MapAliasExample(@Nonnull Map<String, Object> value) {
+    private SetAlias(@Nonnull Set<String> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
-    private MapAliasExample() {
-        this(Collections.emptyMap());
+    private SetAlias() {
+        this(Collections.emptySet());
     }
 
     @JsonValue
-    public Map<String, Object> get() {
+    public Set<String> get() {
         return value;
     }
 
@@ -32,8 +32,7 @@ public final class MapAliasExample {
 
     @Override
     public boolean equals(Object other) {
-        return this == other
-                || (other instanceof MapAliasExample && this.value.equals(((MapAliasExample) other).value));
+        return this == other || (other instanceof SetAlias && this.value.equals(((SetAlias) other).value));
     }
 
     @Override
@@ -42,7 +41,7 @@ public final class MapAliasExample {
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static MapAliasExample of(@Nonnull Map<String, Object> value) {
-        return new MapAliasExample(value);
+    public static SetAlias of(@Nonnull Set<String> value) {
+        return new SetAlias(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -47,10 +47,6 @@ public final class UnionTypeExample {
         return new UnionTypeExample(new StringExampleWrapper(value));
     }
 
-    public static UnionTypeExample set(Set<String> value) {
-        return new UnionTypeExample(new SetWrapper(value));
-    }
-
     public static UnionTypeExample thisFieldIsAnInteger(int value) {
         return new UnionTypeExample(new ThisFieldIsAnIntegerWrapper(value));
     }
@@ -87,8 +83,28 @@ public final class UnionTypeExample {
         return new UnionTypeExample(new ListWrapper(value));
     }
 
+    public static UnionTypeExample set(Set<String> value) {
+        return new UnionTypeExample(new SetWrapper(value));
+    }
+
     public static UnionTypeExample map(Map<String, String> value) {
         return new UnionTypeExample(new MapWrapper(value));
+    }
+
+    public static UnionTypeExample optionalAlias(OptionalAlias value) {
+        return new UnionTypeExample(new OptionalAliasWrapper(value));
+    }
+
+    public static UnionTypeExample listAlias(ListAlias value) {
+        return new UnionTypeExample(new ListAliasWrapper(value));
+    }
+
+    public static UnionTypeExample setAlias(SetAlias value) {
+        return new UnionTypeExample(new SetAliasWrapper(value));
+    }
+
+    public static UnionTypeExample mapAlias(MapAliasExample value) {
+        return new UnionTypeExample(new MapAliasWrapper(value));
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -120,8 +136,6 @@ public final class UnionTypeExample {
          */
         T visitStringExample(StringExample value);
 
-        T visitSet(Set<String> value);
-
         T visitThisFieldIsAnInteger(int value);
 
         T visitAlsoAnInteger(int value);
@@ -140,7 +154,17 @@ public final class UnionTypeExample {
 
         T visitList(List<String> value);
 
+        T visitSet(Set<String> value);
+
         T visitMap(Map<String, String> value);
+
+        T visitOptionalAlias(OptionalAlias value);
+
+        T visitListAlias(ListAlias value);
+
+        T visitSetAlias(SetAlias value);
+
+        T visitMapAlias(MapAliasExample value);
 
         T visitUnknown(String unknownType);
 
@@ -155,10 +179,14 @@ public final class UnionTypeExample {
                     IfStageVisitorBuilder<T>,
                     InterfaceStageVisitorBuilder<T>,
                     ListStageVisitorBuilder<T>,
+                    ListAliasStageVisitorBuilder<T>,
                     MapStageVisitorBuilder<T>,
+                    MapAliasStageVisitorBuilder<T>,
                     NewStageVisitorBuilder<T>,
                     OptionalStageVisitorBuilder<T>,
+                    OptionalAliasStageVisitorBuilder<T>,
                     SetStageVisitorBuilder<T>,
+                    SetAliasStageVisitorBuilder<T>,
                     StringExampleStageVisitorBuilder<T>,
                     ThisFieldIsAnIntegerStageVisitorBuilder<T>,
                     Unknown_StageVisitorBuilder<T>,
@@ -174,13 +202,21 @@ public final class UnionTypeExample {
 
         private Function<List<String>, T> listVisitor;
 
+        private Function<ListAlias, T> listAliasVisitor;
+
         private Function<Map<String, String>, T> mapVisitor;
+
+        private Function<MapAliasExample, T> mapAliasVisitor;
 
         private IntFunction<T> newVisitor;
 
         private Function<Optional<String>, T> optionalVisitor;
 
+        private Function<OptionalAlias, T> optionalAliasVisitor;
+
         private Function<Set<String>, T> setVisitor;
+
+        private Function<SetAlias, T> setAliasVisitor;
 
         private Function<StringExample, T> stringExampleVisitor;
 
@@ -219,16 +255,30 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public MapStageVisitorBuilder<T> list(@Nonnull Function<List<String>, T> listVisitor) {
+        public ListAliasStageVisitorBuilder<T> list(@Nonnull Function<List<String>, T> listVisitor) {
             Preconditions.checkNotNull(listVisitor, "listVisitor cannot be null");
             this.listVisitor = listVisitor;
             return this;
         }
 
         @Override
-        public NewStageVisitorBuilder<T> map(@Nonnull Function<Map<String, String>, T> mapVisitor) {
+        public MapStageVisitorBuilder<T> listAlias(@Nonnull Function<ListAlias, T> listAliasVisitor) {
+            Preconditions.checkNotNull(listAliasVisitor, "listAliasVisitor cannot be null");
+            this.listAliasVisitor = listAliasVisitor;
+            return this;
+        }
+
+        @Override
+        public MapAliasStageVisitorBuilder<T> map(@Nonnull Function<Map<String, String>, T> mapVisitor) {
             Preconditions.checkNotNull(mapVisitor, "mapVisitor cannot be null");
             this.mapVisitor = mapVisitor;
+            return this;
+        }
+
+        @Override
+        public NewStageVisitorBuilder<T> mapAlias(@Nonnull Function<MapAliasExample, T> mapAliasVisitor) {
+            Preconditions.checkNotNull(mapAliasVisitor, "mapAliasVisitor cannot be null");
+            this.mapAliasVisitor = mapAliasVisitor;
             return this;
         }
 
@@ -240,16 +290,30 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public SetStageVisitorBuilder<T> optional(@Nonnull Function<Optional<String>, T> optionalVisitor) {
+        public OptionalAliasStageVisitorBuilder<T> optional(@Nonnull Function<Optional<String>, T> optionalVisitor) {
             Preconditions.checkNotNull(optionalVisitor, "optionalVisitor cannot be null");
             this.optionalVisitor = optionalVisitor;
             return this;
         }
 
         @Override
-        public StringExampleStageVisitorBuilder<T> set(@Nonnull Function<Set<String>, T> setVisitor) {
+        public SetStageVisitorBuilder<T> optionalAlias(@Nonnull Function<OptionalAlias, T> optionalAliasVisitor) {
+            Preconditions.checkNotNull(optionalAliasVisitor, "optionalAliasVisitor cannot be null");
+            this.optionalAliasVisitor = optionalAliasVisitor;
+            return this;
+        }
+
+        @Override
+        public SetAliasStageVisitorBuilder<T> set(@Nonnull Function<Set<String>, T> setVisitor) {
             Preconditions.checkNotNull(setVisitor, "setVisitor cannot be null");
             this.setVisitor = setVisitor;
+            return this;
+        }
+
+        @Override
+        public StringExampleStageVisitorBuilder<T> setAlias(@Nonnull Function<SetAlias, T> setAliasVisitor) {
+            Preconditions.checkNotNull(setAliasVisitor, "setAliasVisitor cannot be null");
+            this.setAliasVisitor = setAliasVisitor;
             return this;
         }
 
@@ -290,10 +354,14 @@ public final class UnionTypeExample {
             final IntFunction<T> ifVisitor = this.ifVisitor;
             final IntFunction<T> interfaceVisitor = this.interfaceVisitor;
             final Function<List<String>, T> listVisitor = this.listVisitor;
+            final Function<ListAlias, T> listAliasVisitor = this.listAliasVisitor;
             final Function<Map<String, String>, T> mapVisitor = this.mapVisitor;
+            final Function<MapAliasExample, T> mapAliasVisitor = this.mapAliasVisitor;
             final IntFunction<T> newVisitor = this.newVisitor;
             final Function<Optional<String>, T> optionalVisitor = this.optionalVisitor;
+            final Function<OptionalAlias, T> optionalAliasVisitor = this.optionalAliasVisitor;
             final Function<Set<String>, T> setVisitor = this.setVisitor;
+            final Function<SetAlias, T> setAliasVisitor = this.setAliasVisitor;
             final Function<StringExample, T> stringExampleVisitor = this.stringExampleVisitor;
             final IntFunction<T> thisFieldIsAnIntegerVisitor = this.thisFieldIsAnIntegerVisitor;
             final IntFunction<T> unknown_Visitor = this.unknown_Visitor;
@@ -325,8 +393,18 @@ public final class UnionTypeExample {
                 }
 
                 @Override
+                public T visitListAlias(ListAlias value) {
+                    return listAliasVisitor.apply(value);
+                }
+
+                @Override
                 public T visitMap(Map<String, String> value) {
                     return mapVisitor.apply(value);
+                }
+
+                @Override
+                public T visitMapAlias(MapAliasExample value) {
+                    return mapAliasVisitor.apply(value);
                 }
 
                 @Override
@@ -340,8 +418,18 @@ public final class UnionTypeExample {
                 }
 
                 @Override
+                public T visitOptionalAlias(OptionalAlias value) {
+                    return optionalAliasVisitor.apply(value);
+                }
+
+                @Override
                 public T visitSet(Set<String> value) {
                     return setVisitor.apply(value);
+                }
+
+                @Override
+                public T visitSetAlias(SetAlias value) {
+                    return setAliasVisitor.apply(value);
                 }
 
                 @Override
@@ -384,11 +472,19 @@ public final class UnionTypeExample {
     }
 
     public interface ListStageVisitorBuilder<T> {
-        MapStageVisitorBuilder<T> list(@Nonnull Function<List<String>, T> listVisitor);
+        ListAliasStageVisitorBuilder<T> list(@Nonnull Function<List<String>, T> listVisitor);
+    }
+
+    public interface ListAliasStageVisitorBuilder<T> {
+        MapStageVisitorBuilder<T> listAlias(@Nonnull Function<ListAlias, T> listAliasVisitor);
     }
 
     public interface MapStageVisitorBuilder<T> {
-        NewStageVisitorBuilder<T> map(@Nonnull Function<Map<String, String>, T> mapVisitor);
+        MapAliasStageVisitorBuilder<T> map(@Nonnull Function<Map<String, String>, T> mapVisitor);
+    }
+
+    public interface MapAliasStageVisitorBuilder<T> {
+        NewStageVisitorBuilder<T> mapAlias(@Nonnull Function<MapAliasExample, T> mapAliasVisitor);
     }
 
     public interface NewStageVisitorBuilder<T> {
@@ -396,11 +492,19 @@ public final class UnionTypeExample {
     }
 
     public interface OptionalStageVisitorBuilder<T> {
-        SetStageVisitorBuilder<T> optional(@Nonnull Function<Optional<String>, T> optionalVisitor);
+        OptionalAliasStageVisitorBuilder<T> optional(@Nonnull Function<Optional<String>, T> optionalVisitor);
+    }
+
+    public interface OptionalAliasStageVisitorBuilder<T> {
+        SetStageVisitorBuilder<T> optionalAlias(@Nonnull Function<OptionalAlias, T> optionalAliasVisitor);
     }
 
     public interface SetStageVisitorBuilder<T> {
-        StringExampleStageVisitorBuilder<T> set(@Nonnull Function<Set<String>, T> setVisitor);
+        SetAliasStageVisitorBuilder<T> set(@Nonnull Function<Set<String>, T> setVisitor);
+    }
+
+    public interface SetAliasStageVisitorBuilder<T> {
+        StringExampleStageVisitorBuilder<T> setAlias(@Nonnull Function<SetAlias, T> setAliasVisitor);
     }
 
     public interface StringExampleStageVisitorBuilder<T> {
@@ -427,7 +531,6 @@ public final class UnionTypeExample {
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true, defaultImpl = UnknownWrapper.class)
     @JsonSubTypes({
         @JsonSubTypes.Type(StringExampleWrapper.class),
-        @JsonSubTypes.Type(SetWrapper.class),
         @JsonSubTypes.Type(ThisFieldIsAnIntegerWrapper.class),
         @JsonSubTypes.Type(AlsoAnIntegerWrapper.class),
         @JsonSubTypes.Type(IfWrapper.class),
@@ -437,7 +540,12 @@ public final class UnionTypeExample {
         @JsonSubTypes.Type(Unknown_Wrapper.class),
         @JsonSubTypes.Type(OptionalWrapper.class),
         @JsonSubTypes.Type(ListWrapper.class),
-        @JsonSubTypes.Type(MapWrapper.class)
+        @JsonSubTypes.Type(SetWrapper.class),
+        @JsonSubTypes.Type(MapWrapper.class),
+        @JsonSubTypes.Type(OptionalAliasWrapper.class),
+        @JsonSubTypes.Type(ListAliasWrapper.class),
+        @JsonSubTypes.Type(SetAliasWrapper.class),
+        @JsonSubTypes.Type(MapAliasWrapper.class)
     })
     @JsonIgnoreProperties(ignoreUnknown = true)
     private interface Base {
@@ -481,46 +589,6 @@ public final class UnionTypeExample {
         @Override
         public String toString() {
             return "StringExampleWrapper{value: " + value + '}';
-        }
-    }
-
-    @JsonTypeName("set")
-    private static final class SetWrapper implements Base {
-        private final Set<String> value;
-
-        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-        private SetWrapper(@JsonSetter(value = "set", nulls = Nulls.AS_EMPTY) @Nonnull Set<String> value) {
-            Preconditions.checkNotNull(value, "set cannot be null");
-            this.value = value;
-        }
-
-        @JsonProperty("set")
-        private Set<String> getValue() {
-            return value;
-        }
-
-        @Override
-        public <T> T accept(Visitor<T> visitor) {
-            return visitor.visitSet(value);
-        }
-
-        @Override
-        public boolean equals(Object other) {
-            return this == other || (other instanceof SetWrapper && equalTo((SetWrapper) other));
-        }
-
-        private boolean equalTo(SetWrapper other) {
-            return this.value.equals(other.value);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hashCode(this.value);
-        }
-
-        @Override
-        public String toString() {
-            return "SetWrapper{value: " + value + '}';
         }
     }
 
@@ -810,7 +878,8 @@ public final class UnionTypeExample {
         private final Optional<String> value;
 
         @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-        private OptionalWrapper(@JsonSetter("optional") @Nonnull Optional<String> value) {
+        private OptionalWrapper(
+                @JsonSetter(value = "optional", nulls = Nulls.AS_EMPTY) @Nonnull Optional<String> value) {
             Preconditions.checkNotNull(value, "optional cannot be null");
             this.value = value;
         }
@@ -885,6 +954,46 @@ public final class UnionTypeExample {
         }
     }
 
+    @JsonTypeName("set")
+    private static final class SetWrapper implements Base {
+        private final Set<String> value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private SetWrapper(@JsonSetter(value = "set", nulls = Nulls.AS_EMPTY) @Nonnull Set<String> value) {
+            Preconditions.checkNotNull(value, "set cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty("set")
+        private Set<String> getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitSet(value);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof SetWrapper && equalTo((SetWrapper) other));
+        }
+
+        private boolean equalTo(SetWrapper other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "SetWrapper{value: " + value + '}';
+        }
+    }
+
     @JsonTypeName("map")
     private static final class MapWrapper implements Base {
         private final Map<String, String> value;
@@ -922,6 +1031,168 @@ public final class UnionTypeExample {
         @Override
         public String toString() {
             return "MapWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("optionalAlias")
+    private static final class OptionalAliasWrapper implements Base {
+        private final OptionalAlias value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private OptionalAliasWrapper(
+                @JsonSetter(value = "optionalAlias", nulls = Nulls.AS_EMPTY) @Nonnull OptionalAlias value) {
+            Preconditions.checkNotNull(value, "optionalAlias cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty("optionalAlias")
+        private OptionalAlias getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitOptionalAlias(value);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof OptionalAliasWrapper && equalTo((OptionalAliasWrapper) other));
+        }
+
+        private boolean equalTo(OptionalAliasWrapper other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "OptionalAliasWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("listAlias")
+    private static final class ListAliasWrapper implements Base {
+        private final ListAlias value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private ListAliasWrapper(@JsonSetter(value = "listAlias", nulls = Nulls.AS_EMPTY) @Nonnull ListAlias value) {
+            Preconditions.checkNotNull(value, "listAlias cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty("listAlias")
+        private ListAlias getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitListAlias(value);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof ListAliasWrapper && equalTo((ListAliasWrapper) other));
+        }
+
+        private boolean equalTo(ListAliasWrapper other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "ListAliasWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("setAlias")
+    private static final class SetAliasWrapper implements Base {
+        private final SetAlias value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private SetAliasWrapper(@JsonSetter(value = "setAlias", nulls = Nulls.AS_EMPTY) @Nonnull SetAlias value) {
+            Preconditions.checkNotNull(value, "setAlias cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty("setAlias")
+        private SetAlias getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitSetAlias(value);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof SetAliasWrapper && equalTo((SetAliasWrapper) other));
+        }
+
+        private boolean equalTo(SetAliasWrapper other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "SetAliasWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("mapAlias")
+    private static final class MapAliasWrapper implements Base {
+        private final MapAliasExample value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private MapAliasWrapper(
+                @JsonSetter(value = "mapAlias", nulls = Nulls.AS_EMPTY) @Nonnull MapAliasExample value) {
+            Preconditions.checkNotNull(value, "mapAlias cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty("mapAlias")
+        private MapAliasExample getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitMapAlias(value);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof MapAliasWrapper && equalTo((MapAliasWrapper) other));
+        }
+
+        private boolean equalTo(MapAliasWrapper other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "MapAliasWrapper{value: " + value + '}';
         }
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasExample.java
@@ -34,7 +34,7 @@ public final class ExternalLongAliasExample {
         return Long.hashCode(value);
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static ExternalLongAliasExample valueOf(String value) {
         return of(Long.valueOf(value));
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasOne.java
@@ -33,7 +33,7 @@ public final class ExternalLongAliasOne {
         return Long.hashCode(value);
     }
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static ExternalLongAliasOne valueOf(String value) {
         return of(Long.valueOf(value));
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListAlias.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListAlias.java
@@ -1,27 +1,27 @@
-package com.palantir.product;
+package test.prefix.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.Collections;
-import java.util.Map;
+import java.util.List;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
-public final class MapAliasExample {
-    private final Map<String, Object> value;
+public final class ListAlias {
+    private final List<String> value;
 
-    private MapAliasExample(@Nonnull Map<String, Object> value) {
+    private ListAlias(@Nonnull List<String> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
-    private MapAliasExample() {
-        this(Collections.emptyMap());
+    private ListAlias() {
+        this(Collections.emptyList());
     }
 
     @JsonValue
-    public Map<String, Object> get() {
+    public List<String> get() {
         return value;
     }
 
@@ -32,8 +32,7 @@ public final class MapAliasExample {
 
     @Override
     public boolean equals(Object other) {
-        return this == other
-                || (other instanceof MapAliasExample && this.value.equals(((MapAliasExample) other).value));
+        return this == other || (other instanceof ListAlias && this.value.equals(((ListAlias) other).value));
     }
 
     @Override
@@ -42,7 +41,7 @@ public final class MapAliasExample {
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static MapAliasExample of(@Nonnull Map<String, Object> value) {
-        return new MapAliasExample(value);
+    public static ListAlias of(@Nonnull List<String> value) {
+        return new ListAlias(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapAliasExample.java
@@ -3,6 +3,7 @@ package test.prefix.com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
+import java.util.Collections;
 import java.util.Map;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -13,6 +14,10 @@ public final class MapAliasExample {
 
     private MapAliasExample(@Nonnull Map<String, Object> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
+    }
+
+    private MapAliasExample() {
+        this(Collections.emptyMap());
     }
 
     @JsonValue

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetAlias.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetAlias.java
@@ -1,27 +1,27 @@
-package com.palantir.product;
+package test.prefix.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.Collections;
-import java.util.Map;
+import java.util.Set;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
-public final class MapAliasExample {
-    private final Map<String, Object> value;
+public final class SetAlias {
+    private final Set<String> value;
 
-    private MapAliasExample(@Nonnull Map<String, Object> value) {
+    private SetAlias(@Nonnull Set<String> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
-    private MapAliasExample() {
-        this(Collections.emptyMap());
+    private SetAlias() {
+        this(Collections.emptySet());
     }
 
     @JsonValue
-    public Map<String, Object> get() {
+    public Set<String> get() {
         return value;
     }
 
@@ -32,8 +32,7 @@ public final class MapAliasExample {
 
     @Override
     public boolean equals(Object other) {
-        return this == other
-                || (other instanceof MapAliasExample && this.value.equals(((MapAliasExample) other).value));
+        return this == other || (other instanceof SetAlias && this.value.equals(((SetAlias) other).value));
     }
 
     @Override
@@ -42,7 +41,7 @@ public final class MapAliasExample {
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static MapAliasExample of(@Nonnull Map<String, Object> value) {
-        return new MapAliasExample(value);
+    public static SetAlias of(@Nonnull Set<String> value) {
+        return new SetAlias(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -47,10 +47,6 @@ public final class UnionTypeExample {
         return new UnionTypeExample(new StringExampleWrapper(value));
     }
 
-    public static UnionTypeExample set(Set<String> value) {
-        return new UnionTypeExample(new SetWrapper(value));
-    }
-
     public static UnionTypeExample thisFieldIsAnInteger(int value) {
         return new UnionTypeExample(new ThisFieldIsAnIntegerWrapper(value));
     }
@@ -87,8 +83,28 @@ public final class UnionTypeExample {
         return new UnionTypeExample(new ListWrapper(value));
     }
 
+    public static UnionTypeExample set(Set<String> value) {
+        return new UnionTypeExample(new SetWrapper(value));
+    }
+
     public static UnionTypeExample map(Map<String, String> value) {
         return new UnionTypeExample(new MapWrapper(value));
+    }
+
+    public static UnionTypeExample optionalAlias(OptionalAlias value) {
+        return new UnionTypeExample(new OptionalAliasWrapper(value));
+    }
+
+    public static UnionTypeExample listAlias(ListAlias value) {
+        return new UnionTypeExample(new ListAliasWrapper(value));
+    }
+
+    public static UnionTypeExample setAlias(SetAlias value) {
+        return new UnionTypeExample(new SetAliasWrapper(value));
+    }
+
+    public static UnionTypeExample mapAlias(MapAliasExample value) {
+        return new UnionTypeExample(new MapAliasWrapper(value));
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -120,8 +136,6 @@ public final class UnionTypeExample {
          */
         T visitStringExample(StringExample value);
 
-        T visitSet(Set<String> value);
-
         T visitThisFieldIsAnInteger(int value);
 
         T visitAlsoAnInteger(int value);
@@ -140,7 +154,17 @@ public final class UnionTypeExample {
 
         T visitList(List<String> value);
 
+        T visitSet(Set<String> value);
+
         T visitMap(Map<String, String> value);
+
+        T visitOptionalAlias(OptionalAlias value);
+
+        T visitListAlias(ListAlias value);
+
+        T visitSetAlias(SetAlias value);
+
+        T visitMapAlias(MapAliasExample value);
 
         T visitUnknown(String unknownType);
 
@@ -155,10 +179,14 @@ public final class UnionTypeExample {
                     IfStageVisitorBuilder<T>,
                     InterfaceStageVisitorBuilder<T>,
                     ListStageVisitorBuilder<T>,
+                    ListAliasStageVisitorBuilder<T>,
                     MapStageVisitorBuilder<T>,
+                    MapAliasStageVisitorBuilder<T>,
                     NewStageVisitorBuilder<T>,
                     OptionalStageVisitorBuilder<T>,
+                    OptionalAliasStageVisitorBuilder<T>,
                     SetStageVisitorBuilder<T>,
+                    SetAliasStageVisitorBuilder<T>,
                     StringExampleStageVisitorBuilder<T>,
                     ThisFieldIsAnIntegerStageVisitorBuilder<T>,
                     Unknown_StageVisitorBuilder<T>,
@@ -174,13 +202,21 @@ public final class UnionTypeExample {
 
         private Function<List<String>, T> listVisitor;
 
+        private Function<ListAlias, T> listAliasVisitor;
+
         private Function<Map<String, String>, T> mapVisitor;
+
+        private Function<MapAliasExample, T> mapAliasVisitor;
 
         private IntFunction<T> newVisitor;
 
         private Function<Optional<String>, T> optionalVisitor;
 
+        private Function<OptionalAlias, T> optionalAliasVisitor;
+
         private Function<Set<String>, T> setVisitor;
+
+        private Function<SetAlias, T> setAliasVisitor;
 
         private Function<StringExample, T> stringExampleVisitor;
 
@@ -219,16 +255,30 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public MapStageVisitorBuilder<T> list(@Nonnull Function<List<String>, T> listVisitor) {
+        public ListAliasStageVisitorBuilder<T> list(@Nonnull Function<List<String>, T> listVisitor) {
             Preconditions.checkNotNull(listVisitor, "listVisitor cannot be null");
             this.listVisitor = listVisitor;
             return this;
         }
 
         @Override
-        public NewStageVisitorBuilder<T> map(@Nonnull Function<Map<String, String>, T> mapVisitor) {
+        public MapStageVisitorBuilder<T> listAlias(@Nonnull Function<ListAlias, T> listAliasVisitor) {
+            Preconditions.checkNotNull(listAliasVisitor, "listAliasVisitor cannot be null");
+            this.listAliasVisitor = listAliasVisitor;
+            return this;
+        }
+
+        @Override
+        public MapAliasStageVisitorBuilder<T> map(@Nonnull Function<Map<String, String>, T> mapVisitor) {
             Preconditions.checkNotNull(mapVisitor, "mapVisitor cannot be null");
             this.mapVisitor = mapVisitor;
+            return this;
+        }
+
+        @Override
+        public NewStageVisitorBuilder<T> mapAlias(@Nonnull Function<MapAliasExample, T> mapAliasVisitor) {
+            Preconditions.checkNotNull(mapAliasVisitor, "mapAliasVisitor cannot be null");
+            this.mapAliasVisitor = mapAliasVisitor;
             return this;
         }
 
@@ -240,16 +290,30 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public SetStageVisitorBuilder<T> optional(@Nonnull Function<Optional<String>, T> optionalVisitor) {
+        public OptionalAliasStageVisitorBuilder<T> optional(@Nonnull Function<Optional<String>, T> optionalVisitor) {
             Preconditions.checkNotNull(optionalVisitor, "optionalVisitor cannot be null");
             this.optionalVisitor = optionalVisitor;
             return this;
         }
 
         @Override
-        public StringExampleStageVisitorBuilder<T> set(@Nonnull Function<Set<String>, T> setVisitor) {
+        public SetStageVisitorBuilder<T> optionalAlias(@Nonnull Function<OptionalAlias, T> optionalAliasVisitor) {
+            Preconditions.checkNotNull(optionalAliasVisitor, "optionalAliasVisitor cannot be null");
+            this.optionalAliasVisitor = optionalAliasVisitor;
+            return this;
+        }
+
+        @Override
+        public SetAliasStageVisitorBuilder<T> set(@Nonnull Function<Set<String>, T> setVisitor) {
             Preconditions.checkNotNull(setVisitor, "setVisitor cannot be null");
             this.setVisitor = setVisitor;
+            return this;
+        }
+
+        @Override
+        public StringExampleStageVisitorBuilder<T> setAlias(@Nonnull Function<SetAlias, T> setAliasVisitor) {
+            Preconditions.checkNotNull(setAliasVisitor, "setAliasVisitor cannot be null");
+            this.setAliasVisitor = setAliasVisitor;
             return this;
         }
 
@@ -290,10 +354,14 @@ public final class UnionTypeExample {
             final IntFunction<T> ifVisitor = this.ifVisitor;
             final IntFunction<T> interfaceVisitor = this.interfaceVisitor;
             final Function<List<String>, T> listVisitor = this.listVisitor;
+            final Function<ListAlias, T> listAliasVisitor = this.listAliasVisitor;
             final Function<Map<String, String>, T> mapVisitor = this.mapVisitor;
+            final Function<MapAliasExample, T> mapAliasVisitor = this.mapAliasVisitor;
             final IntFunction<T> newVisitor = this.newVisitor;
             final Function<Optional<String>, T> optionalVisitor = this.optionalVisitor;
+            final Function<OptionalAlias, T> optionalAliasVisitor = this.optionalAliasVisitor;
             final Function<Set<String>, T> setVisitor = this.setVisitor;
+            final Function<SetAlias, T> setAliasVisitor = this.setAliasVisitor;
             final Function<StringExample, T> stringExampleVisitor = this.stringExampleVisitor;
             final IntFunction<T> thisFieldIsAnIntegerVisitor = this.thisFieldIsAnIntegerVisitor;
             final IntFunction<T> unknown_Visitor = this.unknown_Visitor;
@@ -325,8 +393,18 @@ public final class UnionTypeExample {
                 }
 
                 @Override
+                public T visitListAlias(ListAlias value) {
+                    return listAliasVisitor.apply(value);
+                }
+
+                @Override
                 public T visitMap(Map<String, String> value) {
                     return mapVisitor.apply(value);
+                }
+
+                @Override
+                public T visitMapAlias(MapAliasExample value) {
+                    return mapAliasVisitor.apply(value);
                 }
 
                 @Override
@@ -340,8 +418,18 @@ public final class UnionTypeExample {
                 }
 
                 @Override
+                public T visitOptionalAlias(OptionalAlias value) {
+                    return optionalAliasVisitor.apply(value);
+                }
+
+                @Override
                 public T visitSet(Set<String> value) {
                     return setVisitor.apply(value);
+                }
+
+                @Override
+                public T visitSetAlias(SetAlias value) {
+                    return setAliasVisitor.apply(value);
                 }
 
                 @Override
@@ -384,11 +472,19 @@ public final class UnionTypeExample {
     }
 
     public interface ListStageVisitorBuilder<T> {
-        MapStageVisitorBuilder<T> list(@Nonnull Function<List<String>, T> listVisitor);
+        ListAliasStageVisitorBuilder<T> list(@Nonnull Function<List<String>, T> listVisitor);
+    }
+
+    public interface ListAliasStageVisitorBuilder<T> {
+        MapStageVisitorBuilder<T> listAlias(@Nonnull Function<ListAlias, T> listAliasVisitor);
     }
 
     public interface MapStageVisitorBuilder<T> {
-        NewStageVisitorBuilder<T> map(@Nonnull Function<Map<String, String>, T> mapVisitor);
+        MapAliasStageVisitorBuilder<T> map(@Nonnull Function<Map<String, String>, T> mapVisitor);
+    }
+
+    public interface MapAliasStageVisitorBuilder<T> {
+        NewStageVisitorBuilder<T> mapAlias(@Nonnull Function<MapAliasExample, T> mapAliasVisitor);
     }
 
     public interface NewStageVisitorBuilder<T> {
@@ -396,11 +492,19 @@ public final class UnionTypeExample {
     }
 
     public interface OptionalStageVisitorBuilder<T> {
-        SetStageVisitorBuilder<T> optional(@Nonnull Function<Optional<String>, T> optionalVisitor);
+        OptionalAliasStageVisitorBuilder<T> optional(@Nonnull Function<Optional<String>, T> optionalVisitor);
+    }
+
+    public interface OptionalAliasStageVisitorBuilder<T> {
+        SetStageVisitorBuilder<T> optionalAlias(@Nonnull Function<OptionalAlias, T> optionalAliasVisitor);
     }
 
     public interface SetStageVisitorBuilder<T> {
-        StringExampleStageVisitorBuilder<T> set(@Nonnull Function<Set<String>, T> setVisitor);
+        SetAliasStageVisitorBuilder<T> set(@Nonnull Function<Set<String>, T> setVisitor);
+    }
+
+    public interface SetAliasStageVisitorBuilder<T> {
+        StringExampleStageVisitorBuilder<T> setAlias(@Nonnull Function<SetAlias, T> setAliasVisitor);
     }
 
     public interface StringExampleStageVisitorBuilder<T> {
@@ -427,7 +531,6 @@ public final class UnionTypeExample {
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true, defaultImpl = UnknownWrapper.class)
     @JsonSubTypes({
         @JsonSubTypes.Type(StringExampleWrapper.class),
-        @JsonSubTypes.Type(SetWrapper.class),
         @JsonSubTypes.Type(ThisFieldIsAnIntegerWrapper.class),
         @JsonSubTypes.Type(AlsoAnIntegerWrapper.class),
         @JsonSubTypes.Type(IfWrapper.class),
@@ -437,7 +540,12 @@ public final class UnionTypeExample {
         @JsonSubTypes.Type(Unknown_Wrapper.class),
         @JsonSubTypes.Type(OptionalWrapper.class),
         @JsonSubTypes.Type(ListWrapper.class),
-        @JsonSubTypes.Type(MapWrapper.class)
+        @JsonSubTypes.Type(SetWrapper.class),
+        @JsonSubTypes.Type(MapWrapper.class),
+        @JsonSubTypes.Type(OptionalAliasWrapper.class),
+        @JsonSubTypes.Type(ListAliasWrapper.class),
+        @JsonSubTypes.Type(SetAliasWrapper.class),
+        @JsonSubTypes.Type(MapAliasWrapper.class)
     })
     @JsonIgnoreProperties(ignoreUnknown = true)
     private interface Base {
@@ -481,46 +589,6 @@ public final class UnionTypeExample {
         @Override
         public String toString() {
             return "StringExampleWrapper{value: " + value + '}';
-        }
-    }
-
-    @JsonTypeName("set")
-    private static final class SetWrapper implements Base {
-        private final Set<String> value;
-
-        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-        private SetWrapper(@JsonSetter(value = "set", nulls = Nulls.AS_EMPTY) @Nonnull Set<String> value) {
-            Preconditions.checkNotNull(value, "set cannot be null");
-            this.value = value;
-        }
-
-        @JsonProperty("set")
-        private Set<String> getValue() {
-            return value;
-        }
-
-        @Override
-        public <T> T accept(Visitor<T> visitor) {
-            return visitor.visitSet(value);
-        }
-
-        @Override
-        public boolean equals(Object other) {
-            return this == other || (other instanceof SetWrapper && equalTo((SetWrapper) other));
-        }
-
-        private boolean equalTo(SetWrapper other) {
-            return this.value.equals(other.value);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hashCode(this.value);
-        }
-
-        @Override
-        public String toString() {
-            return "SetWrapper{value: " + value + '}';
         }
     }
 
@@ -810,7 +878,8 @@ public final class UnionTypeExample {
         private final Optional<String> value;
 
         @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-        private OptionalWrapper(@JsonSetter("optional") @Nonnull Optional<String> value) {
+        private OptionalWrapper(
+                @JsonSetter(value = "optional", nulls = Nulls.AS_EMPTY) @Nonnull Optional<String> value) {
             Preconditions.checkNotNull(value, "optional cannot be null");
             this.value = value;
         }
@@ -885,6 +954,46 @@ public final class UnionTypeExample {
         }
     }
 
+    @JsonTypeName("set")
+    private static final class SetWrapper implements Base {
+        private final Set<String> value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private SetWrapper(@JsonSetter(value = "set", nulls = Nulls.AS_EMPTY) @Nonnull Set<String> value) {
+            Preconditions.checkNotNull(value, "set cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty("set")
+        private Set<String> getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitSet(value);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof SetWrapper && equalTo((SetWrapper) other));
+        }
+
+        private boolean equalTo(SetWrapper other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "SetWrapper{value: " + value + '}';
+        }
+    }
+
     @JsonTypeName("map")
     private static final class MapWrapper implements Base {
         private final Map<String, String> value;
@@ -922,6 +1031,168 @@ public final class UnionTypeExample {
         @Override
         public String toString() {
             return "MapWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("optionalAlias")
+    private static final class OptionalAliasWrapper implements Base {
+        private final OptionalAlias value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private OptionalAliasWrapper(
+                @JsonSetter(value = "optionalAlias", nulls = Nulls.AS_EMPTY) @Nonnull OptionalAlias value) {
+            Preconditions.checkNotNull(value, "optionalAlias cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty("optionalAlias")
+        private OptionalAlias getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitOptionalAlias(value);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof OptionalAliasWrapper && equalTo((OptionalAliasWrapper) other));
+        }
+
+        private boolean equalTo(OptionalAliasWrapper other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "OptionalAliasWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("listAlias")
+    private static final class ListAliasWrapper implements Base {
+        private final ListAlias value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private ListAliasWrapper(@JsonSetter(value = "listAlias", nulls = Nulls.AS_EMPTY) @Nonnull ListAlias value) {
+            Preconditions.checkNotNull(value, "listAlias cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty("listAlias")
+        private ListAlias getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitListAlias(value);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof ListAliasWrapper && equalTo((ListAliasWrapper) other));
+        }
+
+        private boolean equalTo(ListAliasWrapper other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "ListAliasWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("setAlias")
+    private static final class SetAliasWrapper implements Base {
+        private final SetAlias value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private SetAliasWrapper(@JsonSetter(value = "setAlias", nulls = Nulls.AS_EMPTY) @Nonnull SetAlias value) {
+            Preconditions.checkNotNull(value, "setAlias cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty("setAlias")
+        private SetAlias getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitSetAlias(value);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof SetAliasWrapper && equalTo((SetAliasWrapper) other));
+        }
+
+        private boolean equalTo(SetAliasWrapper other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "SetAliasWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("mapAlias")
+    private static final class MapAliasWrapper implements Base {
+        private final MapAliasExample value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private MapAliasWrapper(
+                @JsonSetter(value = "mapAlias", nulls = Nulls.AS_EMPTY) @Nonnull MapAliasExample value) {
+            Preconditions.checkNotNull(value, "mapAlias cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty("mapAlias")
+        private MapAliasExample getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitMapAlias(value);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof MapAliasWrapper && equalTo((MapAliasWrapper) other));
+        }
+
+        private boolean equalTo(MapAliasWrapper other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "MapAliasWrapper{value: " + value + '}';
         }
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
@@ -29,6 +29,7 @@ import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.java.util.Packages;
 import com.palantir.conjure.java.util.ParameterOrder;
 import com.palantir.conjure.java.util.TypeFunctions;
+import com.palantir.conjure.java.visitor.DefaultableTypeVisitor;
 import com.palantir.conjure.spec.ArgumentDefinition;
 import com.palantir.conjure.spec.AuthType;
 import com.palantir.conjure.spec.ConjureDefinition;

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
@@ -29,6 +29,7 @@ import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.java.util.Packages;
 import com.palantir.conjure.java.util.ParameterOrder;
 import com.palantir.conjure.java.util.TypeFunctions;
+import com.palantir.conjure.java.visitor.DefaultableTypeVisitor;
 import com.palantir.conjure.spec.ArgumentDefinition;
 import com.palantir.conjure.spec.ArgumentName;
 import com.palantir.conjure.spec.AuthType;

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -238,6 +238,8 @@ public final class AliasGenerator {
 
         @Override
         public Optional<MethodSpec> visitReference(com.palantir.conjure.spec.TypeName value) {
+            // TODO(ckozak): Ideally this would support recursive aliases, for example an alias of alias of list
+            // should have a default constructor.
             return Optional.empty();
         }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ObjectGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ObjectGenerator.java
@@ -21,9 +21,11 @@ import com.palantir.conjure.java.Options;
 import com.palantir.conjure.java.util.TypeFunctions;
 import com.palantir.conjure.spec.ErrorDefinition;
 import com.palantir.conjure.spec.TypeDefinition;
+import com.palantir.conjure.spec.TypeName;
 import com.palantir.conjure.visitor.TypeDefinitionVisitor;
 import com.squareup.javapoet.JavaFile;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public final class ObjectGenerator implements TypeGenerator {
@@ -36,7 +38,8 @@ public final class ObjectGenerator implements TypeGenerator {
 
     @Override
     public List<JavaFile> generateTypes(List<TypeDefinition> types) {
-        TypeMapper typeMapper = new TypeMapper(TypeFunctions.toTypesMap(types), options);
+        Map<TypeName, TypeDefinition> typesMap = TypeFunctions.toTypesMap(types);
+        TypeMapper typeMapper = new TypeMapper(typesMap, options);
 
         return types.stream()
                 .map(typeDef -> {
@@ -45,7 +48,7 @@ public final class ObjectGenerator implements TypeGenerator {
                                 typeMapper, typeDef.accept(TypeDefinitionVisitor.OBJECT), options);
                     } else if (typeDef.accept(TypeDefinitionVisitor.IS_UNION)) {
                         return UnionGenerator.generateUnionType(
-                                typeMapper, typeDef.accept(TypeDefinitionVisitor.UNION), options);
+                                typeMapper, typesMap, typeDef.accept(TypeDefinitionVisitor.UNION), options);
                     } else if (typeDef.accept(TypeDefinitionVisitor.IS_ENUM)) {
                         return EnumGenerator.generateEnumType(typeDef.accept(TypeDefinitionVisitor.ENUM), options);
                     } else if (typeDef.accept(TypeDefinitionVisitor.IS_ALIAS)) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/visitor/DefaultableTypeVisitor.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/visitor/DefaultableTypeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.conjure.java.services;
+package com.palantir.conjure.java.visitor;
 
 import com.palantir.conjure.spec.ExternalReference;
 import com.palantir.conjure.spec.ListType;
@@ -25,7 +25,7 @@ import com.palantir.conjure.spec.SetType;
 import com.palantir.conjure.spec.Type;
 import com.palantir.conjure.spec.TypeName;
 
-enum DefaultableTypeVisitor implements Type.Visitor<Boolean> {
+public enum DefaultableTypeVisitor implements Type.Visitor<Boolean> {
     INSTANCE;
 
     @Override

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -36,9 +36,13 @@ import com.palantir.product.EnumExample;
 import com.palantir.product.ExternalLongAliasExample;
 import com.palantir.product.ExternalStringAliasExample;
 import com.palantir.product.IntegerAliasExample;
+import com.palantir.product.ListAlias;
 import com.palantir.product.ListExample;
+import com.palantir.product.MapAliasExample;
 import com.palantir.product.MapExample;
+import com.palantir.product.OptionalAlias;
 import com.palantir.product.OptionalExample;
+import com.palantir.product.SetAlias;
 import com.palantir.product.SetExample;
 import com.palantir.product.StringAliasExample;
 import com.palantir.product.StringExample;
@@ -354,6 +358,18 @@ public final class WireFormatTests {
     }
 
     @Test
+    public void testUnionType_excludedOptionalAliasValue() throws IOException {
+        assertThat(mapper.readValue("{\"type\":\"optionalAlias\"}", UnionTypeExample.class))
+                .isEqualTo(UnionTypeExample.optionalAlias(OptionalAlias.of(Optional.empty())));
+    }
+
+    @Test
+    public void testUnionType_nullOptionalAliasValue() throws IOException {
+        assertThat(mapper.readValue("{\"type\":\"optionalAlias\",\"optionalAlias\":null}", UnionTypeExample.class))
+                .isEqualTo(UnionTypeExample.optionalAlias(OptionalAlias.of(Optional.empty())));
+    }
+
+    @Test
     public void testUnionType_excludedSetValue() throws IOException {
         assertThat(mapper.readValue("{\"type\":\"set\"}", UnionTypeExample.class))
                 .isEqualTo(UnionTypeExample.set(ImmutableSet.of()));
@@ -363,6 +379,18 @@ public final class WireFormatTests {
     public void testUnionType_nullSetValue() throws IOException {
         assertThat(mapper.readValue("{\"type\":\"set\",\"set\":null}", UnionTypeExample.class))
                 .isEqualTo(UnionTypeExample.set(ImmutableSet.of()));
+    }
+
+    @Test
+    public void testUnionType_excludedSetAliasValue() throws IOException {
+        assertThat(mapper.readValue("{\"type\":\"setAlias\"}", UnionTypeExample.class))
+                .isEqualTo(UnionTypeExample.setAlias(SetAlias.of(ImmutableSet.of())));
+    }
+
+    @Test
+    public void testUnionType_nullSetAliasValue() throws IOException {
+        assertThat(mapper.readValue("{\"type\":\"setAlias\",\"setAlias\":null}", UnionTypeExample.class))
+                .isEqualTo(UnionTypeExample.setAlias(SetAlias.of(ImmutableSet.of())));
     }
 
     @Test
@@ -378,6 +406,18 @@ public final class WireFormatTests {
     }
 
     @Test
+    public void testUnionType_excludedListAliasValue() throws IOException {
+        assertThat(mapper.readValue("{\"type\":\"listAlias\"}", UnionTypeExample.class))
+                .isEqualTo(UnionTypeExample.listAlias(ListAlias.of(ImmutableList.of())));
+    }
+
+    @Test
+    public void testUnionType_nullListAliasValue() throws IOException {
+        assertThat(mapper.readValue("{\"type\":\"listAlias\",\"listAlias\":null}", UnionTypeExample.class))
+                .isEqualTo(UnionTypeExample.listAlias(ListAlias.of(ImmutableList.of())));
+    }
+
+    @Test
     public void testUnionType_excludedMapValue() throws IOException {
         assertThat(mapper.readValue("{\"type\":\"map\"}", UnionTypeExample.class))
                 .isEqualTo(UnionTypeExample.map(ImmutableMap.of()));
@@ -387,6 +427,18 @@ public final class WireFormatTests {
     public void testUnionType_nullMapValue() throws IOException {
         assertThat(mapper.readValue("{\"type\":\"map\",\"map\":null}", UnionTypeExample.class))
                 .isEqualTo(UnionTypeExample.map(ImmutableMap.of()));
+    }
+
+    @Test
+    public void testUnionType_excludedMapAliasValue() throws IOException {
+        assertThat(mapper.readValue("{\"type\":\"mapAlias\"}", UnionTypeExample.class))
+                .isEqualTo(UnionTypeExample.mapAlias(MapAliasExample.of(ImmutableMap.of())));
+    }
+
+    @Test
+    public void testUnionType_nullMapAliasValue() throws IOException {
+        assertThat(mapper.readValue("{\"type\":\"mapAlias\",\"mapAlias\":null}", UnionTypeExample.class))
+                .isEqualTo(UnionTypeExample.mapAlias(MapAliasExample.of(ImmutableMap.of())));
     }
 
     @Test
@@ -561,6 +613,26 @@ public final class WireFormatTests {
         @Override
         public Integer visitMap(Map<String, String> value) {
             return value.size();
+        }
+
+        @Override
+        public Integer visitOptionalAlias(OptionalAlias _value) {
+            return -1;
+        }
+
+        @Override
+        public Integer visitListAlias(ListAlias value) {
+            return value.get().size();
+        }
+
+        @Override
+        public Integer visitSetAlias(SetAlias value) {
+            return value.get().size();
+        }
+
+        @Override
+        public Integer visitMapAlias(MapAliasExample value) {
+            return value.get().size();
         }
 
         @Override

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -170,7 +170,6 @@ types:
           stringExample:
             type: StringExample
             docs: Docs for when UnionTypeExample is of type StringExample.
-          set: set<string>
           thisFieldIsAnInteger: integer
           alsoAnInteger: integer
           if: integer # some 'bad' member names!
@@ -180,7 +179,12 @@ types:
           unknown: integer
           optional: optional<string>
           list: list<string>
+          set: set<string>
           map: map<string, string>
+          optionalAlias: OptionalAlias
+          listAlias: ListAlias
+          setAlias: SetAlias
+          mapAlias: MapAliasExample
       UnionWithUnknownString:
         union:
           unknown: string
@@ -244,3 +248,7 @@ types:
         alias: ExternalLongAliasOne
       OptionalAlias:
         alias: optional<string>
+      ListAlias:
+        alias: list<string>
+      SetAlias:
+        alias: set<string>


### PR DESCRIPTION
This is similar to an earlier change, but applies to aliases.

## Before this PR
The new WireFormatTests fail without this change.
https://github.com/palantir/conjure-java/compare/ckozak/alias_default_ctor?expand=1#diff-7af5d62c67a59ff3e03f1af5202ec0270b5d9d048b5634e6ae4d87fe715b2266

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Support alias of wrapper null coercion
==COMMIT_MSG==

## Possible downsides?
Note that this does allow `{}` to coerce into an empty value, however
it also allows null to work the same between aliases and dealiased
collections. It's more important to correctly support required
parts of the spec than to guard against other edge cases.

Also note that the tests expect null to result in a failure, however
null may be coerced into an empty collection per the conjure spec.