### PR TITLE
Provide clear context when async requests are timed out

### DIFF
--- a/changelog/@unreleased/pr-1558.v2.yml
+++ b/changelog/@unreleased/pr-1558.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Change error code of timed out async requests to TIMEOUT
+  links:
+  - https://github.com/palantir/conjure-java/pull/1558

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/AsyncRequestProcessingTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/AsyncRequestProcessingTest.java
@@ -158,7 +158,9 @@ public final class AsyncRequestProcessingTest extends TestBase {
         try (Response response = requestToDelayEndpoint(OptionalInt.of(2000))) {
             assertThat(response).matches(resp -> resp.code() == 500);
             SerializableError error = CLIENT_MAPPER.readValue(response.body().byteStream(), SerializableError.class);
-            assertThat(error.errorCode()).isEqualTo("INTERNAL");
+            assertThat(error.errorCode()).isEqualTo("TIMEOUT");
+            assertThat(error.errorName()).isEqualTo("Conjure:AsyncRequestProcessingTimeout");
+            assertThat(error.parameters()).containsEntry("timeoutSeconds", "1");
         }
     }
 


### PR DESCRIPTION
==COMMIT_MSG==
Change error code of timed out async requests to TIMEOUT
==COMMIT_MSG==