### PR TITLE
fix #1271 conjure-undertow properly handles optional-alias-primitive query params

### DIFF
--- a/changelog/@unreleased/pr-1272.v2.yml
+++ b/changelog/@unreleased/pr-1272.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: conjure-undertow properly handles optional-alias-primitive query params
+  links:
+  - https://github.com/palantir/conjure-java/pull/1272

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasTestServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasTestServiceEndpoints.java
@@ -1,0 +1,100 @@
+package com.palantir.product;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.java.lib.SafeLong;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import com.palantir.tokens.auth.AuthHeader;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import io.undertow.util.StatusCodes;
+import java.io.IOException;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.services.UndertowServiceHandlerGenerator")
+public final class AliasTestServiceEndpoints implements UndertowService {
+    private final UndertowAliasTestService delegate;
+
+    private AliasTestServiceEndpoints(UndertowAliasTestService delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(UndertowAliasTestService delegate) {
+        return new AliasTestServiceEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return ImmutableList.of(new TestOptionalAliasQueryParamsEndpoint(runtime, delegate));
+    }
+
+    private static final class TestOptionalAliasQueryParamsEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final UndertowAliasTestService delegate;
+
+        TestOptionalAliasQueryParamsEndpoint(UndertowRuntime runtime, UndertowAliasTestService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            OptionalInt optionalAliasIntRaw =
+                    runtime.plainSerDe().deserializeOptionalInteger(queryParams.get("optionalAliasInt"));
+            Optional<AliasedInteger> optionalAliasInt = Optional.ofNullable(
+                    optionalAliasIntRaw.isPresent() ? AliasedInteger.of(optionalAliasIntRaw.getAsInt()) : null);
+            OptionalDouble optionalAliasDoubleRaw =
+                    runtime.plainSerDe().deserializeOptionalDouble(queryParams.get("optionalAliasDouble"));
+            Optional<AliasedDouble> optionalAliasDouble = Optional.ofNullable(
+                    optionalAliasDoubleRaw.isPresent() ? AliasedDouble.of(optionalAliasDoubleRaw.getAsDouble()) : null);
+            Optional<SafeLong> optionalAliasSafeLongRaw =
+                    runtime.plainSerDe().deserializeOptionalSafeLong(queryParams.get("optionalAliasSafeLong"));
+            Optional<AliasedSafeLong> optionalAliasSafeLong = Optional.ofNullable(
+                    optionalAliasSafeLongRaw.isPresent() ? AliasedSafeLong.of(optionalAliasSafeLongRaw.get()) : null);
+            Optional<Boolean> optionalAliasBooleanRaw =
+                    runtime.plainSerDe().deserializeOptionalBoolean(queryParams.get("optionalAliasBoolean"));
+            Optional<AliasedBoolean> optionalAliasBoolean = Optional.ofNullable(
+                    optionalAliasBooleanRaw.isPresent() ? AliasedBoolean.of(optionalAliasBooleanRaw.get()) : null);
+            delegate.testOptionalAliasQueryParams(
+                    authHeader, optionalAliasInt, optionalAliasDouble, optionalAliasSafeLong, optionalAliasBoolean);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/alias/test";
+        }
+
+        @Override
+        public String serviceName() {
+            return "AliasTestService";
+        }
+
+        @Override
+        public String name() {
+            return "testOptionalAliasQueryParams";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedBoolean.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedBoolean.java
@@ -1,0 +1,43 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class AliasedBoolean {
+    private final boolean value;
+
+    private AliasedBoolean(boolean value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public boolean get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other || (other instanceof AliasedBoolean && this.value == ((AliasedBoolean) other).value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Boolean.hashCode(value);
+    }
+
+    public static AliasedBoolean valueOf(String value) {
+        return of(Boolean.parseBoolean(value));
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static AliasedBoolean of(boolean value) {
+        return new AliasedBoolean(value);
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedDouble.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedDouble.java
@@ -1,0 +1,78 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.conjure.java.lib.SafeLong;
+import java.math.BigDecimal;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class AliasedDouble {
+    private final double value;
+
+    private AliasedDouble(double value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public double get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof AliasedDouble
+                        && Double.doubleToLongBits(this.value)
+                                == Double.doubleToLongBits(((AliasedDouble) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return Double.hashCode(value);
+    }
+
+    public static AliasedDouble valueOf(String value) {
+        return of(Double.parseDouble(value));
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static AliasedDouble of(double value) {
+        return new AliasedDouble(value);
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static AliasedDouble of(long value) {
+        long safeValue = SafeLong.of(value).longValue();
+        return new AliasedDouble((double) safeValue);
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static AliasedDouble of(int value) {
+        return new AliasedDouble((double) value);
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    private static AliasedDouble of(BigDecimal value) {
+        return new AliasedDouble(value.doubleValue());
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static AliasedDouble of(String value) {
+        switch (value) {
+            case "NaN":
+                return AliasedDouble.of(Double.NaN);
+            case "Infinity":
+                return AliasedDouble.of(Double.POSITIVE_INFINITY);
+            case "-Infinity":
+                return AliasedDouble.of(Double.NEGATIVE_INFINITY);
+            default:
+                throw new IllegalArgumentException("Cannot deserialize string into double: " + value);
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedInteger.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedInteger.java
@@ -1,0 +1,43 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class AliasedInteger {
+    private final int value;
+
+    private AliasedInteger(int value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public int get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other || (other instanceof AliasedInteger && this.value == ((AliasedInteger) other).value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Integer.hashCode(value);
+    }
+
+    public static AliasedInteger valueOf(String value) {
+        return of(Integer.parseInt(value));
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static AliasedInteger of(int value) {
+        return new AliasedInteger(value);
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedSafeLong.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedSafeLong.java
@@ -1,0 +1,47 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.conjure.java.lib.SafeLong;
+import com.palantir.logsafe.Preconditions;
+import javax.annotation.Generated;
+import javax.annotation.Nonnull;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class AliasedSafeLong {
+    private final SafeLong value;
+
+    private AliasedSafeLong(@Nonnull SafeLong value) {
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
+    }
+
+    @JsonValue
+    public SafeLong get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof AliasedSafeLong && this.value.equals(((AliasedSafeLong) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    public static AliasedSafeLong valueOf(String value) {
+        return of(SafeLong.valueOf(value));
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static AliasedSafeLong of(@Nonnull SafeLong value) {
+        return new AliasedSafeLong(value);
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowAliasTestService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowAliasTestService.java
@@ -1,0 +1,18 @@
+package com.palantir.product;
+
+import com.palantir.tokens.auth.AuthHeader;
+import java.util.Optional;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
+public interface UndertowAliasTestService {
+    /**
+     * @apiNote {@code GET /alias/test}
+     */
+    void testOptionalAliasQueryParams(
+            AuthHeader authHeader,
+            Optional<AliasedInteger> optionalAliasInt,
+            Optional<AliasedDouble> optionalAliasDouble,
+            Optional<AliasedSafeLong> optionalAliasSafeLong,
+            Optional<AliasedBoolean> optionalAliasBoolean);
+}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -915,7 +915,13 @@ final class UndertowServiceHandlerGenerator {
                     Optional.class,
                     decodedVarName,
                     createConstructorForTypeWithReference(
-                            typeOfOptional, decodedVarName + ".get()", typeDefinitions, typeMapper));
+                            typeOfOptional,
+                            decodedVarName + '.'
+                                    + getOptionalAccessor(
+                                            TypeFunctions.toConjureTypeWithoutAliases(typeOfOptional, typeDefinitions))
+                                    + "()",
+                            typeDefinitions,
+                            typeMapper));
         } else {
             // alias
             CodeBlock ofContent;
@@ -950,6 +956,80 @@ final class UndertowServiceHandlerGenerator {
             }
             return CodeBlock.of("$1T.of($2L)", typeMapper.getClassName(inType), ofContent);
         }
+    }
+
+    private static String getOptionalAccessor(Type type) {
+        return type.accept(new DefaultTypeVisitor<String>() {
+            @Override
+            public String visitPrimitive(PrimitiveType value) {
+                return value.accept(new PrimitiveType.Visitor<String>() {
+                    @Override
+                    public String visitString() {
+                        return "get";
+                    }
+
+                    @Override
+                    public String visitDatetime() {
+                        return "get";
+                    }
+
+                    @Override
+                    public String visitInteger() {
+                        return "getAsInt";
+                    }
+
+                    @Override
+                    public String visitDouble() {
+                        return "getAsDouble";
+                    }
+
+                    @Override
+                    public String visitSafelong() {
+                        return "get";
+                    }
+
+                    @Override
+                    public String visitBinary() {
+                        return "get";
+                    }
+
+                    @Override
+                    public String visitAny() {
+                        return "get";
+                    }
+
+                    @Override
+                    public String visitBoolean() {
+                        return "get";
+                    }
+
+                    @Override
+                    public String visitUuid() {
+                        return "get";
+                    }
+
+                    @Override
+                    public String visitRid() {
+                        return "get";
+                    }
+
+                    @Override
+                    public String visitBearertoken() {
+                        return "get";
+                    }
+
+                    @Override
+                    public String visitUnknown(String _unknownValue) {
+                        return "get";
+                    }
+                });
+            }
+
+            @Override
+            public String visitDefault() {
+                return "get";
+            }
+        });
     }
 
     private static String deserializeFunctionName(Type type) {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -512,7 +512,9 @@ public final class UndertowServiceEteTest extends TestBase {
     @BeforeAll
     public static void beforeClass() throws IOException {
         ConjureDefinition def = Conjure.parse(ImmutableList.of(
-                new File("src/test/resources/ete-service.yml"), new File("src/test/resources/ete-binary.yml")));
+                new File("src/test/resources/ete-service.yml"),
+                new File("src/test/resources/ete-binary.yml"),
+                new File("src/test/resources/alias-test-service.yml")));
         Options options = Options.builder()
                 .undertowServicePrefix(true)
                 .nonNullCollections(true)

--- a/conjure-java-core/src/test/resources/alias-test-service.yml
+++ b/conjure-java-core/src/test/resources/alias-test-service.yml
@@ -1,0 +1,36 @@
+types:
+  definitions:
+    default-package: com.palantir.product
+    objects:
+      AliasedInteger:
+        alias: integer
+      AliasedDouble:
+        alias: double
+      AliasedSafeLong:
+        alias: safelong
+      AliasedBoolean:
+        alias: boolean
+
+services:
+  AliasTestService:
+    name: Alias Test Service
+    package: com.palantir.product
+    default-auth: header
+    base-path: /alias
+
+    endpoints:
+      testOptionalAliasQueryParams:
+        http: GET /test
+        args:
+          optionalAliasInt:
+            type: optional<AliasedInteger>
+            param-type: query
+          optionalAliasDouble:
+            type: optional<AliasedDouble>
+            param-type: query
+          optionalAliasSafeLong:
+            type: optional<AliasedSafeLong>
+            param-type: query
+          optionalAliasBoolean:
+            type: optional<AliasedBoolean>
+            param-type: query


### PR DESCRIPTION
Generated code uses the correct optonal accessors `getAsInt` and
`getAsDouble` as necessary.

==COMMIT_MSG==
conjure-undertow properly handles optional-alias-primitive query params
==COMMIT_MSG==

