### PR TITLE
Generated stated builders retain original order for required fields

### DIFF
--- a/changelog/@unreleased/pr-1274.v2.yml
+++ b/changelog/@unreleased/pr-1274.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Generated stated builders retain original order for required fields. This is a break for anyone using the `useStagedBuilders` parameter, however it's still very new and experimental.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1274

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
@@ -66,7 +66,7 @@ public final class CovariantListExample {
     }
 
     public static CovariantListExample of(List<Object> items, List<ExampleExternalReference> externalItems) {
-        return builder().externalItems(externalItems).items(items).build();
+        return builder().items(items).externalItems(externalItems).build();
     }
 
     private static void validateFields(List<Object> items, List<ExampleExternalReference> externalItems) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -80,8 +80,8 @@ public final class ExternalLongExample {
     public static ExternalLongExample of(long externalLong, long optionalExternalLong, List<Long> listExternalLong) {
         return builder()
                 .externalLong(externalLong)
-                .listExternalLong(listExternalLong)
                 .optionalExternalLong(Optional.of(optionalExternalLong))
+                .listExternalLong(listExternalLong)
                 .build();
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
@@ -85,9 +85,9 @@ public final class MapExample {
             Map<String, Optional<String>> optionalItems,
             Map<String, OptionalAlias> aliasOptionalItems) {
         return builder()
-                .aliasOptionalItems(aliasOptionalItems)
                 .items(items)
                 .optionalItems(optionalItems)
+                .aliasOptionalItems(aliasOptionalItems)
                 .build();
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
@@ -116,18 +116,18 @@ public final class MultipleOrderedStages {
         return missingFields;
     }
 
-    public static ItemStageBuilder builder() {
+    public static TokenStageBuilder builder() {
         return new DefaultBuilder();
     }
 
-    public interface ItemStageBuilder {
-        TokenStageBuilder item(@Nonnull String item);
+    public interface TokenStageBuilder {
+        ItemStageBuilder token(@Nonnull OneField token);
 
         Builder from(MultipleOrderedStages other);
     }
 
-    public interface TokenStageBuilder {
-        Completed_StageBuilder token(@Nonnull OneField token);
+    public interface ItemStageBuilder {
+        Completed_StageBuilder item(@Nonnull String item);
     }
 
     public interface Completed_StageBuilder {
@@ -146,7 +146,7 @@ public final class MultipleOrderedStages {
         Completed_StageBuilder mappedRids(ResourceIdentifier key, String value);
     }
 
-    public interface Builder extends ItemStageBuilder, TokenStageBuilder, Completed_StageBuilder {
+    public interface Builder extends TokenStageBuilder, ItemStageBuilder, Completed_StageBuilder {
         @Override
         MultipleOrderedStages build();
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
@@ -67,7 +67,7 @@ public final class SetExample {
     }
 
     public static SetExample of(Set<String> items, Set<Double> doubleItems) {
-        return builder().doubleItems(doubleItems).items(items).build();
+        return builder().items(items).doubleItems(doubleItems).build();
     }
 
     private static void validateFields(Set<String> items, Set<Double> doubleItems) {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
@@ -67,7 +67,7 @@ public final class CovariantListExample {
     }
 
     public static CovariantListExample of(List<Object> items, List<ExampleExternalReference> externalItems) {
-        return builder().externalItems(externalItems).items(items).build();
+        return builder().items(items).externalItems(externalItems).build();
     }
 
     private static void validateFields(List<Object> items, List<ExampleExternalReference> externalItems) {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
@@ -81,8 +81,8 @@ public final class ExternalLongExample {
     public static ExternalLongExample of(long externalLong, long optionalExternalLong, List<Long> listExternalLong) {
         return builder()
                 .externalLong(externalLong)
-                .listExternalLong(listExternalLong)
                 .optionalExternalLong(Optional.of(optionalExternalLong))
+                .listExternalLong(listExternalLong)
                 .build();
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapExample.java
@@ -86,9 +86,9 @@ public final class MapExample {
             Map<String, Optional<String>> optionalItems,
             Map<String, OptionalAlias> aliasOptionalItems) {
         return builder()
-                .aliasOptionalItems(aliasOptionalItems)
                 .items(items)
                 .optionalItems(optionalItems)
+                .aliasOptionalItems(aliasOptionalItems)
                 .build();
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetExample.java
@@ -68,7 +68,7 @@ public final class SetExample {
     }
 
     public static SetExample of(Set<String> items, Set<Double> doubleItems) {
-        return builder().doubleItems(doubleItems).items(items).build();
+        return builder().items(items).doubleItems(doubleItems).build();
     }
 
     private static void validateFields(Set<String> items, Set<Double> doubleItems) {

--- a/conjure-java-server-verifier/src/test/java/com/palantir/conjure/java/verification/server/AutoDeserializeTest.java
+++ b/conjure-java-server-verifier/src/test/java/com/palantir/conjure/java/verification/server/AutoDeserializeTest.java
@@ -112,9 +112,9 @@ public final class AutoDeserializeTest {
     private void expectSuccess(EndpointName endpointName, int index, int port) {
         try {
             verificationService.runTestCase(VerificationClientRequest.builder()
-                    .baseUrl(String.format("http://localhost:%d/test/api", port))
                     .endpointName(endpointName)
                     .testCase(index)
+                    .baseUrl(String.format("http://localhost:%d/test/api", port))
                     .build());
         } catch (RemoteException e) {
             log.error("Caught exception with params: {}", e.getError().parameters(), e);
@@ -125,9 +125,9 @@ public final class AutoDeserializeTest {
     private void expectFailure(EndpointName endpointName, int index, int port) {
         Assertions.assertThatExceptionOfType(Exception.class).isThrownBy(() -> {
             verificationService.runTestCase(VerificationClientRequest.builder()
-                    .baseUrl(String.format("http://localhost:%d/test/api", port))
                     .endpointName(endpointName)
                     .testCase(index)
+                    .baseUrl(String.format("http://localhost:%d/test/api", port))
                     .build());
             log.error("Result should have caused an exception");
         });


### PR DESCRIPTION
==COMMIT_MSG==
Generated stated builders retain original order for required fields
==COMMIT_MSG==

Due to readability concerns around the staged builder code when the fields are defined in a particular order. For example it's common to have a `min` and `max` field defined in that order, however alphabetically they're reversed.

It's uncommon for fields to be reordered, and in most cases we don't require abi compatibility between api producers and consumers.