### PR TITLE
Fix annotation processor optional-complex cookie deserialization

### DIFF
--- a/changelog/@unreleased/pr-1648.v2.yml
+++ b/changelog/@unreleased/pr-1648.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix annotation processor optional-complex cookie deserialization
+  links:
+  - https://github.com/palantir/conjure-java/pull/1648

--- a/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/ParamDecoders.java
+++ b/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/ParamDecoders.java
@@ -259,8 +259,8 @@ public final class ParamDecoders {
 
     public static <T> ParamDecoder<Optional<T>> optionalComplexParamDecoder(
             PlainSerDe serde, Function<String, T> factory) {
-        return DelegatingParamDecoder.of(value -> serde.deserializeOptionalComplex(
-                value == null ? ImmutableList.of() : ImmutableList.of(value), factory));
+        return DelegatingParamDecoder.of(
+                value -> serde.deserializeOptionalComplex(ImmutableList.of(value), factory), Optional.empty());
     }
 
     public static <T> CollectionParamDecoder<T> complexCollectionParamDecoder(

--- a/conjure-undertow-processor-example/src/main/java/com/palantir/conjure/java/undertow/example/ExampleService.java
+++ b/conjure-undertow-processor-example/src/main/java/com/palantir/conjure/java/undertow/example/ExampleService.java
@@ -30,6 +30,7 @@ import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
 import io.undertow.server.HttpServerExchange;
 import java.io.Closeable;
+import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -93,6 +94,9 @@ public interface ExampleService {
 
     @Handle(method = HttpMethod.GET, path = "/authCookie")
     BearerToken authCookie(@Cookie(value = "AUTH_TOKEN") BearerToken token);
+
+    @Handle(method = HttpMethod.GET, path = "/optionalBigIntegerCookie")
+    String optionalBigIntegerCookie(@Cookie(value = "BIG_INTEGER") Optional<BigInteger> cookieValue);
 
     interface CustomBinaryResponseBody extends Closeable, BinaryResponseBody {}
 

--- a/conjure-undertow-processor-example/src/test/java/com/palantir/conjure/java/undertow/example/ExampleResource.java
+++ b/conjure-undertow-processor-example/src/test/java/com/palantir/conjure/java/undertow/example/ExampleResource.java
@@ -26,6 +26,7 @@ import com.palantir.tokens.auth.BearerToken;
 import io.undertow.server.HttpServerExchange;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
@@ -123,6 +124,11 @@ final class ExampleResource implements ExampleService {
     @Override
     public BearerToken authCookie(BearerToken token) {
         return Preconditions.checkNotNull(token, "Token parameter is required");
+    }
+
+    @Override
+    public String optionalBigIntegerCookie(Optional<BigInteger> cookieValue) {
+        return cookieValue.map(BigInteger::toString).orElse("empty");
     }
 
     private enum Binary implements CustomBinaryResponseBody {


### PR DESCRIPTION
Previously a missing value would result in an exception rather
than an empty optional.

==COMMIT_MSG==
Fix annotation processor optional-complex cookie deserialization
==COMMIT_MSG==

