### PR TITLE
conjure-undertow validates exactly one Content-Type is received

### DIFF
--- a/changelog/@unreleased/pr-1312.v2.yml
+++ b/changelog/@unreleased/pr-1312.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: conjure-undertow validates exactly one Content-Type is received
+  links:
+  - https://github.com/palantir/conjure-java/pull/1312

--- a/changelog/@unreleased/pr-1312.v2.yml
+++ b/changelog/@unreleased/pr-1312.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: conjure-undertow validates exactly one Content-Type is received
+  description: conjure-undertow validates exactly one Content-Type is received, previously we validated that at least one value was received.
   links:
   - https://github.com/palantir/conjure-java/pull/1312

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -201,6 +201,16 @@ public final class UndertowServiceEteTest extends TestBase {
     }
 
     @Test
+    public void multipleContentTypeHeadersAreRejected() throws IOException {
+        HttpURLConnection httpUrlConnection = preparePostRequest();
+        httpUrlConnection.setRequestProperty("Authorization", "Bearer authheader");
+        // First Content-Type is already set by preparePostRequest
+        httpUrlConnection.addRequestProperty("Content-Type", "application/json");
+        sendPostRequestData(httpUrlConnection, CLIENT_OBJECT_MAPPER.writeValueAsString(StringAliasExample.of("foo")));
+        assertThat(httpUrlConnection.getResponseCode()).isEqualTo(400);
+    }
+
+    @Test
     public void java_url_client_receives_unauthorized_without_authheader() throws IOException {
         HttpURLConnection httpUrlConnection = preparePostRequest();
         sendPostRequestData(httpUrlConnection, CLIENT_OBJECT_MAPPER.writeValueAsString(StringAliasExample.of("foo")));

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -201,16 +201,6 @@ public final class UndertowServiceEteTest extends TestBase {
     }
 
     @Test
-    public void multipleContentTypeHeadersAreRejected() throws IOException {
-        HttpURLConnection httpUrlConnection = preparePostRequest();
-        httpUrlConnection.setRequestProperty("Authorization", "Bearer authheader");
-        // First Content-Type is already set by preparePostRequest
-        httpUrlConnection.addRequestProperty("Content-Type", "application/json");
-        sendPostRequestData(httpUrlConnection, CLIENT_OBJECT_MAPPER.writeValueAsString(StringAliasExample.of("foo")));
-        assertThat(httpUrlConnection.getResponseCode()).isEqualTo(400);
-    }
-
-    @Test
     public void java_url_client_receives_unauthorized_without_authheader() throws IOException {
         HttpURLConnection httpUrlConnection = preparePostRequest();
         sendPostRequestData(httpUrlConnection, CLIENT_OBJECT_MAPPER.writeValueAsString(StringAliasExample.of("foo")));

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
@@ -251,8 +251,8 @@ final class ConjureBodySerDe implements BodySerDe {
     }
 
     /**
-     * Gets the request {@code Content-Type} header if exactly one value exists, otherwise throws
-     * a {@link SafeIllegalArgumentException}. This prevents unexpected behavior when multiple
+     * Gets the request {@code Content-Type} header if exactly one value exists, otherwise logs
+     * a warning. This notifies us in the unexpected case when multiple
      * content-type headers are incorrectly sent to the server, it's not clear which should
      * be used.
      */

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
@@ -37,11 +37,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PushbackInputStream;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xnio.IoUtils;
 
 /** Package private internal API. */
 final class ConjureBodySerDe implements BodySerDe {
 
+    private static final Logger log = LoggerFactory.getLogger(ConjureBodySerDe.class);
     private static final String BINARY_CONTENT_TYPE = "application/octet-stream";
     private static final Splitter ACCEPT_VALUE_SPLITTER =
             Splitter.on(',').trimResults().omitEmptyStrings();
@@ -258,9 +261,10 @@ final class ConjureBodySerDe implements BodySerDe {
         if (contentTypeValues == null || contentTypeValues.isEmpty()) {
             throw new SafeIllegalArgumentException("Request is missing Content-Type header");
         } else if (contentTypeValues.size() != 1) {
-            throw new SafeIllegalArgumentException(
+            log.warn(
                     "Request has too many Content-Type headers",
                     SafeArg.of("contentTypes", ImmutableList.copyOf(contentTypeValues)));
+            return contentTypeValues.getFirst();
         }
         return contentTypeValues.get(0);
     }

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
@@ -84,10 +84,7 @@ final class ConjureBodySerDe implements BodySerDe {
 
     @Override
     public InputStream deserializeInputStream(HttpServerExchange exchange) {
-        String contentType = exchange.getRequestHeaders().getFirst(Headers.CONTENT_TYPE);
-        if (contentType == null) {
-            throw new SafeIllegalArgumentException("Request is missing Content-Type header");
-        }
+        String contentType = getContentType(exchange);
         if (!contentType.startsWith(BINARY_CONTENT_TYPE)) {
             throw FrameworkException.unsupportedMediaType(
                     "Unsupported Content-Type", SafeArg.of("Content-Type", contentType));
@@ -203,10 +200,7 @@ final class ConjureBodySerDe implements BodySerDe {
         /** Returns the {@link EncodingDeserializerContainer} to use to deserialize the request body. */
         @SuppressWarnings("ForLoopReplaceableByForEach") // performance sensitive code avoids iterator allocation
         EncodingDeserializerContainer<T> getRequestDeserializer(HttpServerExchange exchange) {
-            String contentType = exchange.getRequestHeaders().getFirst(Headers.CONTENT_TYPE);
-            if (contentType == null) {
-                throw new SafeIllegalArgumentException("Request is missing Content-Type header");
-            }
+            String contentType = getContentType(exchange);
             for (int i = 0; i < encodings.size(); i++) {
                 EncodingDeserializerContainer<T> container = encodings.get(i);
                 if (container.encoding.supportsContentType(contentType)) {
@@ -251,5 +245,23 @@ final class ConjureBodySerDe implements BodySerDe {
             adapter.tag(target, "type", "BinaryResponseBody");
             adapter.tag(target, "contentType", BINARY_CONTENT_TYPE);
         }
+    }
+
+    /**
+     * Gets the request {@code Content-Type} header if exactly one value exists, otherwise throws
+     * a {@link SafeIllegalArgumentException}. This prevents unexpected behavior when multiple
+     * content-type headers are incorrectly sent to the server, it's not clear which should
+     * be used.
+     */
+    private static String getContentType(HttpServerExchange exchange) {
+        HeaderValues contentTypeValues = exchange.getRequestHeaders().get(Headers.CONTENT_TYPE);
+        if (contentTypeValues == null || contentTypeValues.isEmpty()) {
+            throw new SafeIllegalArgumentException("Request is missing Content-Type header");
+        } else if (contentTypeValues.size() != 1) {
+            throw new SafeIllegalArgumentException(
+                    "Request has too many Content-Type headers",
+                    SafeArg.of("contentTypes", ImmutableList.copyOf(contentTypeValues)));
+        }
+        return contentTypeValues.get(0);
     }
 }


### PR DESCRIPTION
## Before this PR
Missing validation, allowing invalid requests to potentially succeed, or fail in an unexpected way.

## After this PR
==COMMIT_MSG==
conjure-undertow validates exactly one Content-Type is received
==COMMIT_MSG==

## Possible downsides?
Requests will fail if this was working as expected.
