### PR TITLE
conjure-undertow OPTIONS handler is more self-aware

### DIFF
--- a/changelog/@unreleased/pr-1386.v2.yml
+++ b/changelog/@unreleased/pr-1386.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |-
+    The conjure-undertow `OPTIONS` handler `Allow` header value includes the `OPTIONS` method
+    in addition to other available http methods.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1386

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -380,7 +380,7 @@ public final class UndertowServiceEteTest extends TestBase {
         con.setRequestProperty(
                 HttpHeaders.AUTHORIZATION, AuthHeader.valueOf("authHeader").toString());
         assertThat(con.getResponseCode()).isEqualTo(204);
-        assertThat(con.getHeaderField(HttpHeaders.ALLOW)).isEqualTo("GET, HEAD");
+        assertThat(con.getHeaderField(HttpHeaders.ALLOW)).isEqualTo("OPTIONS, GET, HEAD");
     }
 
     @Test

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/OptionsHandler.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/OptionsHandler.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.java.undertow.runtime;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
 import com.palantir.logsafe.Preconditions;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
@@ -31,7 +32,11 @@ final class OptionsHandler implements HttpHandler {
     private final String allowValue;
 
     OptionsHandler(Set<HttpString> methods) {
-        this.allowValue = Joiner.on(", ").join(methods);
+        this.allowValue = Joiner.on(", ")
+                .join(ImmutableSet.<HttpString>builder()
+                        .add(Methods.OPTIONS)
+                        .addAll(methods)
+                        .build());
     }
 
     @Override

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/OptionsRequestTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/OptionsRequestTest.java
@@ -64,7 +64,7 @@ public final class OptionsRequestTest {
     public void test_getAndPost() {
         Response response = execute("/first");
         assertThat(response.code()).isEqualTo(204);
-        assertThat(response.header(HttpHeaders.ALLOW)).isEqualTo("GET, HEAD, POST");
+        assertThat(response.header(HttpHeaders.ALLOW)).isEqualTo("OPTIONS, GET, HEAD, POST");
     }
 
     @Test
@@ -78,7 +78,7 @@ public final class OptionsRequestTest {
     public void test_parameterized() {
         Response response = execute("/second/paramValue/and/secondParam");
         assertThat(response.code()).isEqualTo(204);
-        assertThat(response.header(HttpHeaders.ALLOW)).isEqualTo("PUT");
+        assertThat(response.header(HttpHeaders.ALLOW)).isEqualTo("OPTIONS, PUT");
     }
 
     private static Response execute(String path) {


### PR DESCRIPTION
The `Allow` header value includes the (current) `OPTIONS` method
in addition to other available methods.

This is a follow-up to resolve an oddity I noticed while implementing #1383

## After this PR
==COMMIT_MSG==
conjure-undertow OPTIONS handler is more self-aware
==COMMIT_MSG==

## Possible downsides?
A couple more bytes on heap in strings?
