### PR TITLE
Improvement: Alias of double can be constructed from BigDecimal

### DIFF
--- a/changelog/@unreleased/pr-1197.v2.yml
+++ b/changelog/@unreleased/pr-1197.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Alias of double can be constructed from BigDecimal
+  links:
+  - https://github.com/palantir/conjure-java/pull/1197

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
@@ -58,7 +58,7 @@ public final class DoubleAliasExample {
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static DoubleAliasExample of(BigDecimal value) {
+    private static DoubleAliasExample of(BigDecimal value) {
         return new DoubleAliasExample(value.doubleValue());
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
@@ -3,6 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.SafeLong;
+import java.math.BigDecimal;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -54,6 +55,11 @@ public final class DoubleAliasExample {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static DoubleAliasExample of(int value) {
         return new DoubleAliasExample((double) value);
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static DoubleAliasExample of(BigDecimal value) {
+        return new DoubleAliasExample(value.doubleValue());
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleAliasExample.java
@@ -3,6 +3,7 @@ package test.prefix.com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.SafeLong;
+import java.math.BigDecimal;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -54,6 +55,11 @@ public final class DoubleAliasExample {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static DoubleAliasExample of(int value) {
         return new DoubleAliasExample((double) value);
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static DoubleAliasExample of(BigDecimal value) {
+        return new DoubleAliasExample(value.doubleValue());
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleAliasExample.java
@@ -58,7 +58,7 @@ public final class DoubleAliasExample {
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static DoubleAliasExample of(BigDecimal value) {
+    private static DoubleAliasExample of(BigDecimal value) {
         return new DoubleAliasExample(value.doubleValue());
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -43,6 +43,7 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Optional;
 import javax.lang.model.element.Modifier;
@@ -143,6 +144,16 @@ public final class AliasGenerator {
                     .addParameter(TypeName.INT, "value")
                     .returns(thisClass)
                     .addCode(intCastCodeBlock)
+                    .build());
+
+            spec.addMethod(MethodSpec.methodBuilder("of")
+                    .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                    .addAnnotation(ConjureAnnotations.delegatingJsonCreator())
+                    .addParameter(BigDecimal.class, "value")
+                    .returns(thisClass)
+                    .addCode(CodeBlock.builder()
+                            .addStatement("return new $T(value.doubleValue())", thisClass)
+                            .build())
                     .build());
 
             CodeBlock doubleFromStringCodeBlock = CodeBlock.builder()

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -147,7 +147,7 @@ public final class AliasGenerator {
                     .build());
 
             spec.addMethod(MethodSpec.methodBuilder("of")
-                    .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                    .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
                     .addAnnotation(ConjureAnnotations.delegatingJsonCreator())
                     .addParameter(BigDecimal.class, "value")
                     .returns(thisClass)


### PR DESCRIPTION
closes #1196 

## Before this PR
In some cases Jackson would interpret the JSON tokens as a BigDecimal and subsequently fail to initialize a Conjure alias of double since there was no static factory method for Alias of double

## After this PR

==COMMIT_MSG==
Alias of double can be constructed from BigDecimal
==COMMIT_MSG==

## Possible downsides?
This does not address cases where there are nested aliases

