### PR TITLE
conjure-undertow logs I/O exceptions from closed connections at INFO

### DIFF
--- a/changelog/@unreleased/pr-1468.v2.yml
+++ b/changelog/@unreleased/pr-1468.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: conjure-undertow logs I/O exceptions from closed connections at INFO
+  links:
+  - https://github.com/palantir/conjure-java/pull/1468

--- a/conjure-java-core/build.gradle
+++ b/conjure-java-core/build.gradle
@@ -77,6 +77,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'jakarta.xml.bind:jakarta.xml.bind-api'
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'com.github.stefanbirkner:system-lambda'
 
     integrationInputImplementation project(':conjure-lib')
     integrationInputImplementation project(':conjure-undertow-lib')

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowBinaryResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowBinaryResource.java
@@ -24,13 +24,12 @@ import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.product.UndertowEteBinaryService;
-import com.palantir.random.SafeThreadLocalRandom;
 import com.palantir.tokens.auth.AuthHeader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import javax.validation.constraints.NotNull;
 
 final class UndertowBinaryResource implements UndertowEteBinaryService {
@@ -67,12 +66,11 @@ final class UndertowBinaryResource implements UndertowEteBinaryService {
     public BinaryResponseBody getBinaryFailure(AuthHeader _authHeader, int numBytes) {
         return responseBody -> {
             byte[] buffer = new byte[Math.min(8 * 1024, numBytes)];
-            Random random = SafeThreadLocalRandom.get();
             int remainingBytes = numBytes;
             while (remainingBytes > 0) {
                 int chunkSize = Math.min(remainingBytes, buffer.length);
                 remainingBytes -= chunkSize;
-                random.nextBytes(buffer);
+                ThreadLocalRandom.current().nextBytes(buffer);
                 responseBody.write(buffer, 0, chunkSize);
             }
             throw new SafeRuntimeException("failure");

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowBinaryResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowBinaryResource.java
@@ -24,6 +24,7 @@ import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.product.UndertowEteBinaryService;
+import com.palantir.random.SafeThreadLocalRandom;
 import com.palantir.tokens.auth.AuthHeader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -65,9 +66,15 @@ final class UndertowBinaryResource implements UndertowEteBinaryService {
     @Override
     public BinaryResponseBody getBinaryFailure(AuthHeader _authHeader, int numBytes) {
         return responseBody -> {
-            byte[] data = new byte[numBytes];
-            new Random().nextBytes(data);
-            responseBody.write(data);
+            byte[] buffer = new byte[Math.min(8 * 1024, numBytes)];
+            Random random = SafeThreadLocalRandom.get();
+            int remainingBytes = numBytes;
+            while (remainingBytes > 0) {
+                int chunkSize = Math.min(remainingBytes, buffer.length);
+                remainingBytes -= chunkSize;
+                random.nextBytes(buffer);
+                responseBody.write(buffer, 0, chunkSize);
+            }
             throw new SafeRuntimeException("failure");
         };
     }

--- a/versions.lock
+++ b/versions.lock
@@ -94,6 +94,7 @@ com.fasterxml.jackson.jaxrs:jackson-jaxrs-cbor-provider:2.12.3 (2 constraints: f
 com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.12.3 (2 constraints: 6e1d2e4b)
 com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.3 (3 constraints: 903d4249)
 com.fasterxml.jackson.module:jackson-module-parameter-names:2.12.3 (2 constraints: 661d2d2f)
+com.github.stefanbirkner:system-lambda:1.2.0 (1 constraints: 0505f635)
 com.helger:profiler:1.1.1 (1 constraints: e21053b8)
 com.jcraft:jzlib:1.1.3 (1 constraints: 0d192ea2)
 com.netflix.concurrency-limits:concurrency-limits-core:0.2.2 (1 constraints: 7d14fe7b)

--- a/versions.props
+++ b/versions.props
@@ -36,6 +36,7 @@ org.junit.vintage:* = 5.7.2
 org.mockito:* = 3.12.4
 org.slf4j:* = 1.7.32
 com.palantir.goethe:* = 0.2.0
+com.github.stefanbirkner:system-lambda = 1.2.0
 
 # dependency-upgrader:OFF
 # Avoid forcing consumers to upgrade jackson


### PR DESCRIPTION
## Before this PR
We logged these at the ERROR level, causing unnecessary panic.

## After this PR
This matches existing client error (4xx) logging, and avoids
noisy logging when clients cancel requests. This is particularly
common for use-cases involving larger binary downloads from
browsers, where clients frequently navigate away from the page,
cancel downloads, or go to sleep.

==COMMIT_MSG==
conjure-undertow logs I/O exceptions from closed connections at INFO
==COMMIT_MSG==

