### PR TITLE
Make min and max public

### DIFF
--- a/changelog/@unreleased/pr-1497.v2.yml
+++ b/changelog/@unreleased/pr-1497.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Make the min and max safelong values public.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1497

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/SafeLong.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/SafeLong.java
@@ -27,7 +27,7 @@ public abstract class SafeLong implements Comparable<SafeLong> {
 
     private static final long MIN_SAFE_VALUE = -(1L << 53) + 1;
     private static final long MAX_SAFE_VALUE = (1L << 53) - 1;
-    
+
     public static final SafeLong MAX_VALUE = SafeLong.of(MAX_SAFE_VALUE);
     public static final SafeLong MIN_VALUE = SafeLong.of(MIN_SAFE_VALUE);
 

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/SafeLong.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/SafeLong.java
@@ -25,8 +25,11 @@ import org.immutables.value.Value;
 @Value.Immutable
 public abstract class SafeLong implements Comparable<SafeLong> {
 
-    public static final long MIN_SAFE_VALUE = -(1L << 53) + 1;
-    public static final long MAX_SAFE_VALUE = (1L << 53) - 1;
+    private static final long MIN_SAFE_VALUE = -(1L << 53) + 1;
+    private static final long MAX_SAFE_VALUE = (1L << 53) - 1;
+    
+    public static final SafeLong MAX_VALUE = SafeLong.of(MAX_SAFE_VALUE);
+    public static final SafeLong MIN_VALUE = SafeLong.of(MIN_SAFE_VALUE);
 
     @JsonValue
     @Value.Parameter

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/SafeLong.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/SafeLong.java
@@ -25,8 +25,8 @@ import org.immutables.value.Value;
 @Value.Immutable
 public abstract class SafeLong implements Comparable<SafeLong> {
 
-    private static final long MIN_SAFE_VALUE = -(1L << 53) + 1;
-    private static final long MAX_SAFE_VALUE = (1L << 53) - 1;
+    public static final long MIN_SAFE_VALUE = -(1L << 53) + 1;
+    public static final long MAX_SAFE_VALUE = (1L << 53) - 1;
 
     @JsonValue
     @Value.Parameter


### PR DESCRIPTION
## Before this PR
Without looking it up in the code and copying the values, there's no programmatic way to know what the min/max values are.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Make the min and max safelong values public.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

