### PR TITLE
Union Visitor builders provide a helper to throw on unknown inputs

### DIFF
--- a/changelog/@unreleased/pr-1223.v2.yml
+++ b/changelog/@unreleased/pr-1223.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Union visitor builders provide a helper to throw on unknown variants without writing out the throw statement/lambda explicitly.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1223

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
@@ -74,7 +74,7 @@ public final class EmptyUnionTypeExample {
         }
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknownThrows() {
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
                 throw new SafeIllegalStateException(
                         "Unknown variant of the 'EmptyUnionTypeExample' union", SafeArg.of("unknownType", unknownType));
@@ -97,7 +97,7 @@ public final class EmptyUnionTypeExample {
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
 
-        Completed_StageVisitorBuilder<T> unknownThrows();
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -72,6 +74,15 @@ public final class EmptyUnionTypeExample {
         }
 
         @Override
+        public Completed_StageVisitorBuilder<T> unknownThrows() {
+            this.unknownVisitor = unknownType -> {
+                throw new SafeIllegalStateException(
+                        "Unknown variant of the 'EmptyUnionTypeExample' union", SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
         public Visitor<T> build() {
             final Function<String, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
@@ -85,6 +96,8 @@ public final class EmptyUnionTypeExample {
 
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> unknownThrows();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -92,7 +92,7 @@ public final class SingleUnion {
         }
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknownThrows() {
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
                 throw new SafeIllegalStateException(
                         "Unknown variant of the 'SingleUnion' union", SafeArg.of("unknownType", unknownType));
@@ -125,7 +125,7 @@ public final class SingleUnion {
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
 
-        Completed_StageVisitorBuilder<T> unknownThrows();
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -90,6 +92,15 @@ public final class SingleUnion {
         }
 
         @Override
+        public Completed_StageVisitorBuilder<T> unknownThrows() {
+            this.unknownVisitor = unknownType -> {
+                throw new SafeIllegalStateException(
+                        "Unknown variant of the 'SingleUnion' union", SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
         public Visitor<T> build() {
             final Function<String, T> fooVisitor = this.fooVisitor;
             final Function<String, T> unknownVisitor = this.unknownVisitor;
@@ -113,6 +124,8 @@ public final class SingleUnion {
 
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> unknownThrows();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -145,7 +145,7 @@ public final class Union {
         }
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknownThrows() {
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
                 throw new SafeIllegalStateException(
                         "Unknown variant of the 'Union' union", SafeArg.of("unknownType", unknownType));
@@ -198,7 +198,7 @@ public final class Union {
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
 
-        Completed_StageVisitorBuilder<T> unknownThrows();
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -143,6 +145,15 @@ public final class Union {
         }
 
         @Override
+        public Completed_StageVisitorBuilder<T> unknownThrows() {
+            this.unknownVisitor = unknownType -> {
+                throw new SafeIllegalStateException(
+                        "Unknown variant of the 'Union' union", SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
         public Visitor<T> build() {
             final IntFunction<T> barVisitor = this.barVisitor;
             final Function<Long, T> bazVisitor = this.bazVisitor;
@@ -186,6 +197,8 @@ public final class Union {
 
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> unknownThrows();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -350,7 +350,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknownThrows() {
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
                 throw new SafeIllegalStateException(
                         "Unknown variant of the 'UnionTypeExample' union", SafeArg.of("unknownType", unknownType));
@@ -534,7 +534,7 @@ public final class UnionTypeExample {
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
 
-        Completed_StageVisitorBuilder<T> unknownThrows();
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -348,6 +350,15 @@ public final class UnionTypeExample {
         }
 
         @Override
+        public Completed_StageVisitorBuilder<T> unknownThrows() {
+            this.unknownVisitor = unknownType -> {
+                throw new SafeIllegalStateException(
+                        "Unknown variant of the 'UnionTypeExample' union", SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
         public Visitor<T> build() {
             final IntFunction<T> alsoAnIntegerVisitor = this.alsoAnIntegerVisitor;
             final IntFunction<T> completedVisitor = this.completedVisitor;
@@ -522,6 +533,8 @@ public final class UnionTypeExample {
 
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> unknownThrows();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
@@ -92,7 +92,7 @@ public final class UnionWithUnknownString {
         }
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknownThrows() {
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
                 throw new SafeIllegalStateException(
                         "Unknown variant of the 'UnionWithUnknownString' union",
@@ -126,7 +126,7 @@ public final class UnionWithUnknownString {
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
 
-        Completed_StageVisitorBuilder<T> unknownThrows();
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -90,6 +92,16 @@ public final class UnionWithUnknownString {
         }
 
         @Override
+        public Completed_StageVisitorBuilder<T> unknownThrows() {
+            this.unknownVisitor = unknownType -> {
+                throw new SafeIllegalStateException(
+                        "Unknown variant of the 'UnionWithUnknownString' union",
+                        SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
         public Visitor<T> build() {
             final Function<String, T> unknown_Visitor = this.unknown_Visitor;
             final Function<String, T> unknownVisitor = this.unknownVisitor;
@@ -113,6 +125,8 @@ public final class UnionWithUnknownString {
 
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> unknownThrows();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
@@ -74,7 +74,7 @@ public final class EmptyUnionTypeExample {
         }
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknownThrows() {
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
                 throw new SafeIllegalStateException(
                         "Unknown variant of the 'EmptyUnionTypeExample' union", SafeArg.of("unknownType", unknownType));
@@ -97,7 +97,7 @@ public final class EmptyUnionTypeExample {
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
 
-        Completed_StageVisitorBuilder<T> unknownThrows();
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -72,6 +74,15 @@ public final class EmptyUnionTypeExample {
         }
 
         @Override
+        public Completed_StageVisitorBuilder<T> unknownThrows() {
+            this.unknownVisitor = unknownType -> {
+                throw new SafeIllegalStateException(
+                        "Unknown variant of the 'EmptyUnionTypeExample' union", SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
         public Visitor<T> build() {
             final Function<String, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
@@ -85,6 +96,8 @@ public final class EmptyUnionTypeExample {
 
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> unknownThrows();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
@@ -92,7 +92,7 @@ public final class SingleUnion {
         }
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknownThrows() {
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
                 throw new SafeIllegalStateException(
                         "Unknown variant of the 'SingleUnion' union", SafeArg.of("unknownType", unknownType));
@@ -125,7 +125,7 @@ public final class SingleUnion {
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
 
-        Completed_StageVisitorBuilder<T> unknownThrows();
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -90,6 +92,15 @@ public final class SingleUnion {
         }
 
         @Override
+        public Completed_StageVisitorBuilder<T> unknownThrows() {
+            this.unknownVisitor = unknownType -> {
+                throw new SafeIllegalStateException(
+                        "Unknown variant of the 'SingleUnion' union", SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
         public Visitor<T> build() {
             final Function<String, T> fooVisitor = this.fooVisitor;
             final Function<String, T> unknownVisitor = this.unknownVisitor;
@@ -113,6 +124,8 @@ public final class SingleUnion {
 
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> unknownThrows();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
@@ -145,7 +145,7 @@ public final class Union {
         }
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknownThrows() {
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
                 throw new SafeIllegalStateException(
                         "Unknown variant of the 'Union' union", SafeArg.of("unknownType", unknownType));
@@ -198,7 +198,7 @@ public final class Union {
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
 
-        Completed_StageVisitorBuilder<T> unknownThrows();
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -143,6 +145,15 @@ public final class Union {
         }
 
         @Override
+        public Completed_StageVisitorBuilder<T> unknownThrows() {
+            this.unknownVisitor = unknownType -> {
+                throw new SafeIllegalStateException(
+                        "Unknown variant of the 'Union' union", SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
         public Visitor<T> build() {
             final IntFunction<T> barVisitor = this.barVisitor;
             final Function<Long, T> bazVisitor = this.bazVisitor;
@@ -186,6 +197,8 @@ public final class Union {
 
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> unknownThrows();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -350,7 +350,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknownThrows() {
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
                 throw new SafeIllegalStateException(
                         "Unknown variant of the 'UnionTypeExample' union", SafeArg.of("unknownType", unknownType));
@@ -534,7 +534,7 @@ public final class UnionTypeExample {
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
 
-        Completed_StageVisitorBuilder<T> unknownThrows();
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -348,6 +350,15 @@ public final class UnionTypeExample {
         }
 
         @Override
+        public Completed_StageVisitorBuilder<T> unknownThrows() {
+            this.unknownVisitor = unknownType -> {
+                throw new SafeIllegalStateException(
+                        "Unknown variant of the 'UnionTypeExample' union", SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
         public Visitor<T> build() {
             final IntFunction<T> alsoAnIntegerVisitor = this.alsoAnIntegerVisitor;
             final IntFunction<T> completedVisitor = this.completedVisitor;
@@ -522,6 +533,8 @@ public final class UnionTypeExample {
 
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> unknownThrows();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
@@ -92,7 +92,7 @@ public final class UnionWithUnknownString {
         }
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknownThrows() {
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
                 throw new SafeIllegalStateException(
                         "Unknown variant of the 'UnionWithUnknownString' union",
@@ -126,7 +126,7 @@ public final class UnionWithUnknownString {
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
 
-        Completed_StageVisitorBuilder<T> unknownThrows();
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -90,6 +92,16 @@ public final class UnionWithUnknownString {
         }
 
         @Override
+        public Completed_StageVisitorBuilder<T> unknownThrows() {
+            this.unknownVisitor = unknownType -> {
+                throw new SafeIllegalStateException(
+                        "Unknown variant of the 'UnionWithUnknownString' union",
+                        SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
         public Visitor<T> build() {
             final Function<String, T> unknown_Visitor = this.unknown_Visitor;
             final Function<String, T> unknownVisitor = this.unknownVisitor;
@@ -113,6 +125,8 @@ public final class UnionWithUnknownString {
 
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> unknownThrows();
     }
 
     public interface Completed_StageVisitorBuilder<T> {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -42,6 +42,8 @@ import com.palantir.conjure.spec.FieldName;
 import com.palantir.conjure.spec.Type;
 import com.palantir.conjure.spec.TypeDefinition;
 import com.palantir.conjure.spec.UnionDefinition;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
@@ -286,11 +288,9 @@ public final class UnionGenerator {
         while (memberIter.hasNext()) {
             NameTypePair pair = memberIter.next();
             String nextBuilderStage = memberIter.hasNext() ? memberIter.peek().memberName : COMPLETED;
+            ClassName nextVisitorStageClassName = visitorStageInterfaceName(enclosingClass, nextBuilderStage);
             MethodSpec.Builder setterPrototype = visitorBuilderSetterPrototype(
-                    pair.memberName,
-                    pair.type,
-                    visitResultType,
-                    visitorStageInterfaceName(enclosingClass, nextBuilderStage));
+                    pair.memberName, pair.type, visitResultType, nextVisitorStageClassName);
             setterMethods.add(setterPrototype
                     .addModifiers(Modifier.PUBLIC)
                     .addAnnotation(Override.class)
@@ -302,6 +302,20 @@ public final class UnionGenerator {
                     .addStatement("this.$1L = $1L", visitorFieldName(pair.memberName))
                     .addStatement("return this")
                     .build());
+            if (NameTypePair.UNKNOWN.equals(pair)) {
+                setterMethods.add(visitorBuilderUnknownThrowPrototype(visitResultType, nextVisitorStageClassName)
+                        .addModifiers(Modifier.PUBLIC)
+                        .addAnnotation(Override.class)
+                        .addStatement(
+                                "this.$L = unknownType -> { throw new $T($S, $T.of($S, unknownType)); }",
+                                visitorFieldName(pair.memberName),
+                                SafeIllegalStateException.class,
+                                "Unknown variant of the '" + enclosingClass.simpleName() + "' union",
+                                SafeArg.class,
+                                "unknownType")
+                        .addStatement("return this")
+                        .build());
+            }
         }
         return setterMethods.build();
     }
@@ -431,16 +445,21 @@ public final class UnionGenerator {
         while (memberIter.hasNext()) {
             NameTypePair member = memberIter.next();
             String nextBuilderStageName = memberIter.hasNext() ? memberIter.peek().memberName : COMPLETED;
+            ClassName nextStageClassName = visitorStageInterfaceName(enclosingClass, nextBuilderStageName);
             interfaces.add(TypeSpec.interfaceBuilder(visitorStageInterfaceName(enclosingClass, member.memberName))
                     .addTypeVariable(visitResultType)
                     .addModifiers(Modifier.PUBLIC)
                     .addMethod(visitorBuilderSetterPrototype(
-                                    member.memberName,
-                                    member.type,
-                                    visitResultType,
-                                    visitorStageInterfaceName(enclosingClass, nextBuilderStageName))
+                                    member.memberName, member.type, visitResultType, nextStageClassName)
                             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                             .build())
+                    .addMethods(
+                            NameTypePair.UNKNOWN.equals(member)
+                                    ? ImmutableList.of(
+                                            visitorBuilderUnknownThrowPrototype(visitResultType, nextStageClassName)
+                                                    .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                                                    .build())
+                                    : ImmutableList.of())
                     .build());
         }
         interfaces.add(TypeSpec.interfaceBuilder(visitorStageInterfaceName(enclosingClass, COMPLETED))
@@ -478,6 +497,12 @@ public final class UnionGenerator {
                 .addParameter(ParameterSpec.builder(visitorObject, visitorFieldName(memberName))
                         .addAnnotation(Nonnull.class)
                         .build())
+                .returns(ParameterizedTypeName.get(nextBuilderStage, visitResultType));
+    }
+
+    private static MethodSpec.Builder visitorBuilderUnknownThrowPrototype(
+            TypeName visitResultType, ClassName nextBuilderStage) {
+        return MethodSpec.methodBuilder("unknownThrows")
                 .returns(ParameterizedTypeName.get(nextBuilderStage, visitResultType));
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -502,7 +502,7 @@ public final class UnionGenerator {
 
     private static MethodSpec.Builder visitorBuilderUnknownThrowPrototype(
             TypeName visitResultType, ClassName nextBuilderStage) {
-        return MethodSpec.methodBuilder("unknownThrows")
+        return MethodSpec.methodBuilder("throwOnUnknown")
                 .returns(ParameterizedTypeName.get(nextBuilderStage, visitResultType));
     }
 

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/UnionTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/UnionTests.java
@@ -35,7 +35,7 @@ class UnionTests {
         EmptyUnionTypeExample value =
                 MAPPER.readValue("{\"type\":\"foo\",\"foo\":\"bar\"}", EmptyUnionTypeExample.class);
         EmptyUnionTypeExample.Visitor<?> visitor =
-                EmptyUnionTypeExample.Visitor.builder().unknownThrows().build();
+                EmptyUnionTypeExample.Visitor.builder().throwOnUnknown().build();
         assertThatLoggableExceptionThrownBy(() -> value.accept(visitor))
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasLogMessage("Unknown variant of the 'EmptyUnionTypeExample' union")

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/UnionTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/UnionTests.java
@@ -1,0 +1,44 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.types;
+
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palantir.conjure.java.serialization.ObjectMappers;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.product.EmptyUnionTypeExample;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class UnionTests {
+
+    private static final ObjectMapper MAPPER = ObjectMappers.newServerObjectMapper();
+
+    @Test
+    void testUnknownThrowingVariant() throws IOException {
+        EmptyUnionTypeExample value =
+                MAPPER.readValue("{\"type\":\"foo\",\"foo\":\"bar\"}", EmptyUnionTypeExample.class);
+        EmptyUnionTypeExample.Visitor<?> visitor =
+                EmptyUnionTypeExample.Visitor.builder().unknownThrows().build();
+        assertThatLoggableExceptionThrownBy(() -> value.accept(visitor))
+                .isInstanceOf(SafeIllegalStateException.class)
+                .hasLogMessage("Unknown variant of the 'EmptyUnionTypeExample' union")
+                .hasExactlyArgs(SafeArg.of("unknownType", "foo"));
+    }
+}


### PR DESCRIPTION
## Before this PR
Previously we found a great deal of variance between how folks
reported unknowns, some using UnsafeArg while others used Safe.
Additionally, this is a common chunk of code that we find duplicated
unnecessarily.

We opted not to implement unknown handling using default methods
on the visitor interface in order to make it an explicit design decision
to throw. The new helper allows developers to make the throwing
behavior obvious without the overhead, complexity, or duplication.

## After this PR
==COMMIT_MSG==
Union visitor builders provide a helper to throw on unknown variants without writing out the throw statement/lambda explicitly.
==COMMIT_MSG==

## Possible downsides?
More generated code.

