### PR TITLE
work around javapoet deadlock

### DIFF
--- a/changelog/@unreleased/pr-1211.v2.yml
+++ b/changelog/@unreleased/pr-1211.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: work around javapoet class loading deadlock between ClassName and TypeName
+  links:
+  - https://github.com/palantir/conjure-java/pull/1211

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -79,7 +79,7 @@ public final class AliasGenerator {
                 .addMethod(MethodSpec.methodBuilder("equals")
                         .addModifiers(Modifier.PUBLIC)
                         .addAnnotation(Override.class)
-                        .addParameter(TypeName.OBJECT, "other")
+                        .addParameter(ClassName.OBJECT, "other")
                         .returns(TypeName.BOOLEAN)
                         .addCode(primitiveSafeEquality(thisClass, aliasTypeName, typeDef))
                         .build())

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -284,7 +284,7 @@ public final class BeanGenerator {
         ParameterSpec listParam =
                 ParameterSpec.builder(listOfStringType, "prev").build();
         ParameterSpec fieldValueParam =
-                ParameterSpec.builder(TypeName.OBJECT, "fieldValue").build();
+                ParameterSpec.builder(ClassName.OBJECT, "fieldValue").build();
         ParameterSpec fieldNameParam =
                 ParameterSpec.builder(ClassName.get(String.class), "fieldName").build();
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -303,7 +303,7 @@ public final class EnumGenerator {
     }
 
     private static MethodSpec createEquals(TypeName thisClass) {
-        ParameterSpec other = ParameterSpec.builder(TypeName.OBJECT, "other").build();
+        ParameterSpec other = ParameterSpec.builder(ClassName.OBJECT, "other").build();
         return MethodSpec.methodBuilder("equals")
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(Override.class)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/MethodSpecs.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/MethodSpecs.java
@@ -39,7 +39,7 @@ import javax.lang.model.element.Modifier;
 public final class MethodSpecs {
 
     public static MethodSpec createEquals(TypeName thisClass) {
-        ParameterSpec other = ParameterSpec.builder(TypeName.OBJECT, "other").build();
+        ParameterSpec other = ParameterSpec.builder(ClassName.OBJECT, "other").build();
         return MethodSpec.methodBuilder("equals")
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(Override.class)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -187,7 +187,7 @@ public final class UnionGenerator {
     }
 
     private static MethodSpec generateEquals(ClassName unionClass) {
-        ParameterSpec other = ParameterSpec.builder(TypeName.OBJECT, "other").build();
+        ParameterSpec other = ParameterSpec.builder(ClassName.OBJECT, "other").build();
         CodeBlock.Builder codeBuilder = CodeBlock.builder()
                 .add("return this == $1N || ($1N instanceof $2T && equalTo(($2T) $1N))", other, unionClass);
 

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -34,6 +34,7 @@ import com.palantir.conjure.java.types.ErrorGenerator;
 import com.palantir.conjure.java.types.ObjectGenerator;
 import com.palantir.conjure.spec.ConjureDefinition;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import com.squareup.javapoet.ClassName;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -49,6 +50,11 @@ import picocli.CommandLine;
         mixinStandardHelpOptions = true,
         subcommands = ConjureJavaCli.GenerateCommand.class)
 public final class ConjureJavaCli implements Runnable {
+    // Load TypeName to prevent a deadlock
+    // https://github.com/square/javapoet/issues/637
+    @SuppressWarnings("unused")
+    private static final ClassName _loaded = ClassName.get(Runnable.class);
+
     public static void main(String[] args) {
         CommandLine.run(new ConjureJavaCli(), args);
     }


### PR DESCRIPTION
See https://github.com/square/javapoet/issues/637

## Before this PR
Deadlock... sometimes.

## After this PR
==COMMIT_MSG==
work around javapoet class loading deadlock between ClassName and TypeName
==COMMIT_MSG==

## Possible downsides?
Code is a little wonky.

