### PR TITLE
Pass endpoint to serde factory

### DIFF
--- a/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/DefaultSerDe.java
+++ b/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/DefaultSerDe.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.undertow.annotations;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.conjure.java.undertow.lib.BodySerDe;
 import com.palantir.conjure.java.undertow.lib.Deserializer;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
 import com.palantir.conjure.java.undertow.lib.Serializer;
 import com.palantir.conjure.java.undertow.lib.TypeMarker;
 import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
@@ -40,7 +41,7 @@ public enum DefaultSerDe implements SerializerFactory<Object>, DeserializerFacto
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> Deserializer<T> deserializer(TypeMarker<T> marker, UndertowRuntime runtime) {
+    public <T> Deserializer<T> deserializer(TypeMarker<T> marker, UndertowRuntime runtime, Endpoint _endpoint) {
         if (INPUT_STREAM.getType().equals(marker.getType())) {
             return (Deserializer<T>) new BinaryDeserializer(runtime.bodySerDe());
         }
@@ -49,7 +50,7 @@ public enum DefaultSerDe implements SerializerFactory<Object>, DeserializerFacto
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> Serializer<T> serializer(TypeMarker<T> marker, UndertowRuntime runtime) {
+    public <T> Serializer<T> serializer(TypeMarker<T> marker, UndertowRuntime runtime, Endpoint _endpoint) {
         Type type = marker.getType();
         Serializer<T> maybeSpecialSerializer = (Serializer<T>) maybeSpecialSerializer(type, runtime);
         if (maybeSpecialSerializer != null) {

--- a/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/DeserializerFactory.java
+++ b/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/DeserializerFactory.java
@@ -17,9 +17,10 @@
 package com.palantir.conjure.java.undertow.annotations;
 
 import com.palantir.conjure.java.undertow.lib.Deserializer;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
 import com.palantir.conjure.java.undertow.lib.TypeMarker;
 import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
 
 public interface DeserializerFactory<U> {
-    <T extends U> Deserializer<T> deserializer(TypeMarker<T> type, UndertowRuntime runtime);
+    <T extends U> Deserializer<T> deserializer(TypeMarker<T> type, UndertowRuntime runtime, Endpoint endpoint);
 }

--- a/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/SerializerFactory.java
+++ b/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/SerializerFactory.java
@@ -16,10 +16,11 @@
 
 package com.palantir.conjure.java.undertow.annotations;
 
+import com.palantir.conjure.java.undertow.lib.Endpoint;
 import com.palantir.conjure.java.undertow.lib.Serializer;
 import com.palantir.conjure.java.undertow.lib.TypeMarker;
 import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
 
 public interface SerializerFactory<U> {
-    <T extends U> Serializer<T> serializer(TypeMarker<T> type, UndertowRuntime runtime);
+    <T extends U> Serializer<T> serializer(TypeMarker<T> type, UndertowRuntime runtime, Endpoint endpoint);
 }

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
@@ -140,7 +140,7 @@ public final class ConjureUndertowEndpointsGenerator {
                             .build())
                     .constructorInitializer(CodeBlock.builder()
                             .addStatement(
-                                    "this.$N = $L.serializer(new $T<$T>() {}, $N)",
+                                    "this.$N = $L.serializer(new $T<$T>() {}, $N, this)",
                                     returnType.serializerFieldName(),
                                     returnType.serializerFactory(),
                                     TypeMarker.class,
@@ -168,7 +168,7 @@ public final class ConjureUndertowEndpointsGenerator {
                                 .build())
                         .constructorInitializer(CodeBlock.builder()
                                 .addStatement(
-                                        "this.$N = $L.deserializer(new $T<$T>() {}, $N)",
+                                        "this.$N = $L.deserializer(new $T<$T>() {}, $N, this)",
                                         deserializerFieldName,
                                         deserializerFactory,
                                         TypeMarker.class,

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/CookieParamsEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/CookieParamsEndpoints.java.generated
@@ -63,7 +63,7 @@ public final class CookieParamsEndpoints implements UndertowService {
         CookieParamsEndpoint(UndertowRuntime runtime, CookieParams delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.cookieParamsSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime);
+            this.cookieParamsSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
             this.stringCookieDeserializer =
                     new CookieDeserializer<>("stringCookie", ParamDecoders.stringParamDecoder(runtime.plainSerDe()));
             this.optionalStringCookieDeserializer = new CookieDeserializer<>(

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderServiceEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderServiceEndpoints.java.generated
@@ -77,7 +77,7 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
         QueryParamEndpoint(UndertowRuntime runtime, DefaultDecoderService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.queryParamSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime);
+            this.queryParamSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
             this.stringParamDeserializer = new QueryParamDeserializer<>(
                     "stringParam", ParamDecoders.stringCollectionParamDecoder(runtime.plainSerDe()));
             this.booleanParamDeserializer = new QueryParamDeserializer<>(
@@ -160,7 +160,8 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
         MoreQueryParamsEndpoint(UndertowRuntime runtime, DefaultDecoderService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.moreQueryParamsSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime);
+            this.moreQueryParamsSerializer =
+                    DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
             this.optionalIntParamDeserializer = new QueryParamDeserializer<>(
                     "optionalInt", ParamDecoders.optionalIntegerCollectionParamDecoder(runtime.plainSerDe()));
             this.dateTimeParamDeserializer = new QueryParamDeserializer<>(
@@ -253,7 +254,7 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
         HeadersEndpoint(UndertowRuntime runtime, DefaultDecoderService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.headersSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime);
+            this.headersSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
             this.stringParamDeserializer = new HeaderParamDeserializer<>(
                     "stringParam", ParamDecoders.stringCollectionParamDecoder(runtime.plainSerDe()));
             this.booleanParamDeserializer = new HeaderParamDeserializer<>(
@@ -345,7 +346,7 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
         PathParamEndpoint(UndertowRuntime runtime, DefaultDecoderService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.pathParamSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime);
+            this.pathParamSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
             this.stringParamDeserializer =
                     new PathParamDeserializer<>("stringParam", ParamDecoders.stringParamDecoder(runtime.plainSerDe()));
             this.booleanParamDeserializer = new PathParamDeserializer<>(


### PR DESCRIPTION
## Before this PR
In some cases, we want to have access to the endpoint metadata when serializing / deserializing a request.

When discussing this offline, an idea was to modify the [`Serializer#serialize`](https://github.com/palantir/conjure-java/blob/bafb0b6715b410f2d12c20935e92940f271604a1/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/Serializer.java#L26) interface to also accept the `Endpoints` object while adding a default method for backwards compatibility:

```java
public interface Serializer<T> {
    default void serialize(T value, HttpServerExchange exchange) throws IOException {
        serialize(value, exchange, Optional.empty())
    }

    void serialize(T value, HttpServerExchange exchange, Optional<Endpoint> endpoint) throws IOException;
}
```

However couldn't we just modify the `SerializerFactory` to receive an endpoint reference? The factory could then pass the endpoint object to the actual `Serializer` and we would avoid changing the `Serializer` interface. It's okay to break the `SerializerFactory` API because it's unused.

## After this PR

==COMMIT_MSG==
Pass endpoint to serde factory
==COMMIT_MSG==