### PR TITLE
Require endpoint templates to be absolute

### DIFF
--- a/changelog/@unreleased/pr-1446.v2.yml
+++ b/changelog/@unreleased/pr-1446.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Undertow endpoint path templates are now required to start with `/`.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1446

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureHandler.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureHandler.java
@@ -270,6 +270,14 @@ public final class ConjureHandler implements HttpHandler {
                         SafeArg.of("service", value.serviceName()),
                         SafeArg.of("name", value.name()));
             }
+            if (!value.template().startsWith("/")) {
+                throw new SafeIllegalStateException(
+                        "Endpoint template must start with \"/\"",
+                        SafeArg.of("method", value.method()),
+                        SafeArg.of("template", value.template()),
+                        SafeArg.of("service", value.serviceName()),
+                        SafeArg.of("name", value.name()));
+            }
             return value;
         }
 

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureHandlerBuilderTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureHandlerBuilderTest.java
@@ -69,7 +69,11 @@ public class ConjureHandlerBuilderTest {
                         .build())
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasLogMessage("Endpoint method is not recognized")
-                .containsArgs(SafeArg.of("method", Methods.OPTIONS));
+                .hasExactlyArgs(
+                        SafeArg.of("method", Methods.OPTIONS),
+                        SafeArg.of("template", "/template"),
+                        SafeArg.of("service", "service"),
+                        SafeArg.of("name", "name"));
     }
 
     @Test
@@ -85,7 +89,31 @@ public class ConjureHandlerBuilderTest {
                         .build())
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasLogMessage("Endpoint method is not recognized")
-                .containsArgs(SafeArg.of("method", Methods.TRACE));
+                .hasExactlyArgs(
+                        SafeArg.of("method", Methods.TRACE),
+                        SafeArg.of("template", "/template"),
+                        SafeArg.of("service", "service"),
+                        SafeArg.of("name", "name"));
+    }
+
+    @Test
+    public void testAddEndpoint_relativeTemplate() {
+        assertThatLoggableExceptionThrownBy(() -> ConjureHandler.builder()
+                        .services(EndpointService.of(Endpoint.builder()
+                                .name("name")
+                                .serviceName("service")
+                                .handler(ResponseCodeHandler.HANDLE_200)
+                                .method(Methods.GET)
+                                .template("template")
+                                .build()))
+                        .build())
+                .isInstanceOf(SafeIllegalStateException.class)
+                .hasLogMessage("Endpoint template must start with \"/\"")
+                .hasExactlyArgs(
+                        SafeArg.of("method", Methods.GET),
+                        SafeArg.of("template", "template"),
+                        SafeArg.of("service", "service"),
+                        SafeArg.of("name", "name"));
     }
 
     private Endpoint buildEndpoint(HttpString method, String template, String serviceName, String name) {


### PR DESCRIPTION
See discussion in https://g.p.b/foundry/witchcraft/pull/3498

## Before this PR
Consumers may register Undertow endpoints without a leading `/`. This can lead to incorrect behavior when path prefixes are prepended.

## After this PR
Undertow endpoint path templates must have a leading `/`.

## Possible downsides?
This will break consumers who are registering Undertow endpoints without a leading `/`. However this seems acceptable because:
- These consumers are already broken on newer versions of Witchcraft.
- This doesn't affect anyone using Conjure-generated Undertow endpoints.
- This PR actually improves the behavior. Currently these failures manifest as runtime 404s, but now they will manifest as initialization failures.