### PR TITLE
Expose creating unknown unions and visiting their unknown values

### DIFF
--- a/changelog/@unreleased/pr-1579.v2.yml
+++ b/changelog/@unreleased/pr-1579.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Expose creating unknown unions and visiting their unknown values. This
+    will allow propagating unknown union types, for example.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1579

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
@@ -61,6 +61,10 @@ public final class EmptyUnionTypeExample {
     public interface Visitor<T> {
         T visitUnknown(String unknownType);
 
+        default T visitUnknownWithValue(String type, Map<String, Object> _value) {
+            return visitUnknown(type);
+        }
+
         static <T> UnknownStageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
         }
@@ -153,7 +157,7 @@ public final class EmptyUnionTypeExample {
 
         @Override
         public <T> T accept(Visitor<T> visitor) {
-            return visitor.visitUnknown(type);
+            return visitor.visitUnknownWithValue(type, value);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
@@ -31,6 +31,10 @@ public final class EmptyUnionTypeExample {
         return value;
     }
 
+    public static EmptyUnionTypeExample unknown(String type, Map<String, Object> value) {
+        return new EmptyUnionTypeExample(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -70,6 +70,10 @@ public final class SingleUnion {
 
         T visitUnknown(String unknownType);
 
+        default T visitUnknownWithValue(String type, Map<String, Object> _value) {
+            return visitUnknown(type);
+        }
+
         static <T> FooStageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
         }
@@ -227,7 +231,7 @@ public final class SingleUnion {
 
         @Override
         public <T> T accept(Visitor<T> visitor) {
-            return visitor.visitUnknown(type);
+            return visitor.visitUnknownWithValue(type, value);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -38,6 +38,10 @@ public final class SingleUnion {
         return new SingleUnion(new FooWrapper(value));
     }
 
+    public static SingleUnion unknown(String type, Map<String, Object> value) {
+        return new SingleUnion(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -16,6 +16,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -85,6 +86,9 @@ public final class SingleUnion {
 
         private Function<String, T> unknownVisitor;
 
+        private BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor =
+                (type, _value) -> unknownVisitor.apply(type);
+
         @Override
         public UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor) {
             Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
@@ -96,6 +100,14 @@ public final class SingleUnion {
         public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> unknownWithValue(
+                @Nonnull BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor) {
+            Preconditions.checkNotNull(unknownWithValueVisitor, "unknownWithValueVisitor cannot be null");
+            this.unknownWithValueVisitor = unknownWithValueVisitor;
             return this;
         }
 
@@ -112,6 +124,7 @@ public final class SingleUnion {
         public Visitor<T> build() {
             final Function<String, T> fooVisitor = this.fooVisitor;
             final Function<String, T> unknownVisitor = this.unknownVisitor;
+            final BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor = this.unknownWithValueVisitor;
             return new Visitor<T>() {
                 @Override
                 public T visitFoo(String value) {
@@ -121,6 +134,11 @@ public final class SingleUnion {
                 @Override
                 public T visitUnknown(String value) {
                     return unknownVisitor.apply(value);
+                }
+
+                @Override
+                public T visitUnknownWithValue(String type, Map<String, Object> value) {
+                    return unknownWithValueVisitor.apply(type, value);
                 }
             };
         }
@@ -132,6 +150,9 @@ public final class SingleUnion {
 
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> unknownWithValue(
+                @Nonnull BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -56,6 +56,10 @@ public final class Union {
         return new Union(new BazWrapper(value));
     }
 
+    public static Union unknown(String type, Map<String, Object> value) {
+        return new Union(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -101,6 +101,10 @@ public final class Union {
 
         T visitUnknown(String unknownType);
 
+        default T visitUnknownWithValue(String type, Map<String, Object> _value) {
+            return visitUnknown(type);
+        }
+
         static <T> BarStageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
         }
@@ -396,7 +400,7 @@ public final class Union {
 
         @Override
         public <T> T accept(Visitor<T> visitor) {
-            return visitor.visitUnknown(type);
+            return visitor.visitUnknownWithValue(type, value);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -174,6 +174,10 @@ public final class UnionTypeExample {
 
         T visitUnknown(String unknownType);
 
+        default T visitUnknownWithValue(String type, Map<String, Object> _value) {
+            return visitUnknown(type);
+        }
+
         static <T> AlsoAnIntegerStageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
         }
@@ -1332,7 +1336,7 @@ public final class UnionTypeExample {
 
         @Override
         public <T> T accept(Visitor<T> visitor) {
-            return visitor.visitUnknown(type);
+            return visitor.visitUnknownWithValue(type, value);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -109,6 +109,10 @@ public final class UnionTypeExample {
         return new UnionTypeExample(new MapAliasWrapper(value));
     }
 
+    public static UnionTypeExample unknown(String type, Map<String, Object> value) {
+        return new UnionTypeExample(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import javax.annotation.Generated;
@@ -236,6 +237,9 @@ public final class UnionTypeExample {
 
         private Function<String, T> unknownVisitor;
 
+        private BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor =
+                (type, _value) -> unknownVisitor.apply(type);
+
         @Override
         public CompletedStageVisitorBuilder<T> alsoAnInteger(@Nonnull IntFunction<T> alsoAnIntegerVisitor) {
             Preconditions.checkNotNull(alsoAnIntegerVisitor, "alsoAnIntegerVisitor cannot be null");
@@ -358,6 +362,14 @@ public final class UnionTypeExample {
         }
 
         @Override
+        public Completed_StageVisitorBuilder<T> unknownWithValue(
+                @Nonnull BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor) {
+            Preconditions.checkNotNull(unknownWithValueVisitor, "unknownWithValueVisitor cannot be null");
+            this.unknownWithValueVisitor = unknownWithValueVisitor;
+            return this;
+        }
+
+        @Override
         public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
                 throw new SafeIllegalArgumentException(
@@ -385,6 +397,7 @@ public final class UnionTypeExample {
             final IntFunction<T> thisFieldIsAnIntegerVisitor = this.thisFieldIsAnIntegerVisitor;
             final IntFunction<T> unknown_Visitor = this.unknown_Visitor;
             final Function<String, T> unknownVisitor = this.unknownVisitor;
+            final BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor = this.unknownWithValueVisitor;
             return new Visitor<T>() {
                 @Override
                 public T visitAlsoAnInteger(int value) {
@@ -470,6 +483,11 @@ public final class UnionTypeExample {
                 public T visitUnknown(String value) {
                     return unknownVisitor.apply(value);
                 }
+
+                @Override
+                public T visitUnknownWithValue(String type, Map<String, Object> value) {
+                    return unknownWithValueVisitor.apply(type, value);
+                }
             };
         }
     }
@@ -541,6 +559,9 @@ public final class UnionTypeExample {
 
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> unknownWithValue(
+                @Nonnull BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
@@ -70,6 +70,10 @@ public final class UnionWithUnknownString {
 
         T visitUnknown(String unknownType);
 
+        default T visitUnknownWithValue(String type, Map<String, Object> _value) {
+            return visitUnknown(type);
+        }
+
         static <T> Unknown_StageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
         }
@@ -228,7 +232,7 @@ public final class UnionWithUnknownString {
 
         @Override
         public <T> T accept(Visitor<T> visitor) {
-            return visitor.visitUnknown(type);
+            return visitor.visitUnknownWithValue(type, value);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
@@ -16,6 +16,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -85,6 +86,9 @@ public final class UnionWithUnknownString {
 
         private Function<String, T> unknownVisitor;
 
+        private BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor =
+                (type, _value) -> unknownVisitor.apply(type);
+
         @Override
         public UnknownStageVisitorBuilder<T> unknown_(@Nonnull Function<String, T> unknown_Visitor) {
             Preconditions.checkNotNull(unknown_Visitor, "unknown_Visitor cannot be null");
@@ -96,6 +100,14 @@ public final class UnionWithUnknownString {
         public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> unknownWithValue(
+                @Nonnull BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor) {
+            Preconditions.checkNotNull(unknownWithValueVisitor, "unknownWithValueVisitor cannot be null");
+            this.unknownWithValueVisitor = unknownWithValueVisitor;
             return this;
         }
 
@@ -113,6 +125,7 @@ public final class UnionWithUnknownString {
         public Visitor<T> build() {
             final Function<String, T> unknown_Visitor = this.unknown_Visitor;
             final Function<String, T> unknownVisitor = this.unknownVisitor;
+            final BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor = this.unknownWithValueVisitor;
             return new Visitor<T>() {
                 @Override
                 public T visitUnknown_(String value) {
@@ -122,6 +135,11 @@ public final class UnionWithUnknownString {
                 @Override
                 public T visitUnknown(String value) {
                     return unknownVisitor.apply(value);
+                }
+
+                @Override
+                public T visitUnknownWithValue(String type, Map<String, Object> value) {
+                    return unknownWithValueVisitor.apply(type, value);
                 }
             };
         }
@@ -133,6 +151,9 @@ public final class UnionWithUnknownString {
 
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> unknownWithValue(
+                @Nonnull BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
@@ -38,6 +38,10 @@ public final class UnionWithUnknownString {
         return new UnionWithUnknownString(new Unknown_Wrapper(value));
     }
 
+    public static UnionWithUnknownString unknown(String type, Map<String, Object> value) {
+        return new UnionWithUnknownString(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
@@ -61,6 +61,10 @@ public final class EmptyUnionTypeExample {
     public interface Visitor<T> {
         T visitUnknown(String unknownType);
 
+        default T visitUnknownWithValue(String type, Map<String, Object> _value) {
+            return visitUnknown(type);
+        }
+
         static <T> UnknownStageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
         }
@@ -153,7 +157,7 @@ public final class EmptyUnionTypeExample {
 
         @Override
         public <T> T accept(Visitor<T> visitor) {
-            return visitor.visitUnknown(type);
+            return visitor.visitUnknownWithValue(type, value);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
@@ -31,6 +31,10 @@ public final class EmptyUnionTypeExample {
         return value;
     }
 
+    public static EmptyUnionTypeExample unknown(String type, Map<String, Object> value) {
+        return new EmptyUnionTypeExample(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
@@ -70,6 +70,10 @@ public final class SingleUnion {
 
         T visitUnknown(String unknownType);
 
+        default T visitUnknownWithValue(String type, Map<String, Object> _value) {
+            return visitUnknown(type);
+        }
+
         static <T> FooStageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
         }
@@ -227,7 +231,7 @@ public final class SingleUnion {
 
         @Override
         public <T> T accept(Visitor<T> visitor) {
-            return visitor.visitUnknown(type);
+            return visitor.visitUnknownWithValue(type, value);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
@@ -38,6 +38,10 @@ public final class SingleUnion {
         return new SingleUnion(new FooWrapper(value));
     }
 
+    public static SingleUnion unknown(String type, Map<String, Object> value) {
+        return new SingleUnion(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
@@ -16,6 +16,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -85,6 +86,9 @@ public final class SingleUnion {
 
         private Function<String, T> unknownVisitor;
 
+        private BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor =
+                (type, _value) -> unknownVisitor.apply(type);
+
         @Override
         public UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor) {
             Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
@@ -96,6 +100,14 @@ public final class SingleUnion {
         public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> unknownWithValue(
+                @Nonnull BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor) {
+            Preconditions.checkNotNull(unknownWithValueVisitor, "unknownWithValueVisitor cannot be null");
+            this.unknownWithValueVisitor = unknownWithValueVisitor;
             return this;
         }
 
@@ -112,6 +124,7 @@ public final class SingleUnion {
         public Visitor<T> build() {
             final Function<String, T> fooVisitor = this.fooVisitor;
             final Function<String, T> unknownVisitor = this.unknownVisitor;
+            final BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor = this.unknownWithValueVisitor;
             return new Visitor<T>() {
                 @Override
                 public T visitFoo(String value) {
@@ -121,6 +134,11 @@ public final class SingleUnion {
                 @Override
                 public T visitUnknown(String value) {
                     return unknownVisitor.apply(value);
+                }
+
+                @Override
+                public T visitUnknownWithValue(String type, Map<String, Object> value) {
+                    return unknownWithValueVisitor.apply(type, value);
                 }
             };
         }
@@ -132,6 +150,9 @@ public final class SingleUnion {
 
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> unknownWithValue(
+                @Nonnull BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
@@ -56,6 +56,10 @@ public final class Union {
         return new Union(new BazWrapper(value));
     }
 
+    public static Union unknown(String type, Map<String, Object> value) {
+        return new Union(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
@@ -101,6 +101,10 @@ public final class Union {
 
         T visitUnknown(String unknownType);
 
+        default T visitUnknownWithValue(String type, Map<String, Object> _value) {
+            return visitUnknown(type);
+        }
+
         static <T> BarStageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
         }
@@ -396,7 +400,7 @@ public final class Union {
 
         @Override
         public <T> T accept(Visitor<T> visitor) {
-            return visitor.visitUnknown(type);
+            return visitor.visitUnknownWithValue(type, value);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -174,6 +174,10 @@ public final class UnionTypeExample {
 
         T visitUnknown(String unknownType);
 
+        default T visitUnknownWithValue(String type, Map<String, Object> _value) {
+            return visitUnknown(type);
+        }
+
         static <T> AlsoAnIntegerStageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
         }
@@ -1332,7 +1336,7 @@ public final class UnionTypeExample {
 
         @Override
         public <T> T accept(Visitor<T> visitor) {
-            return visitor.visitUnknown(type);
+            return visitor.visitUnknownWithValue(type, value);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -109,6 +109,10 @@ public final class UnionTypeExample {
         return new UnionTypeExample(new MapAliasWrapper(value));
     }
 
+    public static UnionTypeExample unknown(String type, Map<String, Object> value) {
+        return new UnionTypeExample(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import javax.annotation.Generated;
@@ -236,6 +237,9 @@ public final class UnionTypeExample {
 
         private Function<String, T> unknownVisitor;
 
+        private BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor =
+                (type, _value) -> unknownVisitor.apply(type);
+
         @Override
         public CompletedStageVisitorBuilder<T> alsoAnInteger(@Nonnull IntFunction<T> alsoAnIntegerVisitor) {
             Preconditions.checkNotNull(alsoAnIntegerVisitor, "alsoAnIntegerVisitor cannot be null");
@@ -358,6 +362,14 @@ public final class UnionTypeExample {
         }
 
         @Override
+        public Completed_StageVisitorBuilder<T> unknownWithValue(
+                @Nonnull BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor) {
+            Preconditions.checkNotNull(unknownWithValueVisitor, "unknownWithValueVisitor cannot be null");
+            this.unknownWithValueVisitor = unknownWithValueVisitor;
+            return this;
+        }
+
+        @Override
         public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
                 throw new SafeIllegalArgumentException(
@@ -385,6 +397,7 @@ public final class UnionTypeExample {
             final IntFunction<T> thisFieldIsAnIntegerVisitor = this.thisFieldIsAnIntegerVisitor;
             final IntFunction<T> unknown_Visitor = this.unknown_Visitor;
             final Function<String, T> unknownVisitor = this.unknownVisitor;
+            final BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor = this.unknownWithValueVisitor;
             return new Visitor<T>() {
                 @Override
                 public T visitAlsoAnInteger(int value) {
@@ -470,6 +483,11 @@ public final class UnionTypeExample {
                 public T visitUnknown(String value) {
                     return unknownVisitor.apply(value);
                 }
+
+                @Override
+                public T visitUnknownWithValue(String type, Map<String, Object> value) {
+                    return unknownWithValueVisitor.apply(type, value);
+                }
             };
         }
     }
@@ -541,6 +559,9 @@ public final class UnionTypeExample {
 
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> unknownWithValue(
+                @Nonnull BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
@@ -70,6 +70,10 @@ public final class UnionWithUnknownString {
 
         T visitUnknown(String unknownType);
 
+        default T visitUnknownWithValue(String type, Map<String, Object> _value) {
+            return visitUnknown(type);
+        }
+
         static <T> Unknown_StageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
         }
@@ -228,7 +232,7 @@ public final class UnionWithUnknownString {
 
         @Override
         public <T> T accept(Visitor<T> visitor) {
-            return visitor.visitUnknown(type);
+            return visitor.visitUnknownWithValue(type, value);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
@@ -16,6 +16,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -85,6 +86,9 @@ public final class UnionWithUnknownString {
 
         private Function<String, T> unknownVisitor;
 
+        private BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor =
+                (type, _value) -> unknownVisitor.apply(type);
+
         @Override
         public UnknownStageVisitorBuilder<T> unknown_(@Nonnull Function<String, T> unknown_Visitor) {
             Preconditions.checkNotNull(unknown_Visitor, "unknown_Visitor cannot be null");
@@ -96,6 +100,14 @@ public final class UnionWithUnknownString {
         public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> unknownWithValue(
+                @Nonnull BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor) {
+            Preconditions.checkNotNull(unknownWithValueVisitor, "unknownWithValueVisitor cannot be null");
+            this.unknownWithValueVisitor = unknownWithValueVisitor;
             return this;
         }
 
@@ -113,6 +125,7 @@ public final class UnionWithUnknownString {
         public Visitor<T> build() {
             final Function<String, T> unknown_Visitor = this.unknown_Visitor;
             final Function<String, T> unknownVisitor = this.unknownVisitor;
+            final BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor = this.unknownWithValueVisitor;
             return new Visitor<T>() {
                 @Override
                 public T visitUnknown_(String value) {
@@ -122,6 +135,11 @@ public final class UnionWithUnknownString {
                 @Override
                 public T visitUnknown(String value) {
                     return unknownVisitor.apply(value);
+                }
+
+                @Override
+                public T visitUnknownWithValue(String type, Map<String, Object> value) {
+                    return unknownWithValueVisitor.apply(type, value);
                 }
             };
         }
@@ -133,6 +151,9 @@ public final class UnionWithUnknownString {
 
     public interface UnknownStageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> unknownWithValue(
+                @Nonnull BiFunction<String, Map<String, Object>, T> unknownWithValueVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
@@ -38,6 +38,10 @@ public final class UnionWithUnknownString {
         return new UnionWithUnknownString(new Unknown_Wrapper(value));
     }
 
+    public static UnionWithUnknownString unknown(String type, Map<String, Object> value) {
+        return new UnionWithUnknownString(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }


### PR DESCRIPTION
## Before this PR
There is no way to propagate unknown union types. The most concrete use case for this functionality is to adapt between API types while preserving unknowns. Currently, you are forced to either throw an error or throw away all the unknown types (assuming you have a corresponding empty type to build on the converted side).

## After this PR

1. Expose a static factory for creating unknown types:
```java
    public static Union unknown(String type, Map<String, Object> value) {
        return new Union(new UnknownWrapper(type, value));
    }
```
2. Add a new method to the visitor interface for the richer unknown visitor, but provide a default implementation which delegates to the existing:
```java
        default T visitUnknownWithValue(String type, Map<String, Object> _value) {
            return visitUnknown(type);
        }
```
3. Plumb it through on the VisitorBuilder

==COMMIT_MSG==
Expose creating unknown unions and visiting their unknown values. This will allow propagating unknown union types, for example.
==COMMIT_MSG==

## Possible downsides?
This changes codegen and adds a new visitor method with a default delegating implementation. While this adds no burden to visitor implementers, it isn't obvious that only the new `visitUnknownWithValue()` method will be called if provided even though `visitUnknown()` must still be implemented. However, the VisitorBuilder is easy to use and enforces the exclusive-or semantics due to the StagedBuilder.

