### PR TITLE
Conjure builders throw when they're reused after a `build()` invocation

### DIFF
--- a/changelog/@unreleased/pr-1492.v2.yml
+++ b/changelog/@unreleased/pr-1492.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Conjure builders throw when they're reused after a `build()` invocation
+  links:
+  - https://github.com/palantir/conjure-java/pull/1492

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryExample.java
@@ -80,17 +80,21 @@ public final class BinaryExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private ByteBuffer binary;
 
         private Builder() {}
 
         public Builder from(BinaryExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             binary(other.getBinary());
             return this;
         }
 
         @JsonSetter("binary")
         public Builder binary(@Nonnull ByteBuffer binary) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             Preconditions.checkNotNull(binary, "binary cannot be null");
             this.binary = ByteBuffer.allocate(binary.remaining()).put(binary.duplicate());
             ((Buffer) this.binary).rewind();
@@ -98,6 +102,8 @@ public final class BinaryExample {
         }
 
         public BinaryExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new BinaryExample(binary);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryExample.java
@@ -87,14 +87,14 @@ public final class BinaryExample {
         private Builder() {}
 
         public Builder from(BinaryExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             binary(other.getBinary());
             return this;
         }
 
         @JsonSetter("binary")
         public Builder binary(@Nonnull ByteBuffer binary) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             Preconditions.checkNotNull(binary, "binary cannot be null");
             this.binary = ByteBuffer.allocate(binary.remaining()).put(binary.duplicate());
             ((Buffer) this.binary).rewind();
@@ -102,9 +102,13 @@ public final class BinaryExample {
         }
 
         public BinaryExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new BinaryExample(binary);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
@@ -90,28 +90,32 @@ public final class OptionalExample {
         private Builder() {}
 
         public Builder from(OptionalExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             item(other.getItem());
             return this;
         }
 
         @JsonSetter(value = "item", nulls = Nulls.SKIP)
         public Builder item(@Nonnull Optional<ByteBuffer> item) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.item = Preconditions.checkNotNull(item, "item cannot be null");
             return this;
         }
 
         public Builder item(@Nonnull ByteBuffer item) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.item = Optional.of(Preconditions.checkNotNull(item, "item cannot be null"));
             return this;
         }
 
         public OptionalExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new OptionalExample(item);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
@@ -83,27 +83,34 @@ public final class OptionalExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private Optional<ByteBuffer> item = Optional.empty();
 
         private Builder() {}
 
         public Builder from(OptionalExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             item(other.getItem());
             return this;
         }
 
         @JsonSetter(value = "item", nulls = Nulls.SKIP)
         public Builder item(@Nonnull Optional<ByteBuffer> item) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.item = Preconditions.checkNotNull(item, "item cannot be null");
             return this;
         }
 
         public Builder item(@Nonnull ByteBuffer item) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.item = Optional.of(Preconditions.checkNotNull(item, "item cannot be null"));
             return this;
         }
 
         public OptionalExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new OptionalExample(item);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
@@ -166,6 +166,8 @@ public final class AliasAsMapKeyExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private Map<StringAliasExample, ManyFieldExample> strings = new LinkedHashMap<>();
 
         private Map<RidAliasExample, ManyFieldExample> rids = new LinkedHashMap<>();
@@ -183,6 +185,7 @@ public final class AliasAsMapKeyExample {
         private Builder() {}
 
         public Builder from(AliasAsMapKeyExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             strings(other.getStrings());
             rids(other.getRids());
             bearertokens(other.getBearertokens());
@@ -195,124 +198,147 @@ public final class AliasAsMapKeyExample {
 
         @JsonSetter(value = "strings", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder strings(@Nonnull Map<StringAliasExample, ManyFieldExample> strings) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.strings.clear();
             this.strings.putAll(Preconditions.checkNotNull(strings, "strings cannot be null"));
             return this;
         }
 
         public Builder putAllStrings(@Nonnull Map<StringAliasExample, ManyFieldExample> strings) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.strings.putAll(Preconditions.checkNotNull(strings, "strings cannot be null"));
             return this;
         }
 
         public Builder strings(StringAliasExample key, ManyFieldExample value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.strings.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "rids", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder rids(@Nonnull Map<RidAliasExample, ManyFieldExample> rids) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.rids.clear();
             this.rids.putAll(Preconditions.checkNotNull(rids, "rids cannot be null"));
             return this;
         }
 
         public Builder putAllRids(@Nonnull Map<RidAliasExample, ManyFieldExample> rids) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.rids.putAll(Preconditions.checkNotNull(rids, "rids cannot be null"));
             return this;
         }
 
         public Builder rids(RidAliasExample key, ManyFieldExample value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.rids.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "bearertokens", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder bearertokens(@Nonnull Map<BearerTokenAliasExample, ManyFieldExample> bearertokens) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.bearertokens.clear();
             this.bearertokens.putAll(Preconditions.checkNotNull(bearertokens, "bearertokens cannot be null"));
             return this;
         }
 
         public Builder putAllBearertokens(@Nonnull Map<BearerTokenAliasExample, ManyFieldExample> bearertokens) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.bearertokens.putAll(Preconditions.checkNotNull(bearertokens, "bearertokens cannot be null"));
             return this;
         }
 
         public Builder bearertokens(BearerTokenAliasExample key, ManyFieldExample value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.bearertokens.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "integers", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder integers(@Nonnull Map<IntegerAliasExample, ManyFieldExample> integers) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.integers.clear();
             this.integers.putAll(Preconditions.checkNotNull(integers, "integers cannot be null"));
             return this;
         }
 
         public Builder putAllIntegers(@Nonnull Map<IntegerAliasExample, ManyFieldExample> integers) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.integers.putAll(Preconditions.checkNotNull(integers, "integers cannot be null"));
             return this;
         }
 
         public Builder integers(IntegerAliasExample key, ManyFieldExample value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.integers.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "safelongs", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder safelongs(@Nonnull Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.safelongs.clear();
             this.safelongs.putAll(Preconditions.checkNotNull(safelongs, "safelongs cannot be null"));
             return this;
         }
 
         public Builder putAllSafelongs(@Nonnull Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.safelongs.putAll(Preconditions.checkNotNull(safelongs, "safelongs cannot be null"));
             return this;
         }
 
         public Builder safelongs(SafeLongAliasExample key, ManyFieldExample value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.safelongs.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "datetimes", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder datetimes(@Nonnull Map<DateTimeAliasExample, ManyFieldExample> datetimes) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.datetimes.clear();
             this.datetimes.putAll(Preconditions.checkNotNull(datetimes, "datetimes cannot be null"));
             return this;
         }
 
         public Builder putAllDatetimes(@Nonnull Map<DateTimeAliasExample, ManyFieldExample> datetimes) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.datetimes.putAll(Preconditions.checkNotNull(datetimes, "datetimes cannot be null"));
             return this;
         }
 
         public Builder datetimes(DateTimeAliasExample key, ManyFieldExample value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.datetimes.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "uuids", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder uuids(@Nonnull Map<UuidAliasExample, ManyFieldExample> uuids) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.uuids.clear();
             this.uuids.putAll(Preconditions.checkNotNull(uuids, "uuids cannot be null"));
             return this;
         }
 
         public Builder putAllUuids(@Nonnull Map<UuidAliasExample, ManyFieldExample> uuids) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.uuids.putAll(Preconditions.checkNotNull(uuids, "uuids cannot be null"));
             return this;
         }
 
         public Builder uuids(UuidAliasExample key, ManyFieldExample value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.uuids.put(key, value);
             return this;
         }
 
         public AliasAsMapKeyExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new AliasAsMapKeyExample(strings, rids, bearertokens, integers, safelongs, datetimes, uuids);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
@@ -185,7 +185,7 @@ public final class AliasAsMapKeyExample {
         private Builder() {}
 
         public Builder from(AliasAsMapKeyExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             strings(other.getStrings());
             rids(other.getRids());
             bearertokens(other.getBearertokens());
@@ -198,148 +198,152 @@ public final class AliasAsMapKeyExample {
 
         @JsonSetter(value = "strings", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder strings(@Nonnull Map<StringAliasExample, ManyFieldExample> strings) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.strings.clear();
             this.strings.putAll(Preconditions.checkNotNull(strings, "strings cannot be null"));
             return this;
         }
 
         public Builder putAllStrings(@Nonnull Map<StringAliasExample, ManyFieldExample> strings) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.strings.putAll(Preconditions.checkNotNull(strings, "strings cannot be null"));
             return this;
         }
 
         public Builder strings(StringAliasExample key, ManyFieldExample value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.strings.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "rids", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder rids(@Nonnull Map<RidAliasExample, ManyFieldExample> rids) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.rids.clear();
             this.rids.putAll(Preconditions.checkNotNull(rids, "rids cannot be null"));
             return this;
         }
 
         public Builder putAllRids(@Nonnull Map<RidAliasExample, ManyFieldExample> rids) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.rids.putAll(Preconditions.checkNotNull(rids, "rids cannot be null"));
             return this;
         }
 
         public Builder rids(RidAliasExample key, ManyFieldExample value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.rids.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "bearertokens", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder bearertokens(@Nonnull Map<BearerTokenAliasExample, ManyFieldExample> bearertokens) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.bearertokens.clear();
             this.bearertokens.putAll(Preconditions.checkNotNull(bearertokens, "bearertokens cannot be null"));
             return this;
         }
 
         public Builder putAllBearertokens(@Nonnull Map<BearerTokenAliasExample, ManyFieldExample> bearertokens) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.bearertokens.putAll(Preconditions.checkNotNull(bearertokens, "bearertokens cannot be null"));
             return this;
         }
 
         public Builder bearertokens(BearerTokenAliasExample key, ManyFieldExample value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.bearertokens.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "integers", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder integers(@Nonnull Map<IntegerAliasExample, ManyFieldExample> integers) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.integers.clear();
             this.integers.putAll(Preconditions.checkNotNull(integers, "integers cannot be null"));
             return this;
         }
 
         public Builder putAllIntegers(@Nonnull Map<IntegerAliasExample, ManyFieldExample> integers) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.integers.putAll(Preconditions.checkNotNull(integers, "integers cannot be null"));
             return this;
         }
 
         public Builder integers(IntegerAliasExample key, ManyFieldExample value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.integers.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "safelongs", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder safelongs(@Nonnull Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.safelongs.clear();
             this.safelongs.putAll(Preconditions.checkNotNull(safelongs, "safelongs cannot be null"));
             return this;
         }
 
         public Builder putAllSafelongs(@Nonnull Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.safelongs.putAll(Preconditions.checkNotNull(safelongs, "safelongs cannot be null"));
             return this;
         }
 
         public Builder safelongs(SafeLongAliasExample key, ManyFieldExample value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.safelongs.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "datetimes", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder datetimes(@Nonnull Map<DateTimeAliasExample, ManyFieldExample> datetimes) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.datetimes.clear();
             this.datetimes.putAll(Preconditions.checkNotNull(datetimes, "datetimes cannot be null"));
             return this;
         }
 
         public Builder putAllDatetimes(@Nonnull Map<DateTimeAliasExample, ManyFieldExample> datetimes) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.datetimes.putAll(Preconditions.checkNotNull(datetimes, "datetimes cannot be null"));
             return this;
         }
 
         public Builder datetimes(DateTimeAliasExample key, ManyFieldExample value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.datetimes.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "uuids", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder uuids(@Nonnull Map<UuidAliasExample, ManyFieldExample> uuids) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.uuids.clear();
             this.uuids.putAll(Preconditions.checkNotNull(uuids, "uuids cannot be null"));
             return this;
         }
 
         public Builder putAllUuids(@Nonnull Map<UuidAliasExample, ManyFieldExample> uuids) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.uuids.putAll(Preconditions.checkNotNull(uuids, "uuids cannot be null"));
             return this;
         }
 
         public Builder uuids(UuidAliasExample key, ManyFieldExample value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.uuids.put(key, value);
             return this;
         }
 
         public AliasAsMapKeyExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new AliasAsMapKeyExample(strings, rids, bearertokens, integers, safelongs, datetimes, uuids);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
@@ -83,22 +83,26 @@ public final class AnyExample {
         private Builder() {}
 
         public Builder from(AnyExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             any(other.getAny());
             return this;
         }
 
         @JsonSetter("any")
         public Builder any(@Nonnull Object any) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.any = Preconditions.checkNotNull(any, "any cannot be null");
             return this;
         }
 
         public AnyExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new AnyExample(any);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
@@ -76,22 +76,28 @@ public final class AnyExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private Object any;
 
         private Builder() {}
 
         public Builder from(AnyExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             any(other.getAny());
             return this;
         }
 
         @JsonSetter("any")
         public Builder any(@Nonnull Object any) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.any = Preconditions.checkNotNull(any, "any cannot be null");
             return this;
         }
 
         public AnyExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new AnyExample(any);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
@@ -87,33 +87,41 @@ public final class AnyMapExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private Map<String, Object> items = new LinkedHashMap<>();
 
         private Builder() {}
 
         public Builder from(AnyMapExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             items(other.getItems());
             return this;
         }
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Map<String, Object> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.clear();
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder putAllItems(@Nonnull Map<String, Object> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(String key, Object value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.put(key, value);
             return this;
         }
 
         public AnyMapExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new AnyMapExample(items);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
@@ -94,35 +94,39 @@ public final class AnyMapExample {
         private Builder() {}
 
         public Builder from(AnyMapExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             items(other.getItems());
             return this;
         }
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Map<String, Object> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.clear();
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder putAllItems(@Nonnull Map<String, Object> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(String key, Object value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.put(key, value);
             return this;
         }
 
         public AnyMapExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new AnyMapExample(items);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
@@ -84,22 +84,26 @@ public final class BearerTokenExample {
         private Builder() {}
 
         public Builder from(BearerTokenExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             bearerTokenValue(other.getBearerTokenValue());
             return this;
         }
 
         @JsonSetter("bearerTokenValue")
         public Builder bearerTokenValue(@Nonnull BearerToken bearerTokenValue) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.bearerTokenValue = Preconditions.checkNotNull(bearerTokenValue, "bearerTokenValue cannot be null");
             return this;
         }
 
         public BearerTokenExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new BearerTokenExample(bearerTokenValue);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
@@ -77,22 +77,28 @@ public final class BearerTokenExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private BearerToken bearerTokenValue;
 
         private Builder() {}
 
         public Builder from(BearerTokenExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             bearerTokenValue(other.getBearerTokenValue());
             return this;
         }
 
         @JsonSetter("bearerTokenValue")
         public Builder bearerTokenValue(@Nonnull BearerToken bearerTokenValue) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.bearerTokenValue = Preconditions.checkNotNull(bearerTokenValue, "bearerTokenValue cannot be null");
             return this;
         }
 
         public BearerTokenExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new BearerTokenExample(bearerTokenValue);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
@@ -84,22 +84,26 @@ public final class BinaryExample {
         private Builder() {}
 
         public Builder from(BinaryExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             binary(other.getBinary());
             return this;
         }
 
         @JsonSetter("binary")
         public Builder binary(@Nonnull Bytes binary) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.binary = Preconditions.checkNotNull(binary, "binary cannot be null");
             return this;
         }
 
         public BinaryExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new BinaryExample(binary);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
@@ -77,22 +77,28 @@ public final class BinaryExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private Bytes binary;
 
         private Builder() {}
 
         public Builder from(BinaryExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             binary(other.getBinary());
             return this;
         }
 
         @JsonSetter("binary")
         public Builder binary(@Nonnull Bytes binary) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.binary = Preconditions.checkNotNull(binary, "binary cannot be null");
             return this;
         }
 
         public BinaryExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new BinaryExample(binary);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
@@ -3,6 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
@@ -52,6 +53,8 @@ public final class BooleanExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private boolean coin;
 
         private boolean _coinInitialized = false;
@@ -59,12 +62,14 @@ public final class BooleanExample {
         private Builder() {}
 
         public Builder from(BooleanExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             coin(other.getCoin());
             return this;
         }
 
         @JsonSetter("coin")
         public Builder coin(boolean coin) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.coin = coin;
             this._coinInitialized = true;
             return this;
@@ -91,6 +96,8 @@ public final class BooleanExample {
         }
 
         public BooleanExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new BooleanExample(coin);
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
@@ -62,14 +62,14 @@ public final class BooleanExample {
         private Builder() {}
 
         public Builder from(BooleanExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             coin(other.getCoin());
             return this;
         }
 
         @JsonSetter("coin")
         public Builder coin(boolean coin) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.coin = coin;
             this._coinInitialized = true;
             return this;
@@ -96,10 +96,14 @@ public final class BooleanExample {
         }
 
         public BooleanExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new BooleanExample(coin);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
@@ -96,6 +96,8 @@ public final class CovariantListExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private List<Object> items = new ArrayList<>();
 
         private List<ExampleExternalReference> externalItems = new ArrayList<>();
@@ -103,6 +105,7 @@ public final class CovariantListExample {
         private Builder() {}
 
         public Builder from(CovariantListExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             items(other.getItems());
             externalItems(other.getExternalItems());
             return this;
@@ -110,23 +113,27 @@ public final class CovariantListExample {
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Iterable<?> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder addAllItems(@Nonnull Iterable<?> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(Object items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.add(items);
             return this;
         }
 
         @JsonSetter(value = "externalItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder externalItems(@Nonnull Iterable<? extends ExampleExternalReference> externalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.externalItems.clear();
             ConjureCollections.addAll(
                     this.externalItems, Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
@@ -134,17 +141,21 @@ public final class CovariantListExample {
         }
 
         public Builder addAllExternalItems(@Nonnull Iterable<? extends ExampleExternalReference> externalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(
                     this.externalItems, Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
             return this;
         }
 
         public Builder externalItems(ExampleExternalReference externalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.externalItems.add(externalItems);
             return this;
         }
 
         public CovariantListExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new CovariantListExample(items, externalItems);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
@@ -105,7 +105,7 @@ public final class CovariantListExample {
         private Builder() {}
 
         public Builder from(CovariantListExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             items(other.getItems());
             externalItems(other.getExternalItems());
             return this;
@@ -113,27 +113,27 @@ public final class CovariantListExample {
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Iterable<?> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder addAllItems(@Nonnull Iterable<?> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(Object items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.add(items);
             return this;
         }
 
         @JsonSetter(value = "externalItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder externalItems(@Nonnull Iterable<? extends ExampleExternalReference> externalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.externalItems.clear();
             ConjureCollections.addAll(
                     this.externalItems, Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
@@ -141,22 +141,26 @@ public final class CovariantListExample {
         }
 
         public Builder addAllExternalItems(@Nonnull Iterable<? extends ExampleExternalReference> externalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(
                     this.externalItems, Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
             return this;
         }
 
         public Builder externalItems(ExampleExternalReference externalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.externalItems.add(externalItems);
             return this;
         }
 
         public CovariantListExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new CovariantListExample(items, externalItems);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
@@ -109,7 +109,7 @@ public final class CovariantOptionalExample {
         private Builder() {}
 
         public Builder from(CovariantOptionalExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             item(other.getItem());
             setItem(other.getSetItem());
             return this;
@@ -117,35 +117,39 @@ public final class CovariantOptionalExample {
 
         @JsonSetter(value = "item", nulls = Nulls.SKIP)
         public Builder item(@Nonnull Optional<?> item) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.item = Preconditions.checkNotNull(item, "item cannot be null").map(Function.identity());
             return this;
         }
 
         public Builder item(@Nonnull Object item) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.item = Optional.of(Preconditions.checkNotNull(item, "item cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "setItem", nulls = Nulls.SKIP)
         public Builder setItem(@Nonnull Optional<? extends Set<StringAliasExample>> setItem) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.setItem = Preconditions.checkNotNull(setItem, "setItem cannot be null")
                     .map(Function.identity());
             return this;
         }
 
         public Builder setItem(@Nonnull Set<StringAliasExample> setItem) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.setItem = Optional.of(Preconditions.checkNotNull(setItem, "setItem cannot be null"));
             return this;
         }
 
         public CovariantOptionalExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new CovariantOptionalExample(item, setItem);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
@@ -100,6 +100,8 @@ public final class CovariantOptionalExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private Optional<Object> item = Optional.empty();
 
         private Optional<Set<StringAliasExample>> setItem = Optional.empty();
@@ -107,6 +109,7 @@ public final class CovariantOptionalExample {
         private Builder() {}
 
         public Builder from(CovariantOptionalExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             item(other.getItem());
             setItem(other.getSetItem());
             return this;
@@ -114,28 +117,34 @@ public final class CovariantOptionalExample {
 
         @JsonSetter(value = "item", nulls = Nulls.SKIP)
         public Builder item(@Nonnull Optional<?> item) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.item = Preconditions.checkNotNull(item, "item cannot be null").map(Function.identity());
             return this;
         }
 
         public Builder item(@Nonnull Object item) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.item = Optional.of(Preconditions.checkNotNull(item, "item cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "setItem", nulls = Nulls.SKIP)
         public Builder setItem(@Nonnull Optional<? extends Set<StringAliasExample>> setItem) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.setItem = Preconditions.checkNotNull(setItem, "setItem cannot be null")
                     .map(Function.identity());
             return this;
         }
 
         public Builder setItem(@Nonnull Set<StringAliasExample> setItem) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.setItem = Optional.of(Preconditions.checkNotNull(setItem, "setItem cannot be null"));
             return this;
         }
 
         public CovariantOptionalExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new CovariantOptionalExample(item, setItem);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
@@ -84,22 +84,28 @@ public final class DateTimeExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private OffsetDateTime datetime;
 
         private Builder() {}
 
         public Builder from(DateTimeExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             datetime(other.getDatetime());
             return this;
         }
 
         @JsonSetter("datetime")
         public Builder datetime(@Nonnull OffsetDateTime datetime) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.datetime = Preconditions.checkNotNull(datetime, "datetime cannot be null");
             return this;
         }
 
         public DateTimeExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new DateTimeExample(datetime);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
@@ -91,22 +91,26 @@ public final class DateTimeExample {
         private Builder() {}
 
         public Builder from(DateTimeExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             datetime(other.getDatetime());
             return this;
         }
 
         @JsonSetter("datetime")
         public Builder datetime(@Nonnull OffsetDateTime datetime) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.datetime = Preconditions.checkNotNull(datetime, "datetime cannot be null");
             return this;
         }
 
         public DateTimeExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new DateTimeExample(datetime);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
@@ -62,14 +62,14 @@ public final class DoubleExample {
         private Builder() {}
 
         public Builder from(DoubleExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             doubleValue(other.getDoubleValue());
             return this;
         }
 
         @JsonSetter("doubleValue")
         public Builder doubleValue(double doubleValue) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.doubleValue = doubleValue;
             this._doubleValueInitialized = true;
             return this;
@@ -96,10 +96,14 @@ public final class DoubleExample {
         }
 
         public DoubleExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new DoubleExample(doubleValue);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
@@ -3,6 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
@@ -52,6 +53,8 @@ public final class DoubleExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private double doubleValue;
 
         private boolean _doubleValueInitialized = false;
@@ -59,12 +62,14 @@ public final class DoubleExample {
         private Builder() {}
 
         public Builder from(DoubleExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             doubleValue(other.getDoubleValue());
             return this;
         }
 
         @JsonSetter("doubleValue")
         public Builder doubleValue(double doubleValue) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.doubleValue = doubleValue;
             this._doubleValueInitialized = true;
             return this;
@@ -91,6 +96,8 @@ public final class DoubleExample {
         }
 
         public DoubleExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new DoubleExample(doubleValue);
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
@@ -83,22 +83,26 @@ public final class EnumFieldExample {
         private Builder() {}
 
         public Builder from(EnumFieldExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             enum_(other.getEnum());
             return this;
         }
 
         @JsonSetter("enum")
         public Builder enum_(@Nonnull EnumExample enum_) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.enum_ = Preconditions.checkNotNull(enum_, "enum cannot be null");
             return this;
         }
 
         public EnumFieldExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new EnumFieldExample(enum_);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
@@ -76,22 +76,28 @@ public final class EnumFieldExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private EnumExample enum_;
 
         private Builder() {}
 
         public Builder from(EnumFieldExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             enum_(other.getEnum());
             return this;
         }
 
         @JsonSetter("enum")
         public Builder enum_(@Nonnull EnumExample enum_) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.enum_ = Preconditions.checkNotNull(enum_, "enum cannot be null");
             return this;
         }
 
         public EnumFieldExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new EnumFieldExample(enum_);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -114,6 +114,8 @@ public final class ExternalLongExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private long externalLong;
 
         private Optional<Long> optionalExternalLong = Optional.empty();
@@ -125,6 +127,7 @@ public final class ExternalLongExample {
         private Builder() {}
 
         public Builder from(ExternalLongExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             externalLong(other.getExternalLong());
             optionalExternalLong(other.getOptionalExternalLong());
             listExternalLong(other.getListExternalLong());
@@ -133,6 +136,7 @@ public final class ExternalLongExample {
 
         @JsonSetter("externalLong")
         public Builder externalLong(long externalLong) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.externalLong = externalLong;
             this._externalLongInitialized = true;
             return this;
@@ -140,6 +144,7 @@ public final class ExternalLongExample {
 
         @JsonSetter(value = "optionalExternalLong", nulls = Nulls.SKIP)
         public Builder optionalExternalLong(@Nonnull Optional<? extends Long> optionalExternalLong) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalExternalLong = Preconditions.checkNotNull(
                             optionalExternalLong, "optionalExternalLong cannot be null")
                     .map(Function.identity());
@@ -147,6 +152,7 @@ public final class ExternalLongExample {
         }
 
         public Builder optionalExternalLong(long optionalExternalLong) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalExternalLong = Optional.of(
                     Preconditions.checkNotNull(optionalExternalLong, "optionalExternalLong cannot be null"));
             return this;
@@ -154,6 +160,7 @@ public final class ExternalLongExample {
 
         @JsonSetter(value = "listExternalLong", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder listExternalLong(@Nonnull Iterable<? extends Long> listExternalLong) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.listExternalLong.clear();
             ConjureCollections.addAll(
                     this.listExternalLong,
@@ -162,6 +169,7 @@ public final class ExternalLongExample {
         }
 
         public Builder addAllListExternalLong(@Nonnull Iterable<? extends Long> listExternalLong) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(
                     this.listExternalLong,
                     Preconditions.checkNotNull(listExternalLong, "listExternalLong cannot be null"));
@@ -169,6 +177,7 @@ public final class ExternalLongExample {
         }
 
         public Builder listExternalLong(long listExternalLong) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.listExternalLong.add(listExternalLong);
             return this;
         }
@@ -194,6 +203,8 @@ public final class ExternalLongExample {
         }
 
         public ExternalLongExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new ExternalLongExample(externalLong, optionalExternalLong, listExternalLong);
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -127,7 +127,7 @@ public final class ExternalLongExample {
         private Builder() {}
 
         public Builder from(ExternalLongExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             externalLong(other.getExternalLong());
             optionalExternalLong(other.getOptionalExternalLong());
             listExternalLong(other.getListExternalLong());
@@ -136,7 +136,7 @@ public final class ExternalLongExample {
 
         @JsonSetter("externalLong")
         public Builder externalLong(long externalLong) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.externalLong = externalLong;
             this._externalLongInitialized = true;
             return this;
@@ -144,7 +144,7 @@ public final class ExternalLongExample {
 
         @JsonSetter(value = "optionalExternalLong", nulls = Nulls.SKIP)
         public Builder optionalExternalLong(@Nonnull Optional<? extends Long> optionalExternalLong) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalExternalLong = Preconditions.checkNotNull(
                             optionalExternalLong, "optionalExternalLong cannot be null")
                     .map(Function.identity());
@@ -152,7 +152,7 @@ public final class ExternalLongExample {
         }
 
         public Builder optionalExternalLong(long optionalExternalLong) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalExternalLong = Optional.of(
                     Preconditions.checkNotNull(optionalExternalLong, "optionalExternalLong cannot be null"));
             return this;
@@ -160,7 +160,7 @@ public final class ExternalLongExample {
 
         @JsonSetter(value = "listExternalLong", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder listExternalLong(@Nonnull Iterable<? extends Long> listExternalLong) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.listExternalLong.clear();
             ConjureCollections.addAll(
                     this.listExternalLong,
@@ -169,7 +169,7 @@ public final class ExternalLongExample {
         }
 
         public Builder addAllListExternalLong(@Nonnull Iterable<? extends Long> listExternalLong) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(
                     this.listExternalLong,
                     Preconditions.checkNotNull(listExternalLong, "listExternalLong cannot be null"));
@@ -177,7 +177,7 @@ public final class ExternalLongExample {
         }
 
         public Builder listExternalLong(long listExternalLong) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.listExternalLong.add(listExternalLong);
             return this;
         }
@@ -203,10 +203,14 @@ public final class ExternalLongExample {
         }
 
         public ExternalLongExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new ExternalLongExample(externalLong, optionalExternalLong, listExternalLong);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
@@ -62,14 +62,14 @@ public final class IntegerExample {
         private Builder() {}
 
         public Builder from(IntegerExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             integer(other.getInteger());
             return this;
         }
 
         @JsonSetter("integer")
         public Builder integer(int integer) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.integer = integer;
             this._integerInitialized = true;
             return this;
@@ -96,10 +96,14 @@ public final class IntegerExample {
         }
 
         public IntegerExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new IntegerExample(integer);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
@@ -3,6 +3,7 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
@@ -52,6 +53,8 @@ public final class IntegerExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private int integer;
 
         private boolean _integerInitialized = false;
@@ -59,12 +62,14 @@ public final class IntegerExample {
         private Builder() {}
 
         public Builder from(IntegerExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             integer(other.getInteger());
             return this;
         }
 
         @JsonSetter("integer")
         public Builder integer(int integer) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.integer = integer;
             this._integerInitialized = true;
             return this;
@@ -91,6 +96,8 @@ public final class IntegerExample {
         }
 
         public IntegerExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new IntegerExample(integer);
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
@@ -153,6 +153,8 @@ public final class ListExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private List<String> items = new ArrayList<>();
 
         private List<Integer> primitiveItems = new ArrayList<>();
@@ -168,6 +170,7 @@ public final class ListExample {
         private Builder() {}
 
         public Builder from(ListExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             items(other.getItems());
             primitiveItems(other.getPrimitiveItems());
             doubleItems(other.getDoubleItems());
@@ -179,23 +182,27 @@ public final class ListExample {
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Iterable<String> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder addAllItems(@Nonnull Iterable<String> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(String items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.add(items);
             return this;
         }
 
         @JsonSetter(value = "primitiveItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder primitiveItems(@Nonnull Iterable<Integer> primitiveItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.primitiveItems.clear();
             ConjureCollections.addAll(
                     this.primitiveItems, Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
@@ -203,18 +210,21 @@ public final class ListExample {
         }
 
         public Builder addAllPrimitiveItems(@Nonnull Iterable<Integer> primitiveItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(
                     this.primitiveItems, Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
             return this;
         }
 
         public Builder primitiveItems(int primitiveItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.primitiveItems.add(primitiveItems);
             return this;
         }
 
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.doubleItems.clear();
             ConjureCollections.addAll(
                     this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
@@ -222,18 +232,21 @@ public final class ListExample {
         }
 
         public Builder addAllDoubleItems(@Nonnull Iterable<Double> doubleItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(
                     this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
             return this;
         }
 
         public Builder doubleItems(double doubleItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.doubleItems.add(doubleItems);
             return this;
         }
 
         @JsonSetter(value = "optionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder optionalItems(@Nonnull Iterable<Optional<String>> optionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalItems.clear();
             ConjureCollections.addAll(
                     this.optionalItems, Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
@@ -241,18 +254,21 @@ public final class ListExample {
         }
 
         public Builder addAllOptionalItems(@Nonnull Iterable<Optional<String>> optionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(
                     this.optionalItems, Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
         }
 
         public Builder optionalItems(Optional<String> optionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalItems.add(optionalItems);
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalItems(@Nonnull Iterable<OptionalAlias> aliasOptionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOptionalItems.clear();
             ConjureCollections.addAll(
                     this.aliasOptionalItems,
@@ -261,6 +277,7 @@ public final class ListExample {
         }
 
         public Builder addAllAliasOptionalItems(@Nonnull Iterable<OptionalAlias> aliasOptionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(
                     this.aliasOptionalItems,
                     Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
@@ -268,12 +285,14 @@ public final class ListExample {
         }
 
         public Builder aliasOptionalItems(OptionalAlias aliasOptionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOptionalItems.add(aliasOptionalItems);
             return this;
         }
 
         @JsonSetter(value = "nestedItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder nestedItems(@Nonnull Iterable<? extends List<String>> nestedItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.nestedItems.clear();
             ConjureCollections.addAll(
                     this.nestedItems, Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
@@ -281,17 +300,21 @@ public final class ListExample {
         }
 
         public Builder addAllNestedItems(@Nonnull Iterable<? extends List<String>> nestedItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(
                     this.nestedItems, Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
             return this;
         }
 
         public Builder nestedItems(List<String> nestedItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.nestedItems.add(nestedItems);
             return this;
         }
 
         public ListExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new ListExample(items, primitiveItems, doubleItems, optionalItems, aliasOptionalItems, nestedItems);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
@@ -170,7 +170,7 @@ public final class ListExample {
         private Builder() {}
 
         public Builder from(ListExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             items(other.getItems());
             primitiveItems(other.getPrimitiveItems());
             doubleItems(other.getDoubleItems());
@@ -182,27 +182,27 @@ public final class ListExample {
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Iterable<String> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder addAllItems(@Nonnull Iterable<String> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(String items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.add(items);
             return this;
         }
 
         @JsonSetter(value = "primitiveItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder primitiveItems(@Nonnull Iterable<Integer> primitiveItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.primitiveItems.clear();
             ConjureCollections.addAll(
                     this.primitiveItems, Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
@@ -210,21 +210,21 @@ public final class ListExample {
         }
 
         public Builder addAllPrimitiveItems(@Nonnull Iterable<Integer> primitiveItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(
                     this.primitiveItems, Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
             return this;
         }
 
         public Builder primitiveItems(int primitiveItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.primitiveItems.add(primitiveItems);
             return this;
         }
 
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.doubleItems.clear();
             ConjureCollections.addAll(
                     this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
@@ -232,21 +232,21 @@ public final class ListExample {
         }
 
         public Builder addAllDoubleItems(@Nonnull Iterable<Double> doubleItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(
                     this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
             return this;
         }
 
         public Builder doubleItems(double doubleItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.doubleItems.add(doubleItems);
             return this;
         }
 
         @JsonSetter(value = "optionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder optionalItems(@Nonnull Iterable<Optional<String>> optionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalItems.clear();
             ConjureCollections.addAll(
                     this.optionalItems, Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
@@ -254,21 +254,21 @@ public final class ListExample {
         }
 
         public Builder addAllOptionalItems(@Nonnull Iterable<Optional<String>> optionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(
                     this.optionalItems, Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
         }
 
         public Builder optionalItems(Optional<String> optionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalItems.add(optionalItems);
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalItems(@Nonnull Iterable<OptionalAlias> aliasOptionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOptionalItems.clear();
             ConjureCollections.addAll(
                     this.aliasOptionalItems,
@@ -277,7 +277,7 @@ public final class ListExample {
         }
 
         public Builder addAllAliasOptionalItems(@Nonnull Iterable<OptionalAlias> aliasOptionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(
                     this.aliasOptionalItems,
                     Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
@@ -285,14 +285,14 @@ public final class ListExample {
         }
 
         public Builder aliasOptionalItems(OptionalAlias aliasOptionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOptionalItems.add(aliasOptionalItems);
             return this;
         }
 
         @JsonSetter(value = "nestedItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder nestedItems(@Nonnull Iterable<? extends List<String>> nestedItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.nestedItems.clear();
             ConjureCollections.addAll(
                     this.nestedItems, Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
@@ -300,22 +300,26 @@ public final class ListExample {
         }
 
         public Builder addAllNestedItems(@Nonnull Iterable<? extends List<String>> nestedItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(
                     this.nestedItems, Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
             return this;
         }
 
         public Builder nestedItems(List<String> nestedItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.nestedItems.add(nestedItems);
             return this;
         }
 
         public ListExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new ListExample(items, primitiveItems, doubleItems, optionalItems, aliasOptionalItems, nestedItems);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -208,6 +208,8 @@ public final class ManyFieldExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private String string;
 
         private int integer;
@@ -231,6 +233,7 @@ public final class ManyFieldExample {
         private Builder() {}
 
         public Builder from(ManyFieldExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             string(other.getString());
             integer(other.getInteger());
             doubleValue(other.getDoubleValue());
@@ -247,6 +250,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter("string")
         public Builder string(@Nonnull String string) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.string = Preconditions.checkNotNull(string, "string cannot be null");
             return this;
         }
@@ -256,6 +260,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter("integer")
         public Builder integer(int integer) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.integer = integer;
             this._integerInitialized = true;
             return this;
@@ -266,6 +271,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter("doubleValue")
         public Builder doubleValue(double doubleValue) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.doubleValue = doubleValue;
             this._doubleValueInitialized = true;
             return this;
@@ -276,6 +282,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter(value = "optionalItem", nulls = Nulls.SKIP)
         public Builder optionalItem(@Nonnull Optional<String> optionalItem) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalItem = Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null");
             return this;
         }
@@ -284,6 +291,7 @@ public final class ManyFieldExample {
          * docs for optionalItem field
          */
         public Builder optionalItem(@Nonnull String optionalItem) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalItem = Optional.of(Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null"));
             return this;
         }
@@ -293,6 +301,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Iterable<String> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
@@ -302,6 +311,7 @@ public final class ManyFieldExample {
          * docs for items field with exciting character$ used by javapoet.
          */
         public Builder addAllItems(@Nonnull Iterable<String> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
@@ -310,6 +320,7 @@ public final class ManyFieldExample {
          * docs for items field with exciting character$ used by javapoet.
          */
         public Builder items(String items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.add(items);
             return this;
         }
@@ -319,6 +330,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter(value = "set", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder set(@Nonnull Iterable<String> set) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.set.clear();
             ConjureCollections.addAll(this.set, Preconditions.checkNotNull(set, "set cannot be null"));
             return this;
@@ -328,6 +340,7 @@ public final class ManyFieldExample {
          * docs for set field
          */
         public Builder addAllSet(@Nonnull Iterable<String> set) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(this.set, Preconditions.checkNotNull(set, "set cannot be null"));
             return this;
         }
@@ -336,6 +349,7 @@ public final class ManyFieldExample {
          * docs for set field
          */
         public Builder set(String set) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.set.add(set);
             return this;
         }
@@ -346,6 +360,7 @@ public final class ManyFieldExample {
         @Deprecated
         @JsonSetter(value = "map", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder map(@Nonnull Map<String, String> map) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.map.clear();
             this.map.putAll(Preconditions.checkNotNull(map, "map cannot be null"));
             return this;
@@ -356,6 +371,7 @@ public final class ManyFieldExample {
          */
         @Deprecated
         public Builder putAllMap(@Nonnull Map<String, String> map) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.map.putAll(Preconditions.checkNotNull(map, "map cannot be null"));
             return this;
         }
@@ -365,6 +381,7 @@ public final class ManyFieldExample {
          */
         @Deprecated
         public Builder map(String key, String value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.map.put(key, value);
             return this;
         }
@@ -376,6 +393,7 @@ public final class ManyFieldExample {
         @Deprecated
         @JsonSetter("alias")
         public Builder alias(@Nonnull StringAliasExample alias) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.alias = Preconditions.checkNotNull(alias, "alias cannot be null");
             return this;
         }
@@ -402,6 +420,8 @@ public final class ManyFieldExample {
         }
 
         public ManyFieldExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new ManyFieldExample(string, integer, doubleValue, optionalItem, items, set, map, alias);
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -233,7 +233,7 @@ public final class ManyFieldExample {
         private Builder() {}
 
         public Builder from(ManyFieldExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             string(other.getString());
             integer(other.getInteger());
             doubleValue(other.getDoubleValue());
@@ -250,7 +250,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter("string")
         public Builder string(@Nonnull String string) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.string = Preconditions.checkNotNull(string, "string cannot be null");
             return this;
         }
@@ -260,7 +260,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter("integer")
         public Builder integer(int integer) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.integer = integer;
             this._integerInitialized = true;
             return this;
@@ -271,7 +271,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter("doubleValue")
         public Builder doubleValue(double doubleValue) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.doubleValue = doubleValue;
             this._doubleValueInitialized = true;
             return this;
@@ -282,7 +282,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter(value = "optionalItem", nulls = Nulls.SKIP)
         public Builder optionalItem(@Nonnull Optional<String> optionalItem) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalItem = Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null");
             return this;
         }
@@ -291,7 +291,7 @@ public final class ManyFieldExample {
          * docs for optionalItem field
          */
         public Builder optionalItem(@Nonnull String optionalItem) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalItem = Optional.of(Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null"));
             return this;
         }
@@ -301,7 +301,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Iterable<String> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
@@ -311,7 +311,7 @@ public final class ManyFieldExample {
          * docs for items field with exciting character$ used by javapoet.
          */
         public Builder addAllItems(@Nonnull Iterable<String> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
@@ -320,7 +320,7 @@ public final class ManyFieldExample {
          * docs for items field with exciting character$ used by javapoet.
          */
         public Builder items(String items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.add(items);
             return this;
         }
@@ -330,7 +330,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter(value = "set", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder set(@Nonnull Iterable<String> set) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.set.clear();
             ConjureCollections.addAll(this.set, Preconditions.checkNotNull(set, "set cannot be null"));
             return this;
@@ -340,7 +340,7 @@ public final class ManyFieldExample {
          * docs for set field
          */
         public Builder addAllSet(@Nonnull Iterable<String> set) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(this.set, Preconditions.checkNotNull(set, "set cannot be null"));
             return this;
         }
@@ -349,7 +349,7 @@ public final class ManyFieldExample {
          * docs for set field
          */
         public Builder set(String set) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.set.add(set);
             return this;
         }
@@ -360,7 +360,7 @@ public final class ManyFieldExample {
         @Deprecated
         @JsonSetter(value = "map", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder map(@Nonnull Map<String, String> map) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.map.clear();
             this.map.putAll(Preconditions.checkNotNull(map, "map cannot be null"));
             return this;
@@ -371,7 +371,7 @@ public final class ManyFieldExample {
          */
         @Deprecated
         public Builder putAllMap(@Nonnull Map<String, String> map) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.map.putAll(Preconditions.checkNotNull(map, "map cannot be null"));
             return this;
         }
@@ -381,7 +381,7 @@ public final class ManyFieldExample {
          */
         @Deprecated
         public Builder map(String key, String value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.map.put(key, value);
             return this;
         }
@@ -393,7 +393,7 @@ public final class ManyFieldExample {
         @Deprecated
         @JsonSetter("alias")
         public Builder alias(@Nonnull StringAliasExample alias) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.alias = Preconditions.checkNotNull(alias, "alias cannot be null");
             return this;
         }
@@ -420,10 +420,14 @@ public final class ManyFieldExample {
         }
 
         public ManyFieldExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new ManyFieldExample(string, integer, doubleValue, optionalItem, items, set, map, alias);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
@@ -122,6 +122,8 @@ public final class MapExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private Map<String, String> items = new LinkedHashMap<>();
 
         private Map<String, Optional<String>> optionalItems = new LinkedHashMap<>();
@@ -131,6 +133,7 @@ public final class MapExample {
         private Builder() {}
 
         public Builder from(MapExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             items(other.getItems());
             optionalItems(other.getOptionalItems());
             aliasOptionalItems(other.getAliasOptionalItems());
@@ -139,40 +142,47 @@ public final class MapExample {
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Map<String, String> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.clear();
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder putAllItems(@Nonnull Map<String, String> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(String key, String value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "optionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder optionalItems(@Nonnull Map<String, Optional<String>> optionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalItems.clear();
             this.optionalItems.putAll(Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
         }
 
         public Builder putAllOptionalItems(@Nonnull Map<String, Optional<String>> optionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalItems.putAll(Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
         }
 
         public Builder optionalItems(String key, Optional<String> value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalItems.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalItems(@Nonnull Map<String, OptionalAlias> aliasOptionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOptionalItems.clear();
             this.aliasOptionalItems.putAll(
                     Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
@@ -180,17 +190,21 @@ public final class MapExample {
         }
 
         public Builder putAllAliasOptionalItems(@Nonnull Map<String, OptionalAlias> aliasOptionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOptionalItems.putAll(
                     Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
             return this;
         }
 
         public Builder aliasOptionalItems(String key, OptionalAlias value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOptionalItems.put(key, value);
             return this;
         }
 
         public MapExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new MapExample(items, optionalItems, aliasOptionalItems);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
@@ -133,7 +133,7 @@ public final class MapExample {
         private Builder() {}
 
         public Builder from(MapExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             items(other.getItems());
             optionalItems(other.getOptionalItems());
             aliasOptionalItems(other.getAliasOptionalItems());
@@ -142,47 +142,47 @@ public final class MapExample {
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Map<String, String> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.clear();
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder putAllItems(@Nonnull Map<String, String> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(String key, String value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "optionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder optionalItems(@Nonnull Map<String, Optional<String>> optionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalItems.clear();
             this.optionalItems.putAll(Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
         }
 
         public Builder putAllOptionalItems(@Nonnull Map<String, Optional<String>> optionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalItems.putAll(Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
         }
 
         public Builder optionalItems(String key, Optional<String> value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalItems.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalItems(@Nonnull Map<String, OptionalAlias> aliasOptionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOptionalItems.clear();
             this.aliasOptionalItems.putAll(
                     Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
@@ -190,22 +190,26 @@ public final class MapExample {
         }
 
         public Builder putAllAliasOptionalItems(@Nonnull Map<String, OptionalAlias> aliasOptionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOptionalItems.putAll(
                     Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
             return this;
         }
 
         public Builder aliasOptionalItems(String key, OptionalAlias value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOptionalItems.put(key, value);
             return this;
         }
 
         public MapExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new MapExample(items, optionalItems, aliasOptionalItems);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleFieldsOnlyFinalStage.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleFieldsOnlyFinalStage.java
@@ -138,7 +138,7 @@ public final class MultipleFieldsOnlyFinalStage {
         private Builder() {}
 
         public Builder from(MultipleFieldsOnlyFinalStage other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             items(other.getItems());
             itemsMap(other.getItemsMap());
             optionalItem(other.getOptionalItem());
@@ -148,81 +148,85 @@ public final class MultipleFieldsOnlyFinalStage {
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<String> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder addAllItems(@Nonnull Iterable<String> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(String items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.add(items);
             return this;
         }
 
         @JsonSetter(value = "itemsMap", nulls = Nulls.SKIP)
         public Builder itemsMap(@Nonnull Map<String, Integer> itemsMap) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.itemsMap.clear();
             this.itemsMap.putAll(Preconditions.checkNotNull(itemsMap, "itemsMap cannot be null"));
             return this;
         }
 
         public Builder putAllItemsMap(@Nonnull Map<String, Integer> itemsMap) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.itemsMap.putAll(Preconditions.checkNotNull(itemsMap, "itemsMap cannot be null"));
             return this;
         }
 
         public Builder itemsMap(String key, int value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.itemsMap.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "optionalItem", nulls = Nulls.SKIP)
         public Builder optionalItem(@Nonnull Optional<String> optionalItem) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalItem = Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null");
             return this;
         }
 
         public Builder optionalItem(@Nonnull String optionalItem) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalItem = Optional.of(Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "itemsSet", nulls = Nulls.SKIP)
         public Builder itemsSet(@Nonnull Iterable<String> itemsSet) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.itemsSet.clear();
             ConjureCollections.addAll(this.itemsSet, Preconditions.checkNotNull(itemsSet, "itemsSet cannot be null"));
             return this;
         }
 
         public Builder addAllItemsSet(@Nonnull Iterable<String> itemsSet) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(this.itemsSet, Preconditions.checkNotNull(itemsSet, "itemsSet cannot be null"));
             return this;
         }
 
         public Builder itemsSet(String itemsSet) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.itemsSet.add(itemsSet);
             return this;
         }
 
         public MultipleFieldsOnlyFinalStage build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new MultipleFieldsOnlyFinalStage(items, itemsMap, optionalItem, itemsSet);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleFieldsOnlyFinalStage.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleFieldsOnlyFinalStage.java
@@ -125,6 +125,8 @@ public final class MultipleFieldsOnlyFinalStage {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private List<String> items = new ArrayList<>();
 
         private Map<String, Integer> itemsMap = new LinkedHashMap<>();
@@ -136,6 +138,7 @@ public final class MultipleFieldsOnlyFinalStage {
         private Builder() {}
 
         public Builder from(MultipleFieldsOnlyFinalStage other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             items(other.getItems());
             itemsMap(other.getItemsMap());
             optionalItem(other.getOptionalItem());
@@ -145,67 +148,80 @@ public final class MultipleFieldsOnlyFinalStage {
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<String> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder addAllItems(@Nonnull Iterable<String> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(String items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.add(items);
             return this;
         }
 
         @JsonSetter(value = "itemsMap", nulls = Nulls.SKIP)
         public Builder itemsMap(@Nonnull Map<String, Integer> itemsMap) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.itemsMap.clear();
             this.itemsMap.putAll(Preconditions.checkNotNull(itemsMap, "itemsMap cannot be null"));
             return this;
         }
 
         public Builder putAllItemsMap(@Nonnull Map<String, Integer> itemsMap) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.itemsMap.putAll(Preconditions.checkNotNull(itemsMap, "itemsMap cannot be null"));
             return this;
         }
 
         public Builder itemsMap(String key, int value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.itemsMap.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "optionalItem", nulls = Nulls.SKIP)
         public Builder optionalItem(@Nonnull Optional<String> optionalItem) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalItem = Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null");
             return this;
         }
 
         public Builder optionalItem(@Nonnull String optionalItem) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalItem = Optional.of(Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "itemsSet", nulls = Nulls.SKIP)
         public Builder itemsSet(@Nonnull Iterable<String> itemsSet) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.itemsSet.clear();
             ConjureCollections.addAll(this.itemsSet, Preconditions.checkNotNull(itemsSet, "itemsSet cannot be null"));
             return this;
         }
 
         public Builder addAllItemsSet(@Nonnull Iterable<String> itemsSet) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(this.itemsSet, Preconditions.checkNotNull(itemsSet, "itemsSet cannot be null"));
             return this;
         }
 
         public Builder itemsSet(String itemsSet) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.itemsSet.add(itemsSet);
             return this;
         }
 
         public MultipleFieldsOnlyFinalStage build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new MultipleFieldsOnlyFinalStage(items, itemsMap, optionalItem, itemsSet);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
@@ -194,7 +194,7 @@ public final class MultipleOrderedStages {
         private DefaultBuilder() {}
 
         public Builder from(MultipleOrderedStages other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             token(other.getToken());
             item(other.getItem());
             items(other.getItems());
@@ -204,62 +204,66 @@ public final class MultipleOrderedStages {
 
         @JsonSetter("token")
         public Builder token(@Nonnull OneField token) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.token = Preconditions.checkNotNull(token, "token cannot be null");
             return this;
         }
 
         @JsonSetter("item")
         public Builder item(@Nonnull String item) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.item = Preconditions.checkNotNull(item, "item cannot be null");
             return this;
         }
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<SafeLong> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder addAllItems(@Nonnull Iterable<SafeLong> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(SafeLong items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.add(items);
             return this;
         }
 
         @JsonSetter(value = "mappedRids", nulls = Nulls.SKIP)
         public Builder mappedRids(@Nonnull Map<ResourceIdentifier, String> mappedRids) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.mappedRids.clear();
             this.mappedRids.putAll(Preconditions.checkNotNull(mappedRids, "mappedRids cannot be null"));
             return this;
         }
 
         public Builder putAllMappedRids(@Nonnull Map<ResourceIdentifier, String> mappedRids) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.mappedRids.putAll(Preconditions.checkNotNull(mappedRids, "mappedRids cannot be null"));
             return this;
         }
 
         public Builder mappedRids(ResourceIdentifier key, String value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.mappedRids.put(key, value);
             return this;
         }
 
         public MultipleOrderedStages build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new MultipleOrderedStages(token, item, items, mappedRids);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
@@ -181,6 +181,8 @@ public final class MultipleOrderedStages {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     static final class DefaultBuilder implements Builder {
+        boolean _buildInvoked;
+
         private OneField token;
 
         private String item;
@@ -192,6 +194,7 @@ public final class MultipleOrderedStages {
         private DefaultBuilder() {}
 
         public Builder from(MultipleOrderedStages other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             token(other.getToken());
             item(other.getItem());
             items(other.getItems());
@@ -201,51 +204,61 @@ public final class MultipleOrderedStages {
 
         @JsonSetter("token")
         public Builder token(@Nonnull OneField token) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.token = Preconditions.checkNotNull(token, "token cannot be null");
             return this;
         }
 
         @JsonSetter("item")
         public Builder item(@Nonnull String item) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.item = Preconditions.checkNotNull(item, "item cannot be null");
             return this;
         }
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<SafeLong> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder addAllItems(@Nonnull Iterable<SafeLong> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(SafeLong items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.add(items);
             return this;
         }
 
         @JsonSetter(value = "mappedRids", nulls = Nulls.SKIP)
         public Builder mappedRids(@Nonnull Map<ResourceIdentifier, String> mappedRids) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.mappedRids.clear();
             this.mappedRids.putAll(Preconditions.checkNotNull(mappedRids, "mappedRids cannot be null"));
             return this;
         }
 
         public Builder putAllMappedRids(@Nonnull Map<ResourceIdentifier, String> mappedRids) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.mappedRids.putAll(Preconditions.checkNotNull(mappedRids, "mappedRids cannot be null"));
             return this;
         }
 
         public Builder mappedRids(ResourceIdentifier key, String value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.mappedRids.put(key, value);
             return this;
         }
 
         public MultipleOrderedStages build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new MultipleOrderedStages(token, item, items, mappedRids);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OneField.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OneField.java
@@ -100,22 +100,28 @@ public final class OneField {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     static final class DefaultBuilder implements Builder {
+        boolean _buildInvoked;
+
         private BearerToken bearerTokenValue;
 
         private DefaultBuilder() {}
 
         public Builder from(OneField other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             bearerTokenValue(other.getBearerTokenValue());
             return this;
         }
 
         @JsonSetter("bearerTokenValue")
         public Builder bearerTokenValue(@Nonnull BearerToken bearerTokenValue) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.bearerTokenValue = Preconditions.checkNotNull(bearerTokenValue, "bearerTokenValue cannot be null");
             return this;
         }
 
         public OneField build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new OneField(bearerTokenValue);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OneField.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OneField.java
@@ -107,22 +107,26 @@ public final class OneField {
         private DefaultBuilder() {}
 
         public Builder from(OneField other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             bearerTokenValue(other.getBearerTokenValue());
             return this;
         }
 
         @JsonSetter("bearerTokenValue")
         public Builder bearerTokenValue(@Nonnull BearerToken bearerTokenValue) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.bearerTokenValue = Preconditions.checkNotNull(bearerTokenValue, "bearerTokenValue cannot be null");
             return this;
         }
 
         public OneField build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new OneField(bearerTokenValue);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OneFieldOnlyFinalStage.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OneFieldOnlyFinalStage.java
@@ -82,27 +82,34 @@ public final class OneFieldOnlyFinalStage {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private Optional<String> optionalItem = Optional.empty();
 
         private Builder() {}
 
         public Builder from(OneFieldOnlyFinalStage other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             optionalItem(other.getOptionalItem());
             return this;
         }
 
         @JsonSetter(value = "optionalItem", nulls = Nulls.SKIP)
         public Builder optionalItem(@Nonnull Optional<String> optionalItem) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalItem = Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null");
             return this;
         }
 
         public Builder optionalItem(@Nonnull String optionalItem) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalItem = Optional.of(Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null"));
             return this;
         }
 
         public OneFieldOnlyFinalStage build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new OneFieldOnlyFinalStage(optionalItem);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OneFieldOnlyFinalStage.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OneFieldOnlyFinalStage.java
@@ -89,28 +89,32 @@ public final class OneFieldOnlyFinalStage {
         private Builder() {}
 
         public Builder from(OneFieldOnlyFinalStage other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             optionalItem(other.getOptionalItem());
             return this;
         }
 
         @JsonSetter(value = "optionalItem", nulls = Nulls.SKIP)
         public Builder optionalItem(@Nonnull Optional<String> optionalItem) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalItem = Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null");
             return this;
         }
 
         public Builder optionalItem(@Nonnull String optionalItem) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalItem = Optional.of(Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null"));
             return this;
         }
 
         public OneFieldOnlyFinalStage build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new OneFieldOnlyFinalStage(optionalItem);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAliasExample.java
@@ -79,22 +79,28 @@ public final class OptionalAliasExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private OptionalAlias optionalAlias;
 
         private Builder() {}
 
         public Builder from(OptionalAliasExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             optionalAlias(other.getOptionalAlias());
             return this;
         }
 
         @JsonSetter(value = "optionalAlias", nulls = Nulls.AS_EMPTY)
         public Builder optionalAlias(@Nonnull OptionalAlias optionalAlias) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalAlias = Preconditions.checkNotNull(optionalAlias, "optionalAlias cannot be null");
             return this;
         }
 
         public OptionalAliasExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new OptionalAliasExample(optionalAlias);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAliasExample.java
@@ -86,22 +86,26 @@ public final class OptionalAliasExample {
         private Builder() {}
 
         public Builder from(OptionalAliasExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             optionalAlias(other.getOptionalAlias());
             return this;
         }
 
         @JsonSetter(value = "optionalAlias", nulls = Nulls.AS_EMPTY)
         public Builder optionalAlias(@Nonnull OptionalAlias optionalAlias) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalAlias = Preconditions.checkNotNull(optionalAlias, "optionalAlias cannot be null");
             return this;
         }
 
         public OptionalAliasExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new OptionalAliasExample(optionalAlias);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
@@ -87,28 +87,32 @@ public final class OptionalExample {
         private Builder() {}
 
         public Builder from(OptionalExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             item(other.getItem());
             return this;
         }
 
         @JsonSetter(value = "item", nulls = Nulls.SKIP)
         public Builder item(@Nonnull Optional<String> item) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.item = Preconditions.checkNotNull(item, "item cannot be null");
             return this;
         }
 
         public Builder item(@Nonnull String item) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.item = Optional.of(Preconditions.checkNotNull(item, "item cannot be null"));
             return this;
         }
 
         public OptionalExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new OptionalExample(item);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
@@ -80,27 +80,34 @@ public final class OptionalExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private Optional<String> item = Optional.empty();
 
         private Builder() {}
 
         public Builder from(OptionalExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             item(other.getItem());
             return this;
         }
 
         @JsonSetter(value = "item", nulls = Nulls.SKIP)
         public Builder item(@Nonnull Optional<String> item) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.item = Preconditions.checkNotNull(item, "item cannot be null");
             return this;
         }
 
         public Builder item(@Nonnull String item) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.item = Optional.of(Preconditions.checkNotNull(item, "item cannot be null"));
             return this;
         }
 
         public OptionalExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new OptionalExample(item);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
@@ -398,7 +398,7 @@ public final class PrimitiveOptionalsExample {
         private Builder() {}
 
         public Builder from(PrimitiveOptionalsExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             num(other.getNum());
             bool(other.getBool());
             integer(other.getInteger());
@@ -422,210 +422,210 @@ public final class PrimitiveOptionalsExample {
 
         @JsonSetter(value = "num", nulls = Nulls.SKIP)
         public Builder num(@Nonnull OptionalDouble num) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.num = Preconditions.checkNotNull(num, "num cannot be null");
             return this;
         }
 
         public Builder num(double num) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.num = OptionalDouble.of(num);
             return this;
         }
 
         @JsonSetter(value = "bool", nulls = Nulls.SKIP)
         public Builder bool(@Nonnull Optional<Boolean> bool) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.bool = Preconditions.checkNotNull(bool, "bool cannot be null");
             return this;
         }
 
         public Builder bool(boolean bool) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.bool = Optional.of(bool);
             return this;
         }
 
         @JsonSetter(value = "integer", nulls = Nulls.SKIP)
         public Builder integer(@Nonnull OptionalInt integer) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.integer = Preconditions.checkNotNull(integer, "integer cannot be null");
             return this;
         }
 
         public Builder integer(int integer) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.integer = OptionalInt.of(integer);
             return this;
         }
 
         @JsonSetter(value = "safelong", nulls = Nulls.SKIP)
         public Builder safelong(@Nonnull Optional<SafeLong> safelong) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.safelong = Preconditions.checkNotNull(safelong, "safelong cannot be null");
             return this;
         }
 
         public Builder safelong(@Nonnull SafeLong safelong) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.safelong = Optional.of(Preconditions.checkNotNull(safelong, "safelong cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "rid", nulls = Nulls.SKIP)
         public Builder rid(@Nonnull Optional<ResourceIdentifier> rid) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.rid = Preconditions.checkNotNull(rid, "rid cannot be null");
             return this;
         }
 
         public Builder rid(@Nonnull ResourceIdentifier rid) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.rid = Optional.of(Preconditions.checkNotNull(rid, "rid cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "bearertoken", nulls = Nulls.SKIP)
         public Builder bearertoken(@Nonnull Optional<BearerToken> bearertoken) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.bearertoken = Preconditions.checkNotNull(bearertoken, "bearertoken cannot be null");
             return this;
         }
 
         public Builder bearertoken(@Nonnull BearerToken bearertoken) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.bearertoken = Optional.of(Preconditions.checkNotNull(bearertoken, "bearertoken cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "uuid", nulls = Nulls.SKIP)
         public Builder uuid(@Nonnull Optional<UUID> uuid) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.uuid = Preconditions.checkNotNull(uuid, "uuid cannot be null");
             return this;
         }
 
         public Builder uuid(@Nonnull UUID uuid) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.uuid = Optional.of(Preconditions.checkNotNull(uuid, "uuid cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(@Nonnull Optional<? extends Map<String, String>> map) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.map = Preconditions.checkNotNull(map, "map cannot be null").map(Function.identity());
             return this;
         }
 
         public Builder map(@Nonnull Map<String, String> map) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.map = Optional.of(Preconditions.checkNotNull(map, "map cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "list", nulls = Nulls.SKIP)
         public Builder list(@Nonnull Optional<? extends List<String>> list) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.list = Preconditions.checkNotNull(list, "list cannot be null").map(Function.identity());
             return this;
         }
 
         public Builder list(@Nonnull List<String> list) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.list = Optional.of(Preconditions.checkNotNull(list, "list cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "set", nulls = Nulls.SKIP)
         public Builder set(@Nonnull Optional<? extends Set<String>> set) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.set = Preconditions.checkNotNull(set, "set cannot be null").map(Function.identity());
             return this;
         }
 
         public Builder set(@Nonnull Set<String> set) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.set = Optional.of(Preconditions.checkNotNull(set, "set cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "aliasOne", nulls = Nulls.SKIP)
         public Builder aliasOne(@Nonnull Optional<StringAliasOne> aliasOne) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOne = Preconditions.checkNotNull(aliasOne, "aliasOne cannot be null");
             return this;
         }
 
         public Builder aliasOne(@Nonnull StringAliasOne aliasOne) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOne = Optional.of(Preconditions.checkNotNull(aliasOne, "aliasOne cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "aliasTwo", nulls = Nulls.AS_EMPTY)
         public Builder aliasTwo(@Nonnull StringAliasTwo aliasTwo) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasTwo = Preconditions.checkNotNull(aliasTwo, "aliasTwo cannot be null");
             return this;
         }
 
         @JsonSetter(value = "aliasList", nulls = Nulls.SKIP)
         public Builder aliasList(@Nonnull Optional<ListAlias> aliasList) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasList = Preconditions.checkNotNull(aliasList, "aliasList cannot be null");
             return this;
         }
 
         public Builder aliasList(@Nonnull ListAlias aliasList) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasList = Optional.of(Preconditions.checkNotNull(aliasList, "aliasList cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "aliasMap", nulls = Nulls.SKIP)
         public Builder aliasMap(@Nonnull Optional<MapAliasExample> aliasMap) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasMap = Preconditions.checkNotNull(aliasMap, "aliasMap cannot be null");
             return this;
         }
 
         public Builder aliasMap(@Nonnull MapAliasExample aliasMap) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasMap = Optional.of(Preconditions.checkNotNull(aliasMap, "aliasMap cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "aliasOptional", nulls = Nulls.AS_EMPTY)
         public Builder aliasOptional(@Nonnull OptionalAlias aliasOptional) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOptional = Preconditions.checkNotNull(aliasOptional, "aliasOptional cannot be null");
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalMap", nulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalMap(@Nonnull OptionalMapAliasExample aliasOptionalMap) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOptionalMap = Preconditions.checkNotNull(aliasOptionalMap, "aliasOptionalMap cannot be null");
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalList", nulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalList(@Nonnull OptionalListAliasExample aliasOptionalList) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOptionalList = Preconditions.checkNotNull(aliasOptionalList, "aliasOptionalList cannot be null");
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalSet", nulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalSet(@Nonnull OptionalSetAliasExample aliasOptionalSet) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOptionalSet = Preconditions.checkNotNull(aliasOptionalSet, "aliasOptionalSet cannot be null");
             return this;
         }
 
         public PrimitiveOptionalsExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new PrimitiveOptionalsExample(
                     num,
@@ -646,6 +646,10 @@ public final class PrimitiveOptionalsExample {
                     aliasOptionalMap,
                     aliasOptionalList,
                     aliasOptionalSet);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
@@ -357,6 +357,8 @@ public final class PrimitiveOptionalsExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private OptionalDouble num = OptionalDouble.empty();
 
         private Optional<Boolean> bool = Optional.empty();
@@ -396,6 +398,7 @@ public final class PrimitiveOptionalsExample {
         private Builder() {}
 
         public Builder from(PrimitiveOptionalsExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             num(other.getNum());
             bool(other.getBool());
             integer(other.getInteger());
@@ -419,178 +422,211 @@ public final class PrimitiveOptionalsExample {
 
         @JsonSetter(value = "num", nulls = Nulls.SKIP)
         public Builder num(@Nonnull OptionalDouble num) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.num = Preconditions.checkNotNull(num, "num cannot be null");
             return this;
         }
 
         public Builder num(double num) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.num = OptionalDouble.of(num);
             return this;
         }
 
         @JsonSetter(value = "bool", nulls = Nulls.SKIP)
         public Builder bool(@Nonnull Optional<Boolean> bool) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.bool = Preconditions.checkNotNull(bool, "bool cannot be null");
             return this;
         }
 
         public Builder bool(boolean bool) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.bool = Optional.of(bool);
             return this;
         }
 
         @JsonSetter(value = "integer", nulls = Nulls.SKIP)
         public Builder integer(@Nonnull OptionalInt integer) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.integer = Preconditions.checkNotNull(integer, "integer cannot be null");
             return this;
         }
 
         public Builder integer(int integer) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.integer = OptionalInt.of(integer);
             return this;
         }
 
         @JsonSetter(value = "safelong", nulls = Nulls.SKIP)
         public Builder safelong(@Nonnull Optional<SafeLong> safelong) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.safelong = Preconditions.checkNotNull(safelong, "safelong cannot be null");
             return this;
         }
 
         public Builder safelong(@Nonnull SafeLong safelong) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.safelong = Optional.of(Preconditions.checkNotNull(safelong, "safelong cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "rid", nulls = Nulls.SKIP)
         public Builder rid(@Nonnull Optional<ResourceIdentifier> rid) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.rid = Preconditions.checkNotNull(rid, "rid cannot be null");
             return this;
         }
 
         public Builder rid(@Nonnull ResourceIdentifier rid) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.rid = Optional.of(Preconditions.checkNotNull(rid, "rid cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "bearertoken", nulls = Nulls.SKIP)
         public Builder bearertoken(@Nonnull Optional<BearerToken> bearertoken) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.bearertoken = Preconditions.checkNotNull(bearertoken, "bearertoken cannot be null");
             return this;
         }
 
         public Builder bearertoken(@Nonnull BearerToken bearertoken) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.bearertoken = Optional.of(Preconditions.checkNotNull(bearertoken, "bearertoken cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "uuid", nulls = Nulls.SKIP)
         public Builder uuid(@Nonnull Optional<UUID> uuid) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.uuid = Preconditions.checkNotNull(uuid, "uuid cannot be null");
             return this;
         }
 
         public Builder uuid(@Nonnull UUID uuid) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.uuid = Optional.of(Preconditions.checkNotNull(uuid, "uuid cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(@Nonnull Optional<? extends Map<String, String>> map) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.map = Preconditions.checkNotNull(map, "map cannot be null").map(Function.identity());
             return this;
         }
 
         public Builder map(@Nonnull Map<String, String> map) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.map = Optional.of(Preconditions.checkNotNull(map, "map cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "list", nulls = Nulls.SKIP)
         public Builder list(@Nonnull Optional<? extends List<String>> list) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.list = Preconditions.checkNotNull(list, "list cannot be null").map(Function.identity());
             return this;
         }
 
         public Builder list(@Nonnull List<String> list) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.list = Optional.of(Preconditions.checkNotNull(list, "list cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "set", nulls = Nulls.SKIP)
         public Builder set(@Nonnull Optional<? extends Set<String>> set) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.set = Preconditions.checkNotNull(set, "set cannot be null").map(Function.identity());
             return this;
         }
 
         public Builder set(@Nonnull Set<String> set) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.set = Optional.of(Preconditions.checkNotNull(set, "set cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "aliasOne", nulls = Nulls.SKIP)
         public Builder aliasOne(@Nonnull Optional<StringAliasOne> aliasOne) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOne = Preconditions.checkNotNull(aliasOne, "aliasOne cannot be null");
             return this;
         }
 
         public Builder aliasOne(@Nonnull StringAliasOne aliasOne) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOne = Optional.of(Preconditions.checkNotNull(aliasOne, "aliasOne cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "aliasTwo", nulls = Nulls.AS_EMPTY)
         public Builder aliasTwo(@Nonnull StringAliasTwo aliasTwo) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasTwo = Preconditions.checkNotNull(aliasTwo, "aliasTwo cannot be null");
             return this;
         }
 
         @JsonSetter(value = "aliasList", nulls = Nulls.SKIP)
         public Builder aliasList(@Nonnull Optional<ListAlias> aliasList) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasList = Preconditions.checkNotNull(aliasList, "aliasList cannot be null");
             return this;
         }
 
         public Builder aliasList(@Nonnull ListAlias aliasList) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasList = Optional.of(Preconditions.checkNotNull(aliasList, "aliasList cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "aliasMap", nulls = Nulls.SKIP)
         public Builder aliasMap(@Nonnull Optional<MapAliasExample> aliasMap) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasMap = Preconditions.checkNotNull(aliasMap, "aliasMap cannot be null");
             return this;
         }
 
         public Builder aliasMap(@Nonnull MapAliasExample aliasMap) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasMap = Optional.of(Preconditions.checkNotNull(aliasMap, "aliasMap cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "aliasOptional", nulls = Nulls.AS_EMPTY)
         public Builder aliasOptional(@Nonnull OptionalAlias aliasOptional) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOptional = Preconditions.checkNotNull(aliasOptional, "aliasOptional cannot be null");
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalMap", nulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalMap(@Nonnull OptionalMapAliasExample aliasOptionalMap) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOptionalMap = Preconditions.checkNotNull(aliasOptionalMap, "aliasOptionalMap cannot be null");
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalList", nulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalList(@Nonnull OptionalListAliasExample aliasOptionalList) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOptionalList = Preconditions.checkNotNull(aliasOptionalList, "aliasOptionalList cannot be null");
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalSet", nulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalSet(@Nonnull OptionalSetAliasExample aliasOptionalSet) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOptionalSet = Preconditions.checkNotNull(aliasOptionalSet, "aliasOptionalSet cannot be null");
             return this;
         }
 
         public PrimitiveOptionalsExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new PrimitiveOptionalsExample(
                     num,
                     bool,

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -163,7 +163,7 @@ public final class ReservedKeyExample {
         private Builder() {}
 
         public Builder from(ReservedKeyExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             package_(other.getPackage());
             interface_(other.getInterface());
             fieldNameWithDashes(other.getFieldNameWithDashes());
@@ -175,21 +175,21 @@ public final class ReservedKeyExample {
 
         @JsonSetter("package")
         public Builder package_(@Nonnull String package_) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.package_ = Preconditions.checkNotNull(package_, "package cannot be null");
             return this;
         }
 
         @JsonSetter("interface")
         public Builder interface_(@Nonnull String interface_) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.interface_ = Preconditions.checkNotNull(interface_, "interface cannot be null");
             return this;
         }
 
         @JsonSetter("field-name-with-dashes")
         public Builder fieldNameWithDashes(@Nonnull String fieldNameWithDashes) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.fieldNameWithDashes =
                     Preconditions.checkNotNull(fieldNameWithDashes, "field-name-with-dashes cannot be null");
             return this;
@@ -197,7 +197,7 @@ public final class ReservedKeyExample {
 
         @JsonSetter("primitve-field-name-with-dashes")
         public Builder primitveFieldNameWithDashes(int primitveFieldNameWithDashes) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.primitveFieldNameWithDashes = primitveFieldNameWithDashes;
             this._primitveFieldNameWithDashesInitialized = true;
             return this;
@@ -205,7 +205,7 @@ public final class ReservedKeyExample {
 
         @JsonSetter("memoizedHashCode")
         public Builder memoizedHashCode_(int memoizedHashCode_) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.memoizedHashCode_ = memoizedHashCode_;
             this._memoizedHashCode_Initialized = true;
             return this;
@@ -213,7 +213,7 @@ public final class ReservedKeyExample {
 
         @JsonSetter("result")
         public Builder result(int result) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.result = result;
             this._resultInitialized = true;
             return this;
@@ -243,11 +243,15 @@ public final class ReservedKeyExample {
         }
 
         public ReservedKeyExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new ReservedKeyExample(
                     package_, interface_, fieldNameWithDashes, primitveFieldNameWithDashes, memoizedHashCode_, result);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -140,6 +140,8 @@ public final class ReservedKeyExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private String package_;
 
         private String interface_;
@@ -161,6 +163,7 @@ public final class ReservedKeyExample {
         private Builder() {}
 
         public Builder from(ReservedKeyExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             package_(other.getPackage());
             interface_(other.getInterface());
             fieldNameWithDashes(other.getFieldNameWithDashes());
@@ -172,18 +175,21 @@ public final class ReservedKeyExample {
 
         @JsonSetter("package")
         public Builder package_(@Nonnull String package_) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.package_ = Preconditions.checkNotNull(package_, "package cannot be null");
             return this;
         }
 
         @JsonSetter("interface")
         public Builder interface_(@Nonnull String interface_) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.interface_ = Preconditions.checkNotNull(interface_, "interface cannot be null");
             return this;
         }
 
         @JsonSetter("field-name-with-dashes")
         public Builder fieldNameWithDashes(@Nonnull String fieldNameWithDashes) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.fieldNameWithDashes =
                     Preconditions.checkNotNull(fieldNameWithDashes, "field-name-with-dashes cannot be null");
             return this;
@@ -191,6 +197,7 @@ public final class ReservedKeyExample {
 
         @JsonSetter("primitve-field-name-with-dashes")
         public Builder primitveFieldNameWithDashes(int primitveFieldNameWithDashes) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.primitveFieldNameWithDashes = primitveFieldNameWithDashes;
             this._primitveFieldNameWithDashesInitialized = true;
             return this;
@@ -198,6 +205,7 @@ public final class ReservedKeyExample {
 
         @JsonSetter("memoizedHashCode")
         public Builder memoizedHashCode_(int memoizedHashCode_) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.memoizedHashCode_ = memoizedHashCode_;
             this._memoizedHashCode_Initialized = true;
             return this;
@@ -205,6 +213,7 @@ public final class ReservedKeyExample {
 
         @JsonSetter("result")
         public Builder result(int result) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.result = result;
             this._resultInitialized = true;
             return this;
@@ -234,6 +243,8 @@ public final class ReservedKeyExample {
         }
 
         public ReservedKeyExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new ReservedKeyExample(
                     package_, interface_, fieldNameWithDashes, primitveFieldNameWithDashes, memoizedHashCode_, result);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
@@ -77,22 +77,28 @@ public final class RidExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private ResourceIdentifier ridValue;
 
         private Builder() {}
 
         public Builder from(RidExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ridValue(other.getRidValue());
             return this;
         }
 
         @JsonSetter("ridValue")
         public Builder ridValue(@Nonnull ResourceIdentifier ridValue) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.ridValue = Preconditions.checkNotNull(ridValue, "ridValue cannot be null");
             return this;
         }
 
         public RidExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new RidExample(ridValue);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
@@ -84,22 +84,26 @@ public final class RidExample {
         private Builder() {}
 
         public Builder from(RidExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ridValue(other.getRidValue());
             return this;
         }
 
         @JsonSetter("ridValue")
         public Builder ridValue(@Nonnull ResourceIdentifier ridValue) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.ridValue = Preconditions.checkNotNull(ridValue, "ridValue cannot be null");
             return this;
         }
 
         public RidExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new RidExample(ridValue);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
@@ -77,22 +77,28 @@ public final class SafeLongExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private SafeLong safeLongValue;
 
         private Builder() {}
 
         public Builder from(SafeLongExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             safeLongValue(other.getSafeLongValue());
             return this;
         }
 
         @JsonSetter("safeLongValue")
         public Builder safeLongValue(@Nonnull SafeLong safeLongValue) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.safeLongValue = Preconditions.checkNotNull(safeLongValue, "safeLongValue cannot be null");
             return this;
         }
 
         public SafeLongExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new SafeLongExample(safeLongValue);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
@@ -84,22 +84,26 @@ public final class SafeLongExample {
         private Builder() {}
 
         public Builder from(SafeLongExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             safeLongValue(other.getSafeLongValue());
             return this;
         }
 
         @JsonSetter("safeLongValue")
         public Builder safeLongValue(@Nonnull SafeLong safeLongValue) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.safeLongValue = Preconditions.checkNotNull(safeLongValue, "safeLongValue cannot be null");
             return this;
         }
 
         public SafeLongExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new SafeLongExample(safeLongValue);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
@@ -106,7 +106,7 @@ public final class SetExample {
         private Builder() {}
 
         public Builder from(SetExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             items(other.getItems());
             doubleItems(other.getDoubleItems());
             return this;
@@ -114,27 +114,27 @@ public final class SetExample {
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Iterable<String> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder addAllItems(@Nonnull Iterable<String> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(String items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.add(items);
             return this;
         }
 
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.doubleItems.clear();
             ConjureCollections.addAll(
                     this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
@@ -142,22 +142,26 @@ public final class SetExample {
         }
 
         public Builder addAllDoubleItems(@Nonnull Iterable<Double> doubleItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(
                     this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
             return this;
         }
 
         public Builder doubleItems(double doubleItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.doubleItems.add(doubleItems);
             return this;
         }
 
         public SetExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new SetExample(items, doubleItems);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
@@ -97,6 +97,8 @@ public final class SetExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private Set<String> items = new LinkedHashSet<>();
 
         private Set<Double> doubleItems = new LinkedHashSet<>();
@@ -104,6 +106,7 @@ public final class SetExample {
         private Builder() {}
 
         public Builder from(SetExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             items(other.getItems());
             doubleItems(other.getDoubleItems());
             return this;
@@ -111,23 +114,27 @@ public final class SetExample {
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Iterable<String> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder addAllItems(@Nonnull Iterable<String> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(String items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.add(items);
             return this;
         }
 
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.doubleItems.clear();
             ConjureCollections.addAll(
                     this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
@@ -135,17 +142,21 @@ public final class SetExample {
         }
 
         public Builder addAllDoubleItems(@Nonnull Iterable<Double> doubleItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(
                     this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
             return this;
         }
 
         public Builder doubleItems(double doubleItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.doubleItems.add(doubleItems);
             return this;
         }
 
         public SetExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new SetExample(items, doubleItems);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
@@ -83,22 +83,26 @@ public final class StringExample {
         private Builder() {}
 
         public Builder from(StringExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             string(other.getString());
             return this;
         }
 
         @JsonSetter("string")
         public Builder string(@Nonnull String string) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.string = Preconditions.checkNotNull(string, "string cannot be null");
             return this;
         }
 
         public StringExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new StringExample(string);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
@@ -76,22 +76,28 @@ public final class StringExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private String string;
 
         private Builder() {}
 
         public Builder from(StringExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             string(other.getString());
             return this;
         }
 
         @JsonSetter("string")
         public Builder string(@Nonnull String string) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.string = Preconditions.checkNotNull(string, "string cannot be null");
             return this;
         }
 
         public StringExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new StringExample(string);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
@@ -84,22 +84,26 @@ public final class UuidExample {
         private Builder() {}
 
         public Builder from(UuidExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             uuid(other.getUuid());
             return this;
         }
 
         @JsonSetter("uuid")
         public Builder uuid(@Nonnull UUID uuid) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.uuid = Preconditions.checkNotNull(uuid, "uuid cannot be null");
             return this;
         }
 
         public UuidExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new UuidExample(uuid);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
@@ -77,22 +77,28 @@ public final class UuidExample {
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     public static final class Builder {
+        boolean _buildInvoked;
+
         private UUID uuid;
 
         private Builder() {}
 
         public Builder from(UuidExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             uuid(other.getUuid());
             return this;
         }
 
         @JsonSetter("uuid")
         public Builder uuid(@Nonnull UUID uuid) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.uuid = Preconditions.checkNotNull(uuid, "uuid cannot be null");
             return this;
         }
 
         public UuidExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new UuidExample(uuid);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AliasAsMapKeyExample.java
@@ -168,6 +168,8 @@ public final class AliasAsMapKeyExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private Map<StringAliasExample, ManyFieldExample> strings = new LinkedHashMap<>();
 
         private Map<RidAliasExample, ManyFieldExample> rids = new LinkedHashMap<>();
@@ -185,6 +187,7 @@ public final class AliasAsMapKeyExample {
         private Builder() {}
 
         public Builder from(AliasAsMapKeyExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             strings(other.getStrings());
             rids(other.getRids());
             bearertokens(other.getBearertokens());
@@ -197,124 +200,147 @@ public final class AliasAsMapKeyExample {
 
         @JsonSetter(value = "strings", nulls = Nulls.SKIP)
         public Builder strings(@Nonnull Map<StringAliasExample, ManyFieldExample> strings) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.strings.clear();
             this.strings.putAll(Preconditions.checkNotNull(strings, "strings cannot be null"));
             return this;
         }
 
         public Builder putAllStrings(@Nonnull Map<StringAliasExample, ManyFieldExample> strings) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.strings.putAll(Preconditions.checkNotNull(strings, "strings cannot be null"));
             return this;
         }
 
         public Builder strings(StringAliasExample key, ManyFieldExample value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.strings.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "rids", nulls = Nulls.SKIP)
         public Builder rids(@Nonnull Map<RidAliasExample, ManyFieldExample> rids) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.rids.clear();
             this.rids.putAll(Preconditions.checkNotNull(rids, "rids cannot be null"));
             return this;
         }
 
         public Builder putAllRids(@Nonnull Map<RidAliasExample, ManyFieldExample> rids) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.rids.putAll(Preconditions.checkNotNull(rids, "rids cannot be null"));
             return this;
         }
 
         public Builder rids(RidAliasExample key, ManyFieldExample value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.rids.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "bearertokens", nulls = Nulls.SKIP)
         public Builder bearertokens(@Nonnull Map<BearerTokenAliasExample, ManyFieldExample> bearertokens) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.bearertokens.clear();
             this.bearertokens.putAll(Preconditions.checkNotNull(bearertokens, "bearertokens cannot be null"));
             return this;
         }
 
         public Builder putAllBearertokens(@Nonnull Map<BearerTokenAliasExample, ManyFieldExample> bearertokens) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.bearertokens.putAll(Preconditions.checkNotNull(bearertokens, "bearertokens cannot be null"));
             return this;
         }
 
         public Builder bearertokens(BearerTokenAliasExample key, ManyFieldExample value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.bearertokens.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "integers", nulls = Nulls.SKIP)
         public Builder integers(@Nonnull Map<IntegerAliasExample, ManyFieldExample> integers) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.integers.clear();
             this.integers.putAll(Preconditions.checkNotNull(integers, "integers cannot be null"));
             return this;
         }
 
         public Builder putAllIntegers(@Nonnull Map<IntegerAliasExample, ManyFieldExample> integers) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.integers.putAll(Preconditions.checkNotNull(integers, "integers cannot be null"));
             return this;
         }
 
         public Builder integers(IntegerAliasExample key, ManyFieldExample value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.integers.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "safelongs", nulls = Nulls.SKIP)
         public Builder safelongs(@Nonnull Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.safelongs.clear();
             this.safelongs.putAll(Preconditions.checkNotNull(safelongs, "safelongs cannot be null"));
             return this;
         }
 
         public Builder putAllSafelongs(@Nonnull Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.safelongs.putAll(Preconditions.checkNotNull(safelongs, "safelongs cannot be null"));
             return this;
         }
 
         public Builder safelongs(SafeLongAliasExample key, ManyFieldExample value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.safelongs.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "datetimes", nulls = Nulls.SKIP)
         public Builder datetimes(@Nonnull Map<DateTimeAliasExample, ManyFieldExample> datetimes) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.datetimes.clear();
             this.datetimes.putAll(Preconditions.checkNotNull(datetimes, "datetimes cannot be null"));
             return this;
         }
 
         public Builder putAllDatetimes(@Nonnull Map<DateTimeAliasExample, ManyFieldExample> datetimes) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.datetimes.putAll(Preconditions.checkNotNull(datetimes, "datetimes cannot be null"));
             return this;
         }
 
         public Builder datetimes(DateTimeAliasExample key, ManyFieldExample value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.datetimes.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "uuids", nulls = Nulls.SKIP)
         public Builder uuids(@Nonnull Map<UuidAliasExample, ManyFieldExample> uuids) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.uuids.clear();
             this.uuids.putAll(Preconditions.checkNotNull(uuids, "uuids cannot be null"));
             return this;
         }
 
         public Builder putAllUuids(@Nonnull Map<UuidAliasExample, ManyFieldExample> uuids) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.uuids.putAll(Preconditions.checkNotNull(uuids, "uuids cannot be null"));
             return this;
         }
 
         public Builder uuids(UuidAliasExample key, ManyFieldExample value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.uuids.put(key, value);
             return this;
         }
 
         public AliasAsMapKeyExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new AliasAsMapKeyExample(strings, rids, bearertokens, integers, safelongs, datetimes, uuids);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AliasAsMapKeyExample.java
@@ -187,7 +187,7 @@ public final class AliasAsMapKeyExample {
         private Builder() {}
 
         public Builder from(AliasAsMapKeyExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             strings(other.getStrings());
             rids(other.getRids());
             bearertokens(other.getBearertokens());
@@ -200,148 +200,152 @@ public final class AliasAsMapKeyExample {
 
         @JsonSetter(value = "strings", nulls = Nulls.SKIP)
         public Builder strings(@Nonnull Map<StringAliasExample, ManyFieldExample> strings) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.strings.clear();
             this.strings.putAll(Preconditions.checkNotNull(strings, "strings cannot be null"));
             return this;
         }
 
         public Builder putAllStrings(@Nonnull Map<StringAliasExample, ManyFieldExample> strings) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.strings.putAll(Preconditions.checkNotNull(strings, "strings cannot be null"));
             return this;
         }
 
         public Builder strings(StringAliasExample key, ManyFieldExample value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.strings.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "rids", nulls = Nulls.SKIP)
         public Builder rids(@Nonnull Map<RidAliasExample, ManyFieldExample> rids) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.rids.clear();
             this.rids.putAll(Preconditions.checkNotNull(rids, "rids cannot be null"));
             return this;
         }
 
         public Builder putAllRids(@Nonnull Map<RidAliasExample, ManyFieldExample> rids) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.rids.putAll(Preconditions.checkNotNull(rids, "rids cannot be null"));
             return this;
         }
 
         public Builder rids(RidAliasExample key, ManyFieldExample value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.rids.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "bearertokens", nulls = Nulls.SKIP)
         public Builder bearertokens(@Nonnull Map<BearerTokenAliasExample, ManyFieldExample> bearertokens) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.bearertokens.clear();
             this.bearertokens.putAll(Preconditions.checkNotNull(bearertokens, "bearertokens cannot be null"));
             return this;
         }
 
         public Builder putAllBearertokens(@Nonnull Map<BearerTokenAliasExample, ManyFieldExample> bearertokens) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.bearertokens.putAll(Preconditions.checkNotNull(bearertokens, "bearertokens cannot be null"));
             return this;
         }
 
         public Builder bearertokens(BearerTokenAliasExample key, ManyFieldExample value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.bearertokens.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "integers", nulls = Nulls.SKIP)
         public Builder integers(@Nonnull Map<IntegerAliasExample, ManyFieldExample> integers) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.integers.clear();
             this.integers.putAll(Preconditions.checkNotNull(integers, "integers cannot be null"));
             return this;
         }
 
         public Builder putAllIntegers(@Nonnull Map<IntegerAliasExample, ManyFieldExample> integers) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.integers.putAll(Preconditions.checkNotNull(integers, "integers cannot be null"));
             return this;
         }
 
         public Builder integers(IntegerAliasExample key, ManyFieldExample value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.integers.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "safelongs", nulls = Nulls.SKIP)
         public Builder safelongs(@Nonnull Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.safelongs.clear();
             this.safelongs.putAll(Preconditions.checkNotNull(safelongs, "safelongs cannot be null"));
             return this;
         }
 
         public Builder putAllSafelongs(@Nonnull Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.safelongs.putAll(Preconditions.checkNotNull(safelongs, "safelongs cannot be null"));
             return this;
         }
 
         public Builder safelongs(SafeLongAliasExample key, ManyFieldExample value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.safelongs.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "datetimes", nulls = Nulls.SKIP)
         public Builder datetimes(@Nonnull Map<DateTimeAliasExample, ManyFieldExample> datetimes) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.datetimes.clear();
             this.datetimes.putAll(Preconditions.checkNotNull(datetimes, "datetimes cannot be null"));
             return this;
         }
 
         public Builder putAllDatetimes(@Nonnull Map<DateTimeAliasExample, ManyFieldExample> datetimes) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.datetimes.putAll(Preconditions.checkNotNull(datetimes, "datetimes cannot be null"));
             return this;
         }
 
         public Builder datetimes(DateTimeAliasExample key, ManyFieldExample value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.datetimes.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "uuids", nulls = Nulls.SKIP)
         public Builder uuids(@Nonnull Map<UuidAliasExample, ManyFieldExample> uuids) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.uuids.clear();
             this.uuids.putAll(Preconditions.checkNotNull(uuids, "uuids cannot be null"));
             return this;
         }
 
         public Builder putAllUuids(@Nonnull Map<UuidAliasExample, ManyFieldExample> uuids) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.uuids.putAll(Preconditions.checkNotNull(uuids, "uuids cannot be null"));
             return this;
         }
 
         public Builder uuids(UuidAliasExample key, ManyFieldExample value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.uuids.put(key, value);
             return this;
         }
 
         public AliasAsMapKeyExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new AliasAsMapKeyExample(strings, rids, bearertokens, integers, safelongs, datetimes, uuids);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyExample.java
@@ -85,22 +85,26 @@ public final class AnyExample {
         private Builder() {}
 
         public Builder from(AnyExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             any(other.getAny());
             return this;
         }
 
         @JsonSetter("any")
         public Builder any(@Nonnull Object any) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.any = Preconditions.checkNotNull(any, "any cannot be null");
             return this;
         }
 
         public AnyExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new AnyExample(any);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyExample.java
@@ -78,22 +78,28 @@ public final class AnyExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private Object any;
 
         private Builder() {}
 
         public Builder from(AnyExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             any(other.getAny());
             return this;
         }
 
         @JsonSetter("any")
         public Builder any(@Nonnull Object any) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.any = Preconditions.checkNotNull(any, "any cannot be null");
             return this;
         }
 
         public AnyExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new AnyExample(any);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyMapExample.java
@@ -96,35 +96,39 @@ public final class AnyMapExample {
         private Builder() {}
 
         public Builder from(AnyMapExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             items(other.getItems());
             return this;
         }
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Map<String, Object> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.clear();
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder putAllItems(@Nonnull Map<String, Object> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(String key, Object value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.put(key, value);
             return this;
         }
 
         public AnyMapExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new AnyMapExample(items);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyMapExample.java
@@ -89,33 +89,41 @@ public final class AnyMapExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private Map<String, Object> items = new LinkedHashMap<>();
 
         private Builder() {}
 
         public Builder from(AnyMapExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             items(other.getItems());
             return this;
         }
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Map<String, Object> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.clear();
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder putAllItems(@Nonnull Map<String, Object> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(String key, Object value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.put(key, value);
             return this;
         }
 
         public AnyMapExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new AnyMapExample(items);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BearerTokenExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BearerTokenExample.java
@@ -86,22 +86,26 @@ public final class BearerTokenExample {
         private Builder() {}
 
         public Builder from(BearerTokenExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             bearerTokenValue(other.getBearerTokenValue());
             return this;
         }
 
         @JsonSetter("bearerTokenValue")
         public Builder bearerTokenValue(@Nonnull BearerToken bearerTokenValue) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.bearerTokenValue = Preconditions.checkNotNull(bearerTokenValue, "bearerTokenValue cannot be null");
             return this;
         }
 
         public BearerTokenExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new BearerTokenExample(bearerTokenValue);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BearerTokenExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BearerTokenExample.java
@@ -79,22 +79,28 @@ public final class BearerTokenExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private BearerToken bearerTokenValue;
 
         private Builder() {}
 
         public Builder from(BearerTokenExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             bearerTokenValue(other.getBearerTokenValue());
             return this;
         }
 
         @JsonSetter("bearerTokenValue")
         public Builder bearerTokenValue(@Nonnull BearerToken bearerTokenValue) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.bearerTokenValue = Preconditions.checkNotNull(bearerTokenValue, "bearerTokenValue cannot be null");
             return this;
         }
 
         public BearerTokenExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new BearerTokenExample(bearerTokenValue);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryExample.java
@@ -80,17 +80,21 @@ public final class BinaryExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private ByteBuffer binary;
 
         private Builder() {}
 
         public Builder from(BinaryExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             binary(other.getBinary());
             return this;
         }
 
         @JsonSetter("binary")
         public Builder binary(@Nonnull ByteBuffer binary) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             Preconditions.checkNotNull(binary, "binary cannot be null");
             this.binary = ByteBuffer.allocate(binary.remaining()).put(binary.duplicate());
             ((Buffer) this.binary).rewind();
@@ -98,6 +102,8 @@ public final class BinaryExample {
         }
 
         public BinaryExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new BinaryExample(binary);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryExample.java
@@ -87,14 +87,14 @@ public final class BinaryExample {
         private Builder() {}
 
         public Builder from(BinaryExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             binary(other.getBinary());
             return this;
         }
 
         @JsonSetter("binary")
         public Builder binary(@Nonnull ByteBuffer binary) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             Preconditions.checkNotNull(binary, "binary cannot be null");
             this.binary = ByteBuffer.allocate(binary.remaining()).put(binary.duplicate());
             ((Buffer) this.binary).rewind();
@@ -102,9 +102,13 @@ public final class BinaryExample {
         }
 
         public BinaryExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new BinaryExample(binary);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BooleanExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BooleanExample.java
@@ -64,14 +64,14 @@ public final class BooleanExample {
         private Builder() {}
 
         public Builder from(BooleanExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             coin(other.getCoin());
             return this;
         }
 
         @JsonSetter("coin")
         public Builder coin(boolean coin) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.coin = coin;
             this._coinInitialized = true;
             return this;
@@ -98,10 +98,14 @@ public final class BooleanExample {
         }
 
         public BooleanExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new BooleanExample(coin);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BooleanExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BooleanExample.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
@@ -54,6 +55,8 @@ public final class BooleanExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private boolean coin;
 
         private boolean _coinInitialized = false;
@@ -61,12 +64,14 @@ public final class BooleanExample {
         private Builder() {}
 
         public Builder from(BooleanExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             coin(other.getCoin());
             return this;
         }
 
         @JsonSetter("coin")
         public Builder coin(boolean coin) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.coin = coin;
             this._coinInitialized = true;
             return this;
@@ -93,6 +98,8 @@ public final class BooleanExample {
         }
 
         public BooleanExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new BooleanExample(coin);
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
@@ -98,6 +98,8 @@ public final class CovariantListExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private List<Object> items = new ArrayList<>();
 
         private List<ExampleExternalReference> externalItems = new ArrayList<>();
@@ -105,6 +107,7 @@ public final class CovariantListExample {
         private Builder() {}
 
         public Builder from(CovariantListExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             items(other.getItems());
             externalItems(other.getExternalItems());
             return this;
@@ -112,23 +115,27 @@ public final class CovariantListExample {
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<?> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder addAllItems(@Nonnull Iterable<?> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(Object items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.add(items);
             return this;
         }
 
         @JsonSetter(value = "externalItems", nulls = Nulls.SKIP)
         public Builder externalItems(@Nonnull Iterable<? extends ExampleExternalReference> externalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.externalItems.clear();
             ConjureCollections.addAll(
                     this.externalItems, Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
@@ -136,17 +143,21 @@ public final class CovariantListExample {
         }
 
         public Builder addAllExternalItems(@Nonnull Iterable<? extends ExampleExternalReference> externalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(
                     this.externalItems, Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
             return this;
         }
 
         public Builder externalItems(ExampleExternalReference externalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.externalItems.add(externalItems);
             return this;
         }
 
         public CovariantListExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new CovariantListExample(items, externalItems);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
@@ -107,7 +107,7 @@ public final class CovariantListExample {
         private Builder() {}
 
         public Builder from(CovariantListExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             items(other.getItems());
             externalItems(other.getExternalItems());
             return this;
@@ -115,27 +115,27 @@ public final class CovariantListExample {
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<?> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder addAllItems(@Nonnull Iterable<?> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(Object items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.add(items);
             return this;
         }
 
         @JsonSetter(value = "externalItems", nulls = Nulls.SKIP)
         public Builder externalItems(@Nonnull Iterable<? extends ExampleExternalReference> externalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.externalItems.clear();
             ConjureCollections.addAll(
                     this.externalItems, Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
@@ -143,22 +143,26 @@ public final class CovariantListExample {
         }
 
         public Builder addAllExternalItems(@Nonnull Iterable<? extends ExampleExternalReference> externalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(
                     this.externalItems, Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
             return this;
         }
 
         public Builder externalItems(ExampleExternalReference externalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.externalItems.add(externalItems);
             return this;
         }
 
         public CovariantListExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new CovariantListExample(items, externalItems);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantOptionalExample.java
@@ -111,7 +111,7 @@ public final class CovariantOptionalExample {
         private Builder() {}
 
         public Builder from(CovariantOptionalExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             item(other.getItem());
             setItem(other.getSetItem());
             return this;
@@ -119,35 +119,39 @@ public final class CovariantOptionalExample {
 
         @JsonSetter(value = "item", nulls = Nulls.SKIP)
         public Builder item(@Nonnull Optional<?> item) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.item = Preconditions.checkNotNull(item, "item cannot be null").map(Function.identity());
             return this;
         }
 
         public Builder item(@Nonnull Object item) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.item = Optional.of(Preconditions.checkNotNull(item, "item cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "setItem", nulls = Nulls.SKIP)
         public Builder setItem(@Nonnull Optional<? extends Set<StringAliasExample>> setItem) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.setItem = Preconditions.checkNotNull(setItem, "setItem cannot be null")
                     .map(Function.identity());
             return this;
         }
 
         public Builder setItem(@Nonnull Set<StringAliasExample> setItem) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.setItem = Optional.of(Preconditions.checkNotNull(setItem, "setItem cannot be null"));
             return this;
         }
 
         public CovariantOptionalExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new CovariantOptionalExample(item, setItem);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantOptionalExample.java
@@ -102,6 +102,8 @@ public final class CovariantOptionalExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private Optional<Object> item = Optional.empty();
 
         private Optional<Set<StringAliasExample>> setItem = Optional.empty();
@@ -109,6 +111,7 @@ public final class CovariantOptionalExample {
         private Builder() {}
 
         public Builder from(CovariantOptionalExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             item(other.getItem());
             setItem(other.getSetItem());
             return this;
@@ -116,28 +119,34 @@ public final class CovariantOptionalExample {
 
         @JsonSetter(value = "item", nulls = Nulls.SKIP)
         public Builder item(@Nonnull Optional<?> item) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.item = Preconditions.checkNotNull(item, "item cannot be null").map(Function.identity());
             return this;
         }
 
         public Builder item(@Nonnull Object item) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.item = Optional.of(Preconditions.checkNotNull(item, "item cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "setItem", nulls = Nulls.SKIP)
         public Builder setItem(@Nonnull Optional<? extends Set<StringAliasExample>> setItem) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.setItem = Preconditions.checkNotNull(setItem, "setItem cannot be null")
                     .map(Function.identity());
             return this;
         }
 
         public Builder setItem(@Nonnull Set<StringAliasExample> setItem) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.setItem = Optional.of(Preconditions.checkNotNull(setItem, "setItem cannot be null"));
             return this;
         }
 
         public CovariantOptionalExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new CovariantOptionalExample(item, setItem);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeExample.java
@@ -86,22 +86,28 @@ public final class DateTimeExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private OffsetDateTime datetime;
 
         private Builder() {}
 
         public Builder from(DateTimeExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             datetime(other.getDatetime());
             return this;
         }
 
         @JsonSetter("datetime")
         public Builder datetime(@Nonnull OffsetDateTime datetime) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.datetime = Preconditions.checkNotNull(datetime, "datetime cannot be null");
             return this;
         }
 
         public DateTimeExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new DateTimeExample(datetime);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeExample.java
@@ -93,22 +93,26 @@ public final class DateTimeExample {
         private Builder() {}
 
         public Builder from(DateTimeExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             datetime(other.getDatetime());
             return this;
         }
 
         @JsonSetter("datetime")
         public Builder datetime(@Nonnull OffsetDateTime datetime) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.datetime = Preconditions.checkNotNull(datetime, "datetime cannot be null");
             return this;
         }
 
         public DateTimeExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new DateTimeExample(datetime);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleExample.java
@@ -64,14 +64,14 @@ public final class DoubleExample {
         private Builder() {}
 
         public Builder from(DoubleExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             doubleValue(other.getDoubleValue());
             return this;
         }
 
         @JsonSetter("doubleValue")
         public Builder doubleValue(double doubleValue) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.doubleValue = doubleValue;
             this._doubleValueInitialized = true;
             return this;
@@ -98,10 +98,14 @@ public final class DoubleExample {
         }
 
         public DoubleExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new DoubleExample(doubleValue);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleExample.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
@@ -54,6 +55,8 @@ public final class DoubleExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private double doubleValue;
 
         private boolean _doubleValueInitialized = false;
@@ -61,12 +64,14 @@ public final class DoubleExample {
         private Builder() {}
 
         public Builder from(DoubleExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             doubleValue(other.getDoubleValue());
             return this;
         }
 
         @JsonSetter("doubleValue")
         public Builder doubleValue(double doubleValue) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.doubleValue = doubleValue;
             this._doubleValueInitialized = true;
             return this;
@@ -93,6 +98,8 @@ public final class DoubleExample {
         }
 
         public DoubleExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new DoubleExample(doubleValue);
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumFieldExample.java
@@ -78,22 +78,28 @@ public final class EnumFieldExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private EnumExample enum_;
 
         private Builder() {}
 
         public Builder from(EnumFieldExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             enum_(other.getEnum());
             return this;
         }
 
         @JsonSetter("enum")
         public Builder enum_(@Nonnull EnumExample enum_) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.enum_ = Preconditions.checkNotNull(enum_, "enum cannot be null");
             return this;
         }
 
         public EnumFieldExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new EnumFieldExample(enum_);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumFieldExample.java
@@ -85,22 +85,26 @@ public final class EnumFieldExample {
         private Builder() {}
 
         public Builder from(EnumFieldExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             enum_(other.getEnum());
             return this;
         }
 
         @JsonSetter("enum")
         public Builder enum_(@Nonnull EnumExample enum_) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.enum_ = Preconditions.checkNotNull(enum_, "enum cannot be null");
             return this;
         }
 
         public EnumFieldExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new EnumFieldExample(enum_);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
@@ -116,6 +116,8 @@ public final class ExternalLongExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private long externalLong;
 
         private Optional<Long> optionalExternalLong = Optional.empty();
@@ -127,6 +129,7 @@ public final class ExternalLongExample {
         private Builder() {}
 
         public Builder from(ExternalLongExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             externalLong(other.getExternalLong());
             optionalExternalLong(other.getOptionalExternalLong());
             listExternalLong(other.getListExternalLong());
@@ -135,6 +138,7 @@ public final class ExternalLongExample {
 
         @JsonSetter("externalLong")
         public Builder externalLong(long externalLong) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.externalLong = externalLong;
             this._externalLongInitialized = true;
             return this;
@@ -142,6 +146,7 @@ public final class ExternalLongExample {
 
         @JsonSetter(value = "optionalExternalLong", nulls = Nulls.SKIP)
         public Builder optionalExternalLong(@Nonnull Optional<? extends Long> optionalExternalLong) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalExternalLong = Preconditions.checkNotNull(
                             optionalExternalLong, "optionalExternalLong cannot be null")
                     .map(Function.identity());
@@ -149,6 +154,7 @@ public final class ExternalLongExample {
         }
 
         public Builder optionalExternalLong(long optionalExternalLong) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalExternalLong = Optional.of(
                     Preconditions.checkNotNull(optionalExternalLong, "optionalExternalLong cannot be null"));
             return this;
@@ -156,6 +162,7 @@ public final class ExternalLongExample {
 
         @JsonSetter(value = "listExternalLong", nulls = Nulls.SKIP)
         public Builder listExternalLong(@Nonnull Iterable<? extends Long> listExternalLong) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.listExternalLong.clear();
             ConjureCollections.addAll(
                     this.listExternalLong,
@@ -164,6 +171,7 @@ public final class ExternalLongExample {
         }
 
         public Builder addAllListExternalLong(@Nonnull Iterable<? extends Long> listExternalLong) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(
                     this.listExternalLong,
                     Preconditions.checkNotNull(listExternalLong, "listExternalLong cannot be null"));
@@ -171,6 +179,7 @@ public final class ExternalLongExample {
         }
 
         public Builder listExternalLong(long listExternalLong) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.listExternalLong.add(listExternalLong);
             return this;
         }
@@ -196,6 +205,8 @@ public final class ExternalLongExample {
         }
 
         public ExternalLongExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new ExternalLongExample(externalLong, optionalExternalLong, listExternalLong);
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
@@ -129,7 +129,7 @@ public final class ExternalLongExample {
         private Builder() {}
 
         public Builder from(ExternalLongExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             externalLong(other.getExternalLong());
             optionalExternalLong(other.getOptionalExternalLong());
             listExternalLong(other.getListExternalLong());
@@ -138,7 +138,7 @@ public final class ExternalLongExample {
 
         @JsonSetter("externalLong")
         public Builder externalLong(long externalLong) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.externalLong = externalLong;
             this._externalLongInitialized = true;
             return this;
@@ -146,7 +146,7 @@ public final class ExternalLongExample {
 
         @JsonSetter(value = "optionalExternalLong", nulls = Nulls.SKIP)
         public Builder optionalExternalLong(@Nonnull Optional<? extends Long> optionalExternalLong) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalExternalLong = Preconditions.checkNotNull(
                             optionalExternalLong, "optionalExternalLong cannot be null")
                     .map(Function.identity());
@@ -154,7 +154,7 @@ public final class ExternalLongExample {
         }
 
         public Builder optionalExternalLong(long optionalExternalLong) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalExternalLong = Optional.of(
                     Preconditions.checkNotNull(optionalExternalLong, "optionalExternalLong cannot be null"));
             return this;
@@ -162,7 +162,7 @@ public final class ExternalLongExample {
 
         @JsonSetter(value = "listExternalLong", nulls = Nulls.SKIP)
         public Builder listExternalLong(@Nonnull Iterable<? extends Long> listExternalLong) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.listExternalLong.clear();
             ConjureCollections.addAll(
                     this.listExternalLong,
@@ -171,7 +171,7 @@ public final class ExternalLongExample {
         }
 
         public Builder addAllListExternalLong(@Nonnull Iterable<? extends Long> listExternalLong) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(
                     this.listExternalLong,
                     Preconditions.checkNotNull(listExternalLong, "listExternalLong cannot be null"));
@@ -179,7 +179,7 @@ public final class ExternalLongExample {
         }
 
         public Builder listExternalLong(long listExternalLong) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.listExternalLong.add(listExternalLong);
             return this;
         }
@@ -205,10 +205,14 @@ public final class ExternalLongExample {
         }
 
         public ExternalLongExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new ExternalLongExample(externalLong, optionalExternalLong, listExternalLong);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/IntegerExample.java
@@ -64,14 +64,14 @@ public final class IntegerExample {
         private Builder() {}
 
         public Builder from(IntegerExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             integer(other.getInteger());
             return this;
         }
 
         @JsonSetter("integer")
         public Builder integer(int integer) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.integer = integer;
             this._integerInitialized = true;
             return this;
@@ -98,10 +98,14 @@ public final class IntegerExample {
         }
 
         public IntegerExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new IntegerExample(integer);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/IntegerExample.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
@@ -54,6 +55,8 @@ public final class IntegerExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private int integer;
 
         private boolean _integerInitialized = false;
@@ -61,12 +64,14 @@ public final class IntegerExample {
         private Builder() {}
 
         public Builder from(IntegerExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             integer(other.getInteger());
             return this;
         }
 
         @JsonSetter("integer")
         public Builder integer(int integer) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.integer = integer;
             this._integerInitialized = true;
             return this;
@@ -93,6 +98,8 @@ public final class IntegerExample {
         }
 
         public IntegerExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new IntegerExample(integer);
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListExample.java
@@ -172,7 +172,7 @@ public final class ListExample {
         private Builder() {}
 
         public Builder from(ListExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             items(other.getItems());
             primitiveItems(other.getPrimitiveItems());
             doubleItems(other.getDoubleItems());
@@ -184,27 +184,27 @@ public final class ListExample {
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<String> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder addAllItems(@Nonnull Iterable<String> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(String items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.add(items);
             return this;
         }
 
         @JsonSetter(value = "primitiveItems", nulls = Nulls.SKIP)
         public Builder primitiveItems(@Nonnull Iterable<Integer> primitiveItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.primitiveItems.clear();
             ConjureCollections.addAll(
                     this.primitiveItems, Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
@@ -212,21 +212,21 @@ public final class ListExample {
         }
 
         public Builder addAllPrimitiveItems(@Nonnull Iterable<Integer> primitiveItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(
                     this.primitiveItems, Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
             return this;
         }
 
         public Builder primitiveItems(int primitiveItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.primitiveItems.add(primitiveItems);
             return this;
         }
 
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP)
         public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.doubleItems.clear();
             ConjureCollections.addAll(
                     this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
@@ -234,21 +234,21 @@ public final class ListExample {
         }
 
         public Builder addAllDoubleItems(@Nonnull Iterable<Double> doubleItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(
                     this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
             return this;
         }
 
         public Builder doubleItems(double doubleItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.doubleItems.add(doubleItems);
             return this;
         }
 
         @JsonSetter(value = "optionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder optionalItems(@Nonnull Iterable<Optional<String>> optionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalItems.clear();
             ConjureCollections.addAll(
                     this.optionalItems, Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
@@ -256,21 +256,21 @@ public final class ListExample {
         }
 
         public Builder addAllOptionalItems(@Nonnull Iterable<Optional<String>> optionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(
                     this.optionalItems, Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
         }
 
         public Builder optionalItems(Optional<String> optionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalItems.add(optionalItems);
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalItems(@Nonnull Iterable<OptionalAlias> aliasOptionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOptionalItems.clear();
             ConjureCollections.addAll(
                     this.aliasOptionalItems,
@@ -279,7 +279,7 @@ public final class ListExample {
         }
 
         public Builder addAllAliasOptionalItems(@Nonnull Iterable<OptionalAlias> aliasOptionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(
                     this.aliasOptionalItems,
                     Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
@@ -287,14 +287,14 @@ public final class ListExample {
         }
 
         public Builder aliasOptionalItems(OptionalAlias aliasOptionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOptionalItems.add(aliasOptionalItems);
             return this;
         }
 
         @JsonSetter(value = "nestedItems", nulls = Nulls.SKIP)
         public Builder nestedItems(@Nonnull Iterable<? extends List<String>> nestedItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.nestedItems.clear();
             ConjureCollections.addAll(
                     this.nestedItems, Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
@@ -302,22 +302,26 @@ public final class ListExample {
         }
 
         public Builder addAllNestedItems(@Nonnull Iterable<? extends List<String>> nestedItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(
                     this.nestedItems, Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
             return this;
         }
 
         public Builder nestedItems(List<String> nestedItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.nestedItems.add(nestedItems);
             return this;
         }
 
         public ListExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new ListExample(items, primitiveItems, doubleItems, optionalItems, aliasOptionalItems, nestedItems);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListExample.java
@@ -155,6 +155,8 @@ public final class ListExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private List<String> items = new ArrayList<>();
 
         private List<Integer> primitiveItems = new ArrayList<>();
@@ -170,6 +172,7 @@ public final class ListExample {
         private Builder() {}
 
         public Builder from(ListExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             items(other.getItems());
             primitiveItems(other.getPrimitiveItems());
             doubleItems(other.getDoubleItems());
@@ -181,23 +184,27 @@ public final class ListExample {
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<String> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder addAllItems(@Nonnull Iterable<String> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(String items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.add(items);
             return this;
         }
 
         @JsonSetter(value = "primitiveItems", nulls = Nulls.SKIP)
         public Builder primitiveItems(@Nonnull Iterable<Integer> primitiveItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.primitiveItems.clear();
             ConjureCollections.addAll(
                     this.primitiveItems, Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
@@ -205,18 +212,21 @@ public final class ListExample {
         }
 
         public Builder addAllPrimitiveItems(@Nonnull Iterable<Integer> primitiveItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(
                     this.primitiveItems, Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
             return this;
         }
 
         public Builder primitiveItems(int primitiveItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.primitiveItems.add(primitiveItems);
             return this;
         }
 
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP)
         public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.doubleItems.clear();
             ConjureCollections.addAll(
                     this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
@@ -224,18 +234,21 @@ public final class ListExample {
         }
 
         public Builder addAllDoubleItems(@Nonnull Iterable<Double> doubleItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(
                     this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
             return this;
         }
 
         public Builder doubleItems(double doubleItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.doubleItems.add(doubleItems);
             return this;
         }
 
         @JsonSetter(value = "optionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder optionalItems(@Nonnull Iterable<Optional<String>> optionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalItems.clear();
             ConjureCollections.addAll(
                     this.optionalItems, Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
@@ -243,18 +256,21 @@ public final class ListExample {
         }
 
         public Builder addAllOptionalItems(@Nonnull Iterable<Optional<String>> optionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(
                     this.optionalItems, Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
         }
 
         public Builder optionalItems(Optional<String> optionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalItems.add(optionalItems);
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalItems(@Nonnull Iterable<OptionalAlias> aliasOptionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOptionalItems.clear();
             ConjureCollections.addAll(
                     this.aliasOptionalItems,
@@ -263,6 +279,7 @@ public final class ListExample {
         }
 
         public Builder addAllAliasOptionalItems(@Nonnull Iterable<OptionalAlias> aliasOptionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(
                     this.aliasOptionalItems,
                     Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
@@ -270,12 +287,14 @@ public final class ListExample {
         }
 
         public Builder aliasOptionalItems(OptionalAlias aliasOptionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOptionalItems.add(aliasOptionalItems);
             return this;
         }
 
         @JsonSetter(value = "nestedItems", nulls = Nulls.SKIP)
         public Builder nestedItems(@Nonnull Iterable<? extends List<String>> nestedItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.nestedItems.clear();
             ConjureCollections.addAll(
                     this.nestedItems, Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
@@ -283,17 +302,21 @@ public final class ListExample {
         }
 
         public Builder addAllNestedItems(@Nonnull Iterable<? extends List<String>> nestedItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(
                     this.nestedItems, Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
             return this;
         }
 
         public Builder nestedItems(List<String> nestedItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.nestedItems.add(nestedItems);
             return this;
         }
 
         public ListExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new ListExample(items, primitiveItems, doubleItems, optionalItems, aliasOptionalItems, nestedItems);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
@@ -210,6 +210,8 @@ public final class ManyFieldExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private String string;
 
         private int integer;
@@ -233,6 +235,7 @@ public final class ManyFieldExample {
         private Builder() {}
 
         public Builder from(ManyFieldExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             string(other.getString());
             integer(other.getInteger());
             doubleValue(other.getDoubleValue());
@@ -249,6 +252,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter("string")
         public Builder string(@Nonnull String string) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.string = Preconditions.checkNotNull(string, "string cannot be null");
             return this;
         }
@@ -258,6 +262,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter("integer")
         public Builder integer(int integer) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.integer = integer;
             this._integerInitialized = true;
             return this;
@@ -268,6 +273,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter("doubleValue")
         public Builder doubleValue(double doubleValue) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.doubleValue = doubleValue;
             this._doubleValueInitialized = true;
             return this;
@@ -278,6 +284,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter(value = "optionalItem", nulls = Nulls.SKIP)
         public Builder optionalItem(@Nonnull Optional<String> optionalItem) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalItem = Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null");
             return this;
         }
@@ -286,6 +293,7 @@ public final class ManyFieldExample {
          * docs for optionalItem field
          */
         public Builder optionalItem(@Nonnull String optionalItem) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalItem = Optional.of(Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null"));
             return this;
         }
@@ -295,6 +303,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<String> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
@@ -304,6 +313,7 @@ public final class ManyFieldExample {
          * docs for items field with exciting character$ used by javapoet.
          */
         public Builder addAllItems(@Nonnull Iterable<String> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
@@ -312,6 +322,7 @@ public final class ManyFieldExample {
          * docs for items field with exciting character$ used by javapoet.
          */
         public Builder items(String items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.add(items);
             return this;
         }
@@ -321,6 +332,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter(value = "set", nulls = Nulls.SKIP)
         public Builder set(@Nonnull Iterable<String> set) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.set.clear();
             ConjureCollections.addAll(this.set, Preconditions.checkNotNull(set, "set cannot be null"));
             return this;
@@ -330,6 +342,7 @@ public final class ManyFieldExample {
          * docs for set field
          */
         public Builder addAllSet(@Nonnull Iterable<String> set) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(this.set, Preconditions.checkNotNull(set, "set cannot be null"));
             return this;
         }
@@ -338,6 +351,7 @@ public final class ManyFieldExample {
          * docs for set field
          */
         public Builder set(String set) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.set.add(set);
             return this;
         }
@@ -348,6 +362,7 @@ public final class ManyFieldExample {
         @Deprecated
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(@Nonnull Map<String, String> map) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.map.clear();
             this.map.putAll(Preconditions.checkNotNull(map, "map cannot be null"));
             return this;
@@ -358,6 +373,7 @@ public final class ManyFieldExample {
          */
         @Deprecated
         public Builder putAllMap(@Nonnull Map<String, String> map) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.map.putAll(Preconditions.checkNotNull(map, "map cannot be null"));
             return this;
         }
@@ -367,6 +383,7 @@ public final class ManyFieldExample {
          */
         @Deprecated
         public Builder map(String key, String value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.map.put(key, value);
             return this;
         }
@@ -378,6 +395,7 @@ public final class ManyFieldExample {
         @Deprecated
         @JsonSetter("alias")
         public Builder alias(@Nonnull StringAliasExample alias) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.alias = Preconditions.checkNotNull(alias, "alias cannot be null");
             return this;
         }
@@ -404,6 +422,8 @@ public final class ManyFieldExample {
         }
 
         public ManyFieldExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new ManyFieldExample(string, integer, doubleValue, optionalItem, items, set, map, alias);
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
@@ -235,7 +235,7 @@ public final class ManyFieldExample {
         private Builder() {}
 
         public Builder from(ManyFieldExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             string(other.getString());
             integer(other.getInteger());
             doubleValue(other.getDoubleValue());
@@ -252,7 +252,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter("string")
         public Builder string(@Nonnull String string) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.string = Preconditions.checkNotNull(string, "string cannot be null");
             return this;
         }
@@ -262,7 +262,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter("integer")
         public Builder integer(int integer) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.integer = integer;
             this._integerInitialized = true;
             return this;
@@ -273,7 +273,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter("doubleValue")
         public Builder doubleValue(double doubleValue) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.doubleValue = doubleValue;
             this._doubleValueInitialized = true;
             return this;
@@ -284,7 +284,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter(value = "optionalItem", nulls = Nulls.SKIP)
         public Builder optionalItem(@Nonnull Optional<String> optionalItem) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalItem = Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null");
             return this;
         }
@@ -293,7 +293,7 @@ public final class ManyFieldExample {
          * docs for optionalItem field
          */
         public Builder optionalItem(@Nonnull String optionalItem) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalItem = Optional.of(Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null"));
             return this;
         }
@@ -303,7 +303,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<String> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
@@ -313,7 +313,7 @@ public final class ManyFieldExample {
          * docs for items field with exciting character$ used by javapoet.
          */
         public Builder addAllItems(@Nonnull Iterable<String> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
@@ -322,7 +322,7 @@ public final class ManyFieldExample {
          * docs for items field with exciting character$ used by javapoet.
          */
         public Builder items(String items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.add(items);
             return this;
         }
@@ -332,7 +332,7 @@ public final class ManyFieldExample {
          */
         @JsonSetter(value = "set", nulls = Nulls.SKIP)
         public Builder set(@Nonnull Iterable<String> set) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.set.clear();
             ConjureCollections.addAll(this.set, Preconditions.checkNotNull(set, "set cannot be null"));
             return this;
@@ -342,7 +342,7 @@ public final class ManyFieldExample {
          * docs for set field
          */
         public Builder addAllSet(@Nonnull Iterable<String> set) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(this.set, Preconditions.checkNotNull(set, "set cannot be null"));
             return this;
         }
@@ -351,7 +351,7 @@ public final class ManyFieldExample {
          * docs for set field
          */
         public Builder set(String set) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.set.add(set);
             return this;
         }
@@ -362,7 +362,7 @@ public final class ManyFieldExample {
         @Deprecated
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(@Nonnull Map<String, String> map) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.map.clear();
             this.map.putAll(Preconditions.checkNotNull(map, "map cannot be null"));
             return this;
@@ -373,7 +373,7 @@ public final class ManyFieldExample {
          */
         @Deprecated
         public Builder putAllMap(@Nonnull Map<String, String> map) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.map.putAll(Preconditions.checkNotNull(map, "map cannot be null"));
             return this;
         }
@@ -383,7 +383,7 @@ public final class ManyFieldExample {
          */
         @Deprecated
         public Builder map(String key, String value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.map.put(key, value);
             return this;
         }
@@ -395,7 +395,7 @@ public final class ManyFieldExample {
         @Deprecated
         @JsonSetter("alias")
         public Builder alias(@Nonnull StringAliasExample alias) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.alias = Preconditions.checkNotNull(alias, "alias cannot be null");
             return this;
         }
@@ -422,10 +422,14 @@ public final class ManyFieldExample {
         }
 
         public ManyFieldExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new ManyFieldExample(string, integer, doubleValue, optionalItem, items, set, map, alias);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapExample.java
@@ -135,7 +135,7 @@ public final class MapExample {
         private Builder() {}
 
         public Builder from(MapExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             items(other.getItems());
             optionalItems(other.getOptionalItems());
             aliasOptionalItems(other.getAliasOptionalItems());
@@ -144,47 +144,47 @@ public final class MapExample {
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Map<String, String> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.clear();
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder putAllItems(@Nonnull Map<String, String> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(String key, String value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "optionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder optionalItems(@Nonnull Map<String, Optional<String>> optionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalItems.clear();
             this.optionalItems.putAll(Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
         }
 
         public Builder putAllOptionalItems(@Nonnull Map<String, Optional<String>> optionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalItems.putAll(Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
         }
 
         public Builder optionalItems(String key, Optional<String> value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalItems.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalItems(@Nonnull Map<String, OptionalAlias> aliasOptionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOptionalItems.clear();
             this.aliasOptionalItems.putAll(
                     Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
@@ -192,22 +192,26 @@ public final class MapExample {
         }
 
         public Builder putAllAliasOptionalItems(@Nonnull Map<String, OptionalAlias> aliasOptionalItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOptionalItems.putAll(
                     Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
             return this;
         }
 
         public Builder aliasOptionalItems(String key, OptionalAlias value) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOptionalItems.put(key, value);
             return this;
         }
 
         public MapExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new MapExample(items, optionalItems, aliasOptionalItems);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapExample.java
@@ -124,6 +124,8 @@ public final class MapExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private Map<String, String> items = new LinkedHashMap<>();
 
         private Map<String, Optional<String>> optionalItems = new LinkedHashMap<>();
@@ -133,6 +135,7 @@ public final class MapExample {
         private Builder() {}
 
         public Builder from(MapExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             items(other.getItems());
             optionalItems(other.getOptionalItems());
             aliasOptionalItems(other.getAliasOptionalItems());
@@ -141,40 +144,47 @@ public final class MapExample {
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Map<String, String> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.clear();
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder putAllItems(@Nonnull Map<String, String> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(String key, String value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "optionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder optionalItems(@Nonnull Map<String, Optional<String>> optionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalItems.clear();
             this.optionalItems.putAll(Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
         }
 
         public Builder putAllOptionalItems(@Nonnull Map<String, Optional<String>> optionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalItems.putAll(Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
         }
 
         public Builder optionalItems(String key, Optional<String> value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalItems.put(key, value);
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalItems(@Nonnull Map<String, OptionalAlias> aliasOptionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOptionalItems.clear();
             this.aliasOptionalItems.putAll(
                     Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
@@ -182,17 +192,21 @@ public final class MapExample {
         }
 
         public Builder putAllAliasOptionalItems(@Nonnull Map<String, OptionalAlias> aliasOptionalItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOptionalItems.putAll(
                     Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
             return this;
         }
 
         public Builder aliasOptionalItems(String key, OptionalAlias value) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOptionalItems.put(key, value);
             return this;
         }
 
         public MapExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new MapExample(items, optionalItems, aliasOptionalItems);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAliasExample.java
@@ -81,22 +81,28 @@ public final class OptionalAliasExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private OptionalAlias optionalAlias;
 
         private Builder() {}
 
         public Builder from(OptionalAliasExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             optionalAlias(other.getOptionalAlias());
             return this;
         }
 
         @JsonSetter(value = "optionalAlias", nulls = Nulls.AS_EMPTY)
         public Builder optionalAlias(@Nonnull OptionalAlias optionalAlias) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.optionalAlias = Preconditions.checkNotNull(optionalAlias, "optionalAlias cannot be null");
             return this;
         }
 
         public OptionalAliasExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new OptionalAliasExample(optionalAlias);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAliasExample.java
@@ -88,22 +88,26 @@ public final class OptionalAliasExample {
         private Builder() {}
 
         public Builder from(OptionalAliasExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             optionalAlias(other.getOptionalAlias());
             return this;
         }
 
         @JsonSetter(value = "optionalAlias", nulls = Nulls.AS_EMPTY)
         public Builder optionalAlias(@Nonnull OptionalAlias optionalAlias) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.optionalAlias = Preconditions.checkNotNull(optionalAlias, "optionalAlias cannot be null");
             return this;
         }
 
         public OptionalAliasExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new OptionalAliasExample(optionalAlias);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalExample.java
@@ -89,28 +89,32 @@ public final class OptionalExample {
         private Builder() {}
 
         public Builder from(OptionalExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             item(other.getItem());
             return this;
         }
 
         @JsonSetter(value = "item", nulls = Nulls.SKIP)
         public Builder item(@Nonnull Optional<String> item) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.item = Preconditions.checkNotNull(item, "item cannot be null");
             return this;
         }
 
         public Builder item(@Nonnull String item) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.item = Optional.of(Preconditions.checkNotNull(item, "item cannot be null"));
             return this;
         }
 
         public OptionalExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new OptionalExample(item);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalExample.java
@@ -82,27 +82,34 @@ public final class OptionalExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private Optional<String> item = Optional.empty();
 
         private Builder() {}
 
         public Builder from(OptionalExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             item(other.getItem());
             return this;
         }
 
         @JsonSetter(value = "item", nulls = Nulls.SKIP)
         public Builder item(@Nonnull Optional<String> item) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.item = Preconditions.checkNotNull(item, "item cannot be null");
             return this;
         }
 
         public Builder item(@Nonnull String item) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.item = Optional.of(Preconditions.checkNotNull(item, "item cannot be null"));
             return this;
         }
 
         public OptionalExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new OptionalExample(item);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
@@ -400,7 +400,7 @@ public final class PrimitiveOptionalsExample {
         private Builder() {}
 
         public Builder from(PrimitiveOptionalsExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             num(other.getNum());
             bool(other.getBool());
             integer(other.getInteger());
@@ -424,210 +424,210 @@ public final class PrimitiveOptionalsExample {
 
         @JsonSetter(value = "num", nulls = Nulls.SKIP)
         public Builder num(@Nonnull OptionalDouble num) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.num = Preconditions.checkNotNull(num, "num cannot be null");
             return this;
         }
 
         public Builder num(double num) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.num = OptionalDouble.of(num);
             return this;
         }
 
         @JsonSetter(value = "bool", nulls = Nulls.SKIP)
         public Builder bool(@Nonnull Optional<Boolean> bool) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.bool = Preconditions.checkNotNull(bool, "bool cannot be null");
             return this;
         }
 
         public Builder bool(boolean bool) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.bool = Optional.of(bool);
             return this;
         }
 
         @JsonSetter(value = "integer", nulls = Nulls.SKIP)
         public Builder integer(@Nonnull OptionalInt integer) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.integer = Preconditions.checkNotNull(integer, "integer cannot be null");
             return this;
         }
 
         public Builder integer(int integer) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.integer = OptionalInt.of(integer);
             return this;
         }
 
         @JsonSetter(value = "safelong", nulls = Nulls.SKIP)
         public Builder safelong(@Nonnull Optional<SafeLong> safelong) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.safelong = Preconditions.checkNotNull(safelong, "safelong cannot be null");
             return this;
         }
 
         public Builder safelong(@Nonnull SafeLong safelong) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.safelong = Optional.of(Preconditions.checkNotNull(safelong, "safelong cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "rid", nulls = Nulls.SKIP)
         public Builder rid(@Nonnull Optional<ResourceIdentifier> rid) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.rid = Preconditions.checkNotNull(rid, "rid cannot be null");
             return this;
         }
 
         public Builder rid(@Nonnull ResourceIdentifier rid) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.rid = Optional.of(Preconditions.checkNotNull(rid, "rid cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "bearertoken", nulls = Nulls.SKIP)
         public Builder bearertoken(@Nonnull Optional<BearerToken> bearertoken) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.bearertoken = Preconditions.checkNotNull(bearertoken, "bearertoken cannot be null");
             return this;
         }
 
         public Builder bearertoken(@Nonnull BearerToken bearertoken) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.bearertoken = Optional.of(Preconditions.checkNotNull(bearertoken, "bearertoken cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "uuid", nulls = Nulls.SKIP)
         public Builder uuid(@Nonnull Optional<UUID> uuid) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.uuid = Preconditions.checkNotNull(uuid, "uuid cannot be null");
             return this;
         }
 
         public Builder uuid(@Nonnull UUID uuid) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.uuid = Optional.of(Preconditions.checkNotNull(uuid, "uuid cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(@Nonnull Optional<? extends Map<String, String>> map) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.map = Preconditions.checkNotNull(map, "map cannot be null").map(Function.identity());
             return this;
         }
 
         public Builder map(@Nonnull Map<String, String> map) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.map = Optional.of(Preconditions.checkNotNull(map, "map cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "list", nulls = Nulls.SKIP)
         public Builder list(@Nonnull Optional<? extends List<String>> list) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.list = Preconditions.checkNotNull(list, "list cannot be null").map(Function.identity());
             return this;
         }
 
         public Builder list(@Nonnull List<String> list) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.list = Optional.of(Preconditions.checkNotNull(list, "list cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "set", nulls = Nulls.SKIP)
         public Builder set(@Nonnull Optional<? extends Set<String>> set) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.set = Preconditions.checkNotNull(set, "set cannot be null").map(Function.identity());
             return this;
         }
 
         public Builder set(@Nonnull Set<String> set) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.set = Optional.of(Preconditions.checkNotNull(set, "set cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "aliasOne", nulls = Nulls.SKIP)
         public Builder aliasOne(@Nonnull Optional<StringAliasOne> aliasOne) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOne = Preconditions.checkNotNull(aliasOne, "aliasOne cannot be null");
             return this;
         }
 
         public Builder aliasOne(@Nonnull StringAliasOne aliasOne) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOne = Optional.of(Preconditions.checkNotNull(aliasOne, "aliasOne cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "aliasTwo", nulls = Nulls.AS_EMPTY)
         public Builder aliasTwo(@Nonnull StringAliasTwo aliasTwo) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasTwo = Preconditions.checkNotNull(aliasTwo, "aliasTwo cannot be null");
             return this;
         }
 
         @JsonSetter(value = "aliasList", nulls = Nulls.SKIP)
         public Builder aliasList(@Nonnull Optional<ListAlias> aliasList) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasList = Preconditions.checkNotNull(aliasList, "aliasList cannot be null");
             return this;
         }
 
         public Builder aliasList(@Nonnull ListAlias aliasList) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasList = Optional.of(Preconditions.checkNotNull(aliasList, "aliasList cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "aliasMap", nulls = Nulls.SKIP)
         public Builder aliasMap(@Nonnull Optional<MapAliasExample> aliasMap) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasMap = Preconditions.checkNotNull(aliasMap, "aliasMap cannot be null");
             return this;
         }
 
         public Builder aliasMap(@Nonnull MapAliasExample aliasMap) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasMap = Optional.of(Preconditions.checkNotNull(aliasMap, "aliasMap cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "aliasOptional", nulls = Nulls.AS_EMPTY)
         public Builder aliasOptional(@Nonnull OptionalAlias aliasOptional) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOptional = Preconditions.checkNotNull(aliasOptional, "aliasOptional cannot be null");
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalMap", nulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalMap(@Nonnull OptionalMapAliasExample aliasOptionalMap) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOptionalMap = Preconditions.checkNotNull(aliasOptionalMap, "aliasOptionalMap cannot be null");
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalList", nulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalList(@Nonnull OptionalListAliasExample aliasOptionalList) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOptionalList = Preconditions.checkNotNull(aliasOptionalList, "aliasOptionalList cannot be null");
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalSet", nulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalSet(@Nonnull OptionalSetAliasExample aliasOptionalSet) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.aliasOptionalSet = Preconditions.checkNotNull(aliasOptionalSet, "aliasOptionalSet cannot be null");
             return this;
         }
 
         public PrimitiveOptionalsExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new PrimitiveOptionalsExample(
                     num,
@@ -648,6 +648,10 @@ public final class PrimitiveOptionalsExample {
                     aliasOptionalMap,
                     aliasOptionalList,
                     aliasOptionalSet);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
@@ -359,6 +359,8 @@ public final class PrimitiveOptionalsExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private OptionalDouble num = OptionalDouble.empty();
 
         private Optional<Boolean> bool = Optional.empty();
@@ -398,6 +400,7 @@ public final class PrimitiveOptionalsExample {
         private Builder() {}
 
         public Builder from(PrimitiveOptionalsExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             num(other.getNum());
             bool(other.getBool());
             integer(other.getInteger());
@@ -421,178 +424,211 @@ public final class PrimitiveOptionalsExample {
 
         @JsonSetter(value = "num", nulls = Nulls.SKIP)
         public Builder num(@Nonnull OptionalDouble num) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.num = Preconditions.checkNotNull(num, "num cannot be null");
             return this;
         }
 
         public Builder num(double num) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.num = OptionalDouble.of(num);
             return this;
         }
 
         @JsonSetter(value = "bool", nulls = Nulls.SKIP)
         public Builder bool(@Nonnull Optional<Boolean> bool) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.bool = Preconditions.checkNotNull(bool, "bool cannot be null");
             return this;
         }
 
         public Builder bool(boolean bool) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.bool = Optional.of(bool);
             return this;
         }
 
         @JsonSetter(value = "integer", nulls = Nulls.SKIP)
         public Builder integer(@Nonnull OptionalInt integer) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.integer = Preconditions.checkNotNull(integer, "integer cannot be null");
             return this;
         }
 
         public Builder integer(int integer) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.integer = OptionalInt.of(integer);
             return this;
         }
 
         @JsonSetter(value = "safelong", nulls = Nulls.SKIP)
         public Builder safelong(@Nonnull Optional<SafeLong> safelong) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.safelong = Preconditions.checkNotNull(safelong, "safelong cannot be null");
             return this;
         }
 
         public Builder safelong(@Nonnull SafeLong safelong) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.safelong = Optional.of(Preconditions.checkNotNull(safelong, "safelong cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "rid", nulls = Nulls.SKIP)
         public Builder rid(@Nonnull Optional<ResourceIdentifier> rid) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.rid = Preconditions.checkNotNull(rid, "rid cannot be null");
             return this;
         }
 
         public Builder rid(@Nonnull ResourceIdentifier rid) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.rid = Optional.of(Preconditions.checkNotNull(rid, "rid cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "bearertoken", nulls = Nulls.SKIP)
         public Builder bearertoken(@Nonnull Optional<BearerToken> bearertoken) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.bearertoken = Preconditions.checkNotNull(bearertoken, "bearertoken cannot be null");
             return this;
         }
 
         public Builder bearertoken(@Nonnull BearerToken bearertoken) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.bearertoken = Optional.of(Preconditions.checkNotNull(bearertoken, "bearertoken cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "uuid", nulls = Nulls.SKIP)
         public Builder uuid(@Nonnull Optional<UUID> uuid) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.uuid = Preconditions.checkNotNull(uuid, "uuid cannot be null");
             return this;
         }
 
         public Builder uuid(@Nonnull UUID uuid) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.uuid = Optional.of(Preconditions.checkNotNull(uuid, "uuid cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(@Nonnull Optional<? extends Map<String, String>> map) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.map = Preconditions.checkNotNull(map, "map cannot be null").map(Function.identity());
             return this;
         }
 
         public Builder map(@Nonnull Map<String, String> map) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.map = Optional.of(Preconditions.checkNotNull(map, "map cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "list", nulls = Nulls.SKIP)
         public Builder list(@Nonnull Optional<? extends List<String>> list) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.list = Preconditions.checkNotNull(list, "list cannot be null").map(Function.identity());
             return this;
         }
 
         public Builder list(@Nonnull List<String> list) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.list = Optional.of(Preconditions.checkNotNull(list, "list cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "set", nulls = Nulls.SKIP)
         public Builder set(@Nonnull Optional<? extends Set<String>> set) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.set = Preconditions.checkNotNull(set, "set cannot be null").map(Function.identity());
             return this;
         }
 
         public Builder set(@Nonnull Set<String> set) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.set = Optional.of(Preconditions.checkNotNull(set, "set cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "aliasOne", nulls = Nulls.SKIP)
         public Builder aliasOne(@Nonnull Optional<StringAliasOne> aliasOne) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOne = Preconditions.checkNotNull(aliasOne, "aliasOne cannot be null");
             return this;
         }
 
         public Builder aliasOne(@Nonnull StringAliasOne aliasOne) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOne = Optional.of(Preconditions.checkNotNull(aliasOne, "aliasOne cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "aliasTwo", nulls = Nulls.AS_EMPTY)
         public Builder aliasTwo(@Nonnull StringAliasTwo aliasTwo) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasTwo = Preconditions.checkNotNull(aliasTwo, "aliasTwo cannot be null");
             return this;
         }
 
         @JsonSetter(value = "aliasList", nulls = Nulls.SKIP)
         public Builder aliasList(@Nonnull Optional<ListAlias> aliasList) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasList = Preconditions.checkNotNull(aliasList, "aliasList cannot be null");
             return this;
         }
 
         public Builder aliasList(@Nonnull ListAlias aliasList) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasList = Optional.of(Preconditions.checkNotNull(aliasList, "aliasList cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "aliasMap", nulls = Nulls.SKIP)
         public Builder aliasMap(@Nonnull Optional<MapAliasExample> aliasMap) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasMap = Preconditions.checkNotNull(aliasMap, "aliasMap cannot be null");
             return this;
         }
 
         public Builder aliasMap(@Nonnull MapAliasExample aliasMap) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasMap = Optional.of(Preconditions.checkNotNull(aliasMap, "aliasMap cannot be null"));
             return this;
         }
 
         @JsonSetter(value = "aliasOptional", nulls = Nulls.AS_EMPTY)
         public Builder aliasOptional(@Nonnull OptionalAlias aliasOptional) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOptional = Preconditions.checkNotNull(aliasOptional, "aliasOptional cannot be null");
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalMap", nulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalMap(@Nonnull OptionalMapAliasExample aliasOptionalMap) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOptionalMap = Preconditions.checkNotNull(aliasOptionalMap, "aliasOptionalMap cannot be null");
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalList", nulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalList(@Nonnull OptionalListAliasExample aliasOptionalList) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOptionalList = Preconditions.checkNotNull(aliasOptionalList, "aliasOptionalList cannot be null");
             return this;
         }
 
         @JsonSetter(value = "aliasOptionalSet", nulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalSet(@Nonnull OptionalSetAliasExample aliasOptionalSet) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.aliasOptionalSet = Preconditions.checkNotNull(aliasOptionalSet, "aliasOptionalSet cannot be null");
             return this;
         }
 
         public PrimitiveOptionalsExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new PrimitiveOptionalsExample(
                     num,
                     bool,

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReservedKeyExample.java
@@ -165,7 +165,7 @@ public final class ReservedKeyExample {
         private Builder() {}
 
         public Builder from(ReservedKeyExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             package_(other.getPackage());
             interface_(other.getInterface());
             fieldNameWithDashes(other.getFieldNameWithDashes());
@@ -177,21 +177,21 @@ public final class ReservedKeyExample {
 
         @JsonSetter("package")
         public Builder package_(@Nonnull String package_) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.package_ = Preconditions.checkNotNull(package_, "package cannot be null");
             return this;
         }
 
         @JsonSetter("interface")
         public Builder interface_(@Nonnull String interface_) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.interface_ = Preconditions.checkNotNull(interface_, "interface cannot be null");
             return this;
         }
 
         @JsonSetter("field-name-with-dashes")
         public Builder fieldNameWithDashes(@Nonnull String fieldNameWithDashes) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.fieldNameWithDashes =
                     Preconditions.checkNotNull(fieldNameWithDashes, "field-name-with-dashes cannot be null");
             return this;
@@ -199,7 +199,7 @@ public final class ReservedKeyExample {
 
         @JsonSetter("primitve-field-name-with-dashes")
         public Builder primitveFieldNameWithDashes(int primitveFieldNameWithDashes) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.primitveFieldNameWithDashes = primitveFieldNameWithDashes;
             this._primitveFieldNameWithDashesInitialized = true;
             return this;
@@ -207,7 +207,7 @@ public final class ReservedKeyExample {
 
         @JsonSetter("memoizedHashCode")
         public Builder memoizedHashCode_(int memoizedHashCode_) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.memoizedHashCode_ = memoizedHashCode_;
             this._memoizedHashCode_Initialized = true;
             return this;
@@ -215,7 +215,7 @@ public final class ReservedKeyExample {
 
         @JsonSetter("result")
         public Builder result(int result) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.result = result;
             this._resultInitialized = true;
             return this;
@@ -245,11 +245,15 @@ public final class ReservedKeyExample {
         }
 
         public ReservedKeyExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new ReservedKeyExample(
                     package_, interface_, fieldNameWithDashes, primitveFieldNameWithDashes, memoizedHashCode_, result);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReservedKeyExample.java
@@ -142,6 +142,8 @@ public final class ReservedKeyExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private String package_;
 
         private String interface_;
@@ -163,6 +165,7 @@ public final class ReservedKeyExample {
         private Builder() {}
 
         public Builder from(ReservedKeyExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             package_(other.getPackage());
             interface_(other.getInterface());
             fieldNameWithDashes(other.getFieldNameWithDashes());
@@ -174,18 +177,21 @@ public final class ReservedKeyExample {
 
         @JsonSetter("package")
         public Builder package_(@Nonnull String package_) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.package_ = Preconditions.checkNotNull(package_, "package cannot be null");
             return this;
         }
 
         @JsonSetter("interface")
         public Builder interface_(@Nonnull String interface_) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.interface_ = Preconditions.checkNotNull(interface_, "interface cannot be null");
             return this;
         }
 
         @JsonSetter("field-name-with-dashes")
         public Builder fieldNameWithDashes(@Nonnull String fieldNameWithDashes) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.fieldNameWithDashes =
                     Preconditions.checkNotNull(fieldNameWithDashes, "field-name-with-dashes cannot be null");
             return this;
@@ -193,6 +199,7 @@ public final class ReservedKeyExample {
 
         @JsonSetter("primitve-field-name-with-dashes")
         public Builder primitveFieldNameWithDashes(int primitveFieldNameWithDashes) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.primitveFieldNameWithDashes = primitveFieldNameWithDashes;
             this._primitveFieldNameWithDashesInitialized = true;
             return this;
@@ -200,6 +207,7 @@ public final class ReservedKeyExample {
 
         @JsonSetter("memoizedHashCode")
         public Builder memoizedHashCode_(int memoizedHashCode_) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.memoizedHashCode_ = memoizedHashCode_;
             this._memoizedHashCode_Initialized = true;
             return this;
@@ -207,6 +215,7 @@ public final class ReservedKeyExample {
 
         @JsonSetter("result")
         public Builder result(int result) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.result = result;
             this._resultInitialized = true;
             return this;
@@ -236,6 +245,8 @@ public final class ReservedKeyExample {
         }
 
         public ReservedKeyExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
             return new ReservedKeyExample(
                     package_, interface_, fieldNameWithDashes, primitveFieldNameWithDashes, memoizedHashCode_, result);

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RidExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RidExample.java
@@ -79,22 +79,28 @@ public final class RidExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private ResourceIdentifier ridValue;
 
         private Builder() {}
 
         public Builder from(RidExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ridValue(other.getRidValue());
             return this;
         }
 
         @JsonSetter("ridValue")
         public Builder ridValue(@Nonnull ResourceIdentifier ridValue) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.ridValue = Preconditions.checkNotNull(ridValue, "ridValue cannot be null");
             return this;
         }
 
         public RidExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new RidExample(ridValue);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RidExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RidExample.java
@@ -86,22 +86,26 @@ public final class RidExample {
         private Builder() {}
 
         public Builder from(RidExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ridValue(other.getRidValue());
             return this;
         }
 
         @JsonSetter("ridValue")
         public Builder ridValue(@Nonnull ResourceIdentifier ridValue) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.ridValue = Preconditions.checkNotNull(ridValue, "ridValue cannot be null");
             return this;
         }
 
         public RidExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new RidExample(ridValue);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeLongExample.java
@@ -79,22 +79,28 @@ public final class SafeLongExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private SafeLong safeLongValue;
 
         private Builder() {}
 
         public Builder from(SafeLongExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             safeLongValue(other.getSafeLongValue());
             return this;
         }
 
         @JsonSetter("safeLongValue")
         public Builder safeLongValue(@Nonnull SafeLong safeLongValue) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.safeLongValue = Preconditions.checkNotNull(safeLongValue, "safeLongValue cannot be null");
             return this;
         }
 
         public SafeLongExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new SafeLongExample(safeLongValue);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeLongExample.java
@@ -86,22 +86,26 @@ public final class SafeLongExample {
         private Builder() {}
 
         public Builder from(SafeLongExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             safeLongValue(other.getSafeLongValue());
             return this;
         }
 
         @JsonSetter("safeLongValue")
         public Builder safeLongValue(@Nonnull SafeLong safeLongValue) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.safeLongValue = Preconditions.checkNotNull(safeLongValue, "safeLongValue cannot be null");
             return this;
         }
 
         public SafeLongExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new SafeLongExample(safeLongValue);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetExample.java
@@ -108,7 +108,7 @@ public final class SetExample {
         private Builder() {}
 
         public Builder from(SetExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             items(other.getItems());
             doubleItems(other.getDoubleItems());
             return this;
@@ -116,27 +116,27 @@ public final class SetExample {
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<String> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder addAllItems(@Nonnull Iterable<String> items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(String items) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.items.add(items);
             return this;
         }
 
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP)
         public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.doubleItems.clear();
             ConjureCollections.addAll(
                     this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
@@ -144,22 +144,26 @@ public final class SetExample {
         }
 
         public Builder addAllDoubleItems(@Nonnull Iterable<Double> doubleItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             ConjureCollections.addAll(
                     this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
             return this;
         }
 
         public Builder doubleItems(double doubleItems) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.doubleItems.add(doubleItems);
             return this;
         }
 
         public SetExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new SetExample(items, doubleItems);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetExample.java
@@ -99,6 +99,8 @@ public final class SetExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private Set<String> items = new LinkedHashSet<>();
 
         private Set<Double> doubleItems = new LinkedHashSet<>();
@@ -106,6 +108,7 @@ public final class SetExample {
         private Builder() {}
 
         public Builder from(SetExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             items(other.getItems());
             doubleItems(other.getDoubleItems());
             return this;
@@ -113,23 +116,27 @@ public final class SetExample {
 
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<String> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.clear();
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder addAllItems(@Nonnull Iterable<String> items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
         public Builder items(String items) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.items.add(items);
             return this;
         }
 
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP)
         public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.doubleItems.clear();
             ConjureCollections.addAll(
                     this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
@@ -137,17 +144,21 @@ public final class SetExample {
         }
 
         public Builder addAllDoubleItems(@Nonnull Iterable<Double> doubleItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             ConjureCollections.addAll(
                     this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
             return this;
         }
 
         public Builder doubleItems(double doubleItems) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.doubleItems.add(doubleItems);
             return this;
         }
 
         public SetExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new SetExample(items, doubleItems);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringExample.java
@@ -85,22 +85,26 @@ public final class StringExample {
         private Builder() {}
 
         public Builder from(StringExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             string(other.getString());
             return this;
         }
 
         @JsonSetter("string")
         public Builder string(@Nonnull String string) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.string = Preconditions.checkNotNull(string, "string cannot be null");
             return this;
         }
 
         public StringExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new StringExample(string);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringExample.java
@@ -78,22 +78,28 @@ public final class StringExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private String string;
 
         private Builder() {}
 
         public Builder from(StringExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             string(other.getString());
             return this;
         }
 
         @JsonSetter("string")
         public Builder string(@Nonnull String string) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.string = Preconditions.checkNotNull(string, "string cannot be null");
             return this;
         }
 
         public StringExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new StringExample(string);
         }
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UuidExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UuidExample.java
@@ -86,22 +86,26 @@ public final class UuidExample {
         private Builder() {}
 
         public Builder from(UuidExample other) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             uuid(other.getUuid());
             return this;
         }
 
         @JsonSetter("uuid")
         public Builder uuid(@Nonnull UUID uuid) {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this.uuid = Preconditions.checkNotNull(uuid, "uuid cannot be null");
             return this;
         }
 
         public UuidExample build() {
-            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            checkNotBuilt();
             this._buildInvoked = true;
             return new UuidExample(uuid);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UuidExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UuidExample.java
@@ -79,22 +79,28 @@ public final class UuidExample {
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
+        boolean _buildInvoked;
+
         private UUID uuid;
 
         private Builder() {}
 
         public Builder from(UuidExample other) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             uuid(other.getUuid());
             return this;
         }
 
         @JsonSetter("uuid")
         public Builder uuid(@Nonnull UUID uuid) {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
             this.uuid = Preconditions.checkNotNull(uuid, "uuid cannot be null");
             return this;
         }
 
         public UuidExample build() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+            this._buildInvoked = true;
             return new UuidExample(uuid);
         }
     }


### PR DESCRIPTION
This behavior was never expected to work, and can result in unexpected
mutability in collections.

==COMMIT_MSG==
Conjure builders throw when they're reused after a `build()` invocation
==COMMIT_MSG==

