### PR TITLE
Server request context provides an accessor for peer certificates

### DIFF
--- a/changelog/@unreleased/pr-1359.v2.yml
+++ b/changelog/@unreleased/pr-1359.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Server request context provides an accessor for peer certificates
+  links:
+  - https://github.com/palantir/conjure-java/pull/1359

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
@@ -87,16 +87,16 @@ final class ConjureContexts implements Contexts {
         }
 
         @Override
-        public Optional<ImmutableList<Certificate>> peerCertificates() {
+        public ImmutableList<Certificate> peerCertificates() {
             SSLSession sslSession = exchange.getConnection().getSslSession();
             if (sslSession != null) {
                 try {
-                    return Optional.of(ImmutableList.copyOf(sslSession.getPeerCertificates()));
+                    return ImmutableList.copyOf(sslSession.getPeerCertificates());
                 } catch (SSLPeerUnverifiedException e) {
                     log.debug("Failed to extract peer certificates", e);
                 }
             }
-            return Optional.empty();
+            return ImmutableList.of();
         }
 
         private ImmutableListMultimap<String, String> buildQueryParameters() {

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
@@ -24,13 +24,19 @@ import com.palantir.conjure.java.undertow.lib.RequestContext;
 import com.palantir.logsafe.Arg;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderValues;
+import java.security.cert.Certificate;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class ConjureContexts implements Contexts {
+    private static final Logger log = LoggerFactory.getLogger(ConjureContexts.class);
     private final RequestArgHandler requestArgHandler;
 
     ConjureContexts(RequestArgHandler requestArgHandler) {
@@ -78,6 +84,19 @@ final class ConjureContexts implements Contexts {
         @Override
         public void requestArg(Arg<?> arg) {
             requestArgHandler.arg(exchange, arg);
+        }
+
+        @Override
+        public Optional<ImmutableList<Certificate>> peerCertificates() {
+            SSLSession sslSession = exchange.getConnection().getSslSession();
+            if (sslSession != null) {
+                try {
+                    return Optional.of(ImmutableList.copyOf(sslSession.getPeerCertificates()));
+                } catch (SSLPeerUnverifiedException e) {
+                    log.debug("Failed to extract peer certificates", e);
+                }
+            }
+            return Optional.empty();
         }
 
         private ImmutableListMultimap<String, String> buildQueryParameters() {

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
@@ -54,6 +54,8 @@ public interface RequestContext {
 
     /**
      * Returns the client certificates associated with the connection used to make the current request.
+     * If the connection did not use TLS with client certificate authentication, an {@link ImmutableList#of() empty}
+     * list will be returned.
      */
-    Optional<ImmutableList<Certificate>> peerCertificates();
+    ImmutableList<Certificate> peerCertificates();
 }

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
@@ -55,7 +55,10 @@ public interface RequestContext {
     /**
      * Returns the client certificates associated with the connection used to make the current request.
      * If the connection did not use TLS with client certificate authentication, an {@link ImmutableList#of() empty}
-     * list will be returned.
+     * list will be returned. Otherwise the result is equivalent to
+     * {@link javax.net.ssl.SSLSession#getPeerCertificates()}.
+     *
+     * @see javax.net.ssl.SSLSession#getPeerCertificates()
      */
     ImmutableList<Certificate> peerCertificates();
 }

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
@@ -16,8 +16,10 @@
 
 package com.palantir.conjure.java.undertow.lib;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import com.palantir.logsafe.Arg;
+import java.security.cert.Certificate;
 import java.util.List;
 import java.util.Optional;
 
@@ -49,4 +51,9 @@ public interface RequestContext {
      * Implementations may choose to include this data in the request log.
      */
     void requestArg(Arg<?> arg);
+
+    /**
+     * Returns the client certificates associated with the connection used to make the current request.
+     */
+    Optional<ImmutableList<Certificate>> peerCertificates();
 }


### PR DESCRIPTION
==COMMIT_MSG==
Server request context provides an accessor for peer certificates
==COMMIT_MSG==

Ideally we'd have test coverage, but this is a very thin shim over the undertow/java security APIs. We don't currently do any TLS testing with conjure-undertow in this repo.