### PR TITLE
conjure-undertow GET endpoints support HEAD requests as well

### DIFF
--- a/changelog/@unreleased/pr-1383.v2.yml
+++ b/changelog/@unreleased/pr-1383.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: conjure-undertow GET endpoints support HEAD requests as well
+  links:
+  - https://github.com/palantir/conjure-java/pull/1383

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -358,6 +358,32 @@ public final class UndertowServiceEteTest extends TestBase {
     }
 
     @Test
+    public void testGetMethodsAllowHeadRequests() throws IOException {
+        URL url = new URL("http://0.0.0.0:8080/test-example/api/base/string");
+        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        con.setRequestMethod("HEAD");
+        con.setRequestProperty(HttpHeaders.ACCEPT, "application/json");
+        con.setRequestProperty(
+                HttpHeaders.AUTHORIZATION, AuthHeader.valueOf("authHeader").toString());
+        assertThat(con.getResponseCode()).isEqualTo(200);
+        try (InputStream responseBody = con.getInputStream()) {
+            assertThat(responseBody).hasContent("");
+        }
+    }
+
+    @Test
+    public void testOptionsOnGetIncludesHead() throws IOException {
+        URL url = new URL("http://0.0.0.0:8080/test-example/api/base/string");
+        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        con.setRequestMethod("OPTIONS");
+        con.setRequestProperty(HttpHeaders.ACCEPT, "application/json");
+        con.setRequestProperty(
+                HttpHeaders.AUTHORIZATION, AuthHeader.valueOf("authHeader").toString());
+        assertThat(con.getResponseCode()).isEqualTo(204);
+        assertThat(con.getHeaderField(HttpHeaders.ALLOW)).isEqualTo("GET, HEAD");
+    }
+
+    @Test
     public void testUnknownContentType() {
         assertThatThrownBy(() -> {
                     try {

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/OptionsRequestTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/OptionsRequestTest.java
@@ -64,7 +64,7 @@ public final class OptionsRequestTest {
     public void test_getAndPost() {
         Response response = execute("/first");
         assertThat(response.code()).isEqualTo(204);
-        assertThat(response.header(HttpHeaders.ALLOW)).isEqualTo("GET, POST");
+        assertThat(response.header(HttpHeaders.ALLOW)).isEqualTo("GET, HEAD, POST");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
`HEAD` requests to `GET` endpoints produced 404 "Not Found" responses.

## After this PR

HEAD requests don't produce response bytes, however if a response
is written, the bytes are safely, locally, written to an empty
sink. This matches Jersey behavior.
Depending how this is used, we may eventually want to allow folks
to implement their own HEAD handlers, this change doesn't make
that any more difficult.

==COMMIT_MSG==
conjure-undertow GET endpoints support HEAD requests as well
==COMMIT_MSG==
