### PR TITLE
conjure-undertow uses tracing tags rather than expressive operation names

### DIFF
--- a/changelog/@unreleased/pr-1319.v2.yml
+++ b/changelog/@unreleased/pr-1319.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: conjure-undertow uses tracing tags rather than expressive operation names
+  links:
+  - https://github.com/palantir/conjure-java/pull/1319

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/CompletedRequestTagTranslator.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/CompletedRequestTagTranslator.java
@@ -1,0 +1,46 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import com.palantir.tracing.TagTranslator;
+import com.palantir.tracing.undertow.TracingAttachments;
+import io.undertow.server.HttpServerExchange;
+
+/** Request tracing {@link TagTranslator} which applies tag data to a top level request span. */
+enum CompletedRequestTagTranslator implements TagTranslator<HttpServerExchange> {
+    INSTANCE;
+
+    @Override
+    public <T> void translate(TagAdapter<T> adapter, T target, HttpServerExchange exchange) {
+        String maybeRequestId = exchange.getAttachment(TracingAttachments.REQUEST_ID);
+        if (maybeRequestId != null) {
+            adapter.tag(target, "requestId", maybeRequestId);
+        }
+        adapter.tag(target, "status", statusString(exchange.getStatusCode()));
+    }
+
+    static String statusString(int statusCode) {
+        // handle common cases quickly
+        switch (statusCode) {
+            case 200:
+                return "200";
+            case 204:
+                return "204";
+        }
+        return Integer.toString(statusCode);
+    }
+}

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
@@ -247,7 +247,7 @@ final class ConjureBodySerDe implements BodySerDe {
         INSTANCE;
 
         @Override
-        public <T> void translate(TagAdapter<T> adapter, T target, Object data) {
+        public <T> void translate(TagAdapter<T> adapter, T target, Object _data) {
             adapter.tag(target, "type", "BinaryResponseBody");
             adapter.tag(target, "contentType", BINARY_CONTENT_TYPE);
         }

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/EndpointTagTranslator.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/EndpointTagTranslator.java
@@ -1,0 +1,66 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.tracing.TagTranslator;
+import io.undertow.server.HttpServerExchange;
+
+/** A {@link TagTranslator} which populates {@link Endpoint} metadata. */
+final class EndpointTagTranslator implements TagTranslator<HttpServerExchange> {
+
+    private final String serviceName;
+    private final String endpointName;
+    private final String httpMethod;
+    private final String httpPath;
+    private final boolean deprecated;
+    private final boolean incubating;
+
+    EndpointTagTranslator(Endpoint endpoint) {
+        this.serviceName = endpoint.serviceName();
+        this.endpointName = endpoint.name();
+        this.httpMethod = endpoint.method().toString();
+        this.httpPath = endpoint.template();
+        this.deprecated = endpoint.deprecated().isPresent();
+        this.incubating = endpoint.tags().contains("incubating");
+    }
+
+    @Override
+    public <T> void translate(TagAdapter<T> adapter, T target, HttpServerExchange _data) {
+        adapter.tag(target, "serviceName", serviceName);
+        adapter.tag(target, "endpointName", endpointName);
+        adapter.tag(target, "method", httpMethod);
+        adapter.tag(target, "path", httpPath);
+        if (deprecated) {
+            adapter.tag(target, "deprecated", "true");
+        }
+        if (incubating) {
+            adapter.tag(target, "incubating", "true");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "TracedRequestTagTranslator{serviceName='"
+                + serviceName + "', endpointName='"
+                + endpointName + "', httpMethod='"
+                + httpMethod + "', httpPath='"
+                + httpPath + "', deprecated="
+                + deprecated + ", incubating="
+                + incubating + "}";
+    }
+}

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/TracedEncoding.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/TracedEncoding.java
@@ -27,6 +27,9 @@ import java.lang.reflect.Type;
 /** Encoding implementation which wraps serialization and deserialization with tracing spans. */
 final class TracedEncoding implements Encoding {
 
+    static final String DESERIALIZE_OPERATION = "Undertow: deserialize";
+    static final String SERIALIZE_OPERATION = "Undertow: serialize";
+
     private final Encoding encoding;
 
     private TracedEncoding(Encoding encoding) {
@@ -39,19 +42,17 @@ final class TracedEncoding implements Encoding {
 
     @Override
     public <T> Serializer<T> serializer(TypeMarker<T> type) {
-        String operation = "Undertow: serialize";
         return new TracedSerializer<>(
                 encoding.serializer(type),
-                operation,
+                SERIALIZE_OPERATION,
                 ImmutableMap.of("type", toString(type), "contentType", getContentType()));
     }
 
     @Override
     public <T> Deserializer<T> deserializer(TypeMarker<T> type) {
-        String operation = "Undertow: deserialize";
         return new TracedDeserializer<>(
                 encoding.deserializer(type),
-                operation,
+                DESERIALIZE_OPERATION,
                 ImmutableMap.of("type", toString(type), "contentType", getContentType()));
     }
 


### PR DESCRIPTION
This should allow tracing information to be more easily searchable
using dd APM and similar tools.

==COMMIT_MSG==
conjure-undertow uses tracing tags rather than expressive operation names
==COMMIT_MSG==

## Possible downsides?
Some tooling may not support tags as well as others?
