### PR TITLE
NPE in deserialization results in a 400 response status

### DIFF
--- a/changelog/@unreleased/pr-1381.v2.yml
+++ b/changelog/@unreleased/pr-1381.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: NPE in deserialization results in a 400 response status
+  links:
+  - https://github.com/palantir/conjure-java/pull/1381

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteEndpoints.java
@@ -974,5 +974,38 @@ enum DialogueEteEndpoints implements Endpoint {
         public String version() {
             return "1.2.3";
         }
+    },
+
+    receiveListOfStrings {
+        private final PathTemplate pathTemplate = PathTemplate.builder()
+                .fixed("base")
+                .fixed("list")
+                .fixed("strings")
+                .build();
+
+        @Override
+        public void renderPath(Map<String, String> params, UrlBuilder url) {
+            pathTemplate.fill(params, url);
+        }
+
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.PUT;
+        }
+
+        @Override
+        public String serviceName() {
+            return "EteService";
+        }
+
+        @Override
+        public String endpointName() {
+            return "receiveListOfStrings";
+        }
+
+        @Override
+        public String version() {
+            return "1.2.3";
+        }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
@@ -225,6 +225,12 @@ public interface EteService {
     void receiveSetOfOptionals(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader, @NotNull Set<Optional<String>> value);
 
+    @PUT
+    @Path("base/list/strings")
+    @ClientEndpoint(method = "PUT", path = "/base/list/strings")
+    void receiveListOfStrings(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader, @NotNull List<String> value);
+
     @Deprecated
     @ClientEndpoint(method = "GET", path = "/base/optionalExternalLong")
     default Optional<Long> optionalExternalLongQuery(AuthHeader authHeader) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceAsync.java
@@ -237,6 +237,12 @@ public interface EteServiceAsync {
     ListenableFuture<Void> receiveSetOfOptionals(AuthHeader authHeader, Set<Optional<String>> value);
 
     /**
+     * @apiNote {@code PUT /base/list/strings}
+     */
+    @ClientEndpoint(method = "PUT", path = "/base/list/strings")
+    ListenableFuture<Void> receiveListOfStrings(AuthHeader authHeader, List<String> value);
+
+    /**
      * Creates an asynchronous/non-blocking client for a EteService service.
      */
     static EteServiceAsync of(EndpointChannelFactory _endpointChannelFactory, ConjureRuntime _runtime) {
@@ -429,6 +435,15 @@ public interface EteServiceAsync {
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.receiveSetOfOptionals);
 
             private final Deserializer<Void> receiveSetOfOptionalsDeserializer =
+                    _runtime.bodySerDe().emptyBodyDeserializer();
+
+            private final Serializer<List<String>> receiveListOfStringsSerializer =
+                    _runtime.bodySerDe().serializer(new TypeMarker<List<String>>() {});
+
+            private final EndpointChannel receiveListOfStringsChannel =
+                    _endpointChannelFactory.endpoint(DialogueEteEndpoints.receiveListOfStrings);
+
+            private final Deserializer<Void> receiveListOfStringsDeserializer =
                     _runtime.bodySerDe().emptyBodyDeserializer();
 
             @Override
@@ -724,6 +739,15 @@ public interface EteServiceAsync {
                 _request.body(receiveSetOfOptionalsSerializer.serialize(value));
                 return _runtime.clients()
                         .call(receiveSetOfOptionalsChannel, _request.build(), receiveSetOfOptionalsDeserializer);
+            }
+
+            @Override
+            public ListenableFuture<Void> receiveListOfStrings(AuthHeader authHeader, List<String> value) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.body(receiveListOfStringsSerializer.serialize(value));
+                return _runtime.clients()
+                        .call(receiveListOfStringsChannel, _request.build(), receiveListOfStringsDeserializer);
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceBlocking.java
@@ -233,6 +233,12 @@ public interface EteServiceBlocking {
     void receiveSetOfOptionals(AuthHeader authHeader, Set<Optional<String>> value);
 
     /**
+     * @apiNote {@code PUT /base/list/strings}
+     */
+    @ClientEndpoint(method = "PUT", path = "/base/list/strings")
+    void receiveListOfStrings(AuthHeader authHeader, List<String> value);
+
+    /**
      * Creates a synchronous/blocking client for a EteService service.
      */
     static EteServiceBlocking of(EndpointChannelFactory _endpointChannelFactory, ConjureRuntime _runtime) {
@@ -425,6 +431,15 @@ public interface EteServiceBlocking {
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.receiveSetOfOptionals);
 
             private final Deserializer<Void> receiveSetOfOptionalsDeserializer =
+                    _runtime.bodySerDe().emptyBodyDeserializer();
+
+            private final Serializer<List<String>> receiveListOfStringsSerializer =
+                    _runtime.bodySerDe().serializer(new TypeMarker<List<String>>() {});
+
+            private final EndpointChannel receiveListOfStringsChannel =
+                    _endpointChannelFactory.endpoint(DialogueEteEndpoints.receiveListOfStrings);
+
+            private final Deserializer<Void> receiveListOfStringsDeserializer =
                     _runtime.bodySerDe().emptyBodyDeserializer();
 
             @Override
@@ -720,6 +735,15 @@ public interface EteServiceBlocking {
                 _runtime.clients()
                         .callBlocking(
                                 receiveSetOfOptionalsChannel, _request.build(), receiveSetOfOptionalsDeserializer);
+            }
+
+            @Override
+            public void receiveListOfStrings(AuthHeader authHeader, List<String> value) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.body(receiveListOfStringsSerializer.serialize(value));
+                _runtime.clients()
+                        .callBlocking(receiveListOfStringsChannel, _request.build(), receiveListOfStringsDeserializer);
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
@@ -73,7 +73,8 @@ public final class EteServiceEndpoints implements UndertowService {
                 new AliasLongEndpointEndpoint(runtime, delegate),
                 new ComplexQueryParametersEndpoint(runtime, delegate),
                 new ReceiveListOfOptionalsEndpoint(runtime, delegate),
-                new ReceiveSetOfOptionalsEndpoint(runtime, delegate));
+                new ReceiveSetOfOptionalsEndpoint(runtime, delegate),
+                new ReceiveListOfStringsEndpoint(runtime, delegate));
     }
 
     private static final class StringEndpoint implements HttpHandler, Endpoint {
@@ -1536,6 +1537,53 @@ public final class EteServiceEndpoints implements UndertowService {
         @Override
         public String name() {
             return "receiveSetOfOptionals";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class ReceiveListOfStringsEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final UndertowEteService delegate;
+
+        private final Deserializer<ImmutableList<String>> deserializer;
+
+        ReceiveListOfStringsEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<ImmutableList<String>>() {});
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            List<String> value = deserializer.deserialize(exchange);
+            delegate.receiveListOfStrings(authHeader, value);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.PUT;
+        }
+
+        @Override
+        public String template() {
+            return "/base/list/strings";
+        }
+
+        @Override
+        public String serviceName() {
+            return "EteService";
+        }
+
+        @Override
+        public String name() {
+            return "receiveListOfStrings";
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
@@ -215,6 +215,12 @@ public interface EteServiceRetrofit {
     ListenableFuture<Void> receiveSetOfOptionals(
             @Header("Authorization") AuthHeader authHeader, @Body Set<Optional<String>> value);
 
+    @PUT("./base/list/strings")
+    @Headers({"hr-path-template: /base/list/strings", "Accept: application/json"})
+    @ClientEndpoint(method = "PUT", path = "/base/list/strings")
+    ListenableFuture<Void> receiveListOfStrings(
+            @Header("Authorization") AuthHeader authHeader, @Body List<String> value);
+
     @Deprecated
     @ClientEndpoint(method = "GET", path = "/base/optionalExternalLong")
     default ListenableFuture<Optional<Long>> optionalExternalLongQuery(@Header("Authorization") AuthHeader authHeader) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
@@ -177,4 +177,9 @@ public interface UndertowEteService {
      * @apiNote {@code PUT /base/set/optionals}
      */
     void receiveSetOfOptionals(AuthHeader authHeader, Set<Optional<String>> value);
+
+    /**
+     * @apiNote {@code PUT /base/list/strings}
+     */
+    void receiveListOfStrings(AuthHeader authHeader, List<String> value);
 }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/EteResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/EteResource.java
@@ -193,5 +193,8 @@ public class EteResource implements EteService {
     @Override
     public void receiveSetOfOptionals(AuthHeader _authHeader, Set<Optional<String>> _value) {}
 
+    @Override
+    public void receiveListOfStrings(AuthHeader _authHeader, List<String> _value) {}
+
     interface Streaming extends StreamingOutput, BinaryResponseBody {}
 }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -509,6 +509,14 @@ public final class UndertowServiceEteTest extends TestBase {
                 .isEqualTo(SimpleEnum.VALUE);
     }
 
+    @Test
+    public void testListOfNull() {
+        assertThatThrownBy(() ->
+                        client.receiveListOfStrings(AuthHeader.valueOf("authHeader"), Collections.singletonList(null)))
+                .isInstanceOfSatisfying(
+                        RemoteException.class, re -> assertThat(re.getStatus()).isEqualTo(400));
+    }
+
     @BeforeAll
     public static void beforeClass() throws IOException {
         ConjureDefinition def = Conjure.parse(ImmutableList.of(

--- a/conjure-java-core/src/test/resources/ete-service.yml
+++ b/conjure-java-core/src/test/resources/ete-service.yml
@@ -236,3 +236,8 @@ services:
         http: PUT /set/optionals
         args:
           value: set<optional<string>>
+
+      receiveListOfStrings:
+        http: PUT /list/strings
+        args:
+          value: list<string>

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encodings.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encodings.java
@@ -95,6 +95,7 @@ public final class Encodings {
                             SafeArg.of("type", type));
                 } catch (JsonParseException | NullPointerException e) {
                     // JsonParseException is thrown when the input cannot be parsed as JSON, for example '{"value"}'.
+                    // NPE is often thrown when an unexpected `null` is contained within the request, e.g. '[null]'.
                     throw new SafeIllegalArgumentException(
                             "Failed to parse request due to malformed content",
                             e,

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encodings.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encodings.java
@@ -93,7 +93,7 @@ public final class Encodings {
                             e,
                             SafeArg.of("contentType", getContentType()),
                             SafeArg.of("type", type));
-                } catch (JsonParseException e) {
+                } catch (JsonParseException | NullPointerException e) {
                     // JsonParseException is thrown when the input cannot be parsed as JSON, for example '{"value"}'.
                     throw new SafeIllegalArgumentException(
                             "Failed to parse request due to malformed content",


### PR DESCRIPTION
This is equivalent to the JsonParseException path.

## Before this PR
`[null]` with `nonNullCollections = true` resulted in a 500 status code where we expect a 400 status for a malformed request.

## After this PR
==COMMIT_MSG==
NPE in deserialization results in a 400 response status
==COMMIT_MSG==

## Possible downsides?
It's possible that a server-side bug may result in an NPE. It's much more likely that this is the result of bad input, and it's a tradeoff we've already made in handling JsonParseException as a 400.
