### PR TITLE
The Incubating annotation uses runtime retention rather than class.

### DIFF
--- a/changelog/@unreleased/pr-1309.v2.yml
+++ b/changelog/@unreleased/pr-1309.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: The Inherited annotation uses runtime retention rather than class.
+  description: The Incubating annotation uses runtime retention rather than class.
   links:
   - https://github.com/palantir/conjure-java/pull/1309

--- a/changelog/@unreleased/pr-1309.v2.yml
+++ b/changelog/@unreleased/pr-1309.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: The Inherited annotation uses runtime retention rather than class.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1309

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/Incubating.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/Incubating.java
@@ -36,7 +36,7 @@ import java.lang.annotation.Target;
  *   returns: map<string, BackingFileSystem>
  * }</pre>
  */
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 @Documented
 public @interface Incubating {}


### PR DESCRIPTION
This allows runtime instrumentation to take incubating calls
into account. Originall the annotation used CLASS retention out
of an abundance of caution.
I plan to update metrics for our jersey interfaces to differentiate
incubating endpoints from their stable and deprecated brethren.

## After this PR
==COMMIT_MSG==
The Incubating annotation uses runtime retention rather than class.
==COMMIT_MSG==

## Possible downsides?
Very slightly broader API -- Incubating may be detected at runtime now.

