### PR TITLE
Generate ErrorNs.is{Error} static methods for checking conjure errors

### DIFF
--- a/changelog/@unreleased/pr-1507.v2.yml
+++ b/changelog/@unreleased/pr-1507.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Generate convenience `is{Error}` static methods for Conjure errors.
+    It checks if a `RemoteException` has the same name as the Conjure defined error.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1507

--- a/conjure-java-core/src/integrationInput/java/com/palantir/another/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/another/ConjureErrors.java
@@ -3,6 +3,7 @@ package com.palantir.another;
 import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.ServiceException;
+import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.ErrorGenerator")
@@ -37,6 +38,7 @@ public final class ConjureErrors {
      * Returns true if the {@link RemoteException} is named Conjure:DifferentPackage
      */
     public static boolean isDifferentPackage(RemoteException remoteException) {
+        Preconditions.checkNotNull(remoteException, "remote exception must not be null");
         return DIFFERENT_PACKAGE.name().equals(remoteException.getError().errorName());
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/another/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/another/ConjureErrors.java
@@ -1,6 +1,7 @@
 package com.palantir.another;
 
 import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.ServiceException;
 import javax.annotation.Generated;
 
@@ -30,5 +31,12 @@ public final class ConjureErrors {
         if (shouldThrow) {
             throw differentPackage();
         }
+    }
+
+    /**
+     * Returns true if the {@link RemoteException} is named Conjure:DifferentPackage
+     */
+    public static boolean isDifferentPackage(RemoteException remoteException) {
+        return DIFFERENT_PACKAGE.name().equals(remoteException.getError().errorName());
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/another/ConjureJavaOtherErrors.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/another/ConjureJavaOtherErrors.java
@@ -1,4 +1,4 @@
-package com.palantir.product;
+package com.palantir.another;
 
 import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.RemoteException;
@@ -7,14 +7,14 @@ import com.palantir.logsafe.Preconditions;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.conjure.java.types.ErrorGenerator")
-public final class ConjureJavaErrors {
+public final class ConjureJavaOtherErrors {
     /**
      * Failed to compile Conjure definition to Java code.
      */
     public static final ErrorType JAVA_COMPILATION_FAILED =
-            ErrorType.create(ErrorType.Code.INTERNAL, "ConjureJava:JavaCompilationFailed");
+            ErrorType.create(ErrorType.Code.INTERNAL, "ConjureJavaOther:JavaCompilationFailed");
 
-    private ConjureJavaErrors() {}
+    private ConjureJavaOtherErrors() {}
 
     public static ServiceException javaCompilationFailed() {
         return new ServiceException(JAVA_COMPILATION_FAILED);
@@ -35,7 +35,7 @@ public final class ConjureJavaErrors {
     }
 
     /**
-     * Returns true if the {@link RemoteException} is named ConjureJava:JavaCompilationFailed
+     * Returns true if the {@link RemoteException} is named ConjureJavaOther:JavaCompilationFailed
      */
     public static boolean isJavaCompilationFailed(RemoteException remoteException) {
         Preconditions.checkNotNull(remoteException, "remote exception must not be null");

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ConjureErrors.java
@@ -3,6 +3,7 @@ package com.palantir.product;
 import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.ServiceException;
+import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import javax.annotation.Generated;
@@ -84,6 +85,7 @@ public final class ConjureErrors {
      * Returns true if the {@link RemoteException} is named Conjure:InvalidServiceDefinition
      */
     public static boolean isInvalidServiceDefinition(RemoteException remoteException) {
+        Preconditions.checkNotNull(remoteException, "remote exception must not be null");
         return INVALID_SERVICE_DEFINITION
                 .name()
                 .equals(remoteException.getError().errorName());
@@ -93,6 +95,7 @@ public final class ConjureErrors {
      * Returns true if the {@link RemoteException} is named Conjure:InvalidTypeDefinition
      */
     public static boolean isInvalidTypeDefinition(RemoteException remoteException) {
+        Preconditions.checkNotNull(remoteException, "remote exception must not be null");
         return INVALID_TYPE_DEFINITION.name().equals(remoteException.getError().errorName());
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ConjureErrors.java
@@ -1,6 +1,7 @@
 package com.palantir.product;
 
 import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
@@ -77,5 +78,21 @@ public final class ConjureErrors {
         if (shouldThrow) {
             throw invalidTypeDefinition(typeName, typeDef);
         }
+    }
+
+    /**
+     * Returns true if the {@link RemoteException} is named Conjure:InvalidServiceDefinition
+     */
+    public static boolean isInvalidServiceDefinition(RemoteException remoteException) {
+        return INVALID_SERVICE_DEFINITION
+                .name()
+                .equals(remoteException.getError().errorName());
+    }
+
+    /**
+     * Returns true if the {@link RemoteException} is named Conjure:InvalidTypeDefinition
+     */
+    public static boolean isInvalidTypeDefinition(RemoteException remoteException) {
+        return INVALID_TYPE_DEFINITION.name().equals(remoteException.getError().errorName());
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ConjureJavaErrors.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ConjureJavaErrors.java
@@ -1,6 +1,7 @@
 package com.palantir.product;
 
 import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.ServiceException;
 import javax.annotation.Generated;
 
@@ -30,5 +31,12 @@ public final class ConjureJavaErrors {
         if (shouldThrow) {
             throw javaCompilationFailed();
         }
+    }
+
+    /**
+     * Returns true if the {@link RemoteException} is named ConjureJava:JavaCompilationFailed
+     */
+    public static boolean isJavaCompilationFailed(RemoteException remoteException) {
+        return JAVA_COMPILATION_FAILED.name().equals(remoteException.getError().errorName());
     }
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ErrorGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ErrorGenerator.java
@@ -52,6 +52,8 @@ import org.apache.commons.lang3.StringUtils;
 
 public final class ErrorGenerator implements Generator {
 
+    private static final String REMOTE_EXCEPTION_VAR = "remoteException";
+
     private final Options options;
 
     public ErrorGenerator(Options options) {
@@ -177,16 +179,19 @@ public final class ErrorGenerator implements Generator {
                             CaseFormat.UPPER_UNDERSCORE, entry.getErrorName().getName());
                     String methodName = "is" + entry.getErrorName().getName();
 
-                    String remoteExceptionVar = "remoteException";
-
                     return MethodSpec.methodBuilder(methodName)
                             .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                            .addParameter(RemoteException.class, remoteExceptionVar)
+                            .addParameter(RemoteException.class, REMOTE_EXCEPTION_VAR)
                             .returns(TypeName.BOOLEAN)
+                            .addStatement(Expressions.requireNonNull(
+                                    REMOTE_EXCEPTION_VAR, "remote exception must not be null"))
                             .addStatement(
-                                    "return $L.name().equals($L.getError().errorName())", typeName, remoteExceptionVar)
+                                    "return $N.name().equals($N.getError().errorName())",
+                                    typeName,
+                                    REMOTE_EXCEPTION_VAR)
                             .addJavadoc(
-                                    "Returns true if the {@link RemoteException} is named $L:$L",
+                                    "Returns true if the {@link $T} is named $L:$L",
+                                    RemoteException.class,
                                     entry.getNamespace(),
                                     entry.getErrorName().getName())
                             .build();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ErrorGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ErrorGenerator.java
@@ -179,19 +179,17 @@ public final class ErrorGenerator implements Generator {
 
                     String remoteExceptionVar = "remoteException";
 
-                    MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(methodName)
+                    return MethodSpec.methodBuilder(methodName)
                             .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                             .addParameter(RemoteException.class, remoteExceptionVar)
                             .returns(TypeName.BOOLEAN)
                             .addStatement(
-                                    "return $L.name().equals($L.getError().errorName())", typeName, remoteExceptionVar);
-
-                    methodBuilder.addJavadoc(
-                            "Returns true if the {@link RemoteException} is named $L:$L",
-                            entry.getNamespace(),
-                            entry.getErrorName().getName());
-
-                    return methodBuilder.build();
+                                    "return $L.name().equals($L.getError().errorName())", typeName, remoteExceptionVar)
+                            .addJavadoc(
+                                    "Returns true if the {@link RemoteException} is named $L:$L",
+                                    entry.getNamespace(),
+                                    entry.getErrorName().getName())
+                            .build();
                 })
                 .collect(Collectors.toList());
 

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/EteErrors.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/EteErrors.java
@@ -1,0 +1,53 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.another.ConjureJavaOtherErrors;
+import com.palantir.conjure.java.api.errors.RemoteException;
+import com.palantir.conjure.java.api.errors.SerializableError;
+import com.palantir.conjure.java.api.errors.ServiceException;
+import com.palantir.product.ConjureErrors;
+import com.palantir.product.ConjureJavaErrors;
+import org.junit.jupiter.api.Test;
+
+public class EteErrors {
+
+    @Test
+    void testIsError() {
+        RemoteException remoteException =
+                serializeServiceException(ConjureErrors.invalidServiceDefinition("my-service", "service-def"));
+
+        assertThat(ConjureErrors.isInvalidServiceDefinition(remoteException)).isTrue();
+        assertThat(ConjureErrors.isInvalidTypeDefinition(remoteException)).isFalse();
+    }
+
+    @Test
+    void testIsError_differentNamespaces() {
+        RemoteException remoteException = serializeServiceException(ConjureJavaErrors.javaCompilationFailed());
+
+        assertThat(ConjureJavaErrors.isJavaCompilationFailed(remoteException)).isTrue();
+        assertThat(ConjureJavaOtherErrors.isJavaCompilationFailed(remoteException))
+                .isFalse();
+    }
+
+    private static RemoteException serializeServiceException(ServiceException serviceException) {
+        SerializableError serializable = SerializableError.forException(serviceException);
+        return new RemoteException(serializable, 200);
+    }
+}

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
@@ -127,7 +127,9 @@ public final class ObjectGeneratorTests {
 
     @Test
     public void testConjureErrors() throws IOException {
-        ConjureDefinition def = Conjure.parse(ImmutableList.of(new File("src/test/resources/example-errors.yml")));
+        ConjureDefinition def = Conjure.parse(ImmutableList.of(
+                new File("src/test/resources/example-errors.yml"),
+                new File("src/test/resources/example-errors-other.yml")));
         List<Path> files = new GenerationCoordinator(
                         MoreExecutors.directExecutor(),
                         ImmutableSet.of(new ErrorGenerator(Options.builder()

--- a/conjure-java-core/src/test/resources/example-errors-other.yml
+++ b/conjure-java-core/src/test/resources/example-errors-other.yml
@@ -1,0 +1,8 @@
+types:
+  definitions:
+    default-package: com.palantir.another
+    errors:
+      JavaCompilationFailed:
+        namespace: ConjureJavaOther
+        docs: Failed to compile Conjure definition to Java code.
+        code: INTERNAL


### PR DESCRIPTION
## Before this PR
It was very common for people to write this method that checks for the type of the remote exception. But writing this by hand is very error prone, especially because it's not clear if one should use ServiceException or RemoteException in the catch clause, and what exactly to compare.

## After this PR
Generate is{Error} methods for conjure errors.

An example usage based on this error definition
```yaml
types:
  definitions:
    default-package: com.palantir.example
    errors:
      PermissionDenied:
        namespace: ExampleErrors
        code: PERMISSION_DENIED

```

could be like this:
```java

public void main() {
    try {
        exampleServiceBlocking.getExample();
    } catch (RemoteException e) {
        if (ExampleErrors.isPermissionDenied(e)) {
            log.error("Permission denied");
        } else {
            throw e;
        }
    }
}

```



## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

