### PR TITLE
Revert default optional field handling to serialize a null value

### DIFF
--- a/changelog/@unreleased/pr-1375.v2.yml
+++ b/changelog/@unreleased/pr-1375.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Revert default optional field handling to serialize a null value
+  links:
+  - https://github.com/palantir/conjure-java/pull/1375

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
@@ -111,6 +111,14 @@ public interface Options {
         return false;
     }
 
+    /**
+     * Generated objects which exclude fields with empty optional values.
+     */
+    @Value.Default
+    default boolean excludeEmptyOptionals() {
+        return false;
+    }
+
     Optional<String> packagePrefix();
 
     Optional<String> apiVersion();

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -518,6 +518,7 @@ public final class UndertowServiceEteTest extends TestBase {
         Options options = Options.builder()
                 .undertowServicePrefix(true)
                 .nonNullCollections(true)
+                .excludeEmptyOptionals(true)
                 .build();
         List<Path> files = new GenerationCoordinator(
                         MoreExecutors.directExecutor(),

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
@@ -51,6 +51,7 @@ public final class ObjectGeneratorTests {
                                 .useImmutableBytes(true)
                                 .strictObjects(true)
                                 .nonNullCollections(true)
+                                .excludeEmptyOptionals(true)
                                 .build())))
                 .emit(def, tempDir);
 
@@ -62,7 +63,9 @@ public final class ObjectGeneratorTests {
         ConjureDefinition def =
                 Conjure.parse(ImmutableList.of(new File("src/test/resources/example-binary-types.yml")));
         List<Path> files = new GenerationCoordinator(
-                        MoreExecutors.directExecutor(), ImmutableSet.of(new ObjectGenerator(Options.empty())))
+                        MoreExecutors.directExecutor(),
+                        ImmutableSet.of(new ObjectGenerator(
+                                Options.builder().excludeEmptyOptionals(true).build())))
                 .emit(def, tempDir);
 
         assertThatFilesAreTheSame(files, REFERENCE_FILES_FOLDER);
@@ -73,8 +76,10 @@ public final class ObjectGeneratorTests {
         ConjureDefinition def = Conjure.parse(ImmutableList.of(new File("src/test/resources/example-types.yml")));
         List<Path> files = new GenerationCoordinator(
                         MoreExecutors.directExecutor(),
-                        ImmutableSet.of(new ObjectGenerator(
-                                Options.builder().packagePrefix("test.prefix").build())))
+                        ImmutableSet.of(new ObjectGenerator(Options.builder()
+                                .packagePrefix("test.prefix")
+                                .excludeEmptyOptionals(true)
+                                .build())))
                 .emit(def, tempDir);
 
         assertThatFilesAreTheSame(files, REFERENCE_FILES_FOLDER);
@@ -86,8 +91,10 @@ public final class ObjectGeneratorTests {
                 Conjure.parse(ImmutableList.of(new File("src/test/resources/example-staged-types.yml")));
         List<Path> files = new GenerationCoordinator(
                         MoreExecutors.directExecutor(),
-                        ImmutableSet.of(new ObjectGenerator(
-                                Options.builder().useStagedBuilders(true).build())))
+                        ImmutableSet.of(new ObjectGenerator(Options.builder()
+                                .useStagedBuilders(true)
+                                .excludeEmptyOptionals(true)
+                                .build())))
                 .emit(def, tempDir);
 
         assertThatFilesAreTheSame(files, REFERENCE_FILES_FOLDER);
@@ -102,8 +109,10 @@ public final class ObjectGeneratorTests {
         File src = Files.createDirectory(tempDir.toPath().resolve("src")).toFile();
         new GenerationCoordinator(
                         MoreExecutors.directExecutor(),
-                        ImmutableSet.of(new ObjectGenerator(
-                                Options.builder().useImmutableBytes(true).build())))
+                        ImmutableSet.of(new ObjectGenerator(Options.builder()
+                                .useImmutableBytes(true)
+                                .excludeEmptyOptionals(true)
+                                .build())))
                 .emit(conjure, src);
 
         // Generated files contain imports
@@ -121,8 +130,10 @@ public final class ObjectGeneratorTests {
         ConjureDefinition def = Conjure.parse(ImmutableList.of(new File("src/test/resources/example-errors.yml")));
         List<Path> files = new GenerationCoordinator(
                         MoreExecutors.directExecutor(),
-                        ImmutableSet.of(new ErrorGenerator(
-                                Options.builder().useImmutableBytes(true).build())))
+                        ImmutableSet.of(new ErrorGenerator(Options.builder()
+                                .useImmutableBytes(true)
+                                .excludeEmptyOptionals(true)
+                                .build())))
                 .emit(def, tempDir);
 
         assertThatFilesAreTheSame(files, REFERENCE_FILES_FOLDER);

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -189,6 +189,12 @@ public final class ConjureJavaCli implements Runnable {
                 description = "Generates compile-time safe builders to ensure all required attributes are set.")
         private boolean useStagedBuilders;
 
+        @CommandLine.Option(
+                names = "--excludeEmptyOptionals",
+                defaultValue = "false",
+                description = "Objects exclude empty optionals in serialization based on the conjure spec.")
+        private boolean excludeEmptyOptionals;
+
         @SuppressWarnings("unused")
         @CommandLine.Unmatched
         private List<String> unmatchedOptions;
@@ -254,6 +260,7 @@ public final class ConjureJavaCli implements Runnable {
                             .packagePrefix(Optional.ofNullable(packagePrefix))
                             .apiVersion(Optional.ofNullable(apiVersion))
                             .useStagedBuilders(useStagedBuilders)
+                            .excludeEmptyOptionals(excludeEmptyOptionals)
                             .build())
                     .build();
         }


### PR DESCRIPTION
This reverts the default behavior to serialize empty optional
values as null until Typescript uses can be cleaned up to use
the provided type information from the typescript generator.

## This is meant to be reverted within the next month

==COMMIT_MSG==
Revert default optional field handling to serialize a null value
==COMMIT_MSG==

## Possible downsides?
More backcompat p0s

