### PR TITLE
Dialogue generators use the new DialogueService annotation

### DIFF
--- a/changelog/@unreleased/pr-1255.v2.yml
+++ b/changelog/@unreleased/pr-1255.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Dialogue generators use the new DialogueService annotation
+  links:
+  - https://github.com/palantir/conjure-java/pull/1255

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CookieServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CookieServiceAsync.java
@@ -4,6 +4,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.EndpointChannelFactory;
@@ -16,6 +18,7 @@ import java.lang.Void;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(CookieServiceAsync.Factory.class)
 public interface CookieServiceAsync {
     /**
      * @apiNote {@code GET /cookies}
@@ -65,5 +68,12 @@ public interface CookieServiceAsync {
                     }
                 },
                 _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<CookieServiceAsync> {
+        @Override
+        public CookieServiceAsync create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return CookieServiceAsync.of(endpointChannelFactory, runtime);
+        }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CookieServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CookieServiceBlocking.java
@@ -3,6 +3,8 @@ package test.api;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.EndpointChannelFactory;
@@ -15,6 +17,7 @@ import java.lang.Void;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(CookieServiceBlocking.Factory.class)
 public interface CookieServiceBlocking {
     /**
      * @apiNote {@code GET /cookies}
@@ -64,5 +67,12 @@ public interface CookieServiceBlocking {
                     }
                 },
                 _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<CookieServiceBlocking> {
+        @Override
+        public CookieServiceBlocking create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return CookieServiceBlocking.of(endpointChannelFactory, runtime);
+        }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceAsync.java
@@ -4,6 +4,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.EndpointChannelFactory;
@@ -16,6 +18,7 @@ import java.lang.String;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(EmptyPathServiceAsync.Factory.class)
 public interface EmptyPathServiceAsync {
     /**
      * @apiNote {@code GET /}
@@ -64,5 +67,12 @@ public interface EmptyPathServiceAsync {
                     }
                 },
                 _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<EmptyPathServiceAsync> {
+        @Override
+        public EmptyPathServiceAsync create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return EmptyPathServiceAsync.of(endpointChannelFactory, runtime);
+        }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceBlocking.java
@@ -3,6 +3,8 @@ package com.palantir.product;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.EndpointChannelFactory;
@@ -15,6 +17,7 @@ import java.lang.String;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(EmptyPathServiceBlocking.Factory.class)
 public interface EmptyPathServiceBlocking {
     /**
      * @apiNote {@code GET /}
@@ -63,5 +66,12 @@ public interface EmptyPathServiceBlocking {
                     }
                 },
                 _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<EmptyPathServiceBlocking> {
+        @Override
+        public EmptyPathServiceBlocking create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return EmptyPathServiceBlocking.of(endpointChannelFactory, runtime);
+        }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceAsync.java
@@ -4,6 +4,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.EndpointChannelFactory;
@@ -17,6 +19,7 @@ import java.util.Optional;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(EteBinaryServiceAsync.Factory.class)
 public interface EteBinaryServiceAsync {
     /**
      * @apiNote {@code POST /binary}
@@ -168,5 +171,12 @@ public interface EteBinaryServiceAsync {
                     }
                 },
                 _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<EteBinaryServiceAsync> {
+        @Override
+        public EteBinaryServiceAsync create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return EteBinaryServiceAsync.of(endpointChannelFactory, runtime);
+        }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceBlocking.java
@@ -4,6 +4,8 @@ import com.google.errorprone.annotations.MustBeClosed;
 import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.EndpointChannelFactory;
@@ -17,6 +19,7 @@ import java.util.Optional;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(EteBinaryServiceBlocking.Factory.class)
 public interface EteBinaryServiceBlocking {
     /**
      * @apiNote {@code POST /binary}
@@ -170,5 +173,12 @@ public interface EteBinaryServiceBlocking {
                     }
                 },
                 _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<EteBinaryServiceBlocking> {
+        @Override
+        public EteBinaryServiceBlocking create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return EteBinaryServiceBlocking.of(endpointChannelFactory, runtime);
+        }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceAsync.java
@@ -5,6 +5,8 @@ import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.EndpointChannelFactory;
@@ -31,6 +33,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(EteServiceAsync.Factory.class)
 public interface EteServiceAsync {
     /**
      * foo bar baz.
@@ -715,5 +718,12 @@ public interface EteServiceAsync {
                     }
                 },
                 _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<EteServiceAsync> {
+        @Override
+        public EteServiceAsync create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return EteServiceAsync.of(endpointChannelFactory, runtime);
+        }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceBlocking.java
@@ -5,6 +5,8 @@ import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.EndpointChannelFactory;
@@ -31,6 +33,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(EteServiceBlocking.Factory.class)
 public interface EteServiceBlocking {
     /**
      * foo bar baz.
@@ -711,5 +714,12 @@ public interface EteServiceBlocking {
                     }
                 },
                 _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<EteServiceBlocking> {
+        @Override
+        public EteServiceBlocking create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return EteServiceBlocking.of(endpointChannelFactory, runtime);
+        }
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/CookieServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/CookieServiceAsync.java.dialogue
@@ -4,6 +4,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.EndpointChannelFactory;
@@ -16,6 +18,7 @@ import java.lang.Void;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(CookieServiceAsync.Factory.class)
 public interface CookieServiceAsync {
     /**
      * @apiNote {@code GET /cookies}
@@ -65,5 +68,12 @@ public interface CookieServiceAsync {
                     }
                 },
                 _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<CookieServiceAsync> {
+        @Override
+        public CookieServiceAsync create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return CookieServiceAsync.of(endpointChannelFactory, runtime);
+        }
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/CookieServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/CookieServiceBlocking.java.dialogue
@@ -3,6 +3,8 @@ package test.api;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.EndpointChannelFactory;
@@ -15,6 +17,7 @@ import java.lang.Void;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(CookieServiceBlocking.Factory.class)
 public interface CookieServiceBlocking {
     /**
      * @apiNote {@code GET /cookies}
@@ -64,5 +67,12 @@ public interface CookieServiceBlocking {
                     }
                 },
                 _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<CookieServiceBlocking> {
+        @Override
+        public CookieServiceBlocking create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return CookieServiceBlocking.of(endpointChannelFactory, runtime);
+        }
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
@@ -6,6 +6,8 @@ import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.EndpointChannelFactory;
@@ -40,6 +42,7 @@ import javax.annotation.Nonnull;
  * A Markdown description of the service.
  */
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(TestServiceAsync.Factory.class)
 public interface TestServiceAsync {
     /**
      * Returns a mapping from file system id to backing file system configuration.
@@ -577,5 +580,12 @@ public interface TestServiceAsync {
                     }
                 },
                 _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<TestServiceAsync> {
+        @Override
+        public TestServiceAsync create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return TestServiceAsync.of(endpointChannelFactory, runtime);
+        }
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
@@ -6,6 +6,8 @@ import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.EndpointChannelFactory;
@@ -40,6 +42,7 @@ import test.prefix.com.palantir.product.datasets.Dataset;
  * A Markdown description of the service.
  */
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(TestServiceAsync.Factory.class)
 public interface TestServiceAsync {
     /**
      * Returns a mapping from file system id to backing file system configuration.
@@ -577,5 +580,12 @@ public interface TestServiceAsync {
                     }
                 },
                 _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<TestServiceAsync> {
+        @Override
+        public TestServiceAsync create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return TestServiceAsync.of(endpointChannelFactory, runtime);
+        }
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
@@ -6,6 +6,8 @@ import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.EndpointChannelFactory;
@@ -40,6 +42,7 @@ import javax.annotation.Nonnull;
  * A Markdown description of the service.
  */
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(TestServiceBlocking.Factory.class)
 public interface TestServiceBlocking {
     /**
      * Returns a mapping from file system id to backing file system configuration.
@@ -575,5 +578,12 @@ public interface TestServiceBlocking {
                     }
                 },
                 _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<TestServiceBlocking> {
+        @Override
+        public TestServiceBlocking create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return TestServiceBlocking.of(endpointChannelFactory, runtime);
+        }
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
@@ -6,6 +6,8 @@ import com.palantir.dialogue.BinaryRequestBody;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.ConjureRuntime;
 import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
 import com.palantir.dialogue.Endpoint;
 import com.palantir.dialogue.EndpointChannel;
 import com.palantir.dialogue.EndpointChannelFactory;
@@ -40,6 +42,7 @@ import test.prefix.com.palantir.product.datasets.Dataset;
  * A Markdown description of the service.
  */
 @Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(TestServiceBlocking.Factory.class)
 public interface TestServiceBlocking {
     /**
      * Returns a mapping from file system id to backing file system configuration.
@@ -575,5 +578,12 @@ public interface TestServiceBlocking {
                     }
                 },
                 _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<TestServiceBlocking> {
+        @Override
+        public TestServiceBlocking create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return TestServiceBlocking.of(endpointChannelFactory, runtime);
+        }
     }
 }


### PR DESCRIPTION
## Before this PR
Clearer dialogue construction codepath, allows us to consolidate conjure codegen and the annotation processor.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Dialogue generators use the new DialogueService annotation
==COMMIT_MSG==

## Possible downsides?
If codegen updates prior to the dialogue dependency, code won't compile. Updating deps is easy.
If consumers depend on new generated code missing the factory classes at runtime, they should be fine, the Factory class isn't loaded.

