### PR TITLE
RequestContext supports dynamic parameter markers

### DIFF
--- a/changelog/@unreleased/pr-1295.v2.yml
+++ b/changelog/@unreleased/pr-1295.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: RequestContext supports dynamic parameter markers
+  links:
+  - https://github.com/palantir/conjure-java/pull/1295

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureUndertowRuntime.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureUndertowRuntime.java
@@ -39,6 +39,7 @@ public final class ConjureUndertowRuntime implements UndertowRuntime {
     private final MarkerCallback markerCallback;
     private final AsyncRequestProcessing async;
     private final ExceptionHandler exceptionHandler;
+    private final Contexts contexts;
 
     private ConjureUndertowRuntime(Builder builder) {
         this.bodySerDe = new ConjureBodySerDe(
@@ -49,6 +50,7 @@ public final class ConjureUndertowRuntime implements UndertowRuntime {
         this.exceptionHandler = builder.exceptionHandler;
         this.markerCallback = MarkerCallbacks.fold(builder.paramMarkers);
         this.async = new ConjureAsyncRequestProcessing(builder.asyncTimeout, builder.exceptionHandler);
+        this.contexts = new ConjureContexts(markerCallback);
     }
 
     public static Builder builder() {
@@ -87,7 +89,7 @@ public final class ConjureUndertowRuntime implements UndertowRuntime {
 
     @Override
     public Contexts contexts() {
-        return ConjureContexts.INSTANCE;
+        return contexts;
     }
 
     public static final class Builder {

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
@@ -44,4 +44,11 @@ public interface RequestContext {
      * Returns all query parameters associated with the current request.
      */
     ListMultimap<String, String> queryParameters();
+
+    /**
+     * Applies a marker to a parameter on the current request. This uses the same mechanism as
+     * parameter markers in conjure, but may be applied to data that's not directly accessible
+     * as a top level parameter.
+     */
+    void markParameter(String marker, String parameterName, Object parameterValue);
 }


### PR DESCRIPTION
This can be leveraged to add safe-loggable parameters to the
request log.

## Before this PR
ThreadLocals to add request logging metadata... oof.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
RequestContext supports dynamic parameter markers
==COMMIT_MSG==

## Possible downsides?
More API surface. Not much, and beats the alternative.
