### PR TITLE
fix #1297: Include safety annotations on undertow and dialogue interfaces

### DIFF
--- a/changelog/@unreleased/pr-1298.v2.yml
+++ b/changelog/@unreleased/pr-1298.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Include safety annotations on undertow and dialogue interfaces
+  links:
+  - https://github.com/palantir/conjure-java/pull/1298

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/ConjureTags.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/ConjureTags.java
@@ -44,7 +44,7 @@ public final class ConjureTags {
         return tags.contains(UNSAFE);
     }
 
-    public static ImmutableList<AnnotationSpec> tagAnnotations(ArgumentDefinition argument) {
+    public static ImmutableList<AnnotationSpec> safetyAnnotations(ArgumentDefinition argument) {
         validateTags(argument);
         List<String> tags = argument.getTags();
         ImmutableList.Builder<AnnotationSpec> builder = ImmutableList.builderWithExpectedSize(1);

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
@@ -285,7 +285,7 @@ public final class JerseyServiceGenerator implements Generator {
             getParamTypeAnnotation(def).ifPresent(param::addAnnotation);
             param.addAnnotations(ImmutableSet.<AnnotationSpec>builder()
                     .addAll(createMarkers(typeMapper, def.getMarkers()))
-                    .addAll(ConjureTags.tagAnnotations(def))
+                    .addAll(ConjureTags.safetyAnnotations(def))
                     .build());
         }
         return param.build();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceInterfaceGenerator.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.java.services;
 
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.ConjureAnnotations;
+import com.palantir.conjure.java.ConjureTags;
 import com.palantir.conjure.java.Options;
 import com.palantir.conjure.java.types.TypeMapper;
 import com.palantir.conjure.java.undertow.lib.RequestContext;
@@ -137,6 +138,7 @@ final class UndertowServiceInterfaceGenerator {
         return ParameterSpec.builder(
                         typeMapper.getClassName(def.getType()),
                         JavaNameSanitizer.sanitizeParameterName(def.getArgName().get(), endpoint))
+                .addAnnotations(ConjureTags.safetyAnnotations(def))
                 .build();
     }
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DefaultStaticFactoryMethodGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DefaultStaticFactoryMethodGenerator.java
@@ -193,7 +193,7 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
     }
 
     private MethodSpec clientImpl(EndpointDefinition def) {
-        List<ParameterSpec> params = parameterTypes.methodParams(def);
+        List<ParameterSpec> params = parameterTypes.implementationMethodParams(def);
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(
                         def.getEndpointName().get())
                 .addModifiers(Modifier.PUBLIC)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
@@ -152,7 +152,7 @@ public final class DialogueInterfaceGenerator {
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(
                         endpointDef.getEndpointName().get())
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-                .addParameters(parameterTypes.methodParams(endpointDef))
+                .addParameters(parameterTypes.interfaceMethodParams(endpointDef))
                 .addAnnotations(ConjureAnnotations.incubating(endpointDef));
         endpointDef.getMarkers().stream()
                 .filter(marker -> !marker.accept(IsUndertowAsyncMarkerVisitor.INSTANCE))

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/ConjureTagsTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/ConjureTagsTest.java
@@ -38,45 +38,45 @@ class ConjureTagsTest {
 
     @Test
     void testEmpty() {
-        assertThat(ConjureTags.tagAnnotations(tags())).isEmpty();
+        assertThat(ConjureTags.safetyAnnotations(tags())).isEmpty();
     }
 
     @Test
     void testUnknown() {
-        assertThat(ConjureTags.tagAnnotations(tags("unknown tag"))).isEmpty();
+        assertThat(ConjureTags.safetyAnnotations(tags("unknown tag"))).isEmpty();
     }
 
     @Test
     void testSafe() {
-        assertThat(ConjureTags.tagAnnotations(tags("safe")))
+        assertThat(ConjureTags.safetyAnnotations(tags("safe")))
                 .hasSize(1)
                 .allSatisfy(annotationSpec -> assertThat(annotationSpec.type).isEqualTo(ClassName.get(Safe.class)));
     }
 
     @Test
     void testUnsafe() {
-        assertThat(ConjureTags.tagAnnotations(tags("unsafe")))
+        assertThat(ConjureTags.safetyAnnotations(tags("unsafe")))
                 .hasSize(1)
                 .allSatisfy(annotationSpec -> assertThat(annotationSpec.type).isEqualTo(ClassName.get(Unsafe.class)));
     }
 
     @Test
     void testSafeAndUnsafe() {
-        assertThatThrownBy(() -> ConjureTags.tagAnnotations(tags("safe", "unsafe")))
+        assertThatThrownBy(() -> ConjureTags.safetyAnnotations(tags("safe", "unsafe")))
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageContaining("Tags cannot include both safe and unsafe");
     }
 
     @Test
     void testUnexpectedCase() {
-        assertThatThrownBy(() -> ConjureTags.tagAnnotations(tags("Safe")))
+        assertThatThrownBy(() -> ConjureTags.safetyAnnotations(tags("Safe")))
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageContaining("Unexpected capitalization");
     }
 
     @Test
     void testSafeMarkerAndTag() {
-        assertThatThrownBy(() -> ConjureTags.tagAnnotations(ArgumentDefinition.builder()
+        assertThatThrownBy(() -> ConjureTags.safetyAnnotations(ArgumentDefinition.builder()
                         .from(tags("safe"))
                         .markers(Type.external(ExternalReference.builder()
                                 .externalReference(TypeName.of(

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
@@ -2,6 +2,7 @@ package com.palantir.another;
 
 import com.palantir.conjure.java.lib.internal.Incubating;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
+import com.palantir.logsafe.Safe;
 import com.palantir.product.AliasedString;
 import com.palantir.product.CreateDatasetRequest;
 import com.palantir.product.datasets.BackingFileSystem;
@@ -57,7 +58,7 @@ public interface TestService {
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/string-aliased}
      */
-    AliasedString getAliasedString(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    AliasedString getAliasedString(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code POST /catalog/datasets/upload-raw}

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.prefix
@@ -2,6 +2,7 @@ package test.prefix.com.palantir.another;
 
 import com.palantir.conjure.java.lib.internal.Incubating;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
+import com.palantir.logsafe.Safe;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
 import java.io.InputStream;
@@ -57,7 +58,7 @@ public interface TestService {
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/string-aliased}
      */
-    AliasedString getAliasedString(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    AliasedString getAliasedString(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code POST /catalog/datasets/upload-raw}

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
@@ -15,6 +15,7 @@ import com.palantir.dialogue.PlainSerDe;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Serializer;
 import com.palantir.dialogue.TypeMarker;
+import com.palantir.logsafe.Safe;
 import com.palantir.product.AliasedString;
 import com.palantir.product.CreateDatasetRequest;
 import com.palantir.product.datasets.BackingFileSystem;
@@ -81,7 +82,7 @@ public interface TestServiceAsync {
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/string-aliased}
      */
-    ListenableFuture<AliasedString> getAliasedString(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    ListenableFuture<AliasedString> getAliasedString(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code POST /catalog/datasets/upload-raw}

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
@@ -15,6 +15,7 @@ import com.palantir.dialogue.PlainSerDe;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Serializer;
 import com.palantir.dialogue.TypeMarker;
+import com.palantir.logsafe.Safe;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
 import java.io.InputStream;
@@ -81,7 +82,7 @@ public interface TestServiceAsync {
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/string-aliased}
      */
-    ListenableFuture<AliasedString> getAliasedString(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    ListenableFuture<AliasedString> getAliasedString(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code POST /catalog/datasets/upload-raw}

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
@@ -15,6 +15,7 @@ import com.palantir.dialogue.PlainSerDe;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Serializer;
 import com.palantir.dialogue.TypeMarker;
+import com.palantir.logsafe.Safe;
 import com.palantir.product.AliasedString;
 import com.palantir.product.CreateDatasetRequest;
 import com.palantir.product.datasets.BackingFileSystem;
@@ -83,7 +84,7 @@ public interface TestServiceBlocking {
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/string-aliased}
      */
-    AliasedString getAliasedString(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    AliasedString getAliasedString(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code POST /catalog/datasets/upload-raw}

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
@@ -15,6 +15,7 @@ import com.palantir.dialogue.PlainSerDe;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Serializer;
 import com.palantir.dialogue.TypeMarker;
+import com.palantir.logsafe.Safe;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
 import java.io.InputStream;
@@ -83,7 +84,7 @@ public interface TestServiceBlocking {
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/string-aliased}
      */
-    AliasedString getAliasedString(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    AliasedString getAliasedString(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code POST /catalog/datasets/upload-raw}


### PR DESCRIPTION
These annotations are helpful both for developers consuming code,
and the static analysis which protects them from foot-guns. Data
leaks are no fun for anyone involved, and the more we can do
to make observability safety classifications obvious the faster
and more safely we'll be able to iterate.

## Before this PR

#1297

## After this PR
==COMMIT_MSG==
Include safety annotations on undertow and dialogue interfaces
==COMMIT_MSG==

