### PR TITLE
Revert "publish conjure-java jar (#1112)"

### DIFF
--- a/changelog/@unreleased/pr-1179.v2.yml
+++ b/changelog/@unreleased/pr-1179.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Revert publishing the conjure-java jar to avoid breaking conjure generator
+    distribution resolution with our standard plugins.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1179

--- a/conjure-java/build.gradle
+++ b/conjure-java/build.gradle
@@ -15,7 +15,6 @@
  */
 
 apply from: "$rootDir/gradle/publish-dist.gradle"
-apply from: "$rootDir/gradle/publish-jar.gradle"
 
 mainClassName = 'com.palantir.conjure.java.cli.ConjureJavaCli'
 


### PR DESCRIPTION
This reverts commit 25cec998c6c9e0cc250be08746d3f85cb3ed7fae.

## Before this PR
Publishing a jar breaks resolution of the tgz distribiution that
our gradle plugins consume. We'll need to publish differently if
we don't want to break compatibility with the gradle plugin,
or roll out a gradle plugin change separately.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Revert publishing the conjure-java jar to avoid breaking conjure generator distribution resolution with our standard plugins.
==COMMIT_MSG==

## Possible downsides?
Unfortunately this is a step back away from getting good generator performance.

