### PR TITLE
Avoid sending empty optional fields

### DIFF
--- a/changelog/@unreleased/pr-1300.v2.yml
+++ b/changelog/@unreleased/pr-1300.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Avoid sending empty optional values within generated objects.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1300

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
@@ -1,6 +1,7 @@
 package com.palantir.binary;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -27,6 +28,7 @@ public final class OptionalExample {
     }
 
     @JsonProperty("item")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<ByteBuffer> getItem() {
         return this.item;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
@@ -1,5 +1,6 @@
 package com.palantir.product;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -32,11 +33,13 @@ public final class CovariantOptionalExample {
     }
 
     @JsonProperty("item")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<Object> getItem() {
         return this.item;
     }
 
     @JsonProperty("setItem")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<Set<StringAliasExample>> getSetItem() {
         return this.setItem;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -1,5 +1,6 @@
 package com.palantir.product;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -41,6 +42,7 @@ public final class ExternalLongExample {
     }
 
     @JsonProperty("optionalExternalLong")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<Long> getOptionalExternalLong() {
         return this.optionalExternalLong;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -1,5 +1,6 @@
 package com.palantir.product;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -89,6 +90,7 @@ public final class ManyFieldExample {
      * docs for optionalItem field
      */
     @JsonProperty("optionalItem")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<String> getOptionalItem() {
         return this.optionalItem;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleFieldsOnlyFinalStage.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleFieldsOnlyFinalStage.java
@@ -1,6 +1,7 @@
 package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -54,6 +55,7 @@ public final class MultipleFieldsOnlyFinalStage {
     }
 
     @JsonProperty("optionalItem")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<String> getOptionalItem() {
         return this.optionalItem;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OneFieldOnlyFinalStage.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OneFieldOnlyFinalStage.java
@@ -1,6 +1,7 @@
 package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -26,6 +27,7 @@ public final class OneFieldOnlyFinalStage {
     }
 
     @JsonProperty("optionalItem")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<String> getOptionalItem() {
         return this.optionalItem;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAliasExample.java
@@ -1,5 +1,6 @@
 package com.palantir.product;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -24,6 +25,7 @@ public final class OptionalAliasExample {
     }
 
     @JsonProperty("optionalAlias")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public OptionalAlias getOptionalAlias() {
         return this.optionalAlias;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
@@ -1,5 +1,6 @@
 package com.palantir.product;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -25,6 +26,7 @@ public final class OptionalExample {
     }
 
     @JsonProperty("item")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<String> getItem() {
         return this.item;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalListAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalListAliasExample.java
@@ -1,0 +1,49 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Generated;
+import javax.annotation.Nonnull;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class OptionalListAliasExample {
+    private final Optional<List<String>> value;
+
+    private OptionalListAliasExample(@Nonnull Optional<List<String>> value) {
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
+    }
+
+    private OptionalListAliasExample() {
+        this(Optional.empty());
+    }
+
+    @JsonValue
+    public Optional<List<String>> get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof OptionalListAliasExample
+                        && this.value.equals(((OptionalListAliasExample) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static OptionalListAliasExample of(@Nonnull Optional<List<String>> value) {
+        return new OptionalListAliasExample(value);
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalMapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalMapAliasExample.java
@@ -1,0 +1,49 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Generated;
+import javax.annotation.Nonnull;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class OptionalMapAliasExample {
+    private final Optional<Map<String, Object>> value;
+
+    private OptionalMapAliasExample(@Nonnull Optional<Map<String, Object>> value) {
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
+    }
+
+    private OptionalMapAliasExample() {
+        this(Optional.empty());
+    }
+
+    @JsonValue
+    public Optional<Map<String, Object>> get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof OptionalMapAliasExample
+                        && this.value.equals(((OptionalMapAliasExample) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static OptionalMapAliasExample of(@Nonnull Optional<Map<String, Object>> value) {
+        return new OptionalMapAliasExample(value);
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalSetAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalSetAliasExample.java
@@ -1,0 +1,49 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.Generated;
+import javax.annotation.Nonnull;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class OptionalSetAliasExample {
+    private final Optional<Set<String>> value;
+
+    private OptionalSetAliasExample(@Nonnull Optional<Set<String>> value) {
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
+    }
+
+    private OptionalSetAliasExample() {
+        this(Optional.empty());
+    }
+
+    @JsonValue
+    public Optional<Set<String>> get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof OptionalSetAliasExample
+                        && this.value.equals(((OptionalSetAliasExample) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static OptionalSetAliasExample of(@Nonnull Optional<Set<String>> value) {
+        return new OptionalSetAliasExample(value);
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
@@ -13,11 +13,14 @@ import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.BearerToken;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
+import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
@@ -38,6 +41,24 @@ public final class PrimitiveOptionalsExample {
 
     private final Optional<UUID> uuid;
 
+    private final Optional<Map<String, String>> map;
+
+    private final Optional<List<String>> list;
+
+    private final Optional<Set<String>> set;
+
+    private final Optional<StringAliasOne> aliasOne;
+
+    private final StringAliasTwo aliasTwo;
+
+    private final Optional<ListAlias> aliasList;
+
+    private final Optional<MapAliasExample> aliasMap;
+
+    private final OptionalAlias aliasOptional;
+
+    private final OptionalMapAliasExample aliasOptionalMap;
+
     private int memoizedHashCode;
 
     private PrimitiveOptionalsExample(
@@ -47,8 +68,33 @@ public final class PrimitiveOptionalsExample {
             Optional<SafeLong> safelong,
             Optional<ResourceIdentifier> rid,
             Optional<BearerToken> bearertoken,
-            Optional<UUID> uuid) {
-        validateFields(num, bool, integer, safelong, rid, bearertoken, uuid);
+            Optional<UUID> uuid,
+            Optional<Map<String, String>> map,
+            Optional<List<String>> list,
+            Optional<Set<String>> set,
+            Optional<StringAliasOne> aliasOne,
+            StringAliasTwo aliasTwo,
+            Optional<ListAlias> aliasList,
+            Optional<MapAliasExample> aliasMap,
+            OptionalAlias aliasOptional,
+            OptionalMapAliasExample aliasOptionalMap) {
+        validateFields(
+                num,
+                bool,
+                integer,
+                safelong,
+                rid,
+                bearertoken,
+                uuid,
+                map,
+                list,
+                set,
+                aliasOne,
+                aliasTwo,
+                aliasList,
+                aliasMap,
+                aliasOptional,
+                aliasOptionalMap);
         this.num = num;
         this.bool = bool;
         this.integer = integer;
@@ -56,6 +102,15 @@ public final class PrimitiveOptionalsExample {
         this.rid = rid;
         this.bearertoken = bearertoken;
         this.uuid = uuid;
+        this.map = map;
+        this.list = list;
+        this.set = set;
+        this.aliasOne = aliasOne;
+        this.aliasTwo = aliasTwo;
+        this.aliasList = aliasList;
+        this.aliasMap = aliasMap;
+        this.aliasOptional = aliasOptional;
+        this.aliasOptionalMap = aliasOptionalMap;
     }
 
     @JsonProperty("num")
@@ -100,6 +155,60 @@ public final class PrimitiveOptionalsExample {
         return this.uuid;
     }
 
+    @JsonProperty("map")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Optional<Map<String, String>> getMap() {
+        return this.map;
+    }
+
+    @JsonProperty("list")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Optional<List<String>> getList() {
+        return this.list;
+    }
+
+    @JsonProperty("set")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Optional<Set<String>> getSet() {
+        return this.set;
+    }
+
+    @JsonProperty("aliasOne")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Optional<StringAliasOne> getAliasOne() {
+        return this.aliasOne;
+    }
+
+    @JsonProperty("aliasTwo")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public StringAliasTwo getAliasTwo() {
+        return this.aliasTwo;
+    }
+
+    @JsonProperty("aliasList")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Optional<ListAlias> getAliasList() {
+        return this.aliasList;
+    }
+
+    @JsonProperty("aliasMap")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Optional<MapAliasExample> getAliasMap() {
+        return this.aliasMap;
+    }
+
+    @JsonProperty("aliasOptional")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public OptionalAlias getAliasOptional() {
+        return this.aliasOptional;
+    }
+
+    @JsonProperty("aliasOptionalMap")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public OptionalMapAliasExample getAliasOptionalMap() {
+        return this.aliasOptionalMap;
+    }
+
     @Override
     public boolean equals(Object other) {
         return this == other
@@ -113,7 +222,16 @@ public final class PrimitiveOptionalsExample {
                 && this.safelong.equals(other.safelong)
                 && this.rid.equals(other.rid)
                 && this.bearertoken.equals(other.bearertoken)
-                && this.uuid.equals(other.uuid);
+                && this.uuid.equals(other.uuid)
+                && this.map.equals(other.map)
+                && this.list.equals(other.list)
+                && this.set.equals(other.set)
+                && this.aliasOne.equals(other.aliasOne)
+                && this.aliasTwo.equals(other.aliasTwo)
+                && this.aliasList.equals(other.aliasList)
+                && this.aliasMap.equals(other.aliasMap)
+                && this.aliasOptional.equals(other.aliasOptional)
+                && this.aliasOptionalMap.equals(other.aliasOptionalMap);
     }
 
     @Override
@@ -121,7 +239,22 @@ public final class PrimitiveOptionalsExample {
         int result = memoizedHashCode;
         if (result == 0) {
             result = Objects.hash(
-                    this.num, this.bool, this.integer, this.safelong, this.rid, this.bearertoken, this.uuid);
+                    this.num,
+                    this.bool,
+                    this.integer,
+                    this.safelong,
+                    this.rid,
+                    this.bearertoken,
+                    this.uuid,
+                    this.map,
+                    this.list,
+                    this.set,
+                    this.aliasOne,
+                    this.aliasTwo,
+                    this.aliasList,
+                    this.aliasMap,
+                    this.aliasOptional,
+                    this.aliasOptionalMap);
             memoizedHashCode = result;
         }
         return result;
@@ -130,7 +263,10 @@ public final class PrimitiveOptionalsExample {
     @Override
     public String toString() {
         return "PrimitiveOptionalsExample{num: " + num + ", bool: " + bool + ", integer: " + integer + ", safelong: "
-                + safelong + ", rid: " + rid + ", bearertoken: " + bearertoken + ", uuid: " + uuid + '}';
+                + safelong + ", rid: " + rid + ", bearertoken: " + bearertoken + ", uuid: " + uuid + ", map: " + map
+                + ", list: " + list + ", set: " + set + ", aliasOne: " + aliasOne + ", aliasTwo: " + aliasTwo
+                + ", aliasList: " + aliasList + ", aliasMap: " + aliasMap + ", aliasOptional: " + aliasOptional
+                + ", aliasOptionalMap: " + aliasOptionalMap + '}';
     }
 
     private static void validateFields(
@@ -140,7 +276,16 @@ public final class PrimitiveOptionalsExample {
             Optional<SafeLong> safelong,
             Optional<ResourceIdentifier> rid,
             Optional<BearerToken> bearertoken,
-            Optional<UUID> uuid) {
+            Optional<UUID> uuid,
+            Optional<Map<String, String>> map,
+            Optional<List<String>> list,
+            Optional<Set<String>> set,
+            Optional<StringAliasOne> aliasOne,
+            StringAliasTwo aliasTwo,
+            Optional<ListAlias> aliasList,
+            Optional<MapAliasExample> aliasMap,
+            OptionalAlias aliasOptional,
+            OptionalMapAliasExample aliasOptionalMap) {
         List<String> missingFields = null;
         missingFields = addFieldIfMissing(missingFields, num, "num");
         missingFields = addFieldIfMissing(missingFields, bool, "bool");
@@ -149,6 +294,15 @@ public final class PrimitiveOptionalsExample {
         missingFields = addFieldIfMissing(missingFields, rid, "rid");
         missingFields = addFieldIfMissing(missingFields, bearertoken, "bearertoken");
         missingFields = addFieldIfMissing(missingFields, uuid, "uuid");
+        missingFields = addFieldIfMissing(missingFields, map, "map");
+        missingFields = addFieldIfMissing(missingFields, list, "list");
+        missingFields = addFieldIfMissing(missingFields, set, "set");
+        missingFields = addFieldIfMissing(missingFields, aliasOne, "aliasOne");
+        missingFields = addFieldIfMissing(missingFields, aliasTwo, "aliasTwo");
+        missingFields = addFieldIfMissing(missingFields, aliasList, "aliasList");
+        missingFields = addFieldIfMissing(missingFields, aliasMap, "aliasMap");
+        missingFields = addFieldIfMissing(missingFields, aliasOptional, "aliasOptional");
+        missingFields = addFieldIfMissing(missingFields, aliasOptionalMap, "aliasOptionalMap");
         if (missingFields != null) {
             throw new SafeIllegalArgumentException(
                     "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
@@ -159,7 +313,7 @@ public final class PrimitiveOptionalsExample {
         List<String> missingFields = prev;
         if (fieldValue == null) {
             if (missingFields == null) {
-                missingFields = new ArrayList<>(7);
+                missingFields = new ArrayList<>(16);
             }
             missingFields.add(fieldName);
         }
@@ -186,6 +340,24 @@ public final class PrimitiveOptionalsExample {
 
         private Optional<UUID> uuid = Optional.empty();
 
+        private Optional<Map<String, String>> map = Optional.empty();
+
+        private Optional<List<String>> list = Optional.empty();
+
+        private Optional<Set<String>> set = Optional.empty();
+
+        private Optional<StringAliasOne> aliasOne = Optional.empty();
+
+        private StringAliasTwo aliasTwo;
+
+        private Optional<ListAlias> aliasList = Optional.empty();
+
+        private Optional<MapAliasExample> aliasMap = Optional.empty();
+
+        private OptionalAlias aliasOptional;
+
+        private OptionalMapAliasExample aliasOptionalMap;
+
         private Builder() {}
 
         public Builder from(PrimitiveOptionalsExample other) {
@@ -196,6 +368,15 @@ public final class PrimitiveOptionalsExample {
             rid(other.getRid());
             bearertoken(other.getBearertoken());
             uuid(other.getUuid());
+            map(other.getMap());
+            list(other.getList());
+            set(other.getSet());
+            aliasOne(other.getAliasOne());
+            aliasTwo(other.getAliasTwo());
+            aliasList(other.getAliasList());
+            aliasMap(other.getAliasMap());
+            aliasOptional(other.getAliasOptional());
+            aliasOptionalMap(other.getAliasOptionalMap());
             return this;
         }
 
@@ -276,8 +457,108 @@ public final class PrimitiveOptionalsExample {
             return this;
         }
 
+        @JsonSetter(value = "map", nulls = Nulls.SKIP)
+        public Builder map(@Nonnull Optional<? extends Map<String, String>> map) {
+            this.map = Preconditions.checkNotNull(map, "map cannot be null").map(Function.identity());
+            return this;
+        }
+
+        public Builder map(@Nonnull Map<String, String> map) {
+            this.map = Optional.of(Preconditions.checkNotNull(map, "map cannot be null"));
+            return this;
+        }
+
+        @JsonSetter(value = "list", nulls = Nulls.SKIP)
+        public Builder list(@Nonnull Optional<? extends List<String>> list) {
+            this.list = Preconditions.checkNotNull(list, "list cannot be null").map(Function.identity());
+            return this;
+        }
+
+        public Builder list(@Nonnull List<String> list) {
+            this.list = Optional.of(Preconditions.checkNotNull(list, "list cannot be null"));
+            return this;
+        }
+
+        @JsonSetter(value = "set", nulls = Nulls.SKIP)
+        public Builder set(@Nonnull Optional<? extends Set<String>> set) {
+            this.set = Preconditions.checkNotNull(set, "set cannot be null").map(Function.identity());
+            return this;
+        }
+
+        public Builder set(@Nonnull Set<String> set) {
+            this.set = Optional.of(Preconditions.checkNotNull(set, "set cannot be null"));
+            return this;
+        }
+
+        @JsonSetter(value = "aliasOne", nulls = Nulls.SKIP)
+        public Builder aliasOne(@Nonnull Optional<StringAliasOne> aliasOne) {
+            this.aliasOne = Preconditions.checkNotNull(aliasOne, "aliasOne cannot be null");
+            return this;
+        }
+
+        public Builder aliasOne(@Nonnull StringAliasOne aliasOne) {
+            this.aliasOne = Optional.of(Preconditions.checkNotNull(aliasOne, "aliasOne cannot be null"));
+            return this;
+        }
+
+        @JsonSetter(value = "aliasTwo", nulls = Nulls.AS_EMPTY)
+        public Builder aliasTwo(@Nonnull StringAliasTwo aliasTwo) {
+            this.aliasTwo = Preconditions.checkNotNull(aliasTwo, "aliasTwo cannot be null");
+            return this;
+        }
+
+        @JsonSetter(value = "aliasList", nulls = Nulls.SKIP)
+        public Builder aliasList(@Nonnull Optional<ListAlias> aliasList) {
+            this.aliasList = Preconditions.checkNotNull(aliasList, "aliasList cannot be null");
+            return this;
+        }
+
+        public Builder aliasList(@Nonnull ListAlias aliasList) {
+            this.aliasList = Optional.of(Preconditions.checkNotNull(aliasList, "aliasList cannot be null"));
+            return this;
+        }
+
+        @JsonSetter(value = "aliasMap", nulls = Nulls.SKIP)
+        public Builder aliasMap(@Nonnull Optional<MapAliasExample> aliasMap) {
+            this.aliasMap = Preconditions.checkNotNull(aliasMap, "aliasMap cannot be null");
+            return this;
+        }
+
+        public Builder aliasMap(@Nonnull MapAliasExample aliasMap) {
+            this.aliasMap = Optional.of(Preconditions.checkNotNull(aliasMap, "aliasMap cannot be null"));
+            return this;
+        }
+
+        @JsonSetter(value = "aliasOptional", nulls = Nulls.AS_EMPTY)
+        public Builder aliasOptional(@Nonnull OptionalAlias aliasOptional) {
+            this.aliasOptional = Preconditions.checkNotNull(aliasOptional, "aliasOptional cannot be null");
+            return this;
+        }
+
+        @JsonSetter(value = "aliasOptionalMap", nulls = Nulls.AS_EMPTY)
+        public Builder aliasOptionalMap(@Nonnull OptionalMapAliasExample aliasOptionalMap) {
+            this.aliasOptionalMap = Preconditions.checkNotNull(aliasOptionalMap, "aliasOptionalMap cannot be null");
+            return this;
+        }
+
         public PrimitiveOptionalsExample build() {
-            return new PrimitiveOptionalsExample(num, bool, integer, safelong, rid, bearertoken, uuid);
+            return new PrimitiveOptionalsExample(
+                    num,
+                    bool,
+                    integer,
+                    safelong,
+                    rid,
+                    bearertoken,
+                    uuid,
+                    map,
+                    list,
+                    set,
+                    aliasOne,
+                    aliasTwo,
+                    aliasList,
+                    aliasMap,
+                    aliasOptional,
+                    aliasOptionalMap);
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
@@ -59,6 +59,10 @@ public final class PrimitiveOptionalsExample {
 
     private final OptionalMapAliasExample aliasOptionalMap;
 
+    private final OptionalListAliasExample aliasOptionalList;
+
+    private final OptionalSetAliasExample aliasOptionalSet;
+
     private int memoizedHashCode;
 
     private PrimitiveOptionalsExample(
@@ -77,7 +81,9 @@ public final class PrimitiveOptionalsExample {
             Optional<ListAlias> aliasList,
             Optional<MapAliasExample> aliasMap,
             OptionalAlias aliasOptional,
-            OptionalMapAliasExample aliasOptionalMap) {
+            OptionalMapAliasExample aliasOptionalMap,
+            OptionalListAliasExample aliasOptionalList,
+            OptionalSetAliasExample aliasOptionalSet) {
         validateFields(
                 num,
                 bool,
@@ -94,7 +100,9 @@ public final class PrimitiveOptionalsExample {
                 aliasList,
                 aliasMap,
                 aliasOptional,
-                aliasOptionalMap);
+                aliasOptionalMap,
+                aliasOptionalList,
+                aliasOptionalSet);
         this.num = num;
         this.bool = bool;
         this.integer = integer;
@@ -111,6 +119,8 @@ public final class PrimitiveOptionalsExample {
         this.aliasMap = aliasMap;
         this.aliasOptional = aliasOptional;
         this.aliasOptionalMap = aliasOptionalMap;
+        this.aliasOptionalList = aliasOptionalList;
+        this.aliasOptionalSet = aliasOptionalSet;
     }
 
     @JsonProperty("num")
@@ -209,6 +219,18 @@ public final class PrimitiveOptionalsExample {
         return this.aliasOptionalMap;
     }
 
+    @JsonProperty("aliasOptionalList")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public OptionalListAliasExample getAliasOptionalList() {
+        return this.aliasOptionalList;
+    }
+
+    @JsonProperty("aliasOptionalSet")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public OptionalSetAliasExample getAliasOptionalSet() {
+        return this.aliasOptionalSet;
+    }
+
     @Override
     public boolean equals(Object other) {
         return this == other
@@ -231,7 +253,9 @@ public final class PrimitiveOptionalsExample {
                 && this.aliasList.equals(other.aliasList)
                 && this.aliasMap.equals(other.aliasMap)
                 && this.aliasOptional.equals(other.aliasOptional)
-                && this.aliasOptionalMap.equals(other.aliasOptionalMap);
+                && this.aliasOptionalMap.equals(other.aliasOptionalMap)
+                && this.aliasOptionalList.equals(other.aliasOptionalList)
+                && this.aliasOptionalSet.equals(other.aliasOptionalSet);
     }
 
     @Override
@@ -254,7 +278,9 @@ public final class PrimitiveOptionalsExample {
                     this.aliasList,
                     this.aliasMap,
                     this.aliasOptional,
-                    this.aliasOptionalMap);
+                    this.aliasOptionalMap,
+                    this.aliasOptionalList,
+                    this.aliasOptionalSet);
             memoizedHashCode = result;
         }
         return result;
@@ -266,7 +292,8 @@ public final class PrimitiveOptionalsExample {
                 + safelong + ", rid: " + rid + ", bearertoken: " + bearertoken + ", uuid: " + uuid + ", map: " + map
                 + ", list: " + list + ", set: " + set + ", aliasOne: " + aliasOne + ", aliasTwo: " + aliasTwo
                 + ", aliasList: " + aliasList + ", aliasMap: " + aliasMap + ", aliasOptional: " + aliasOptional
-                + ", aliasOptionalMap: " + aliasOptionalMap + '}';
+                + ", aliasOptionalMap: " + aliasOptionalMap + ", aliasOptionalList: " + aliasOptionalList
+                + ", aliasOptionalSet: " + aliasOptionalSet + '}';
     }
 
     private static void validateFields(
@@ -285,7 +312,9 @@ public final class PrimitiveOptionalsExample {
             Optional<ListAlias> aliasList,
             Optional<MapAliasExample> aliasMap,
             OptionalAlias aliasOptional,
-            OptionalMapAliasExample aliasOptionalMap) {
+            OptionalMapAliasExample aliasOptionalMap,
+            OptionalListAliasExample aliasOptionalList,
+            OptionalSetAliasExample aliasOptionalSet) {
         List<String> missingFields = null;
         missingFields = addFieldIfMissing(missingFields, num, "num");
         missingFields = addFieldIfMissing(missingFields, bool, "bool");
@@ -303,6 +332,8 @@ public final class PrimitiveOptionalsExample {
         missingFields = addFieldIfMissing(missingFields, aliasMap, "aliasMap");
         missingFields = addFieldIfMissing(missingFields, aliasOptional, "aliasOptional");
         missingFields = addFieldIfMissing(missingFields, aliasOptionalMap, "aliasOptionalMap");
+        missingFields = addFieldIfMissing(missingFields, aliasOptionalList, "aliasOptionalList");
+        missingFields = addFieldIfMissing(missingFields, aliasOptionalSet, "aliasOptionalSet");
         if (missingFields != null) {
             throw new SafeIllegalArgumentException(
                     "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
@@ -313,7 +344,7 @@ public final class PrimitiveOptionalsExample {
         List<String> missingFields = prev;
         if (fieldValue == null) {
             if (missingFields == null) {
-                missingFields = new ArrayList<>(16);
+                missingFields = new ArrayList<>(18);
             }
             missingFields.add(fieldName);
         }
@@ -358,6 +389,10 @@ public final class PrimitiveOptionalsExample {
 
         private OptionalMapAliasExample aliasOptionalMap;
 
+        private OptionalListAliasExample aliasOptionalList;
+
+        private OptionalSetAliasExample aliasOptionalSet;
+
         private Builder() {}
 
         public Builder from(PrimitiveOptionalsExample other) {
@@ -377,6 +412,8 @@ public final class PrimitiveOptionalsExample {
             aliasMap(other.getAliasMap());
             aliasOptional(other.getAliasOptional());
             aliasOptionalMap(other.getAliasOptionalMap());
+            aliasOptionalList(other.getAliasOptionalList());
+            aliasOptionalSet(other.getAliasOptionalSet());
             return this;
         }
 
@@ -541,6 +578,18 @@ public final class PrimitiveOptionalsExample {
             return this;
         }
 
+        @JsonSetter(value = "aliasOptionalList", nulls = Nulls.AS_EMPTY)
+        public Builder aliasOptionalList(@Nonnull OptionalListAliasExample aliasOptionalList) {
+            this.aliasOptionalList = Preconditions.checkNotNull(aliasOptionalList, "aliasOptionalList cannot be null");
+            return this;
+        }
+
+        @JsonSetter(value = "aliasOptionalSet", nulls = Nulls.AS_EMPTY)
+        public Builder aliasOptionalSet(@Nonnull OptionalSetAliasExample aliasOptionalSet) {
+            this.aliasOptionalSet = Preconditions.checkNotNull(aliasOptionalSet, "aliasOptionalSet cannot be null");
+            return this;
+        }
+
         public PrimitiveOptionalsExample build() {
             return new PrimitiveOptionalsExample(
                     num,
@@ -558,7 +607,9 @@ public final class PrimitiveOptionalsExample {
                     aliasList,
                     aliasMap,
                     aliasOptional,
-                    aliasOptionalMap);
+                    aliasOptionalMap,
+                    aliasOptionalList,
+                    aliasOptionalSet);
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
@@ -1,5 +1,6 @@
 package com.palantir.product;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -58,36 +59,43 @@ public final class PrimitiveOptionalsExample {
     }
 
     @JsonProperty("num")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public OptionalDouble getNum() {
         return this.num;
     }
 
     @JsonProperty("bool")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<Boolean> getBool() {
         return this.bool;
     }
 
     @JsonProperty("integer")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public OptionalInt getInteger() {
         return this.integer;
     }
 
     @JsonProperty("safelong")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<SafeLong> getSafelong() {
         return this.safelong;
     }
 
     @JsonProperty("rid")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<ResourceIdentifier> getRid() {
         return this.rid;
     }
 
     @JsonProperty("bearertoken")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<BearerToken> getBearertoken() {
         return this.bearertoken;
     }
 
     @JsonProperty("uuid")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<UUID> getUuid() {
         return this.uuid;
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantOptionalExample.java
@@ -1,6 +1,7 @@
 package test.prefix.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -33,11 +34,13 @@ public final class CovariantOptionalExample {
     }
 
     @JsonProperty("item")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<Object> getItem() {
         return this.item;
     }
 
     @JsonProperty("setItem")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<Set<StringAliasExample>> getSetItem() {
         return this.setItem;
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
@@ -1,6 +1,7 @@
 package test.prefix.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -42,6 +43,7 @@ public final class ExternalLongExample {
     }
 
     @JsonProperty("optionalExternalLong")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<Long> getOptionalExternalLong() {
         return this.optionalExternalLong;
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
@@ -1,6 +1,7 @@
 package test.prefix.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -90,6 +91,7 @@ public final class ManyFieldExample {
      * docs for optionalItem field
      */
     @JsonProperty("optionalItem")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<String> getOptionalItem() {
         return this.optionalItem;
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAliasExample.java
@@ -1,6 +1,7 @@
 package test.prefix.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -25,6 +26,7 @@ public final class OptionalAliasExample {
     }
 
     @JsonProperty("optionalAlias")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public OptionalAlias getOptionalAlias() {
         return this.optionalAlias;
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalExample.java
@@ -1,6 +1,7 @@
 package test.prefix.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -26,6 +27,7 @@ public final class OptionalExample {
     }
 
     @JsonProperty("item")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<String> getItem() {
         return this.item;
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalListAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalListAliasExample.java
@@ -1,0 +1,49 @@
+package test.prefix.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Generated;
+import javax.annotation.Nonnull;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class OptionalListAliasExample {
+    private final Optional<List<String>> value;
+
+    private OptionalListAliasExample(@Nonnull Optional<List<String>> value) {
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
+    }
+
+    private OptionalListAliasExample() {
+        this(Optional.empty());
+    }
+
+    @JsonValue
+    public Optional<List<String>> get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof OptionalListAliasExample
+                        && this.value.equals(((OptionalListAliasExample) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static OptionalListAliasExample of(@Nonnull Optional<List<String>> value) {
+        return new OptionalListAliasExample(value);
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalMapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalMapAliasExample.java
@@ -1,0 +1,49 @@
+package test.prefix.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Generated;
+import javax.annotation.Nonnull;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class OptionalMapAliasExample {
+    private final Optional<Map<String, Object>> value;
+
+    private OptionalMapAliasExample(@Nonnull Optional<Map<String, Object>> value) {
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
+    }
+
+    private OptionalMapAliasExample() {
+        this(Optional.empty());
+    }
+
+    @JsonValue
+    public Optional<Map<String, Object>> get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof OptionalMapAliasExample
+                        && this.value.equals(((OptionalMapAliasExample) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static OptionalMapAliasExample of(@Nonnull Optional<Map<String, Object>> value) {
+        return new OptionalMapAliasExample(value);
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalSetAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalSetAliasExample.java
@@ -1,0 +1,49 @@
+package test.prefix.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.Generated;
+import javax.annotation.Nonnull;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class OptionalSetAliasExample {
+    private final Optional<Set<String>> value;
+
+    private OptionalSetAliasExample(@Nonnull Optional<Set<String>> value) {
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
+    }
+
+    private OptionalSetAliasExample() {
+        this(Optional.empty());
+    }
+
+    @JsonValue
+    public Optional<Set<String>> get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || (other instanceof OptionalSetAliasExample
+                        && this.value.equals(((OptionalSetAliasExample) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static OptionalSetAliasExample of(@Nonnull Optional<Set<String>> value) {
+        return new OptionalSetAliasExample(value);
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
@@ -60,6 +60,10 @@ public final class PrimitiveOptionalsExample {
 
     private final OptionalMapAliasExample aliasOptionalMap;
 
+    private final OptionalListAliasExample aliasOptionalList;
+
+    private final OptionalSetAliasExample aliasOptionalSet;
+
     private int memoizedHashCode;
 
     private PrimitiveOptionalsExample(
@@ -78,7 +82,9 @@ public final class PrimitiveOptionalsExample {
             Optional<ListAlias> aliasList,
             Optional<MapAliasExample> aliasMap,
             OptionalAlias aliasOptional,
-            OptionalMapAliasExample aliasOptionalMap) {
+            OptionalMapAliasExample aliasOptionalMap,
+            OptionalListAliasExample aliasOptionalList,
+            OptionalSetAliasExample aliasOptionalSet) {
         validateFields(
                 num,
                 bool,
@@ -95,7 +101,9 @@ public final class PrimitiveOptionalsExample {
                 aliasList,
                 aliasMap,
                 aliasOptional,
-                aliasOptionalMap);
+                aliasOptionalMap,
+                aliasOptionalList,
+                aliasOptionalSet);
         this.num = num;
         this.bool = bool;
         this.integer = integer;
@@ -112,6 +120,8 @@ public final class PrimitiveOptionalsExample {
         this.aliasMap = aliasMap;
         this.aliasOptional = aliasOptional;
         this.aliasOptionalMap = aliasOptionalMap;
+        this.aliasOptionalList = aliasOptionalList;
+        this.aliasOptionalSet = aliasOptionalSet;
     }
 
     @JsonProperty("num")
@@ -210,6 +220,18 @@ public final class PrimitiveOptionalsExample {
         return this.aliasOptionalMap;
     }
 
+    @JsonProperty("aliasOptionalList")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public OptionalListAliasExample getAliasOptionalList() {
+        return this.aliasOptionalList;
+    }
+
+    @JsonProperty("aliasOptionalSet")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public OptionalSetAliasExample getAliasOptionalSet() {
+        return this.aliasOptionalSet;
+    }
+
     @Override
     public boolean equals(Object other) {
         return this == other
@@ -232,7 +254,9 @@ public final class PrimitiveOptionalsExample {
                 && this.aliasList.equals(other.aliasList)
                 && this.aliasMap.equals(other.aliasMap)
                 && this.aliasOptional.equals(other.aliasOptional)
-                && this.aliasOptionalMap.equals(other.aliasOptionalMap);
+                && this.aliasOptionalMap.equals(other.aliasOptionalMap)
+                && this.aliasOptionalList.equals(other.aliasOptionalList)
+                && this.aliasOptionalSet.equals(other.aliasOptionalSet);
     }
 
     @Override
@@ -255,7 +279,9 @@ public final class PrimitiveOptionalsExample {
                     this.aliasList,
                     this.aliasMap,
                     this.aliasOptional,
-                    this.aliasOptionalMap);
+                    this.aliasOptionalMap,
+                    this.aliasOptionalList,
+                    this.aliasOptionalSet);
             memoizedHashCode = result;
         }
         return result;
@@ -267,7 +293,8 @@ public final class PrimitiveOptionalsExample {
                 + safelong + ", rid: " + rid + ", bearertoken: " + bearertoken + ", uuid: " + uuid + ", map: " + map
                 + ", list: " + list + ", set: " + set + ", aliasOne: " + aliasOne + ", aliasTwo: " + aliasTwo
                 + ", aliasList: " + aliasList + ", aliasMap: " + aliasMap + ", aliasOptional: " + aliasOptional
-                + ", aliasOptionalMap: " + aliasOptionalMap + '}';
+                + ", aliasOptionalMap: " + aliasOptionalMap + ", aliasOptionalList: " + aliasOptionalList
+                + ", aliasOptionalSet: " + aliasOptionalSet + '}';
     }
 
     private static void validateFields(
@@ -286,7 +313,9 @@ public final class PrimitiveOptionalsExample {
             Optional<ListAlias> aliasList,
             Optional<MapAliasExample> aliasMap,
             OptionalAlias aliasOptional,
-            OptionalMapAliasExample aliasOptionalMap) {
+            OptionalMapAliasExample aliasOptionalMap,
+            OptionalListAliasExample aliasOptionalList,
+            OptionalSetAliasExample aliasOptionalSet) {
         List<String> missingFields = null;
         missingFields = addFieldIfMissing(missingFields, num, "num");
         missingFields = addFieldIfMissing(missingFields, bool, "bool");
@@ -304,6 +333,8 @@ public final class PrimitiveOptionalsExample {
         missingFields = addFieldIfMissing(missingFields, aliasMap, "aliasMap");
         missingFields = addFieldIfMissing(missingFields, aliasOptional, "aliasOptional");
         missingFields = addFieldIfMissing(missingFields, aliasOptionalMap, "aliasOptionalMap");
+        missingFields = addFieldIfMissing(missingFields, aliasOptionalList, "aliasOptionalList");
+        missingFields = addFieldIfMissing(missingFields, aliasOptionalSet, "aliasOptionalSet");
         if (missingFields != null) {
             throw new SafeIllegalArgumentException(
                     "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
@@ -314,7 +345,7 @@ public final class PrimitiveOptionalsExample {
         List<String> missingFields = prev;
         if (fieldValue == null) {
             if (missingFields == null) {
-                missingFields = new ArrayList<>(16);
+                missingFields = new ArrayList<>(18);
             }
             missingFields.add(fieldName);
         }
@@ -360,6 +391,10 @@ public final class PrimitiveOptionalsExample {
 
         private OptionalMapAliasExample aliasOptionalMap;
 
+        private OptionalListAliasExample aliasOptionalList;
+
+        private OptionalSetAliasExample aliasOptionalSet;
+
         private Builder() {}
 
         public Builder from(PrimitiveOptionalsExample other) {
@@ -379,6 +414,8 @@ public final class PrimitiveOptionalsExample {
             aliasMap(other.getAliasMap());
             aliasOptional(other.getAliasOptional());
             aliasOptionalMap(other.getAliasOptionalMap());
+            aliasOptionalList(other.getAliasOptionalList());
+            aliasOptionalSet(other.getAliasOptionalSet());
             return this;
         }
 
@@ -543,6 +580,18 @@ public final class PrimitiveOptionalsExample {
             return this;
         }
 
+        @JsonSetter(value = "aliasOptionalList", nulls = Nulls.AS_EMPTY)
+        public Builder aliasOptionalList(@Nonnull OptionalListAliasExample aliasOptionalList) {
+            this.aliasOptionalList = Preconditions.checkNotNull(aliasOptionalList, "aliasOptionalList cannot be null");
+            return this;
+        }
+
+        @JsonSetter(value = "aliasOptionalSet", nulls = Nulls.AS_EMPTY)
+        public Builder aliasOptionalSet(@Nonnull OptionalSetAliasExample aliasOptionalSet) {
+            this.aliasOptionalSet = Preconditions.checkNotNull(aliasOptionalSet, "aliasOptionalSet cannot be null");
+            return this;
+        }
+
         public PrimitiveOptionalsExample build() {
             return new PrimitiveOptionalsExample(
                     num,
@@ -560,7 +609,9 @@ public final class PrimitiveOptionalsExample {
                     aliasList,
                     aliasMap,
                     aliasOptional,
-                    aliasOptionalMap);
+                    aliasOptionalMap,
+                    aliasOptionalList,
+                    aliasOptionalSet);
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
@@ -14,11 +14,14 @@ import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.BearerToken;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
+import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
@@ -39,6 +42,24 @@ public final class PrimitiveOptionalsExample {
 
     private final Optional<UUID> uuid;
 
+    private final Optional<Map<String, String>> map;
+
+    private final Optional<List<String>> list;
+
+    private final Optional<Set<String>> set;
+
+    private final Optional<StringAliasOne> aliasOne;
+
+    private final StringAliasTwo aliasTwo;
+
+    private final Optional<ListAlias> aliasList;
+
+    private final Optional<MapAliasExample> aliasMap;
+
+    private final OptionalAlias aliasOptional;
+
+    private final OptionalMapAliasExample aliasOptionalMap;
+
     private int memoizedHashCode;
 
     private PrimitiveOptionalsExample(
@@ -48,8 +69,33 @@ public final class PrimitiveOptionalsExample {
             Optional<SafeLong> safelong,
             Optional<ResourceIdentifier> rid,
             Optional<BearerToken> bearertoken,
-            Optional<UUID> uuid) {
-        validateFields(num, bool, integer, safelong, rid, bearertoken, uuid);
+            Optional<UUID> uuid,
+            Optional<Map<String, String>> map,
+            Optional<List<String>> list,
+            Optional<Set<String>> set,
+            Optional<StringAliasOne> aliasOne,
+            StringAliasTwo aliasTwo,
+            Optional<ListAlias> aliasList,
+            Optional<MapAliasExample> aliasMap,
+            OptionalAlias aliasOptional,
+            OptionalMapAliasExample aliasOptionalMap) {
+        validateFields(
+                num,
+                bool,
+                integer,
+                safelong,
+                rid,
+                bearertoken,
+                uuid,
+                map,
+                list,
+                set,
+                aliasOne,
+                aliasTwo,
+                aliasList,
+                aliasMap,
+                aliasOptional,
+                aliasOptionalMap);
         this.num = num;
         this.bool = bool;
         this.integer = integer;
@@ -57,6 +103,15 @@ public final class PrimitiveOptionalsExample {
         this.rid = rid;
         this.bearertoken = bearertoken;
         this.uuid = uuid;
+        this.map = map;
+        this.list = list;
+        this.set = set;
+        this.aliasOne = aliasOne;
+        this.aliasTwo = aliasTwo;
+        this.aliasList = aliasList;
+        this.aliasMap = aliasMap;
+        this.aliasOptional = aliasOptional;
+        this.aliasOptionalMap = aliasOptionalMap;
     }
 
     @JsonProperty("num")
@@ -101,6 +156,60 @@ public final class PrimitiveOptionalsExample {
         return this.uuid;
     }
 
+    @JsonProperty("map")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Optional<Map<String, String>> getMap() {
+        return this.map;
+    }
+
+    @JsonProperty("list")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Optional<List<String>> getList() {
+        return this.list;
+    }
+
+    @JsonProperty("set")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Optional<Set<String>> getSet() {
+        return this.set;
+    }
+
+    @JsonProperty("aliasOne")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Optional<StringAliasOne> getAliasOne() {
+        return this.aliasOne;
+    }
+
+    @JsonProperty("aliasTwo")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public StringAliasTwo getAliasTwo() {
+        return this.aliasTwo;
+    }
+
+    @JsonProperty("aliasList")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Optional<ListAlias> getAliasList() {
+        return this.aliasList;
+    }
+
+    @JsonProperty("aliasMap")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Optional<MapAliasExample> getAliasMap() {
+        return this.aliasMap;
+    }
+
+    @JsonProperty("aliasOptional")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public OptionalAlias getAliasOptional() {
+        return this.aliasOptional;
+    }
+
+    @JsonProperty("aliasOptionalMap")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public OptionalMapAliasExample getAliasOptionalMap() {
+        return this.aliasOptionalMap;
+    }
+
     @Override
     public boolean equals(Object other) {
         return this == other
@@ -114,7 +223,16 @@ public final class PrimitiveOptionalsExample {
                 && this.safelong.equals(other.safelong)
                 && this.rid.equals(other.rid)
                 && this.bearertoken.equals(other.bearertoken)
-                && this.uuid.equals(other.uuid);
+                && this.uuid.equals(other.uuid)
+                && this.map.equals(other.map)
+                && this.list.equals(other.list)
+                && this.set.equals(other.set)
+                && this.aliasOne.equals(other.aliasOne)
+                && this.aliasTwo.equals(other.aliasTwo)
+                && this.aliasList.equals(other.aliasList)
+                && this.aliasMap.equals(other.aliasMap)
+                && this.aliasOptional.equals(other.aliasOptional)
+                && this.aliasOptionalMap.equals(other.aliasOptionalMap);
     }
 
     @Override
@@ -122,7 +240,22 @@ public final class PrimitiveOptionalsExample {
         int result = memoizedHashCode;
         if (result == 0) {
             result = Objects.hash(
-                    this.num, this.bool, this.integer, this.safelong, this.rid, this.bearertoken, this.uuid);
+                    this.num,
+                    this.bool,
+                    this.integer,
+                    this.safelong,
+                    this.rid,
+                    this.bearertoken,
+                    this.uuid,
+                    this.map,
+                    this.list,
+                    this.set,
+                    this.aliasOne,
+                    this.aliasTwo,
+                    this.aliasList,
+                    this.aliasMap,
+                    this.aliasOptional,
+                    this.aliasOptionalMap);
             memoizedHashCode = result;
         }
         return result;
@@ -131,7 +264,10 @@ public final class PrimitiveOptionalsExample {
     @Override
     public String toString() {
         return "PrimitiveOptionalsExample{num: " + num + ", bool: " + bool + ", integer: " + integer + ", safelong: "
-                + safelong + ", rid: " + rid + ", bearertoken: " + bearertoken + ", uuid: " + uuid + '}';
+                + safelong + ", rid: " + rid + ", bearertoken: " + bearertoken + ", uuid: " + uuid + ", map: " + map
+                + ", list: " + list + ", set: " + set + ", aliasOne: " + aliasOne + ", aliasTwo: " + aliasTwo
+                + ", aliasList: " + aliasList + ", aliasMap: " + aliasMap + ", aliasOptional: " + aliasOptional
+                + ", aliasOptionalMap: " + aliasOptionalMap + '}';
     }
 
     private static void validateFields(
@@ -141,7 +277,16 @@ public final class PrimitiveOptionalsExample {
             Optional<SafeLong> safelong,
             Optional<ResourceIdentifier> rid,
             Optional<BearerToken> bearertoken,
-            Optional<UUID> uuid) {
+            Optional<UUID> uuid,
+            Optional<Map<String, String>> map,
+            Optional<List<String>> list,
+            Optional<Set<String>> set,
+            Optional<StringAliasOne> aliasOne,
+            StringAliasTwo aliasTwo,
+            Optional<ListAlias> aliasList,
+            Optional<MapAliasExample> aliasMap,
+            OptionalAlias aliasOptional,
+            OptionalMapAliasExample aliasOptionalMap) {
         List<String> missingFields = null;
         missingFields = addFieldIfMissing(missingFields, num, "num");
         missingFields = addFieldIfMissing(missingFields, bool, "bool");
@@ -150,6 +295,15 @@ public final class PrimitiveOptionalsExample {
         missingFields = addFieldIfMissing(missingFields, rid, "rid");
         missingFields = addFieldIfMissing(missingFields, bearertoken, "bearertoken");
         missingFields = addFieldIfMissing(missingFields, uuid, "uuid");
+        missingFields = addFieldIfMissing(missingFields, map, "map");
+        missingFields = addFieldIfMissing(missingFields, list, "list");
+        missingFields = addFieldIfMissing(missingFields, set, "set");
+        missingFields = addFieldIfMissing(missingFields, aliasOne, "aliasOne");
+        missingFields = addFieldIfMissing(missingFields, aliasTwo, "aliasTwo");
+        missingFields = addFieldIfMissing(missingFields, aliasList, "aliasList");
+        missingFields = addFieldIfMissing(missingFields, aliasMap, "aliasMap");
+        missingFields = addFieldIfMissing(missingFields, aliasOptional, "aliasOptional");
+        missingFields = addFieldIfMissing(missingFields, aliasOptionalMap, "aliasOptionalMap");
         if (missingFields != null) {
             throw new SafeIllegalArgumentException(
                     "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
@@ -160,7 +314,7 @@ public final class PrimitiveOptionalsExample {
         List<String> missingFields = prev;
         if (fieldValue == null) {
             if (missingFields == null) {
-                missingFields = new ArrayList<>(7);
+                missingFields = new ArrayList<>(16);
             }
             missingFields.add(fieldName);
         }
@@ -188,6 +342,24 @@ public final class PrimitiveOptionalsExample {
 
         private Optional<UUID> uuid = Optional.empty();
 
+        private Optional<Map<String, String>> map = Optional.empty();
+
+        private Optional<List<String>> list = Optional.empty();
+
+        private Optional<Set<String>> set = Optional.empty();
+
+        private Optional<StringAliasOne> aliasOne = Optional.empty();
+
+        private StringAliasTwo aliasTwo;
+
+        private Optional<ListAlias> aliasList = Optional.empty();
+
+        private Optional<MapAliasExample> aliasMap = Optional.empty();
+
+        private OptionalAlias aliasOptional;
+
+        private OptionalMapAliasExample aliasOptionalMap;
+
         private Builder() {}
 
         public Builder from(PrimitiveOptionalsExample other) {
@@ -198,6 +370,15 @@ public final class PrimitiveOptionalsExample {
             rid(other.getRid());
             bearertoken(other.getBearertoken());
             uuid(other.getUuid());
+            map(other.getMap());
+            list(other.getList());
+            set(other.getSet());
+            aliasOne(other.getAliasOne());
+            aliasTwo(other.getAliasTwo());
+            aliasList(other.getAliasList());
+            aliasMap(other.getAliasMap());
+            aliasOptional(other.getAliasOptional());
+            aliasOptionalMap(other.getAliasOptionalMap());
             return this;
         }
 
@@ -278,8 +459,108 @@ public final class PrimitiveOptionalsExample {
             return this;
         }
 
+        @JsonSetter(value = "map", nulls = Nulls.SKIP)
+        public Builder map(@Nonnull Optional<? extends Map<String, String>> map) {
+            this.map = Preconditions.checkNotNull(map, "map cannot be null").map(Function.identity());
+            return this;
+        }
+
+        public Builder map(@Nonnull Map<String, String> map) {
+            this.map = Optional.of(Preconditions.checkNotNull(map, "map cannot be null"));
+            return this;
+        }
+
+        @JsonSetter(value = "list", nulls = Nulls.SKIP)
+        public Builder list(@Nonnull Optional<? extends List<String>> list) {
+            this.list = Preconditions.checkNotNull(list, "list cannot be null").map(Function.identity());
+            return this;
+        }
+
+        public Builder list(@Nonnull List<String> list) {
+            this.list = Optional.of(Preconditions.checkNotNull(list, "list cannot be null"));
+            return this;
+        }
+
+        @JsonSetter(value = "set", nulls = Nulls.SKIP)
+        public Builder set(@Nonnull Optional<? extends Set<String>> set) {
+            this.set = Preconditions.checkNotNull(set, "set cannot be null").map(Function.identity());
+            return this;
+        }
+
+        public Builder set(@Nonnull Set<String> set) {
+            this.set = Optional.of(Preconditions.checkNotNull(set, "set cannot be null"));
+            return this;
+        }
+
+        @JsonSetter(value = "aliasOne", nulls = Nulls.SKIP)
+        public Builder aliasOne(@Nonnull Optional<StringAliasOne> aliasOne) {
+            this.aliasOne = Preconditions.checkNotNull(aliasOne, "aliasOne cannot be null");
+            return this;
+        }
+
+        public Builder aliasOne(@Nonnull StringAliasOne aliasOne) {
+            this.aliasOne = Optional.of(Preconditions.checkNotNull(aliasOne, "aliasOne cannot be null"));
+            return this;
+        }
+
+        @JsonSetter(value = "aliasTwo", nulls = Nulls.AS_EMPTY)
+        public Builder aliasTwo(@Nonnull StringAliasTwo aliasTwo) {
+            this.aliasTwo = Preconditions.checkNotNull(aliasTwo, "aliasTwo cannot be null");
+            return this;
+        }
+
+        @JsonSetter(value = "aliasList", nulls = Nulls.SKIP)
+        public Builder aliasList(@Nonnull Optional<ListAlias> aliasList) {
+            this.aliasList = Preconditions.checkNotNull(aliasList, "aliasList cannot be null");
+            return this;
+        }
+
+        public Builder aliasList(@Nonnull ListAlias aliasList) {
+            this.aliasList = Optional.of(Preconditions.checkNotNull(aliasList, "aliasList cannot be null"));
+            return this;
+        }
+
+        @JsonSetter(value = "aliasMap", nulls = Nulls.SKIP)
+        public Builder aliasMap(@Nonnull Optional<MapAliasExample> aliasMap) {
+            this.aliasMap = Preconditions.checkNotNull(aliasMap, "aliasMap cannot be null");
+            return this;
+        }
+
+        public Builder aliasMap(@Nonnull MapAliasExample aliasMap) {
+            this.aliasMap = Optional.of(Preconditions.checkNotNull(aliasMap, "aliasMap cannot be null"));
+            return this;
+        }
+
+        @JsonSetter(value = "aliasOptional", nulls = Nulls.AS_EMPTY)
+        public Builder aliasOptional(@Nonnull OptionalAlias aliasOptional) {
+            this.aliasOptional = Preconditions.checkNotNull(aliasOptional, "aliasOptional cannot be null");
+            return this;
+        }
+
+        @JsonSetter(value = "aliasOptionalMap", nulls = Nulls.AS_EMPTY)
+        public Builder aliasOptionalMap(@Nonnull OptionalMapAliasExample aliasOptionalMap) {
+            this.aliasOptionalMap = Preconditions.checkNotNull(aliasOptionalMap, "aliasOptionalMap cannot be null");
+            return this;
+        }
+
         public PrimitiveOptionalsExample build() {
-            return new PrimitiveOptionalsExample(num, bool, integer, safelong, rid, bearertoken, uuid);
+            return new PrimitiveOptionalsExample(
+                    num,
+                    bool,
+                    integer,
+                    safelong,
+                    rid,
+                    bearertoken,
+                    uuid,
+                    map,
+                    list,
+                    set,
+                    aliasOne,
+                    aliasTwo,
+                    aliasList,
+                    aliasMap,
+                    aliasOptional,
+                    aliasOptionalMap);
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
@@ -1,6 +1,7 @@
 package test.prefix.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -59,36 +60,43 @@ public final class PrimitiveOptionalsExample {
     }
 
     @JsonProperty("num")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public OptionalDouble getNum() {
         return this.num;
     }
 
     @JsonProperty("bool")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<Boolean> getBool() {
         return this.bool;
     }
 
     @JsonProperty("integer")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public OptionalInt getInteger() {
         return this.integer;
     }
 
     @JsonProperty("safelong")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<SafeLong> getSafelong() {
         return this.safelong;
     }
 
     @JsonProperty("rid")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<ResourceIdentifier> getRid() {
         return this.rid;
     }
 
     @JsonProperty("bearertoken")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<BearerToken> getBearertoken() {
         return this.bearertoken;
     }
 
     @JsonProperty("uuid")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<UUID> getUuid() {
         return this.uuid;
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.types;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -425,6 +426,11 @@ public final class BeanGenerator {
                         .addMember("value", "$S", field.fieldName().get())
                         .build())
                 .returns(field.poetSpec().type);
+        if (field.conjureDef().getType().accept(TypeVisitor.IS_OPTIONAL)) {
+            getterBuilder.addAnnotation(AnnotationSpec.builder(JsonInclude.class)
+                    .addMember("value", "$T.NON_ABSENT", JsonInclude.Include.class)
+                    .build());
+        }
 
         if (field.conjureDef().getType().accept(TypeVisitor.IS_BINARY) && !featureFlags.useImmutableBytes()) {
             getterBuilder.addStatement("return this.$N.asReadOnlyBuffer()", field.poetSpec().name);

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -31,6 +31,7 @@ import com.palantir.conjure.java.Options;
 import com.palantir.conjure.java.util.JavaNameSanitizer;
 import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.java.util.Packages;
+import com.palantir.conjure.java.util.TypeFunctions;
 import com.palantir.conjure.java.visitor.DefaultTypeVisitor;
 import com.palantir.conjure.spec.FieldDefinition;
 import com.palantir.conjure.spec.FieldName;
@@ -103,7 +104,7 @@ public final class BeanGenerator {
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                 .addFields(poetFields)
                 .addMethod(createConstructor(fields, poetFields))
-                .addMethods(createGetters(fields, options));
+                .addMethods(createGetters(fields, typesMap, options));
 
         if (!poetFields.isEmpty()) {
             typeBuilder
@@ -413,26 +414,42 @@ public final class BeanGenerator {
         return builder.build();
     }
 
-    private static Collection<MethodSpec> createGetters(Collection<EnrichedField> fields, Options featureFlags) {
+    private static Collection<MethodSpec> createGetters(
+            Collection<EnrichedField> fields,
+            Map<com.palantir.conjure.spec.TypeName, TypeDefinition> typesMap,
+            Options featureFlags) {
         return fields.stream()
-                .map(field -> BeanGenerator.createGetter(field, featureFlags))
+                .map(field -> BeanGenerator.createGetter(field, typesMap, featureFlags))
                 .collect(Collectors.toList());
     }
 
-    private static MethodSpec createGetter(EnrichedField field, Options featureFlags) {
+    private static MethodSpec createGetter(
+            EnrichedField field,
+            Map<com.palantir.conjure.spec.TypeName, TypeDefinition> typesMap,
+            Options featureFlags) {
         MethodSpec.Builder getterBuilder = MethodSpec.methodBuilder(field.getterName())
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(AnnotationSpec.builder(JsonProperty.class)
                         .addMember("value", "$S", field.fieldName().get())
                         .build())
                 .returns(field.poetSpec().type);
-        if (field.conjureDef().getType().accept(TypeVisitor.IS_OPTIONAL)) {
+        Type conjureDefType = field.conjureDef().getType();
+        if (conjureDefType.accept(TypeVisitor.IS_OPTIONAL)) {
+            // NON_ABSENT is most accurate for java Optional types (including OptionalDouble/OptionalInt, etc)
             getterBuilder.addAnnotation(AnnotationSpec.builder(JsonInclude.class)
                     .addMember("value", "$T.NON_ABSENT", JsonInclude.Include.class)
                     .build());
+        } else if (conjureDefType.accept(TypeVisitor.IS_REFERENCE)
+                && TypeFunctions.toConjureTypeWithoutAliases(conjureDefType, typesMap)
+                        .accept(TypeVisitor.IS_OPTIONAL)) {
+            // Aliases are special, as usual. Inclusion cannot take advantage of the optional delegate types,
+            // however the default (hidden no-arg constructor) can be leveraged using NON_EMPTY.
+            getterBuilder.addAnnotation(AnnotationSpec.builder(JsonInclude.class)
+                    .addMember("value", "$T.NON_EMPTY", JsonInclude.Include.class)
+                    .build());
         }
 
-        if (field.conjureDef().getType().accept(TypeVisitor.IS_BINARY) && !featureFlags.useImmutableBytes()) {
+        if (conjureDefType.accept(TypeVisitor.IS_BINARY) && !featureFlags.useImmutableBytes()) {
             getterBuilder.addStatement("return this.$N.asReadOnlyBuffer()", field.poetSpec().name);
         } else {
             getterBuilder.addStatement("return this.$N", field.poetSpec().name);

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -43,6 +43,7 @@ import com.palantir.product.MapExample;
 import com.palantir.product.OptionalAlias;
 import com.palantir.product.OptionalAliasExample;
 import com.palantir.product.OptionalExample;
+import com.palantir.product.PrimitiveOptionalsExample;
 import com.palantir.product.SetAlias;
 import com.palantir.product.SetExample;
 import com.palantir.product.StringAliasExample;
@@ -559,6 +560,28 @@ public final class WireFormatTests {
     public void testOptionalAliasExample() throws IOException {
         assertThat(mapper.readValue("{\"optionalAlias\":null}", OptionalAliasExample.class))
                 .isEqualTo(OptionalAliasExample.of(OptionalAlias.of(Optional.empty())));
+    }
+
+    @Test
+    public void testEmptyOptionalFieldSerialization() throws IOException {
+        assertThat(mapper.writeValueAsString(PrimitiveOptionalsExample.builder().build()))
+                .isEqualTo("{}");
+    }
+
+    @Test
+    public void testEmptyOptionalFieldSerializationOfAlias() throws IOException {
+        assertThat(mapper.writeValueAsString(OptionalAliasExample.builder()
+                        .optionalAlias(OptionalAlias.of(Optional.empty()))
+                        .build()))
+                .isEqualTo("{}");
+    }
+
+    @Test
+    public void testEmptyOptionalFieldSerializationOfAlias_emptyString() throws IOException {
+        assertThat(mapper.writeValueAsString(OptionalAliasExample.builder()
+                        .optionalAlias(OptionalAlias.of(Optional.of("")))
+                        .build()))
+                .isEqualTo("{\"optionalAlias\":\"\"}");
     }
 
     private static final class TestVisitor implements UnionTypeExample.Visitor<Integer> {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -43,10 +43,13 @@ import com.palantir.product.MapExample;
 import com.palantir.product.OptionalAlias;
 import com.palantir.product.OptionalAliasExample;
 import com.palantir.product.OptionalExample;
+import com.palantir.product.OptionalMapAliasExample;
 import com.palantir.product.PrimitiveOptionalsExample;
 import com.palantir.product.SetAlias;
 import com.palantir.product.SetExample;
 import com.palantir.product.StringAliasExample;
+import com.palantir.product.StringAliasOne;
+import com.palantir.product.StringAliasTwo;
 import com.palantir.product.StringExample;
 import com.palantir.product.UnionTypeExample;
 import com.palantir.product.UuidExample;
@@ -57,6 +60,8 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -564,8 +569,32 @@ public final class WireFormatTests {
 
     @Test
     public void testEmptyOptionalFieldSerialization() throws IOException {
-        assertThat(mapper.writeValueAsString(PrimitiveOptionalsExample.builder().build()))
+        assertThat(mapper.writeValueAsString(PrimitiveOptionalsExample.builder()
+                        .aliasTwo(StringAliasTwo.of(Optional.empty()))
+                        .aliasOptional(OptionalAlias.of(Optional.empty()))
+                        .aliasOptionalMap(OptionalMapAliasExample.of(Optional.empty()))
+                        .build()))
                 .isEqualTo("{}");
+    }
+
+    @Test
+    public void testEmptyOptionalFieldSerialization_nonEmptyValues() throws IOException {
+        PrimitiveOptionalsExample original = PrimitiveOptionalsExample.builder()
+                .num(OptionalDouble.of(0D))
+                .bool(Optional.of(Boolean.FALSE))
+                .integer(OptionalInt.of(0))
+                .map(ImmutableMap.of())
+                .list(ImmutableList.of())
+                .set(ImmutableSet.of())
+                .aliasOne(StringAliasOne.of(""))
+                .aliasTwo(StringAliasTwo.of(Optional.of(StringAliasOne.of(""))))
+                .aliasOptional(OptionalAlias.of(Optional.of("")))
+                .aliasOptionalMap(OptionalMapAliasExample.of(Optional.of(ImmutableMap.of())))
+                .aliasMap(MapAliasExample.of(ImmutableMap.of()))
+                .build();
+        PrimitiveOptionalsExample recreated =
+                mapper.readValue(mapper.writeValueAsBytes(original), PrimitiveOptionalsExample.class);
+        assertThat(recreated).isEqualTo(original);
     }
 
     @Test

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.types;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
@@ -43,7 +44,9 @@ import com.palantir.product.MapExample;
 import com.palantir.product.OptionalAlias;
 import com.palantir.product.OptionalAliasExample;
 import com.palantir.product.OptionalExample;
+import com.palantir.product.OptionalListAliasExample;
 import com.palantir.product.OptionalMapAliasExample;
+import com.palantir.product.OptionalSetAliasExample;
 import com.palantir.product.PrimitiveOptionalsExample;
 import com.palantir.product.SetAlias;
 import com.palantir.product.SetExample;
@@ -573,6 +576,8 @@ public final class WireFormatTests {
                         .aliasTwo(StringAliasTwo.of(Optional.empty()))
                         .aliasOptional(OptionalAlias.of(Optional.empty()))
                         .aliasOptionalMap(OptionalMapAliasExample.of(Optional.empty()))
+                        .aliasOptionalList(OptionalListAliasExample.of(Optional.empty()))
+                        .aliasOptionalSet(OptionalSetAliasExample.of(Optional.empty()))
                         .build()))
                 .isEqualTo("{}");
     }
@@ -590,11 +595,18 @@ public final class WireFormatTests {
                 .aliasTwo(StringAliasTwo.of(Optional.of(StringAliasOne.of(""))))
                 .aliasOptional(OptionalAlias.of(Optional.of("")))
                 .aliasOptionalMap(OptionalMapAliasExample.of(Optional.of(ImmutableMap.of())))
+                .aliasOptionalList(OptionalListAliasExample.of(Optional.of(ImmutableList.of())))
+                .aliasOptionalSet(OptionalSetAliasExample.of(Optional.of(ImmutableSet.of())))
                 .aliasMap(MapAliasExample.of(ImmutableMap.of()))
                 .build();
-        PrimitiveOptionalsExample recreated =
-                mapper.readValue(mapper.writeValueAsBytes(original), PrimitiveOptionalsExample.class);
-        assertThat(recreated).isEqualTo(original);
+        String json = mapper.writeValueAsString(original);
+        assertThat(mapper.readValue(json, new TypeReference<Map<String, Object>>() {}))
+                .as("Unexpected number of fields in '%s'", json)
+                .hasSize(13);
+        PrimitiveOptionalsExample recreated = mapper.readValue(json, PrimitiveOptionalsExample.class);
+        assertThat(recreated)
+                .as("Failed to recreate the original object using '%s'", json)
+                .isEqualTo(original);
     }
 
     @Test

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -116,6 +116,8 @@ types:
         alias: uuid
       MapAliasExample:
         alias: map<string, any>
+      OptionalMapAliasExample:
+        alias: optional<map<string, any>>
       ReferenceAliasExample:
         alias: AnyExample
       DateTimeAliasExample:
@@ -131,6 +133,15 @@ types:
           rid: optional<rid>
           bearertoken: optional<bearertoken>
           uuid: optional<uuid>
+          map: optional<map<string,string>>
+          list: optional<list<string>>
+          set: optional<set<string>>
+          aliasOne: optional<StringAliasOne>
+          aliasTwo: StringAliasTwo
+          aliasList: optional<ListAlias>
+          aliasMap: optional<MapAliasExample>
+          aliasOptional: OptionalAlias
+          aliasOptionalMap: OptionalMapAliasExample
       ExternalLongAliasExample:
         alias: ExternalLong
       ExternalStringAliasExample:

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -118,6 +118,10 @@ types:
         alias: map<string, any>
       OptionalMapAliasExample:
         alias: optional<map<string, any>>
+      OptionalListAliasExample:
+        alias: optional<list<string>>
+      OptionalSetAliasExample:
+        alias: optional<set<string>>
       ReferenceAliasExample:
         alias: AnyExample
       DateTimeAliasExample:
@@ -142,6 +146,8 @@ types:
           aliasMap: optional<MapAliasExample>
           aliasOptional: OptionalAlias
           aliasOptionalMap: OptionalMapAliasExample
+          aliasOptionalList: OptionalListAliasExample
+          aliasOptionalSet: OptionalSetAliasExample
       ExternalLongAliasExample:
         alias: ExternalLong
       ExternalStringAliasExample:


### PR DESCRIPTION
These fields are excluded entirely per the conjure spec:
https://github.com/palantir/conjure/blob/master/docs/spec/wire.md#561-coercing-json-null--absent-to-conjure-types

## Before this PR
Always send `{"filedName":null}`

## After this PR
Becomes `{}`.
==COMMIT_MSG==
Avoid sending empty optional values within generated objects.
==COMMIT_MSG==

## Possible downsides?
Risks:
Typescript/javascript clients will _receive_ `undefined` values
rather than `null`. Consumers which use `==` will not be impacted,
however those using `===` (and friends) _may break_.
I have verified that we have static analysis enabled to enforce the correct use of `==`,
so the risk only applies to cases where users have explicitly disabled the check, or
'splat' objects.

No risk for non-conjure objectmapper uses becuase we explicitly opt in with generated conjure objects.