### PR TITLE
Provide Endpoints to BodySerde factories

### DIFF
--- a/changelog/@unreleased/pr-1650.v2.yml
+++ b/changelog/@unreleased/pr-1650.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Provide Endpoints to BodySerde factories
+  links:
+  - https://github.com/palantir/conjure-java/pull/1650

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AsyncRequestProcessingTestServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AsyncRequestProcessingTestServiceEndpoints.java
@@ -58,7 +58,7 @@ public final class AsyncRequestProcessingTestServiceEndpoints implements Underto
         DelayEndpoint(UndertowRuntime runtime, UndertowAsyncRequestProcessingTestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
         }
 
         @Override
@@ -113,7 +113,7 @@ public final class AsyncRequestProcessingTestServiceEndpoints implements Underto
         DelayFiveSecondTimeoutEndpoint(UndertowRuntime runtime, UndertowAsyncRequestProcessingTestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
         }
 
         @Override
@@ -321,7 +321,7 @@ public final class AsyncRequestProcessingTestServiceEndpoints implements Underto
         FutureTraceIdEndpoint(UndertowRuntime runtime, UndertowAsyncRequestProcessingTestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Object>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Object>() {}, this);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyPathServiceEndpoints.java
@@ -41,7 +41,7 @@ public final class EmptyPathServiceEndpoints implements UndertowService {
         EmptyPathEndpoint(UndertowRuntime runtime, UndertowEmptyPathService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {}, this);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
@@ -89,7 +89,7 @@ public final class EteServiceEndpoints implements UndertowService {
         StringEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
         }
 
         @Override
@@ -140,7 +140,7 @@ public final class EteServiceEndpoints implements UndertowService {
         IntegerEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Integer>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Integer>() {}, this);
         }
 
         @Override
@@ -186,7 +186,7 @@ public final class EteServiceEndpoints implements UndertowService {
         Double_Endpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Double>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Double>() {}, this);
         }
 
         @Override
@@ -232,7 +232,7 @@ public final class EteServiceEndpoints implements UndertowService {
         Boolean_Endpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {}, this);
         }
 
         @Override
@@ -278,7 +278,7 @@ public final class EteServiceEndpoints implements UndertowService {
         SafelongEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<SafeLong>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<SafeLong>() {}, this);
         }
 
         @Override
@@ -324,7 +324,7 @@ public final class EteServiceEndpoints implements UndertowService {
         RidEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<ResourceIdentifier>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<ResourceIdentifier>() {}, this);
         }
 
         @Override
@@ -370,7 +370,7 @@ public final class EteServiceEndpoints implements UndertowService {
         BearertokenEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<BearerToken>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<BearerToken>() {}, this);
         }
 
         @Override
@@ -416,7 +416,7 @@ public final class EteServiceEndpoints implements UndertowService {
         OptionalStringEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {}, this);
         }
 
         @Override
@@ -466,7 +466,7 @@ public final class EteServiceEndpoints implements UndertowService {
         OptionalEmptyEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {}, this);
         }
 
         @Override
@@ -516,7 +516,7 @@ public final class EteServiceEndpoints implements UndertowService {
         DatetimeEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<OffsetDateTime>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<OffsetDateTime>() {}, this);
         }
 
         @Override
@@ -605,7 +605,7 @@ public final class EteServiceEndpoints implements UndertowService {
         PathEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
         }
 
         @Override
@@ -654,7 +654,7 @@ public final class EteServiceEndpoints implements UndertowService {
         ExternalLongPathEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Long>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Long>() {}, this);
         }
 
         @Override
@@ -703,7 +703,7 @@ public final class EteServiceEndpoints implements UndertowService {
         OptionalExternalLongQueryEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<Long>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<Long>>() {}, this);
         }
 
         @Override
@@ -758,8 +758,8 @@ public final class EteServiceEndpoints implements UndertowService {
         NotNullBodyEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<StringAliasExample>() {});
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<StringAliasExample>() {});
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<StringAliasExample>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<StringAliasExample>() {}, this);
         }
 
         @Override
@@ -806,7 +806,7 @@ public final class EteServiceEndpoints implements UndertowService {
         AliasOneEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<StringAliasExample>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<StringAliasExample>() {}, this);
         }
 
         @Override
@@ -855,7 +855,7 @@ public final class EteServiceEndpoints implements UndertowService {
         OptionalAliasOneEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<StringAliasExample>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<StringAliasExample>() {}, this);
         }
 
         @Override
@@ -906,7 +906,7 @@ public final class EteServiceEndpoints implements UndertowService {
         AliasTwoEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<NestedStringAliasExample>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<NestedStringAliasExample>() {}, this);
         }
 
         @Override
@@ -958,8 +958,8 @@ public final class EteServiceEndpoints implements UndertowService {
         NotNullBodyExternalImportEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<StringAliasExample>() {});
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<StringAliasExample>() {});
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<StringAliasExample>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<StringAliasExample>() {}, this);
         }
 
         @Override
@@ -1008,8 +1008,9 @@ public final class EteServiceEndpoints implements UndertowService {
         OptionalBodyExternalImportEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Optional<StringAliasExample>>() {});
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<StringAliasExample>>() {});
+            this.deserializer =
+                    runtime.bodySerDe().deserializer(new TypeMarker<Optional<StringAliasExample>>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<StringAliasExample>>() {}, this);
         }
 
         @Override
@@ -1060,7 +1061,7 @@ public final class EteServiceEndpoints implements UndertowService {
         OptionalQueryExternalImportEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<StringAliasExample>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<StringAliasExample>>() {}, this);
         }
 
         @Override
@@ -1156,7 +1157,7 @@ public final class EteServiceEndpoints implements UndertowService {
         EnumQueryEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<SimpleEnum>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<SimpleEnum>() {}, this);
         }
 
         @Override
@@ -1205,7 +1206,7 @@ public final class EteServiceEndpoints implements UndertowService {
         EnumListQueryEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<List<SimpleEnum>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<List<SimpleEnum>>() {}, this);
         }
 
         @Override
@@ -1254,7 +1255,7 @@ public final class EteServiceEndpoints implements UndertowService {
         OptionalEnumQueryEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<SimpleEnum>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<SimpleEnum>>() {}, this);
         }
 
         @Override
@@ -1307,7 +1308,7 @@ public final class EteServiceEndpoints implements UndertowService {
         EnumHeaderEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<SimpleEnum>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<SimpleEnum>() {}, this);
         }
 
         @Override
@@ -1356,7 +1357,7 @@ public final class EteServiceEndpoints implements UndertowService {
         AliasLongEndpointEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<LongAlias>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<LongAlias>>() {}, this);
         }
 
         @Override
@@ -1461,7 +1462,8 @@ public final class EteServiceEndpoints implements UndertowService {
         ReceiveListOfOptionalsEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<ImmutableList<Optional<String>>>() {});
+            this.deserializer =
+                    runtime.bodySerDe().deserializer(new TypeMarker<ImmutableList<Optional<String>>>() {}, this);
         }
 
         @Override
@@ -1508,7 +1510,8 @@ public final class EteServiceEndpoints implements UndertowService {
         ReceiveSetOfOptionalsEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<ImmutableSet<Optional<String>>>() {});
+            this.deserializer =
+                    runtime.bodySerDe().deserializer(new TypeMarker<ImmutableSet<Optional<String>>>() {}, this);
         }
 
         @Override
@@ -1555,7 +1558,7 @@ public final class EteServiceEndpoints implements UndertowService {
         ReceiveListOfStringsEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<ImmutableList<String>>() {});
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<ImmutableList<String>>() {}, this);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/NameCollisionServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/NameCollisionServiceEndpoints.java
@@ -55,8 +55,8 @@ public final class NameCollisionServiceEndpoints implements UndertowService {
         IntEndpoint(UndertowRuntime runtime, UndertowNameCollisionService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {});
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
         }
 
         @Override
@@ -121,7 +121,7 @@ public final class NameCollisionServiceEndpoints implements UndertowService {
         NoContextEndpoint(UndertowRuntime runtime, UndertowNameCollisionService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {});
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {}, this);
         }
 
         @Override
@@ -169,7 +169,7 @@ public final class NameCollisionServiceEndpoints implements UndertowService {
         ContextEndpoint(UndertowRuntime runtime, UndertowNameCollisionService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {});
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {}, this);
         }
 
         @Override

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -257,7 +257,7 @@ final class UndertowServiceHandlerGenerator {
                             FieldSpec.builder(type, DESERIALIZER_VAR_NAME, Modifier.PRIVATE, Modifier.FINAL)
                                     .build());
                     ctorBuilder.addStatement(
-                            "this.$1N = $2N.bodySerDe().deserializer(new $3T() {})",
+                            "this.$1N = $2N.bodySerDe().deserializer(new $3T() {}, this)",
                             DESERIALIZER_VAR_NAME,
                             RUNTIME_VAR_NAME,
                             ParameterizedTypeName.get(ClassName.get(TypeMarker.class), typeName));
@@ -271,7 +271,7 @@ final class UndertowServiceHandlerGenerator {
                 endpointBuilder.addField(FieldSpec.builder(type, SERIALIZER_VAR_NAME, Modifier.PRIVATE, Modifier.FINAL)
                         .build());
                 ctorBuilder.addStatement(
-                        "this.$1N = $2N.bodySerDe().serializer(new $3T() {})",
+                        "this.$1N = $2N.bodySerDe().serializer(new $3T() {}, this)",
                         SERIALIZER_VAR_NAME,
                         RUNTIME_VAR_NAME,
                         ParameterizedTypeName.get(ClassName.get(TypeMarker.class), typeName));

--- a/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow
@@ -48,7 +48,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
         AsyncMarkerEndpoint(UndertowRuntime runtime, AsyncMarkers delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
         }
 
         @Override
@@ -95,7 +95,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
         AsyncTagEndpoint(UndertowRuntime runtime, AsyncMarkers delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
         }
 
         @Override
@@ -150,7 +150,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
         SyncEndpoint(UndertowRuntime runtime, AsyncMarkers delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
         }
 
         @Override

--- a/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow.async
+++ b/conjure-java-core/src/test/resources/test/api/AsyncMarkersEndpoints.java.undertow.async
@@ -48,7 +48,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
         AsyncMarkerEndpoint(UndertowRuntime runtime, AsyncMarkers delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
         }
 
         @Override
@@ -100,7 +100,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
         AsyncTagEndpoint(UndertowRuntime runtime, AsyncMarkers delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
         }
 
         @Override
@@ -155,7 +155,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
         SyncEndpoint(UndertowRuntime runtime, AsyncMarkers delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
         }
 
         @Override

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
@@ -83,7 +83,7 @@ public final class TestServiceEndpoints implements UndertowService {
         GetFileSystemsEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Map<String, BackingFileSystem>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Map<String, BackingFileSystem>>() {}, this);
         }
 
         @Override
@@ -136,8 +136,8 @@ public final class TestServiceEndpoints implements UndertowService {
         CreateDatasetEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<CreateDatasetRequest>() {});
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Dataset>() {});
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<CreateDatasetRequest>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Dataset>() {}, this);
         }
 
         @Override
@@ -187,7 +187,7 @@ public final class TestServiceEndpoints implements UndertowService {
         GetDatasetEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<Dataset>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<Dataset>>() {}, this);
         }
 
         @Override
@@ -387,7 +387,7 @@ public final class TestServiceEndpoints implements UndertowService {
         GetAliasedStringEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<AliasedString>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<AliasedString>() {}, this);
         }
 
         @Override
@@ -526,7 +526,7 @@ public final class TestServiceEndpoints implements UndertowService {
         GetBranchesEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Set<String>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Set<String>>() {}, this);
         }
 
         @Override
@@ -576,7 +576,7 @@ public final class TestServiceEndpoints implements UndertowService {
         GetBranchesDeprecatedEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Set<String>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Set<String>>() {}, this);
         }
 
         @Override
@@ -632,7 +632,7 @@ public final class TestServiceEndpoints implements UndertowService {
         ResolveBranchEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {}, this);
         }
 
         @Override
@@ -687,7 +687,7 @@ public final class TestServiceEndpoints implements UndertowService {
         TestParamEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {}, this);
         }
 
         @Override
@@ -743,8 +743,8 @@ public final class TestServiceEndpoints implements UndertowService {
         TestQueryParamsEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {});
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Integer>() {});
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Integer>() {}, this);
         }
 
         @Override
@@ -801,7 +801,7 @@ public final class TestServiceEndpoints implements UndertowService {
         TestNoResponseQueryParamsEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {});
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {}, this);
         }
 
         @Override
@@ -857,7 +857,7 @@ public final class TestServiceEndpoints implements UndertowService {
         TestBooleanEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {}, this);
         }
 
         @Override
@@ -903,7 +903,7 @@ public final class TestServiceEndpoints implements UndertowService {
         TestDoubleEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Double>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Double>() {}, this);
         }
 
         @Override
@@ -949,7 +949,7 @@ public final class TestServiceEndpoints implements UndertowService {
         TestIntegerEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Integer>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Integer>() {}, this);
         }
 
         @Override
@@ -997,8 +997,8 @@ public final class TestServiceEndpoints implements UndertowService {
         TestPostOptionalEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {});
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {});
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {}, this);
         }
 
         @Override

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.prefix
@@ -83,7 +83,7 @@ public final class TestServiceEndpoints implements UndertowService {
         GetFileSystemsEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Map<String, BackingFileSystem>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Map<String, BackingFileSystem>>() {}, this);
         }
 
         @Override
@@ -136,8 +136,8 @@ public final class TestServiceEndpoints implements UndertowService {
         CreateDatasetEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<CreateDatasetRequest>() {});
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Dataset>() {});
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<CreateDatasetRequest>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Dataset>() {}, this);
         }
 
         @Override
@@ -187,7 +187,7 @@ public final class TestServiceEndpoints implements UndertowService {
         GetDatasetEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<Dataset>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<Dataset>>() {}, this);
         }
 
         @Override
@@ -387,7 +387,7 @@ public final class TestServiceEndpoints implements UndertowService {
         GetAliasedStringEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<AliasedString>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<AliasedString>() {}, this);
         }
 
         @Override
@@ -526,7 +526,7 @@ public final class TestServiceEndpoints implements UndertowService {
         GetBranchesEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Set<String>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Set<String>>() {}, this);
         }
 
         @Override
@@ -576,7 +576,7 @@ public final class TestServiceEndpoints implements UndertowService {
         GetBranchesDeprecatedEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Set<String>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Set<String>>() {}, this);
         }
 
         @Override
@@ -632,7 +632,7 @@ public final class TestServiceEndpoints implements UndertowService {
         ResolveBranchEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {}, this);
         }
 
         @Override
@@ -687,7 +687,7 @@ public final class TestServiceEndpoints implements UndertowService {
         TestParamEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {}, this);
         }
 
         @Override
@@ -743,8 +743,8 @@ public final class TestServiceEndpoints implements UndertowService {
         TestQueryParamsEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {});
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Integer>() {});
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Integer>() {}, this);
         }
 
         @Override
@@ -801,7 +801,7 @@ public final class TestServiceEndpoints implements UndertowService {
         TestNoResponseQueryParamsEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {});
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {}, this);
         }
 
         @Override
@@ -857,7 +857,7 @@ public final class TestServiceEndpoints implements UndertowService {
         TestBooleanEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {}, this);
         }
 
         @Override
@@ -903,7 +903,7 @@ public final class TestServiceEndpoints implements UndertowService {
         TestDoubleEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Double>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Double>() {}, this);
         }
 
         @Override
@@ -949,7 +949,7 @@ public final class TestServiceEndpoints implements UndertowService {
         TestIntegerEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Integer>() {});
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Integer>() {}, this);
         }
 
         @Override
@@ -997,8 +997,8 @@ public final class TestServiceEndpoints implements UndertowService {
         TestPostOptionalEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {});
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {});
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {}, this);
         }
 
         @Override

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
@@ -67,12 +67,12 @@ final class ConjureBodySerDe implements BodySerDe {
 
     @Override
     public <T> Serializer<T> serializer(TypeMarker<T> token) {
-        return new EncodingSerializerRegistry<>(encodings, token, Optional.empty());
+        return new EncodingSerializerRegistry<>(encodings, token);
     }
 
     @Override
     public <T> Serializer<T> serializer(TypeMarker<T> token, Endpoint endpoint) {
-        return new EncodingSerializerRegistry<>(encodings, token, Optional.of(endpoint));
+        return new EncodingSerializerRegistry<>(encodings, token, endpoint);
     }
 
     @Override
@@ -82,7 +82,7 @@ final class ConjureBodySerDe implements BodySerDe {
 
     @Override
     public <T> Deserializer<T> deserializer(TypeMarker<T> token, Endpoint endpoint) {
-        return new EncodingDeserializerRegistry<>(encodings, token, Optional.of(endpoint));
+        return new EncodingDeserializerRegistry<>(encodings, token, endpoint);
     }
 
     @Override
@@ -112,7 +112,15 @@ final class ConjureBodySerDe implements BodySerDe {
         private final EncodingSerializerContainer<T> defaultEncoding;
         private final List<EncodingSerializerContainer<T>> encodings;
 
-        EncodingSerializerRegistry(List<Encoding> encodings, TypeMarker<T> token, Optional<Endpoint> endpoint) {
+        EncodingSerializerRegistry(List<Encoding> encodings, TypeMarker<T> token) {
+            this(encodings, token, Optional.empty());
+        }
+
+        EncodingSerializerRegistry(List<Encoding> encodings, TypeMarker<T> token, Endpoint endpoint) {
+            this(encodings, token, Optional.of(endpoint));
+        }
+
+        private EncodingSerializerRegistry(List<Encoding> encodings, TypeMarker<T> token, Optional<Endpoint> endpoint) {
             this.encodings = encodings.stream()
                     .map(encoding -> new EncodingSerializerContainer<>(encoding, token, endpoint))
                     .collect(ImmutableList.toImmutableList());
@@ -169,7 +177,16 @@ final class ConjureBodySerDe implements BodySerDe {
         private final boolean optionalType;
         private final TypeMarker<T> marker;
 
-        EncodingDeserializerRegistry(List<Encoding> encodings, TypeMarker<T> token, Optional<Endpoint> endpoint) {
+        EncodingDeserializerRegistry(List<Encoding> encodings, TypeMarker<T> token) {
+            this(encodings, token, Optional.empty());
+        }
+
+        EncodingDeserializerRegistry(List<Encoding> encodings, TypeMarker<T> token, Endpoint endpoint) {
+            this(encodings, token, Optional.of(endpoint));
+        }
+
+        private EncodingDeserializerRegistry(
+                List<Encoding> encodings, TypeMarker<T> token, Optional<Endpoint> endpoint) {
             this.encodings = encodings.stream()
                     .map(encoding -> new EncodingDeserializerContainer<>(encoding, token, endpoint))
                     .collect(ImmutableList.toImmutableList());

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.conjure.java.undertow.lib.BodySerDe;
 import com.palantir.conjure.java.undertow.lib.Deserializer;
-import com.palantir.conjure.java.undertow.lib.Endpoint;
 import com.palantir.conjure.java.undertow.lib.Serializer;
 import com.palantir.conjure.java.undertow.lib.TypeMarker;
 import com.palantir.logsafe.Preconditions;
@@ -40,7 +39,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PushbackInputStream;
 import java.util.List;
-import java.util.Optional;
 import org.xnio.IoUtils;
 
 /** Package private internal API. */
@@ -66,12 +64,12 @@ final class ConjureBodySerDe implements BodySerDe {
     }
 
     @Override
-    public <T> Serializer<T> serializer(TypeMarker<T> token, Optional<Endpoint> _endpoint) {
+    public <T> Serializer<T> serializer(TypeMarker<T> token) {
         return new EncodingSerializerRegistry<>(encodings, token);
     }
 
     @Override
-    public <T> Deserializer<T> deserializer(TypeMarker<T> token, Optional<Endpoint> _endpoint) {
+    public <T> Deserializer<T> deserializer(TypeMarker<T> token) {
         return new EncodingDeserializerRegistry<>(encodings, token);
     }
 

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.conjure.java.undertow.lib.BodySerDe;
 import com.palantir.conjure.java.undertow.lib.Deserializer;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
 import com.palantir.conjure.java.undertow.lib.Serializer;
 import com.palantir.conjure.java.undertow.lib.TypeMarker;
 import com.palantir.logsafe.Preconditions;
@@ -39,6 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PushbackInputStream;
 import java.util.List;
+import java.util.Optional;
 import org.xnio.IoUtils;
 
 /** Package private internal API. */
@@ -64,12 +66,12 @@ final class ConjureBodySerDe implements BodySerDe {
     }
 
     @Override
-    public <T> Serializer<T> serializer(TypeMarker<T> token) {
+    public <T> Serializer<T> serializer(TypeMarker<T> token, Optional<Endpoint> _endpoint) {
         return new EncodingSerializerRegistry<>(encodings, token);
     }
 
     @Override
-    public <T> Deserializer<T> deserializer(TypeMarker<T> token) {
+    public <T> Deserializer<T> deserializer(TypeMarker<T> token, Optional<Endpoint> _endpoint) {
         return new EncodingDeserializerRegistry<>(encodings, token);
     }
 

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
@@ -67,12 +67,12 @@ final class ConjureBodySerDe implements BodySerDe {
 
     @Override
     public <T> Serializer<T> serializer(TypeMarker<T> token) {
-        return new EncodingSerializerRegistry<>(encodings, token);
+        return new EncodingSerializerRegistry<>(encodings, token, Optional.empty());
     }
 
     @Override
     public <T> Serializer<T> serializer(TypeMarker<T> token, Endpoint endpoint) {
-        return new EncodingSerializerRegistry<>(encodings, token, endpoint);
+        return new EncodingSerializerRegistry<>(encodings, token, Optional.of(endpoint));
     }
 
     @Override
@@ -82,7 +82,7 @@ final class ConjureBodySerDe implements BodySerDe {
 
     @Override
     public <T> Deserializer<T> deserializer(TypeMarker<T> token, Endpoint endpoint) {
-        return new EncodingDeserializerRegistry<>(encodings, token, endpoint);
+        return new EncodingDeserializerRegistry<>(encodings, token, Optional.of(endpoint));
     }
 
     @Override
@@ -112,15 +112,7 @@ final class ConjureBodySerDe implements BodySerDe {
         private final EncodingSerializerContainer<T> defaultEncoding;
         private final List<EncodingSerializerContainer<T>> encodings;
 
-        EncodingSerializerRegistry(List<Encoding> encodings, TypeMarker<T> token) {
-            this(encodings, token, Optional.empty());
-        }
-
-        EncodingSerializerRegistry(List<Encoding> encodings, TypeMarker<T> token, Endpoint endpoint) {
-            this(encodings, token, Optional.of(endpoint));
-        }
-
-        private EncodingSerializerRegistry(List<Encoding> encodings, TypeMarker<T> token, Optional<Endpoint> endpoint) {
+        EncodingSerializerRegistry(List<Encoding> encodings, TypeMarker<T> token, Optional<Endpoint> endpoint) {
             this.encodings = encodings.stream()
                     .map(encoding -> new EncodingSerializerContainer<>(encoding, token, endpoint))
                     .collect(ImmutableList.toImmutableList());
@@ -177,16 +169,7 @@ final class ConjureBodySerDe implements BodySerDe {
         private final boolean optionalType;
         private final TypeMarker<T> marker;
 
-        EncodingDeserializerRegistry(List<Encoding> encodings, TypeMarker<T> token) {
-            this(encodings, token, Optional.empty());
-        }
-
-        EncodingDeserializerRegistry(List<Encoding> encodings, TypeMarker<T> token, Endpoint endpoint) {
-            this(encodings, token, Optional.of(endpoint));
-        }
-
-        private EncodingDeserializerRegistry(
-                List<Encoding> encodings, TypeMarker<T> token, Optional<Endpoint> endpoint) {
+        EncodingDeserializerRegistry(List<Encoding> encodings, TypeMarker<T> token, Optional<Endpoint> endpoint) {
             this.encodings = encodings.stream()
                     .map(encoding -> new EncodingDeserializerContainer<>(encoding, token, endpoint))
                     .collect(ImmutableList.toImmutableList());

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encoding.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encoding.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.undertow.runtime;
 
+import com.palantir.conjure.java.undertow.lib.Endpoint;
 import com.palantir.conjure.java.undertow.lib.TypeMarker;
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,11 +41,19 @@ public interface Encoding {
      */
     <T> Serializer<T> serializer(TypeMarker<T> type);
 
+    default <T> Serializer<T> serializer(TypeMarker<T> type, Endpoint _endpoint) {
+        return serializer(type);
+    }
+
     /**
      * Creates a new {@link Deserializer} for the requested type. It is recommended to reuse instances over requesting
      * new ones for each request.
      */
     <T> Deserializer<T> deserializer(TypeMarker<T> type);
+
+    default <T> Deserializer<T> deserializer(TypeMarker<T> type, Endpoint _endpoint) {
+        return deserializer(type);
+    }
 
     /**
      * Returns the value used in response

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/BodySerDe.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/BodySerDe.java
@@ -19,15 +19,34 @@ package com.palantir.conjure.java.undertow.lib;
 import io.undertow.server.HttpServerExchange;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 
 /** Request and response Deserialization and Serialization functionality used by generated code. */
 public interface BodySerDe {
 
     /** Creates a {@link Serializer} for the requested type. Serializer instances should be reused. */
-    <T> Serializer<T> serializer(TypeMarker<T> type);
+    default <T> Serializer<T> serializer(TypeMarker<T> type, Endpoint endpoint) {
+        return serializer(type, Optional.of(endpoint));
+    }
+
+    /** Kept for backwards compatibility. */
+    default <T> Serializer<T> serializer(TypeMarker<T> type) {
+        return serializer(type, Optional.empty());
+    }
+
+    <T> Serializer<T> serializer(TypeMarker<T> type, Optional<Endpoint> endpoint);
 
     /** Creates a {@link Deserializer} for the requested type. Deserializer instances should be reused. */
-    <T> Deserializer<T> deserializer(TypeMarker<T> type);
+    default <T> Deserializer<T> deserializer(TypeMarker<T> type, Endpoint endpoint) {
+        return deserializer(type, Optional.of(endpoint));
+    }
+
+    /** Kept for backwards compatibility. */
+    default <T> Deserializer<T> deserializer(TypeMarker<T> type) {
+        return deserializer(type, Optional.empty());
+    }
+
+    <T> Deserializer<T> deserializer(TypeMarker<T> type, Optional<Endpoint> endpoint);
 
     /**
      * Serializes a {@link BinaryResponseBody} to

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/BodySerDe.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/BodySerDe.java
@@ -19,34 +19,23 @@ package com.palantir.conjure.java.undertow.lib;
 import io.undertow.server.HttpServerExchange;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Optional;
 
 /** Request and response Deserialization and Serialization functionality used by generated code. */
 public interface BodySerDe {
 
     /** Creates a {@link Serializer} for the requested type. Serializer instances should be reused. */
-    default <T> Serializer<T> serializer(TypeMarker<T> type, Endpoint endpoint) {
-        return serializer(type, Optional.of(endpoint));
-    }
+    <T> Serializer<T> serializer(TypeMarker<T> type);
 
-    /** Kept for backwards compatibility. */
-    default <T> Serializer<T> serializer(TypeMarker<T> type) {
-        return serializer(type, Optional.empty());
+    default <T> Serializer<T> serializer(TypeMarker<T> type, Endpoint _endpoint) {
+        return serializer(type);
     }
-
-    <T> Serializer<T> serializer(TypeMarker<T> type, Optional<Endpoint> endpoint);
 
     /** Creates a {@link Deserializer} for the requested type. Deserializer instances should be reused. */
-    default <T> Deserializer<T> deserializer(TypeMarker<T> type, Endpoint endpoint) {
-        return deserializer(type, Optional.of(endpoint));
-    }
+    <T> Deserializer<T> deserializer(TypeMarker<T> type);
 
-    /** Kept for backwards compatibility. */
-    default <T> Deserializer<T> deserializer(TypeMarker<T> type) {
-        return deserializer(type, Optional.empty());
+    default <T> Deserializer<T> deserializer(TypeMarker<T> type, Endpoint _endpoint) {
+        return deserializer(type);
     }
-
-    <T> Deserializer<T> deserializer(TypeMarker<T> type, Optional<Endpoint> endpoint);
 
     /**
      * Serializes a {@link BinaryResponseBody} to


### PR DESCRIPTION
## After this PR

`BodySerde` serializer and deserializer factory methods now accept an optional `Endpoint` argument. This allows us to modify construction of the serializer/deserializer based on endpoint metadata.

 In a FLUP PR, we'll also update the annotation-processor codegen and `(De)SerializerFactory` to also forward the endpoint.

==COMMIT_MSG==
Provide Endpoints to BodySerde factories
==COMMIT_MSG==

## Possible downsides?
This is a compile break for consumers that have custom implementations of `BodySerde`.
