### PR TITLE
Upgrade gradle-external-publish-plugin to fix published .bat scripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:0.4.10'
+        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.0.1'
         classpath 'com.palantir.gradle.conjure:gradle-conjure:4.27.2'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:2.0.1'
         classpath 'com.palantir.baseline:gradle-baseline-java:3.76.0'

--- a/changelog/@unreleased/pr-1308.v2.yml
+++ b/changelog/@unreleased/pr-1308.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix the .bat start script for the generator (used on Windows machines) to use the correct classpath.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1308


### PR DESCRIPTION
See https://github.com/palantir/gradle-external-publish-plugin/pull/4

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The .bat scripts in conjure-java generators failed for Windows users because the gradle-external-publish-plugin modified the scripts incorrectly while shortening their classpaths.

This failure would manifest as `Error: Could not find or load main class com.palantir.conjure.java.cli.ConjureJavaCli` when trying to run tasks like `compileConjureObjects`.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix the .bat start script for the generator (used on Windows machines) to use the correct classpath. 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
The upgrade may cause other changes I'm not aware of.
