### PR TITLE
Fix: Emit bean fields in the same order as the builder stages

### DIFF
--- a/changelog/@unreleased/pr-1369.v2.yml
+++ b/changelog/@unreleased/pr-1369.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Emit bean fields in the same order as the builder stages
+  links:
+  - https://github.com/palantir/conjure-java/pull/1369

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -99,7 +99,12 @@ public final class BeanBuilderGenerator {
             ObjectDefinition typeDef,
             Map<com.palantir.conjure.spec.TypeName, TypeDefinition> typesMap,
             Optional<ClassName> builderInterfaceClass) {
-        Collection<EnrichedField> enrichedFields = enrichFields(typeDef.getFields());
+        ImmutableList<EnrichedField> enrichedFields = enrichFields(typeDef.getFields());
+        if (options.useStagedBuilders()) {
+            enrichedFields =
+                    BeanGenerator.sortedEnrichedFields(enrichedFields).collect(ImmutableList.toImmutableList());
+        }
+
         Collection<FieldSpec> poetFields = EnrichedField.toPoetSpecs(enrichedFields);
 
         TypeSpec.Builder builder = TypeSpec.classBuilder(
@@ -207,8 +212,8 @@ public final class BeanBuilderGenerator {
         return "_" + JavaNameSanitizer.sanitize(field.conjureDef().getFieldName()) + "Initialized";
     }
 
-    private Collection<EnrichedField> enrichFields(List<FieldDefinition> fields) {
-        return fields.stream().map(e -> createField(e.getFieldName(), e)).collect(Collectors.toList());
+    private ImmutableList<EnrichedField> enrichFields(List<FieldDefinition> fields) {
+        return fields.stream().map(e -> createField(e.getFieldName(), e)).collect(ImmutableList.toImmutableList());
     }
 
     private static MethodSpec createConstructor() {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -87,6 +87,10 @@ public final class BeanGenerator {
             Map<com.palantir.conjure.spec.TypeName, TypeDefinition> typesMap,
             Options options) {
         ImmutableList<EnrichedField> fields = createFields(typeMapper, typeDef.getFields());
+        if (options.useStagedBuilders()) {
+            fields = sortedEnrichedFields(fields).collect(ImmutableList.toImmutableList());
+        }
+
         ImmutableList<FieldSpec> poetFields = EnrichedField.toPoetSpecs(fields);
         ImmutableList<EnrichedField> nonPrimitiveEnrichedFields =
                 fields.stream().filter(field -> !field.isPrimitive()).collect(ImmutableList.toImmutableList());
@@ -224,7 +228,7 @@ public final class BeanGenerator {
      * Sorts input fields in the order they should be applied to the builder: Original order with required
      * fields prior to optional/collection values.
      */
-    private static Stream<EnrichedField> sortedEnrichedFields(ImmutableList<EnrichedField> enrichedFields) {
+    static Stream<EnrichedField> sortedEnrichedFields(ImmutableList<EnrichedField> enrichedFields) {
         return enrichedFields.stream()
                 .sorted(Comparator.comparing(BeanGenerator::fieldShouldBeInFinalStage)
                         .thenComparing(enrichedFields::indexOf));


### PR DESCRIPTION
## Before this PR
When using the staged builder feature We would emit fields on the bean in a different order than the stages in the builder

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Emit bean fields in the same order as the builder stages
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

