### PR TITLE
Add deprecated annotation on all completed stage builder methods

### DIFF
--- a/changelog/@unreleased/pr-1569.v2.yml
+++ b/changelog/@unreleased/pr-1569.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: All completed stage builder methods now properly include deprecation
+    annotations, if relevant. Previously, they could be missing for some methods.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1569

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -88,9 +88,11 @@ public final class ManyFieldExample {
 
     /**
      * docs for optionalItem field
+     * @deprecated an optional field is deprecated
      */
     @JsonProperty("optionalItem")
     @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    @Deprecated
     public Optional<String> getOptionalItem() {
         return this.optionalItem;
     }
@@ -279,7 +281,9 @@ public final class ManyFieldExample {
 
         /**
          * docs for optionalItem field
+         * @deprecated an optional field is deprecated
          */
+        @Deprecated
         @JsonSetter(value = "optionalItem", nulls = Nulls.SKIP)
         public Builder optionalItem(@Nonnull Optional<String> optionalItem) {
             checkNotBuilt();
@@ -289,7 +293,9 @@ public final class ManyFieldExample {
 
         /**
          * docs for optionalItem field
+         * @deprecated an optional field is deprecated
          */
+        @Deprecated
         public Builder optionalItem(@Nonnull String optionalItem) {
             checkNotBuilt();
             this.optionalItem = Optional.of(Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null"));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleFieldsOnlyFinalStage.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleFieldsOnlyFinalStage.java
@@ -33,15 +33,34 @@ public final class MultipleFieldsOnlyFinalStage {
 
     private final Set<String> itemsSet;
 
+    private final List<String> itemsOld;
+
+    private final Map<String, Integer> itemsMapOld;
+
+    private final Optional<String> optionalItemOld;
+
+    private final Set<String> itemsSetOld;
+
     private int memoizedHashCode;
 
     private MultipleFieldsOnlyFinalStage(
-            List<String> items, Map<String, Integer> itemsMap, Optional<String> optionalItem, Set<String> itemsSet) {
-        validateFields(items, itemsMap, optionalItem, itemsSet);
+            List<String> items,
+            Map<String, Integer> itemsMap,
+            Optional<String> optionalItem,
+            Set<String> itemsSet,
+            List<String> itemsOld,
+            Map<String, Integer> itemsMapOld,
+            Optional<String> optionalItemOld,
+            Set<String> itemsSetOld) {
+        validateFields(items, itemsMap, optionalItem, itemsSet, itemsOld, itemsMapOld, optionalItemOld, itemsSetOld);
         this.items = Collections.unmodifiableList(items);
         this.itemsMap = Collections.unmodifiableMap(itemsMap);
         this.optionalItem = optionalItem;
         this.itemsSet = Collections.unmodifiableSet(itemsSet);
+        this.itemsOld = Collections.unmodifiableList(itemsOld);
+        this.itemsMapOld = Collections.unmodifiableMap(itemsMapOld);
+        this.optionalItemOld = optionalItemOld;
+        this.itemsSetOld = Collections.unmodifiableSet(itemsSetOld);
     }
 
     @JsonProperty("items")
@@ -65,6 +84,43 @@ public final class MultipleFieldsOnlyFinalStage {
         return this.itemsSet;
     }
 
+    /**
+     * @deprecated this list is deprecated
+     */
+    @JsonProperty("itemsOld")
+    @Deprecated
+    public List<String> getItemsOld() {
+        return this.itemsOld;
+    }
+
+    /**
+     * @deprecated this map is deprecated
+     */
+    @JsonProperty("itemsMapOld")
+    @Deprecated
+    public Map<String, Integer> getItemsMapOld() {
+        return this.itemsMapOld;
+    }
+
+    /**
+     * @deprecated this optional is deprecated
+     */
+    @JsonProperty("optionalItemOld")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    @Deprecated
+    public Optional<String> getOptionalItemOld() {
+        return this.optionalItemOld;
+    }
+
+    /**
+     * @deprecated this set is deprecated
+     */
+    @JsonProperty("itemsSetOld")
+    @Deprecated
+    public Set<String> getItemsSetOld() {
+        return this.itemsSetOld;
+    }
+
     @Override
     public boolean equals(Object other) {
         return this == other
@@ -75,14 +131,26 @@ public final class MultipleFieldsOnlyFinalStage {
         return this.items.equals(other.items)
                 && this.itemsMap.equals(other.itemsMap)
                 && this.optionalItem.equals(other.optionalItem)
-                && this.itemsSet.equals(other.itemsSet);
+                && this.itemsSet.equals(other.itemsSet)
+                && this.itemsOld.equals(other.itemsOld)
+                && this.itemsMapOld.equals(other.itemsMapOld)
+                && this.optionalItemOld.equals(other.optionalItemOld)
+                && this.itemsSetOld.equals(other.itemsSetOld);
     }
 
     @Override
     public int hashCode() {
         int result = memoizedHashCode;
         if (result == 0) {
-            result = Objects.hash(this.items, this.itemsMap, this.optionalItem, this.itemsSet);
+            result = Objects.hash(
+                    this.items,
+                    this.itemsMap,
+                    this.optionalItem,
+                    this.itemsSet,
+                    this.itemsOld,
+                    this.itemsMapOld,
+                    this.optionalItemOld,
+                    this.itemsSetOld);
             memoizedHashCode = result;
         }
         return result;
@@ -91,16 +159,28 @@ public final class MultipleFieldsOnlyFinalStage {
     @Override
     public String toString() {
         return "MultipleFieldsOnlyFinalStage{items: " + items + ", itemsMap: " + itemsMap + ", optionalItem: "
-                + optionalItem + ", itemsSet: " + itemsSet + '}';
+                + optionalItem + ", itemsSet: " + itemsSet + ", itemsOld: " + itemsOld + ", itemsMapOld: " + itemsMapOld
+                + ", optionalItemOld: " + optionalItemOld + ", itemsSetOld: " + itemsSetOld + '}';
     }
 
     private static void validateFields(
-            List<String> items, Map<String, Integer> itemsMap, Optional<String> optionalItem, Set<String> itemsSet) {
+            List<String> items,
+            Map<String, Integer> itemsMap,
+            Optional<String> optionalItem,
+            Set<String> itemsSet,
+            List<String> itemsOld,
+            Map<String, Integer> itemsMapOld,
+            Optional<String> optionalItemOld,
+            Set<String> itemsSetOld) {
         List<String> missingFields = null;
         missingFields = addFieldIfMissing(missingFields, items, "items");
         missingFields = addFieldIfMissing(missingFields, itemsMap, "itemsMap");
         missingFields = addFieldIfMissing(missingFields, optionalItem, "optionalItem");
         missingFields = addFieldIfMissing(missingFields, itemsSet, "itemsSet");
+        missingFields = addFieldIfMissing(missingFields, itemsOld, "itemsOld");
+        missingFields = addFieldIfMissing(missingFields, itemsMapOld, "itemsMapOld");
+        missingFields = addFieldIfMissing(missingFields, optionalItemOld, "optionalItemOld");
+        missingFields = addFieldIfMissing(missingFields, itemsSetOld, "itemsSetOld");
         if (missingFields != null) {
             throw new SafeIllegalArgumentException(
                     "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
@@ -111,7 +191,7 @@ public final class MultipleFieldsOnlyFinalStage {
         List<String> missingFields = prev;
         if (fieldValue == null) {
             if (missingFields == null) {
-                missingFields = new ArrayList<>(4);
+                missingFields = new ArrayList<>(8);
             }
             missingFields.add(fieldName);
         }
@@ -135,6 +215,14 @@ public final class MultipleFieldsOnlyFinalStage {
 
         private Set<String> itemsSet = new LinkedHashSet<>();
 
+        private List<String> itemsOld = new ArrayList<>();
+
+        private Map<String, Integer> itemsMapOld = new LinkedHashMap<>();
+
+        private Optional<String> optionalItemOld = Optional.empty();
+
+        private Set<String> itemsSetOld = new LinkedHashSet<>();
+
         private Builder() {}
 
         public Builder from(MultipleFieldsOnlyFinalStage other) {
@@ -143,6 +231,10 @@ public final class MultipleFieldsOnlyFinalStage {
             itemsMap(other.getItemsMap());
             optionalItem(other.getOptionalItem());
             itemsSet(other.getItemsSet());
+            itemsOld(other.getItemsOld());
+            itemsMapOld(other.getItemsMapOld());
+            optionalItemOld(other.getOptionalItemOld());
+            itemsSetOld(other.getItemsSetOld());
             return this;
         }
 
@@ -219,10 +311,131 @@ public final class MultipleFieldsOnlyFinalStage {
             return this;
         }
 
+        /**
+         * @deprecated this list is deprecated
+         */
+        @Deprecated
+        @JsonSetter(value = "itemsOld", nulls = Nulls.SKIP)
+        public Builder itemsOld(@Nonnull Iterable<String> itemsOld) {
+            checkNotBuilt();
+            this.itemsOld.clear();
+            ConjureCollections.addAll(this.itemsOld, Preconditions.checkNotNull(itemsOld, "itemsOld cannot be null"));
+            return this;
+        }
+
+        /**
+         * @deprecated this list is deprecated
+         */
+        @Deprecated
+        public Builder addAllItemsOld(@Nonnull Iterable<String> itemsOld) {
+            checkNotBuilt();
+            ConjureCollections.addAll(this.itemsOld, Preconditions.checkNotNull(itemsOld, "itemsOld cannot be null"));
+            return this;
+        }
+
+        /**
+         * @deprecated this list is deprecated
+         */
+        @Deprecated
+        public Builder itemsOld(String itemsOld) {
+            checkNotBuilt();
+            this.itemsOld.add(itemsOld);
+            return this;
+        }
+
+        /**
+         * @deprecated this map is deprecated
+         */
+        @Deprecated
+        @JsonSetter(value = "itemsMapOld", nulls = Nulls.SKIP)
+        public Builder itemsMapOld(@Nonnull Map<String, Integer> itemsMapOld) {
+            checkNotBuilt();
+            this.itemsMapOld.clear();
+            this.itemsMapOld.putAll(Preconditions.checkNotNull(itemsMapOld, "itemsMapOld cannot be null"));
+            return this;
+        }
+
+        /**
+         * @deprecated this map is deprecated
+         */
+        @Deprecated
+        public Builder putAllItemsMapOld(@Nonnull Map<String, Integer> itemsMapOld) {
+            checkNotBuilt();
+            this.itemsMapOld.putAll(Preconditions.checkNotNull(itemsMapOld, "itemsMapOld cannot be null"));
+            return this;
+        }
+
+        /**
+         * @deprecated this map is deprecated
+         */
+        @Deprecated
+        public Builder itemsMapOld(String key, int value) {
+            checkNotBuilt();
+            this.itemsMapOld.put(key, value);
+            return this;
+        }
+
+        /**
+         * @deprecated this optional is deprecated
+         */
+        @Deprecated
+        @JsonSetter(value = "optionalItemOld", nulls = Nulls.SKIP)
+        public Builder optionalItemOld(@Nonnull Optional<String> optionalItemOld) {
+            checkNotBuilt();
+            this.optionalItemOld = Preconditions.checkNotNull(optionalItemOld, "optionalItemOld cannot be null");
+            return this;
+        }
+
+        /**
+         * @deprecated this optional is deprecated
+         */
+        @Deprecated
+        public Builder optionalItemOld(@Nonnull String optionalItemOld) {
+            checkNotBuilt();
+            this.optionalItemOld =
+                    Optional.of(Preconditions.checkNotNull(optionalItemOld, "optionalItemOld cannot be null"));
+            return this;
+        }
+
+        /**
+         * @deprecated this set is deprecated
+         */
+        @Deprecated
+        @JsonSetter(value = "itemsSetOld", nulls = Nulls.SKIP)
+        public Builder itemsSetOld(@Nonnull Iterable<String> itemsSetOld) {
+            checkNotBuilt();
+            this.itemsSetOld.clear();
+            ConjureCollections.addAll(
+                    this.itemsSetOld, Preconditions.checkNotNull(itemsSetOld, "itemsSetOld cannot be null"));
+            return this;
+        }
+
+        /**
+         * @deprecated this set is deprecated
+         */
+        @Deprecated
+        public Builder addAllItemsSetOld(@Nonnull Iterable<String> itemsSetOld) {
+            checkNotBuilt();
+            ConjureCollections.addAll(
+                    this.itemsSetOld, Preconditions.checkNotNull(itemsSetOld, "itemsSetOld cannot be null"));
+            return this;
+        }
+
+        /**
+         * @deprecated this set is deprecated
+         */
+        @Deprecated
+        public Builder itemsSetOld(String itemsSetOld) {
+            checkNotBuilt();
+            this.itemsSetOld.add(itemsSetOld);
+            return this;
+        }
+
         public MultipleFieldsOnlyFinalStage build() {
             checkNotBuilt();
             this._buildInvoked = true;
-            return new MultipleFieldsOnlyFinalStage(items, itemsMap, optionalItem, itemsSet);
+            return new MultipleFieldsOnlyFinalStage(
+                    items, itemsMap, optionalItem, itemsSet, itemsOld, itemsMapOld, optionalItemOld, itemsSetOld);
         }
 
         private void checkNotBuilt() {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
@@ -170,6 +170,10 @@ public final class MultipleOrderedStages {
 
         Completed_StageBuilder mappedRids(ResourceIdentifier key, String value);
 
+        /**
+         * @deprecated this optional is deprecated
+         */
+        @Deprecated
         Completed_StageBuilder optionalItem(@Nonnull Optional<OneField> optionalItem);
 
         /**
@@ -180,9 +184,6 @@ public final class MultipleOrderedStages {
     }
 
     public interface Builder extends TokenStageBuilder, ItemStageBuilder, Completed_StageBuilder {
-        @Override
-        Builder optionalItem(@Nonnull Optional<OneField> optionalItem);
-
         @Override
         MultipleOrderedStages build();
 
@@ -203,6 +204,13 @@ public final class MultipleOrderedStages {
 
         @Override
         Builder putAllMappedRids(@Nonnull Map<ResourceIdentifier, String> mappedRids);
+
+        /**
+         * @deprecated this optional is deprecated
+         */
+        @Deprecated
+        @Override
+        Builder optionalItem(@Nonnull Optional<OneField> optionalItem);
 
         @Override
         Builder token(@Nonnull OneField token);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
@@ -1,6 +1,7 @@
 package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -18,6 +19,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -33,15 +35,22 @@ public final class MultipleOrderedStages {
 
     private final Map<ResourceIdentifier, String> mappedRids;
 
+    private final Optional<OneField> optionalItem;
+
     private int memoizedHashCode;
 
     private MultipleOrderedStages(
-            OneField token, String item, Set<SafeLong> items, Map<ResourceIdentifier, String> mappedRids) {
-        validateFields(token, item, items, mappedRids);
+            OneField token,
+            String item,
+            Set<SafeLong> items,
+            Map<ResourceIdentifier, String> mappedRids,
+            Optional<OneField> optionalItem) {
+        validateFields(token, item, items, mappedRids, optionalItem);
         this.token = token;
         this.item = item;
         this.items = Collections.unmodifiableSet(items);
         this.mappedRids = Collections.unmodifiableMap(mappedRids);
+        this.optionalItem = optionalItem;
     }
 
     @JsonProperty("token")
@@ -64,6 +73,16 @@ public final class MultipleOrderedStages {
         return this.mappedRids;
     }
 
+    /**
+     * @deprecated this optional is deprecated
+     */
+    @JsonProperty("optionalItem")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    @Deprecated
+    public Optional<OneField> getOptionalItem() {
+        return this.optionalItem;
+    }
+
     @Override
     public boolean equals(Object other) {
         return this == other || (other instanceof MultipleOrderedStages && equalTo((MultipleOrderedStages) other));
@@ -73,14 +92,15 @@ public final class MultipleOrderedStages {
         return this.token.equals(other.token)
                 && this.item.equals(other.item)
                 && this.items.equals(other.items)
-                && this.mappedRids.equals(other.mappedRids);
+                && this.mappedRids.equals(other.mappedRids)
+                && this.optionalItem.equals(other.optionalItem);
     }
 
     @Override
     public int hashCode() {
         int result = memoizedHashCode;
         if (result == 0) {
-            result = Objects.hash(this.token, this.item, this.items, this.mappedRids);
+            result = Objects.hash(this.token, this.item, this.items, this.mappedRids, this.optionalItem);
             memoizedHashCode = result;
         }
         return result;
@@ -89,16 +109,21 @@ public final class MultipleOrderedStages {
     @Override
     public String toString() {
         return "MultipleOrderedStages{token: " + token + ", item: " + item + ", items: " + items + ", mappedRids: "
-                + mappedRids + '}';
+                + mappedRids + ", optionalItem: " + optionalItem + '}';
     }
 
     private static void validateFields(
-            OneField token, String item, Set<SafeLong> items, Map<ResourceIdentifier, String> mappedRids) {
+            OneField token,
+            String item,
+            Set<SafeLong> items,
+            Map<ResourceIdentifier, String> mappedRids,
+            Optional<OneField> optionalItem) {
         List<String> missingFields = null;
         missingFields = addFieldIfMissing(missingFields, token, "token");
         missingFields = addFieldIfMissing(missingFields, item, "item");
         missingFields = addFieldIfMissing(missingFields, items, "items");
         missingFields = addFieldIfMissing(missingFields, mappedRids, "mappedRids");
+        missingFields = addFieldIfMissing(missingFields, optionalItem, "optionalItem");
         if (missingFields != null) {
             throw new SafeIllegalArgumentException(
                     "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
@@ -109,7 +134,7 @@ public final class MultipleOrderedStages {
         List<String> missingFields = prev;
         if (fieldValue == null) {
             if (missingFields == null) {
-                missingFields = new ArrayList<>(4);
+                missingFields = new ArrayList<>(5);
             }
             missingFields.add(fieldName);
         }
@@ -144,9 +169,20 @@ public final class MultipleOrderedStages {
         Completed_StageBuilder putAllMappedRids(@Nonnull Map<ResourceIdentifier, String> mappedRids);
 
         Completed_StageBuilder mappedRids(ResourceIdentifier key, String value);
+
+        Completed_StageBuilder optionalItem(@Nonnull Optional<OneField> optionalItem);
+
+        /**
+         * @deprecated this optional is deprecated
+         */
+        @Deprecated
+        Completed_StageBuilder optionalItem(@Nonnull OneField optionalItem);
     }
 
     public interface Builder extends TokenStageBuilder, ItemStageBuilder, Completed_StageBuilder {
+        @Override
+        Builder optionalItem(@Nonnull Optional<OneField> optionalItem);
+
         @Override
         MultipleOrderedStages build();
 
@@ -176,6 +212,13 @@ public final class MultipleOrderedStages {
 
         @Override
         Builder item(@Nonnull String item);
+
+        /**
+         * @deprecated this optional is deprecated
+         */
+        @Deprecated
+        @Override
+        Builder optionalItem(@Nonnull OneField optionalItem);
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
@@ -191,6 +234,8 @@ public final class MultipleOrderedStages {
 
         private Map<ResourceIdentifier, String> mappedRids = new LinkedHashMap<>();
 
+        private Optional<OneField> optionalItem = Optional.empty();
+
         private DefaultBuilder() {}
 
         public Builder from(MultipleOrderedStages other) {
@@ -199,6 +244,7 @@ public final class MultipleOrderedStages {
             item(other.getItem());
             items(other.getItems());
             mappedRids(other.getMappedRids());
+            optionalItem(other.getOptionalItem());
             return this;
         }
 
@@ -256,10 +302,31 @@ public final class MultipleOrderedStages {
             return this;
         }
 
+        /**
+         * @deprecated this optional is deprecated
+         */
+        @Deprecated
+        @JsonSetter(value = "optionalItem", nulls = Nulls.SKIP)
+        public Builder optionalItem(@Nonnull Optional<OneField> optionalItem) {
+            checkNotBuilt();
+            this.optionalItem = Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null");
+            return this;
+        }
+
+        /**
+         * @deprecated this optional is deprecated
+         */
+        @Deprecated
+        public Builder optionalItem(@Nonnull OneField optionalItem) {
+            checkNotBuilt();
+            this.optionalItem = Optional.of(Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null"));
+            return this;
+        }
+
         public MultipleOrderedStages build() {
             checkNotBuilt();
             this._buildInvoked = true;
-            return new MultipleOrderedStages(token, item, items, mappedRids);
+            return new MultipleOrderedStages(token, item, items, mappedRids, optionalItem);
         }
 
         private void checkNotBuilt() {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
@@ -89,9 +89,11 @@ public final class ManyFieldExample {
 
     /**
      * docs for optionalItem field
+     * @deprecated an optional field is deprecated
      */
     @JsonProperty("optionalItem")
     @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    @Deprecated
     public Optional<String> getOptionalItem() {
         return this.optionalItem;
     }
@@ -281,7 +283,9 @@ public final class ManyFieldExample {
 
         /**
          * docs for optionalItem field
+         * @deprecated an optional field is deprecated
          */
+        @Deprecated
         @JsonSetter(value = "optionalItem", nulls = Nulls.SKIP)
         public Builder optionalItem(@Nonnull Optional<String> optionalItem) {
             checkNotBuilt();
@@ -291,7 +295,9 @@ public final class ManyFieldExample {
 
         /**
          * docs for optionalItem field
+         * @deprecated an optional field is deprecated
          */
+        @Deprecated
         public Builder optionalItem(@Nonnull String optionalItem) {
             checkNotBuilt();
             this.optionalItem = Optional.of(Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null"));

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -297,6 +297,7 @@ public final class BeanGenerator {
             EnrichedField enriched, TypeMapper typeMapper, ClassName returnClass) {
         List<MethodSpec> methodSpecs = new ArrayList<>();
         Type type = enriched.conjureDef().getType();
+        FieldDefinition definition = enriched.conjureDef();
 
         methodSpecs.add(MethodSpec.methodBuilder(JavaNameSanitizer.sanitize(enriched.fieldName()))
                 .addParameter(ParameterSpec.builder(
@@ -305,6 +306,10 @@ public final class BeanGenerator {
                                 JavaNameSanitizer.sanitize(enriched.fieldName()))
                         .addAnnotation(Nonnull.class)
                         .build())
+                .addJavadoc(Javadoc.render(definition.getDocs(), definition.getDeprecated())
+                        .map(rendered -> CodeBlock.of("$L", rendered))
+                        .orElseGet(() -> CodeBlock.builder().build()))
+                .addAnnotations(ConjureAnnotations.deprecation(definition.getDeprecated()))
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                 .returns(returnClass.box())
                 .build());

--- a/conjure-java-core/src/test/resources/example-staged-types.yml
+++ b/conjure-java-core/src/test/resources/example-staged-types.yml
@@ -14,9 +14,24 @@ types:
           itemsMap: map<string, integer>
           optionalItem: optional<string>
           itemsSet: set<string>
+          itemsOld:
+            type: list<string>
+            deprecated: this list is deprecated
+          itemsMapOld:
+            type: map<string, integer>
+            deprecated: this map is deprecated
+          optionalItemOld:
+            type: optional<string>
+            deprecated: this optional is deprecated
+          itemsSetOld:
+            type: set<string>
+            deprecated: this set is deprecated
       MultipleOrderedStages:
         fields:
           token: OneField
           item: string
           items: set<safelong>
           mappedRids: map<rid, string>
+          optionalItem:
+            type: optional<OneField>
+            deprecated: this optional is deprecated

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -170,6 +170,7 @@ types:
             docs: docs for doubleValue field
           optionalItem:
             type: optional<string>
+            deprecated: an optional field is deprecated
             docs: docs for optionalItem field
           items:
             type: list<string>


### PR DESCRIPTION
## Before this PR


## After this PR
==COMMIT_MSG==
All completed stage builder methods now properly include deprecation annotations, if relevant. Previously, they could be missing for some methods.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

