### PR TITLE
Propagate error code and name for 401 and 403 responses

### DIFF
--- a/changelog/@unreleased/pr-1399.v2.yml
+++ b/changelog/@unreleased/pr-1399.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Undertow endpoints now preserve the error code and error name when
+    propagating remote exceptions with 401 or 403 status codes.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1399

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
@@ -101,7 +101,7 @@ public enum ConjureExceptions implements ExceptionHandler {
                     "Encountered a remote exception",
                     SafeArg.of("errorInstanceId", remoteException.getError().errorInstanceId()),
                     SafeArg.of("errorName", remoteException.getError().errorName()),
-                    SafeArg.of("status", remoteException.getStatus()),
+                    SafeArg.of("statusCode", remoteException.getStatus()),
                     remoteException);
 
             writeResponse(
@@ -118,7 +118,7 @@ public enum ConjureExceptions implements ExceptionHandler {
                     "Encountered a remote exception. Mapping to an internal error before propagating",
                     SafeArg.of("errorInstanceId", remoteException.getError().errorInstanceId()),
                     SafeArg.of("errorName", remoteException.getError().errorName()),
-                    SafeArg.of("status", remoteException.getStatus()),
+                    SafeArg.of("statusCode", remoteException.getStatus()),
                     remoteException);
 
             ServiceException exception = new ServiceException(ErrorType.INTERNAL, remoteException);

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
@@ -84,10 +84,10 @@ public enum ConjureExceptions implements ExceptionHandler {
                 exception.getErrorType().httpErrorCode());
     }
 
-    private static void qosException(HttpServerExchange exchange, QosException exception) {
-        exception.accept(QOS_EXCEPTION_HEADERS).accept(exchange);
-        log.debug("Possible quality-of-service intervention", exception);
-        writeResponse(exchange, Optional.empty(), exception.accept(QOS_EXCEPTION_STATUS_CODE));
+    private static void qosException(HttpServerExchange exchange, QosException qosException) {
+        qosException.accept(QOS_EXCEPTION_HEADERS).accept(exchange);
+        log.debug("Possible quality-of-service intervention", qosException);
+        writeResponse(exchange, Optional.empty(), qosException.accept(QOS_EXCEPTION_STATUS_CODE));
     }
 
     // RemoteExceptions are thrown by Conjure clients to indicate a remote/service-side problem.
@@ -95,49 +95,37 @@ public enum ConjureExceptions implements ExceptionHandler {
     // considered internal to *this* service rather than the originating service. This means in particular
     // that Conjure errors are defined only local to a given service and these error types don't
     // propagate through other services.
-    private static void remoteException(HttpServerExchange exchange, RemoteException exception) {
-        ErrorType errorType = mapRemoteExceptionErrorType(exception);
-        writeResponse(
-                exchange,
-                Optional.of(SerializableError.builder()
-                        .errorName(errorType.name())
-                        .errorCode(errorType.code().toString())
-                        .errorInstanceId(exception.getError().errorInstanceId())
-                        .build()),
-                errorType.httpErrorCode());
-    }
-
-    private static ErrorType mapRemoteExceptionErrorType(RemoteException exception) {
-        if (exception.getStatus() == 401) {
+    private static void remoteException(HttpServerExchange exchange, RemoteException remoteException) {
+        if (remoteException.getStatus() == 401 || remoteException.getStatus() == 403) {
             log.info(
-                    "Encountered a remote unauthorized exception."
-                            + " Mapping to a default unauthorized exception before propagating",
-                    SafeArg.of("errorInstanceId", exception.getError().errorInstanceId()),
-                    SafeArg.of("errorName", exception.getError().errorName()),
-                    SafeArg.of("statusCode", exception.getStatus()),
-                    exception);
+                    "Encountered a remote exception",
+                    SafeArg.of("errorInstanceId", remoteException.getError().errorInstanceId()),
+                    SafeArg.of("errorName", remoteException.getError().errorName()),
+                    SafeArg.of("status", remoteException.getStatus()),
+                    remoteException);
 
-            return ErrorType.UNAUTHORIZED;
-        } else if (exception.getStatus() == 403) {
-            log.info(
-                    "Encountered a remote permission denied exception."
-                            + " Mapping to a default permission denied exception before propagating",
-                    SafeArg.of("errorInstanceId", exception.getError().errorInstanceId()),
-                    SafeArg.of("errorName", exception.getError().errorName()),
-                    SafeArg.of("statusCode", exception.getStatus()),
-                    exception);
-
-            return ErrorType.PERMISSION_DENIED;
+            writeResponse(
+                    exchange,
+                    Optional.of(SerializableError.builder()
+                            .errorCode(remoteException.getError().errorCode())
+                            .errorName(remoteException.getError().errorName())
+                            .errorInstanceId(remoteException.getError().errorInstanceId())
+                            .build()),
+                    remoteException.getStatus());
         } else {
             // log at WARN instead of ERROR because this indicates an issue in a remote server
             log.warn(
                     "Encountered a remote exception. Mapping to an internal error before propagating",
-                    SafeArg.of("errorInstanceId", exception.getError().errorInstanceId()),
-                    SafeArg.of("errorName", exception.getError().errorName()),
-                    SafeArg.of("statusCode", exception.getStatus()),
-                    exception);
+                    SafeArg.of("errorInstanceId", remoteException.getError().errorInstanceId()),
+                    SafeArg.of("errorName", remoteException.getError().errorName()),
+                    SafeArg.of("status", remoteException.getStatus()),
+                    remoteException);
 
-            return ErrorType.INTERNAL;
+            ServiceException exception = new ServiceException(ErrorType.INTERNAL, remoteException);
+            writeResponse(
+                    exchange,
+                    Optional.of(SerializableError.forException(exception)),
+                    exception.getErrorType().httpErrorCode());
         }
     }
 

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptionHandlerTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptionHandlerTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.ErrorType.Code;
 import com.palantir.conjure.java.api.errors.QosException;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.SerializableError;
@@ -103,8 +104,8 @@ public final class ConjureExceptionHandlerTest {
 
     @Test
     public void handles401RemoteException() throws IOException {
-        SerializableError remoteError =
-                SerializableError.forException(new ServiceException(ErrorType.UNAUTHORIZED, SafeArg.of("foo", "bar")));
+        SerializableError remoteError = SerializableError.forException(
+                new ServiceException(ErrorType.create(Code.UNAUTHORIZED, "Test:ErrorName"), SafeArg.of("foo", "bar")));
         exception = new RemoteException(remoteError, ErrorType.UNAUTHORIZED.httpErrorCode());
         Response response = execute();
 
@@ -112,7 +113,7 @@ public final class ConjureExceptionHandlerTest {
         // Does not propagate args
         SerializableError expectedPropagatedError = SerializableError.builder()
                 .errorCode(ErrorType.UNAUTHORIZED.code().toString())
-                .errorName(ErrorType.UNAUTHORIZED.name())
+                .errorName("Test:ErrorName")
                 .errorInstanceId(remoteError.errorInstanceId())
                 .build();
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
@@ -124,8 +125,8 @@ public final class ConjureExceptionHandlerTest {
 
     @Test
     public void handles403RemoteException() throws IOException {
-        SerializableError remoteError = SerializableError.forException(
-                new ServiceException(ErrorType.PERMISSION_DENIED, SafeArg.of("foo", "bar")));
+        SerializableError remoteError = SerializableError.forException(new ServiceException(
+                ErrorType.create(Code.PERMISSION_DENIED, "Test:ErrorName"), SafeArg.of("foo", "bar")));
         exception = new RemoteException(remoteError, ErrorType.PERMISSION_DENIED.httpErrorCode());
         Response response = execute();
 
@@ -133,7 +134,7 @@ public final class ConjureExceptionHandlerTest {
         // Does not propagate args
         SerializableError expectedPropagatedError = SerializableError.builder()
                 .errorCode(ErrorType.PERMISSION_DENIED.code().toString())
-                .errorName(ErrorType.PERMISSION_DENIED.name())
+                .errorName("Test:ErrorName")
                 .errorInstanceId(remoteError.errorInstanceId())
                 .build();
         ByteArrayOutputStream stream = new ByteArrayOutputStream();


### PR DESCRIPTION
For context, see https://github.com/palantir/conjure-java-runtime/pull/2019.

## Before this PR
Remote exceptions with 401 and 403 statuses are propagate as the corresponding generic `ErrorType`.

## After this PR
Remote exceptions with 401 and 403 statuses are propagated preserving the error code and error name. Parameters are still not propagated.