### PR TITLE
`throwOnUnknown` results in SafeIllegalArgumentException

### DIFF
--- a/changelog/@unreleased/pr-1226.v2.yml
+++ b/changelog/@unreleased/pr-1226.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '`throwOnUnknown` results in SafeIllegalArgumentException rather than SafeIllegalStateException.'
+  links:
+  - https://github.com/palantir/conjure-java/pull/1226

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -76,7 +76,7 @@ public final class EmptyUnionTypeExample {
         @Override
         public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
-                throw new SafeIllegalStateException(
+                throw new SafeIllegalArgumentException(
                         "Unknown variant of the 'EmptyUnionTypeExample' union", SafeArg.of("unknownType", unknownType));
             };
             return this;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -94,7 +94,7 @@ public final class SingleUnion {
         @Override
         public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
-                throw new SafeIllegalStateException(
+                throw new SafeIllegalArgumentException(
                         "Unknown variant of the 'SingleUnion' union", SafeArg.of("unknownType", unknownType));
             };
             return this;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -147,7 +147,7 @@ public final class Union {
         @Override
         public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
-                throw new SafeIllegalStateException(
+                throw new SafeIllegalArgumentException(
                         "Unknown variant of the 'Union' union", SafeArg.of("unknownType", unknownType));
             };
             return this;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -352,7 +352,7 @@ public final class UnionTypeExample {
         @Override
         public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
-                throw new SafeIllegalStateException(
+                throw new SafeIllegalArgumentException(
                         "Unknown variant of the 'UnionTypeExample' union", SafeArg.of("unknownType", unknownType));
             };
             return this;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -94,7 +94,7 @@ public final class UnionWithUnknownString {
         @Override
         public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
-                throw new SafeIllegalStateException(
+                throw new SafeIllegalArgumentException(
                         "Unknown variant of the 'UnionWithUnknownString' union",
                         SafeArg.of("unknownType", unknownType));
             };

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -76,7 +76,7 @@ public final class EmptyUnionTypeExample {
         @Override
         public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
-                throw new SafeIllegalStateException(
+                throw new SafeIllegalArgumentException(
                         "Unknown variant of the 'EmptyUnionTypeExample' union", SafeArg.of("unknownType", unknownType));
             };
             return this;

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -94,7 +94,7 @@ public final class SingleUnion {
         @Override
         public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
-                throw new SafeIllegalStateException(
+                throw new SafeIllegalArgumentException(
                         "Unknown variant of the 'SingleUnion' union", SafeArg.of("unknownType", unknownType));
             };
             return this;

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -147,7 +147,7 @@ public final class Union {
         @Override
         public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
-                throw new SafeIllegalStateException(
+                throw new SafeIllegalArgumentException(
                         "Unknown variant of the 'Union' union", SafeArg.of("unknownType", unknownType));
             };
             return this;

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -352,7 +352,7 @@ public final class UnionTypeExample {
         @Override
         public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
-                throw new SafeIllegalStateException(
+                throw new SafeIllegalArgumentException(
                         "Unknown variant of the 'UnionTypeExample' union", SafeArg.of("unknownType", unknownType));
             };
             return this;

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -94,7 +94,7 @@ public final class UnionWithUnknownString {
         @Override
         public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
-                throw new SafeIllegalStateException(
+                throw new SafeIllegalArgumentException(
                         "Unknown variant of the 'UnionWithUnknownString' union",
                         SafeArg.of("unknownType", unknownType));
             };

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -43,7 +43,7 @@ import com.palantir.conjure.spec.Type;
 import com.palantir.conjure.spec.TypeDefinition;
 import com.palantir.conjure.spec.UnionDefinition;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
@@ -309,7 +309,7 @@ public final class UnionGenerator {
                         .addStatement(
                                 "this.$L = unknownType -> { throw new $T($S, $T.of($S, unknownType)); }",
                                 visitorFieldName(pair.memberName),
-                                SafeIllegalStateException.class,
+                                SafeIllegalArgumentException.class,
                                 "Unknown variant of the '" + enclosingClass.simpleName() + "' union",
                                 SafeArg.class,
                                 "unknownType")

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/UnionTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/UnionTests.java
@@ -21,7 +21,7 @@ import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptio
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.product.EmptyUnionTypeExample;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
@@ -37,7 +37,7 @@ class UnionTests {
         EmptyUnionTypeExample.Visitor<?> visitor =
                 EmptyUnionTypeExample.Visitor.builder().throwOnUnknown().build();
         assertThatLoggableExceptionThrownBy(() -> value.accept(visitor))
-                .isInstanceOf(SafeIllegalStateException.class)
+                .isInstanceOf(SafeIllegalArgumentException.class)
                 .hasLogMessage("Unknown variant of the 'EmptyUnionTypeExample' union")
                 .hasExactlyArgs(SafeArg.of("unknownType", "foo"));
     }


### PR DESCRIPTION
## Before this PR
Previously a SafeIllegalStateException was thrown.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
`throwOnUnknown` results in SafeIllegalArgumentException rather than SafeIllegalStateException.
==COMMIT_MSG==

## Possible downsides?
The resulting 400 response status may not always be expected, but it's more likely to be correct than 500.

