### PR TITLE
Static factory for creating unknown union type

### DIFF
--- a/changelog/@unreleased/pr-1605.v2.yml
+++ b/changelog/@unreleased/pr-1605.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Provide a static factory for creating an unknown union type
+  links:
+  - https://github.com/palantir/conjure-java/pull/1605

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
@@ -10,9 +10,12 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -31,8 +34,10 @@ public final class EmptyUnionTypeExample {
         return value;
     }
 
-    public static EmptyUnionTypeExample unknown(String type, Map<String, Object> value) {
-        return new EmptyUnionTypeExample(new UnknownWrapper(type, value));
+    public static EmptyUnionTypeExample unknown(String type, Object value) {
+        Preconditions.checkArgument(
+                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
+        return new EmptyUnionTypeExample(new UnknownWrapper(type, Collections.singletonMap(type, value)));
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -56,6 +61,11 @@ public final class EmptyUnionTypeExample {
     @Override
     public String toString() {
         return "EmptyUnionTypeExample{value: " + value + '}';
+    }
+
+    private static Set<String> allKnownTypes() {
+        Set<String> types = new HashSet<>();
+        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
@@ -31,6 +31,10 @@ public final class EmptyUnionTypeExample {
         return value;
     }
 
+    public static EmptyUnionTypeExample unknown(String type, Map<String, Object> value) {
+        return new EmptyUnionTypeExample(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
@@ -12,10 +12,8 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -35,9 +33,10 @@ public final class EmptyUnionTypeExample {
     }
 
     public static EmptyUnionTypeExample unknown(String type, Object value) {
-        Preconditions.checkArgument(
-                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
-        return new EmptyUnionTypeExample(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        switch (Preconditions.checkNotNull(type, "Type is required")) {
+            default:
+                return new EmptyUnionTypeExample(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        }
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -61,11 +60,6 @@ public final class EmptyUnionTypeExample {
     @Override
     public String toString() {
         return "EmptyUnionTypeExample{value: " + value + '}';
-    }
-
-    private static Set<String> allKnownTypes() {
-        Set<String> types = new HashSet<>();
-        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -13,9 +13,12 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -38,8 +41,10 @@ public final class SingleUnion {
         return new SingleUnion(new FooWrapper(value));
     }
 
-    public static SingleUnion unknown(String type, Map<String, Object> value) {
-        return new SingleUnion(new UnknownWrapper(type, value));
+    public static SingleUnion unknown(String type, Object value) {
+        Preconditions.checkArgument(
+                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
+        return new SingleUnion(new UnknownWrapper(type, Collections.singletonMap(type, value)));
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -63,6 +68,12 @@ public final class SingleUnion {
     @Override
     public String toString() {
         return "SingleUnion{value: " + value + '}';
+    }
+
+    private static Set<String> allKnownTypes() {
+        Set<String> types = new HashSet<>();
+        types.add("foo");
+        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -38,6 +38,10 @@ public final class SingleUnion {
         return new SingleUnion(new FooWrapper(value));
     }
 
+    public static SingleUnion unknown(String type, Map<String, Object> value) {
+        return new SingleUnion(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -15,10 +15,8 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -42,9 +40,13 @@ public final class SingleUnion {
     }
 
     public static SingleUnion unknown(String type, Object value) {
-        Preconditions.checkArgument(
-                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
-        return new SingleUnion(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        switch (Preconditions.checkNotNull(type, "Type is required")) {
+            case "foo":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: foo");
+            default:
+                return new SingleUnion(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        }
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -68,12 +70,6 @@ public final class SingleUnion {
     @Override
     public String toString() {
         return "SingleUnion{value: " + value + '}';
-    }
-
-    private static Set<String> allKnownTypes() {
-        Set<String> types = new HashSet<>();
-        types.add("foo");
-        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -56,6 +56,10 @@ public final class Union {
         return new Union(new BazWrapper(value));
     }
 
+    public static Union unknown(String type, Map<String, Object> value) {
+        return new Union(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -15,10 +15,8 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import javax.annotation.Generated;
@@ -60,9 +58,19 @@ public final class Union {
     }
 
     public static Union unknown(String type, Object value) {
-        Preconditions.checkArgument(
-                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
-        return new Union(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        switch (Preconditions.checkNotNull(type, "Type is required")) {
+            case "foo":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: foo");
+            case "bar":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: bar");
+            case "baz":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: baz");
+            default:
+                return new Union(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        }
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -86,14 +94,6 @@ public final class Union {
     @Override
     public String toString() {
         return "Union{value: " + value + '}';
-    }
-
-    private static Set<String> allKnownTypes() {
-        Set<String> types = new HashSet<>();
-        types.add("foo");
-        types.add("bar");
-        types.add("baz");
-        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -13,9 +13,12 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import javax.annotation.Generated;
@@ -56,8 +59,10 @@ public final class Union {
         return new Union(new BazWrapper(value));
     }
 
-    public static Union unknown(String type, Map<String, Object> value) {
-        return new Union(new UnknownWrapper(type, value));
+    public static Union unknown(String type, Object value) {
+        Preconditions.checkArgument(
+                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
+        return new Union(new UnknownWrapper(type, Collections.singletonMap(type, value)));
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -81,6 +86,14 @@ public final class Union {
     @Override
     public String toString() {
         return "Union{value: " + value + '}';
+    }
+
+    private static Set<String> allKnownTypes() {
+        Set<String> types = new HashSet<>();
+        types.add("foo");
+        types.add("bar");
+        types.add("baz");
+        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -133,9 +133,9 @@ public final class UnionTypeExample {
             case "completed":
                 throw new SafeIllegalArgumentException(
                         "Unknown type cannot be created as the provided type is known: completed");
-            case "unknown_":
+            case "unknown":
                 throw new SafeIllegalArgumentException(
-                        "Unknown type cannot be created as the provided type is known: unknown_");
+                        "Unknown type cannot be created as the provided type is known: unknown");
             case "optional":
                 throw new SafeIllegalArgumentException(
                         "Unknown type cannot be created as the provided type is known: optional");

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -109,6 +109,10 @@ public final class UnionTypeExample {
         return new UnionTypeExample(new MapAliasWrapper(value));
     }
 
+    public static UnionTypeExample unknown(String type, Map<String, Object> value) {
+        return new UnionTypeExample(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -14,7 +14,9 @@ import com.fasterxml.jackson.annotation.Nulls;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -109,8 +111,10 @@ public final class UnionTypeExample {
         return new UnionTypeExample(new MapAliasWrapper(value));
     }
 
-    public static UnionTypeExample unknown(String type, Map<String, Object> value) {
-        return new UnionTypeExample(new UnknownWrapper(type, value));
+    public static UnionTypeExample unknown(String type, Object value) {
+        Preconditions.checkArgument(
+                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
+        return new UnionTypeExample(new UnknownWrapper(type, Collections.singletonMap(type, value)));
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -134,6 +138,27 @@ public final class UnionTypeExample {
     @Override
     public String toString() {
         return "UnionTypeExample{value: " + value + '}';
+    }
+
+    private static Set<String> allKnownTypes() {
+        Set<String> types = new HashSet<>();
+        types.add("stringExample");
+        types.add("thisFieldIsAnInteger");
+        types.add("alsoAnInteger");
+        types.add("if");
+        types.add("new");
+        types.add("interface");
+        types.add("completed");
+        types.add("unknown_");
+        types.add("optional");
+        types.add("list");
+        types.add("set");
+        types.add("map");
+        types.add("optionalAlias");
+        types.add("listAlias");
+        types.add("setAlias");
+        types.add("mapAlias");
+        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -16,7 +16,6 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -112,9 +111,58 @@ public final class UnionTypeExample {
     }
 
     public static UnionTypeExample unknown(String type, Object value) {
-        Preconditions.checkArgument(
-                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
-        return new UnionTypeExample(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        switch (Preconditions.checkNotNull(type, "Type is required")) {
+            case "stringExample":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: stringExample");
+            case "thisFieldIsAnInteger":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: thisFieldIsAnInteger");
+            case "alsoAnInteger":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: alsoAnInteger");
+            case "if":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: if");
+            case "new":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: new");
+            case "interface":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: interface");
+            case "completed":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: completed");
+            case "unknown_":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: unknown_");
+            case "optional":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: optional");
+            case "list":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: list");
+            case "set":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: set");
+            case "map":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: map");
+            case "optionalAlias":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: optionalAlias");
+            case "listAlias":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: listAlias");
+            case "setAlias":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: setAlias");
+            case "mapAlias":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: mapAlias");
+            default:
+                return new UnionTypeExample(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        }
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -138,27 +186,6 @@ public final class UnionTypeExample {
     @Override
     public String toString() {
         return "UnionTypeExample{value: " + value + '}';
-    }
-
-    private static Set<String> allKnownTypes() {
-        Set<String> types = new HashSet<>();
-        types.add("stringExample");
-        types.add("thisFieldIsAnInteger");
-        types.add("alsoAnInteger");
-        types.add("if");
-        types.add("new");
-        types.add("interface");
-        types.add("completed");
-        types.add("unknown_");
-        types.add("optional");
-        types.add("list");
-        types.add("set");
-        types.add("map");
-        types.add("optionalAlias");
-        types.add("listAlias");
-        types.add("setAlias");
-        types.add("mapAlias");
-        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
@@ -15,10 +15,8 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -42,9 +40,13 @@ public final class UnionWithUnknownString {
     }
 
     public static UnionWithUnknownString unknown(String type, Object value) {
-        Preconditions.checkArgument(
-                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
-        return new UnionWithUnknownString(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        switch (Preconditions.checkNotNull(type, "Type is required")) {
+            case "unknown_":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: unknown_");
+            default:
+                return new UnionWithUnknownString(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        }
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -68,12 +70,6 @@ public final class UnionWithUnknownString {
     @Override
     public String toString() {
         return "UnionWithUnknownString{value: " + value + '}';
-    }
-
-    private static Set<String> allKnownTypes() {
-        Set<String> types = new HashSet<>();
-        types.add("unknown_");
-        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
@@ -41,9 +41,9 @@ public final class UnionWithUnknownString {
 
     public static UnionWithUnknownString unknown(String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
-            case "unknown_":
+            case "unknown":
                 throw new SafeIllegalArgumentException(
-                        "Unknown type cannot be created as the provided type is known: unknown_");
+                        "Unknown type cannot be created as the provided type is known: unknown");
             default:
                 return new UnionWithUnknownString(new UnknownWrapper(type, Collections.singletonMap(type, value)));
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
@@ -13,9 +13,12 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -38,8 +41,10 @@ public final class UnionWithUnknownString {
         return new UnionWithUnknownString(new Unknown_Wrapper(value));
     }
 
-    public static UnionWithUnknownString unknown(String type, Map<String, Object> value) {
-        return new UnionWithUnknownString(new UnknownWrapper(type, value));
+    public static UnionWithUnknownString unknown(String type, Object value) {
+        Preconditions.checkArgument(
+                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
+        return new UnionWithUnknownString(new UnknownWrapper(type, Collections.singletonMap(type, value)));
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -63,6 +68,12 @@ public final class UnionWithUnknownString {
     @Override
     public String toString() {
         return "UnionWithUnknownString{value: " + value + '}';
+    }
+
+    private static Set<String> allKnownTypes() {
+        Set<String> types = new HashSet<>();
+        types.add("unknown_");
+        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
@@ -38,6 +38,10 @@ public final class UnionWithUnknownString {
         return new UnionWithUnknownString(new Unknown_Wrapper(value));
     }
 
+    public static UnionWithUnknownString unknown(String type, Map<String, Object> value) {
+        return new UnionWithUnknownString(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
@@ -10,9 +10,12 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -31,8 +34,10 @@ public final class EmptyUnionTypeExample {
         return value;
     }
 
-    public static EmptyUnionTypeExample unknown(String type, Map<String, Object> value) {
-        return new EmptyUnionTypeExample(new UnknownWrapper(type, value));
+    public static EmptyUnionTypeExample unknown(String type, Object value) {
+        Preconditions.checkArgument(
+                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
+        return new EmptyUnionTypeExample(new UnknownWrapper(type, Collections.singletonMap(type, value)));
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -56,6 +61,11 @@ public final class EmptyUnionTypeExample {
     @Override
     public String toString() {
         return "EmptyUnionTypeExample{value: " + value + '}';
+    }
+
+    private static Set<String> allKnownTypes() {
+        Set<String> types = new HashSet<>();
+        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
@@ -31,6 +31,10 @@ public final class EmptyUnionTypeExample {
         return value;
     }
 
+    public static EmptyUnionTypeExample unknown(String type, Map<String, Object> value) {
+        return new EmptyUnionTypeExample(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
@@ -12,10 +12,8 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -35,9 +33,10 @@ public final class EmptyUnionTypeExample {
     }
 
     public static EmptyUnionTypeExample unknown(String type, Object value) {
-        Preconditions.checkArgument(
-                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
-        return new EmptyUnionTypeExample(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        switch (Preconditions.checkNotNull(type, "Type is required")) {
+            default:
+                return new EmptyUnionTypeExample(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        }
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -61,11 +60,6 @@ public final class EmptyUnionTypeExample {
     @Override
     public String toString() {
         return "EmptyUnionTypeExample{value: " + value + '}';
-    }
-
-    private static Set<String> allKnownTypes() {
-        Set<String> types = new HashSet<>();
-        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
@@ -13,9 +13,12 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -38,8 +41,10 @@ public final class SingleUnion {
         return new SingleUnion(new FooWrapper(value));
     }
 
-    public static SingleUnion unknown(String type, Map<String, Object> value) {
-        return new SingleUnion(new UnknownWrapper(type, value));
+    public static SingleUnion unknown(String type, Object value) {
+        Preconditions.checkArgument(
+                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
+        return new SingleUnion(new UnknownWrapper(type, Collections.singletonMap(type, value)));
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -63,6 +68,12 @@ public final class SingleUnion {
     @Override
     public String toString() {
         return "SingleUnion{value: " + value + '}';
+    }
+
+    private static Set<String> allKnownTypes() {
+        Set<String> types = new HashSet<>();
+        types.add("foo");
+        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
@@ -38,6 +38,10 @@ public final class SingleUnion {
         return new SingleUnion(new FooWrapper(value));
     }
 
+    public static SingleUnion unknown(String type, Map<String, Object> value) {
+        return new SingleUnion(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
@@ -15,10 +15,8 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -42,9 +40,13 @@ public final class SingleUnion {
     }
 
     public static SingleUnion unknown(String type, Object value) {
-        Preconditions.checkArgument(
-                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
-        return new SingleUnion(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        switch (Preconditions.checkNotNull(type, "Type is required")) {
+            case "foo":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: foo");
+            default:
+                return new SingleUnion(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        }
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -68,12 +70,6 @@ public final class SingleUnion {
     @Override
     public String toString() {
         return "SingleUnion{value: " + value + '}';
-    }
-
-    private static Set<String> allKnownTypes() {
-        Set<String> types = new HashSet<>();
-        types.add("foo");
-        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
@@ -56,6 +56,10 @@ public final class Union {
         return new Union(new BazWrapper(value));
     }
 
+    public static Union unknown(String type, Map<String, Object> value) {
+        return new Union(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
@@ -15,10 +15,8 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import javax.annotation.Generated;
@@ -60,9 +58,19 @@ public final class Union {
     }
 
     public static Union unknown(String type, Object value) {
-        Preconditions.checkArgument(
-                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
-        return new Union(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        switch (Preconditions.checkNotNull(type, "Type is required")) {
+            case "foo":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: foo");
+            case "bar":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: bar");
+            case "baz":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: baz");
+            default:
+                return new Union(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        }
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -86,14 +94,6 @@ public final class Union {
     @Override
     public String toString() {
         return "Union{value: " + value + '}';
-    }
-
-    private static Set<String> allKnownTypes() {
-        Set<String> types = new HashSet<>();
-        types.add("foo");
-        types.add("bar");
-        types.add("baz");
-        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
@@ -13,9 +13,12 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import javax.annotation.Generated;
@@ -56,8 +59,10 @@ public final class Union {
         return new Union(new BazWrapper(value));
     }
 
-    public static Union unknown(String type, Map<String, Object> value) {
-        return new Union(new UnknownWrapper(type, value));
+    public static Union unknown(String type, Object value) {
+        Preconditions.checkArgument(
+                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
+        return new Union(new UnknownWrapper(type, Collections.singletonMap(type, value)));
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -81,6 +86,14 @@ public final class Union {
     @Override
     public String toString() {
         return "Union{value: " + value + '}';
+    }
+
+    private static Set<String> allKnownTypes() {
+        Set<String> types = new HashSet<>();
+        types.add("foo");
+        types.add("bar");
+        types.add("baz");
+        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -133,9 +133,9 @@ public final class UnionTypeExample {
             case "completed":
                 throw new SafeIllegalArgumentException(
                         "Unknown type cannot be created as the provided type is known: completed");
-            case "unknown_":
+            case "unknown":
                 throw new SafeIllegalArgumentException(
-                        "Unknown type cannot be created as the provided type is known: unknown_");
+                        "Unknown type cannot be created as the provided type is known: unknown");
             case "optional":
                 throw new SafeIllegalArgumentException(
                         "Unknown type cannot be created as the provided type is known: optional");

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -109,6 +109,10 @@ public final class UnionTypeExample {
         return new UnionTypeExample(new MapAliasWrapper(value));
     }
 
+    public static UnionTypeExample unknown(String type, Map<String, Object> value) {
+        return new UnionTypeExample(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -14,7 +14,9 @@ import com.fasterxml.jackson.annotation.Nulls;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -109,8 +111,10 @@ public final class UnionTypeExample {
         return new UnionTypeExample(new MapAliasWrapper(value));
     }
 
-    public static UnionTypeExample unknown(String type, Map<String, Object> value) {
-        return new UnionTypeExample(new UnknownWrapper(type, value));
+    public static UnionTypeExample unknown(String type, Object value) {
+        Preconditions.checkArgument(
+                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
+        return new UnionTypeExample(new UnknownWrapper(type, Collections.singletonMap(type, value)));
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -134,6 +138,27 @@ public final class UnionTypeExample {
     @Override
     public String toString() {
         return "UnionTypeExample{value: " + value + '}';
+    }
+
+    private static Set<String> allKnownTypes() {
+        Set<String> types = new HashSet<>();
+        types.add("stringExample");
+        types.add("thisFieldIsAnInteger");
+        types.add("alsoAnInteger");
+        types.add("if");
+        types.add("new");
+        types.add("interface");
+        types.add("completed");
+        types.add("unknown_");
+        types.add("optional");
+        types.add("list");
+        types.add("set");
+        types.add("map");
+        types.add("optionalAlias");
+        types.add("listAlias");
+        types.add("setAlias");
+        types.add("mapAlias");
+        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -16,7 +16,6 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -112,9 +111,58 @@ public final class UnionTypeExample {
     }
 
     public static UnionTypeExample unknown(String type, Object value) {
-        Preconditions.checkArgument(
-                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
-        return new UnionTypeExample(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        switch (Preconditions.checkNotNull(type, "Type is required")) {
+            case "stringExample":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: stringExample");
+            case "thisFieldIsAnInteger":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: thisFieldIsAnInteger");
+            case "alsoAnInteger":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: alsoAnInteger");
+            case "if":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: if");
+            case "new":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: new");
+            case "interface":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: interface");
+            case "completed":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: completed");
+            case "unknown_":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: unknown_");
+            case "optional":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: optional");
+            case "list":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: list");
+            case "set":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: set");
+            case "map":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: map");
+            case "optionalAlias":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: optionalAlias");
+            case "listAlias":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: listAlias");
+            case "setAlias":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: setAlias");
+            case "mapAlias":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: mapAlias");
+            default:
+                return new UnionTypeExample(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        }
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -138,27 +186,6 @@ public final class UnionTypeExample {
     @Override
     public String toString() {
         return "UnionTypeExample{value: " + value + '}';
-    }
-
-    private static Set<String> allKnownTypes() {
-        Set<String> types = new HashSet<>();
-        types.add("stringExample");
-        types.add("thisFieldIsAnInteger");
-        types.add("alsoAnInteger");
-        types.add("if");
-        types.add("new");
-        types.add("interface");
-        types.add("completed");
-        types.add("unknown_");
-        types.add("optional");
-        types.add("list");
-        types.add("set");
-        types.add("map");
-        types.add("optionalAlias");
-        types.add("listAlias");
-        types.add("setAlias");
-        types.add("mapAlias");
-        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
@@ -15,10 +15,8 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -42,9 +40,13 @@ public final class UnionWithUnknownString {
     }
 
     public static UnionWithUnknownString unknown(String type, Object value) {
-        Preconditions.checkArgument(
-                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
-        return new UnionWithUnknownString(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        switch (Preconditions.checkNotNull(type, "Type is required")) {
+            case "unknown_":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: unknown_");
+            default:
+                return new UnionWithUnknownString(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        }
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -68,12 +70,6 @@ public final class UnionWithUnknownString {
     @Override
     public String toString() {
         return "UnionWithUnknownString{value: " + value + '}';
-    }
-
-    private static Set<String> allKnownTypes() {
-        Set<String> types = new HashSet<>();
-        types.add("unknown_");
-        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
@@ -41,9 +41,9 @@ public final class UnionWithUnknownString {
 
     public static UnionWithUnknownString unknown(String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
-            case "unknown_":
+            case "unknown":
                 throw new SafeIllegalArgumentException(
-                        "Unknown type cannot be created as the provided type is known: unknown_");
+                        "Unknown type cannot be created as the provided type is known: unknown");
             default:
                 return new UnionWithUnknownString(new UnknownWrapper(type, Collections.singletonMap(type, value)));
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
@@ -13,9 +13,12 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
@@ -38,8 +41,10 @@ public final class UnionWithUnknownString {
         return new UnionWithUnknownString(new Unknown_Wrapper(value));
     }
 
-    public static UnionWithUnknownString unknown(String type, Map<String, Object> value) {
-        return new UnionWithUnknownString(new UnknownWrapper(type, value));
+    public static UnionWithUnknownString unknown(String type, Object value) {
+        Preconditions.checkArgument(
+                !allKnownTypes().contains(type), "Unknown type cannot be created as the provided type is known");
+        return new UnionWithUnknownString(new UnknownWrapper(type, Collections.singletonMap(type, value)));
     }
 
     public <T> T accept(Visitor<T> visitor) {
@@ -63,6 +68,12 @@ public final class UnionWithUnknownString {
     @Override
     public String toString() {
         return "UnionWithUnknownString{value: " + value + '}';
+    }
+
+    private static Set<String> allKnownTypes() {
+        Set<String> types = new HashSet<>();
+        types.add("unknown_");
+        return types;
     }
 
     public interface Visitor<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
@@ -38,6 +38,10 @@ public final class UnionWithUnknownString {
         return new UnionWithUnknownString(new Unknown_Wrapper(value));
     }
 
+    public static UnionWithUnknownString unknown(String type, Map<String, Object> value) {
+        return new UnionWithUnknownString(new UnknownWrapper(type, value));
+    }
+
     public <T> T accept(Visitor<T> visitor) {
         return value.accept(visitor);
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -678,6 +678,7 @@ public final class UnionGenerator {
     }
 
     private static TypeSpec generateUnknownWrapper(ClassName baseClass, ClassName visitorClass) {
+        ParameterizedTypeName genericMapType = ParameterizedTypeName.get(Map.class, String.class, Object.class);
         ParameterizedTypeName genericHashMapType = ParameterizedTypeName.get(HashMap.class, String.class, Object.class);
         ParameterSpec typeParameter = ParameterSpec.builder(String.class, "type")
                 .addAnnotation(Nonnull.class)
@@ -692,7 +693,7 @@ public final class UnionGenerator {
         List<FieldSpec> fields = ImmutableList.of(
                 FieldSpec.builder(UNKNOWN_MEMBER_TYPE, "type", Modifier.PRIVATE, Modifier.FINAL)
                         .build(),
-                FieldSpec.builder(genericMapType(), VALUE_FIELD_NAME, Modifier.PRIVATE, Modifier.FINAL)
+                FieldSpec.builder(genericMapType, VALUE_FIELD_NAME, Modifier.PRIVATE, Modifier.FINAL)
                         .build());
         TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(wrapperClass)
                 .addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
@@ -707,7 +708,7 @@ public final class UnionGenerator {
                 .addMethod(MethodSpec.constructorBuilder()
                         .addModifiers(Modifier.PRIVATE)
                         .addParameter(typeParameter)
-                        .addParameter(ParameterSpec.builder(genericMapType(), VALUE_FIELD_NAME)
+                        .addParameter(ParameterSpec.builder(genericMapType, VALUE_FIELD_NAME)
                                 .addAnnotation(Nonnull.class)
                                 .build())
                         .addStatement("$L", Expressions.requireNonNull(typeParameter.name, "type cannot be null"))
@@ -730,7 +731,7 @@ public final class UnionGenerator {
                         .addAnnotation(
                                 AnnotationSpec.builder(JsonAnyGetter.class).build())
                         .addStatement("return $L", VALUE_FIELD_NAME)
-                        .returns(genericMapType())
+                        .returns(genericMapType)
                         .build())
                 .addMethod(MethodSpec.methodBuilder("put")
                         .addModifiers(Modifier.PRIVATE)
@@ -751,10 +752,6 @@ public final class UnionGenerator {
                                 .map(fieldSpec -> FieldName.of(fieldSpec.name))
                                 .collect(Collectors.toList())));
         return typeBuilder.build();
-    }
-
-    private static ParameterizedTypeName genericMapType() {
-        return ParameterizedTypeName.get(Map.class, String.class, Object.class);
     }
 
     private static MethodSpec createWrapperAcceptMethod(

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -187,7 +187,7 @@ public final class UnionGenerator {
                 .addParameter(Object.class, valueParam)
                 .returns(unionClass);
         // begin switch statement
-        builder.beginControlFlow("switch($L)", Expressions.requireNonNull("type", "Type is required"));
+        builder.beginControlFlow("switch($L)", Expressions.requireNonNull(typeParam, "Type is required"));
         // add all cases
         memberTypeDefs.forEach(memberTypeDef -> {
             String memberName = sanitizeUnknown(memberTypeDef.getFieldName()).get();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -190,22 +190,21 @@ public final class UnionGenerator {
         builder.beginControlFlow("switch($L)", Expressions.requireNonNull(typeParam, "Type is required"));
         // add all cases
         memberTypeDefs.forEach(memberTypeDef -> {
-            String memberName = sanitizeUnknown(memberTypeDef.getFieldName()).get();
+            String memberName = memberTypeDef.getFieldName().get();
             builder.addCode("case $S:", memberName);
             builder.addStatement(
-                    "throw new $T(\"$L: $L\")",
+                    "throw new $T($S)",
                     SafeIllegalArgumentException.class,
-                    "Unknown type cannot be created as the provided type is known",
-                    memberName);
+                    "Unknown type cannot be created as the provided type is known: " + memberName);
         });
         // add default case, which actually builds the unknown
         builder.addCode("default:");
         builder.addStatement(
-                "return new $T(new $T($L, $L))",
+                "return new $T(new $T($N, $L))",
                 unionClass,
                 wrapperClass(unionClass, FieldName.of("unknown")),
                 typeParam,
-                CodeBlock.of("$T.singletonMap($L, $L)", Collections.class, typeParam, valueParam));
+                CodeBlock.of("$T.singletonMap($N, $N)", Collections.class, typeParam, valueParam));
         builder.endControlFlow();
         return builder.build();
     }


### PR DESCRIPTION
## Before this PR
There was no way to create an unknown union type via plain Java. Unknown unions were only provided via Jackson deserialization.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Provide a static factory for creating an unknown union type
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

