### PR TITLE
Document server-request-context, no longer beta

### DIFF
--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/Contexts.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/Contexts.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.java.undertow.lib;
 
-import com.google.common.annotations.Beta;
 import io.undertow.server.HttpServerExchange;
 
 /**
@@ -24,7 +23,6 @@ import io.undertow.server.HttpServerExchange;
  * This is an internal interface that should only be used by generated code, it may change without
  * warning, and guarantees are only made for generated code.
  */
-@Beta
 public interface Contexts {
 
     /** Returns a new {@link RequestContext} which describes the incoming request. */

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.java.undertow.lib;
 
-import com.google.common.annotations.Beta;
 import com.google.common.collect.ListMultimap;
 import com.palantir.logsafe.Arg;
 import java.util.List;
@@ -26,7 +25,6 @@ import java.util.Optional;
  * Interface providing a view over data provided by the the original HTTP request including request headers and query
  * parameters. This is a read only interface which should only be implemented by {@code conjure-java-undertow-runtime}.
  */
-@Beta
 public interface RequestContext {
 
     /**

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ The recommended way to use conjure-java is via a build tool like [gradle-conjure
 #### Endpoint Tags
 
 * `incubating`: Describes an endpoint as incubating and likely to change. These endpoints are generated with an `@Incubating` annotation.
-* `server-request-context`: Opt into an additional `RequestContext` parameter in conjure-undertow interfaces, which allows request metadata to be read, and additional arguments to be associated with the request log.
+* `server-request-context`: Opt into an additional [RequestContext](conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java) parameter in conjure-undertow interfaces, which allows request metadata to be read, and additional arguments to be associated with the request log.
 * `server-async`: Opt into asynchronous request processing in conjure-undertow. The generated interface returns a `ListenableFuture` of the defined return type, allowing processing to occur in the background without blocking the request thread.
 
 #### Endpoint Argument Tags

--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ The recommended way to use conjure-java is via a build tool like [gradle-conjure
 
 * `incubating`: Describes an endpoint as incubating and likely to change. These endpoints are generated with an `@Incubating` annotation.
 * `server-request-context`: Opt into an additional [RequestContext](conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java) parameter in conjure-undertow interfaces, which allows request metadata to be read, and additional arguments to be associated with the request log.
-* `server-async`: Opt into asynchronous request processing in conjure-undertow. The generated interface returns a `ListenableFuture` of the defined return type, allowing processing to occur in the background without blocking the request thread.
+* `server-async`: Opt into (#asynchronous-request-processing) in conjure-undertow. The generated interface returns a `ListenableFuture` of the defined return type, allowing processing to occur in the background without blocking the request thread.
 
 #### Endpoint Argument Tags
 


### PR DESCRIPTION
Add documentation for known tag values implemented by conjure-java.

==COMMIT_MSG==
Document server-request-context, no longer beta
==COMMIT_MSG==
