### PR TITLE
Change error code of timed out async requests to TIMEOUT

### DIFF
--- a/changelog/@unreleased/pr-1553.v2.yml
+++ b/changelog/@unreleased/pr-1553.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Change error code of timed out async requests to TIMEOUT
+  links:
+  - https://github.com/palantir/conjure-java/pull/1553

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/AsyncRequestProcessingTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/AsyncRequestProcessingTest.java
@@ -158,7 +158,7 @@ public final class AsyncRequestProcessingTest extends TestBase {
         try (Response response = requestToDelayEndpoint(OptionalInt.of(2000))) {
             assertThat(response).matches(resp -> resp.code() == 500);
             SerializableError error = CLIENT_MAPPER.readValue(response.body().byteStream(), SerializableError.class);
-            assertThat(error.errorCode()).isEqualTo("INTERNAL");
+            assertThat(error.errorCode()).isEqualTo("TIMEOUT");
         }
     }
 


### PR DESCRIPTION
## Before this PR
Timed out async requests are logged as a CancellationException and propagated to clients as code INTERNAL

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Change error code of timed out async requests to TIMEOUT
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

