### PR TITLE
[undertow-annotations] Handle query params with primitive types

### DIFF
--- a/changelog/@unreleased/pr-1629.v2.yml
+++ b/changelog/@unreleased/pr-1629.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Handle query params with primitive types
+  links:
+  - https://github.com/palantir/conjure-java/pull/1629

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
@@ -226,9 +226,7 @@ public final class ConjureUndertowEndpointsGenerator {
                 TypeName paramType = def.argType().match(ArgTypeTypeName.INSTANCE);
                 additionalFields.add(ImmutableAdditionalField.builder()
                         .field(FieldSpec.builder(
-                                        ParameterizedTypeName.get(
-                                                ClassName.get(Deserializer.class),
-                                                paramType.isPrimitive() ? paramType.box() : paramType),
+                                        ParameterizedTypeName.get(ClassName.get(Deserializer.class), paramType.box()),
                                         deserializerFieldName,
                                         Modifier.PRIVATE,
                                         Modifier.FINAL)

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
@@ -226,7 +226,9 @@ public final class ConjureUndertowEndpointsGenerator {
                 TypeName paramType = def.argType().match(ArgTypeTypeName.INSTANCE);
                 additionalFields.add(ImmutableAdditionalField.builder()
                         .field(FieldSpec.builder(
-                                        ParameterizedTypeName.get(ClassName.get(Deserializer.class), paramType),
+                                        ParameterizedTypeName.get(
+                                                ClassName.get(Deserializer.class),
+                                                paramType.isPrimitive() ? paramType.box() : paramType),
                                         deserializerFieldName,
                                         Modifier.PRIVATE,
                                         Modifier.FINAL)

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
@@ -25,6 +25,7 @@ import com.google.common.io.ByteStreams;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.Compiler;
 import com.google.testing.compile.JavaFileObjects;
+import com.palantir.conjure.java.undertow.processor.sample.PrimitiveQueryParams;
 import com.palantir.conjure.java.undertow.processor.sample.PrivateMethodAnnotatedResource;
 import com.palantir.conjure.java.undertow.processor.sample.ProtectedMethodAnnotatedResource;
 import com.palantir.conjure.java.undertow.processor.sample.SimpleInterface;
@@ -50,6 +51,11 @@ public class ConjureUndertowAnnotationProcessorTest {
     @Test
     public void testExampleFileCompiles() {
         assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, SimpleInterface.class);
+    }
+
+    @Test
+    public void testPrimitiveQueryParams() {
+        assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, PrimitiveQueryParams.class);
     }
 
     @Test

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/PrimitiveQueryParams.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/PrimitiveQueryParams.java
@@ -1,0 +1,49 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.google.common.collect.Iterables;
+import com.palantir.conjure.java.undertow.annotations.CollectionParamDecoder;
+import com.palantir.conjure.java.undertow.annotations.Handle;
+import com.palantir.conjure.java.undertow.annotations.HttpMethod;
+import java.util.Collection;
+
+public interface PrimitiveQueryParams {
+
+    @Handle(method = HttpMethod.GET, path = "/ping")
+    void handlePrimitveQueryParams(
+            @Handle.QueryParam(value = "count", decoder = IntParamDecoder.class) int count,
+            @Handle.QueryParam(value = "test", decoder = BooleanParamDecoder.class) boolean test);
+
+    enum IntParamDecoder implements CollectionParamDecoder<Integer> {
+        INSTANCE;
+
+        @Override
+        public Integer decode(Collection<String> value) {
+            return Integer.valueOf(Iterables.getOnlyElement(value));
+        }
+    }
+
+    enum BooleanParamDecoder implements CollectionParamDecoder<Boolean> {
+        INSTANCE;
+
+        @Override
+        public Boolean decode(Collection<String> value) {
+            return Boolean.valueOf(Iterables.getOnlyElement(value));
+        }
+    }
+}

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/PrimitiveQueryParams.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/PrimitiveQueryParams.java
@@ -27,7 +27,8 @@ public interface PrimitiveQueryParams {
     @Handle(method = HttpMethod.GET, path = "/ping")
     void handlePrimitveQueryParams(
             @Handle.QueryParam(value = "count", decoder = IntParamDecoder.class) int count,
-            @Handle.QueryParam(value = "test", decoder = BooleanParamDecoder.class) boolean test);
+            @Handle.QueryParam(value = "test", decoder = BooleanParamDecoder.class) boolean test,
+            @Handle.QueryParam(value = "testboxed", decoder = BooleanParamDecoder.class) Boolean testBoxed);
 
     enum IntParamDecoder implements CollectionParamDecoder<Integer> {
         INSTANCE;

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/PrimitiveQueryParamsEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/PrimitiveQueryParamsEndpoints.java.generated
@@ -45,6 +45,8 @@ public final class PrimitiveQueryParamsEndpoints implements UndertowService {
 
         private final Deserializer<Boolean> testDeserializer;
 
+        private final Deserializer<Boolean> testBoxedDeserializer;
+
         HandlePrimitveQueryParamsEndpoint(UndertowRuntime runtime, PrimitiveQueryParams delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
@@ -52,12 +54,16 @@ public final class PrimitiveQueryParamsEndpoints implements UndertowService {
                     new QueryParamDeserializer<>("count", PrimitiveQueryParams.IntParamDecoder.INSTANCE);
             this.testDeserializer =
                     new QueryParamDeserializer<>("test", PrimitiveQueryParams.BooleanParamDecoder.INSTANCE);
+            this.testBoxedDeserializer =
+                    new QueryParamDeserializer<>("testboxed", PrimitiveQueryParams.BooleanParamDecoder.INSTANCE);
         }
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws Exception {
             this.delegate.handlePrimitveQueryParams(
-                    this.countDeserializer.deserialize(exchange), this.testDeserializer.deserialize(exchange));
+                    this.countDeserializer.deserialize(exchange),
+                    this.testDeserializer.deserialize(exchange),
+                    this.testBoxedDeserializer.deserialize(exchange));
             exchange.setStatusCode(StatusCodes.NO_CONTENT);
         }
 

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/PrimitiveQueryParamsEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/PrimitiveQueryParamsEndpoints.java.generated
@@ -1,0 +1,89 @@
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.java.undertow.annotations.QueryParamDeserializer;
+import com.palantir.conjure.java.undertow.lib.Deserializer;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import io.undertow.util.StatusCodes;
+import java.lang.Boolean;
+import java.lang.Exception;
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.undertow.processor.generate.ConjureUndertowEndpointsGenerator")
+public final class PrimitiveQueryParamsEndpoints implements UndertowService {
+    private final PrimitiveQueryParams delegate;
+
+    private PrimitiveQueryParamsEndpoints(PrimitiveQueryParams delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(PrimitiveQueryParams delegate) {
+        return new PrimitiveQueryParamsEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return ImmutableList.of(new HandlePrimitveQueryParamsEndpoint(runtime, delegate));
+    }
+
+    private static final class HandlePrimitveQueryParamsEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final PrimitiveQueryParams delegate;
+
+        private final Deserializer<Integer> countDeserializer;
+
+        private final Deserializer<Boolean> testDeserializer;
+
+        HandlePrimitveQueryParamsEndpoint(UndertowRuntime runtime, PrimitiveQueryParams delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.countDeserializer =
+                    new QueryParamDeserializer<>("count", PrimitiveQueryParams.IntParamDecoder.INSTANCE);
+            this.testDeserializer =
+                    new QueryParamDeserializer<>("test", PrimitiveQueryParams.BooleanParamDecoder.INSTANCE);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            this.delegate.handlePrimitveQueryParams(
+                    this.countDeserializer.deserialize(exchange), this.testDeserializer.deserialize(exchange));
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/ping";
+        }
+
+        @Override
+        public String serviceName() {
+            return "PrimitiveQueryParams";
+        }
+
+        @Override
+        public String name() {
+            return "handlePrimitveQueryParams";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
## Before this PR

Using primitive types as query parameters would fail when generating the undertow service endpoints class.

Example:

```java
@Handle(method = HttpMethod.GET, path = "/test")
void myEndpoint(
        @Handle.QueryParam(value = "flag", decoder = /* CollectionParamDecoder<Boolean> ... */) boolean flag);
```

<details>
<summary>Stacktrace:</summary>

```
error: Code generation failed: threw an exception java.lang.IllegalArgumentException: invalid type parameter: boolean
public interface PrimitiveQueryParams {
       ^
  	at com.squareup.javapoet.Util.checkArgument(Util.java:53)
  	at com.squareup.javapoet.ParameterizedTypeName.<init>(ParameterizedTypeName.java:51)
  	at com.squareup.javapoet.ParameterizedTypeName.<init>(ParameterizedTypeName.java:38)
  	at com.squareup.javapoet.ParameterizedTypeName.get(ParameterizedTypeName.java:114)
  	at com.palantir.conjure.java.undertow.processor.generate.ConjureUndertowEndpointsGenerator$1.query(ConjureUndertowEndpointsGenerator.java:229)
  	at com.palantir.conjure.java.undertow.processor.generate.ConjureUndertowEndpointsGenerator$1.query(ConjureUndertowEndpointsGenerator.java:156)
  	at com.palantir.conjure.java.undertow.processor.data.ParameterTypes$Query.match(ParameterTypes.java:343)
  	at com.palantir.conjure.java.undertow.processor.generate.ConjureUndertowEndpointsGenerator.lambda$endpoint$2(ConjureUndertowEndpointsGenerator.java:156)
  	[...]
```

</details>

## After this PR

We need to box primitive arguments when generating the parameterized type name of our generic Deserializer.

==COMMIT_MSG==
Handle query params with primitive types
==COMMIT_MSG==
