### PR TITLE
Fix strictObjects

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/strict/EmptyObjectNotStrict.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/strict/EmptyObjectNotStrict.java
@@ -1,0 +1,25 @@
+package com.palantir.strict;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.annotation.Generated;
+
+@JsonSerialize
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Generated("com.palantir.conjure.java.types.BeanGenerator")
+public final class EmptyObjectNotStrict {
+    private static final EmptyObjectNotStrict INSTANCE = new EmptyObjectNotStrict();
+
+    private EmptyObjectNotStrict() {}
+
+    @Override
+    public String toString() {
+        return "EmptyObjectNotStrict{}";
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static EmptyObjectNotStrict of() {
+        return INSTANCE;
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/strict/SingleFieldNotStrict.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/strict/SingleFieldNotStrict.java
@@ -1,0 +1,111 @@
+package com.palantir.strict;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Generated;
+
+@JsonDeserialize(builder = SingleFieldNotStrict.Builder.class)
+@Generated("com.palantir.conjure.java.types.BeanGenerator")
+public final class SingleFieldNotStrict {
+    private final int foo;
+
+    private SingleFieldNotStrict(int foo) {
+        this.foo = foo;
+    }
+
+    @JsonProperty("foo")
+    public int getFoo() {
+        return this.foo;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other || (other instanceof SingleFieldNotStrict && equalTo((SingleFieldNotStrict) other));
+    }
+
+    private boolean equalTo(SingleFieldNotStrict other) {
+        return this.foo == other.foo;
+    }
+
+    @Override
+    public int hashCode() {
+        return Integer.hashCode(this.foo);
+    }
+
+    @Override
+    public String toString() {
+        return "SingleFieldNotStrict{foo: " + foo + '}';
+    }
+
+    public static SingleFieldNotStrict of(int foo) {
+        return builder().foo(foo).build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder {
+        boolean _buildInvoked;
+
+        private int foo;
+
+        private boolean _fooInitialized = false;
+
+        private Builder() {}
+
+        public Builder from(SingleFieldNotStrict other) {
+            checkNotBuilt();
+            foo(other.getFoo());
+            return this;
+        }
+
+        @JsonSetter("foo")
+        public Builder foo(int foo) {
+            checkNotBuilt();
+            this.foo = foo;
+            this._fooInitialized = true;
+            return this;
+        }
+
+        private void validatePrimitiveFieldsHaveBeenInitialized() {
+            List<String> missingFields = null;
+            missingFields = addFieldIfMissing(missingFields, _fooInitialized, "foo");
+            if (missingFields != null) {
+                throw new SafeIllegalArgumentException(
+                        "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
+            }
+        }
+
+        private static List<String> addFieldIfMissing(List<String> prev, boolean initialized, String fieldName) {
+            List<String> missingFields = prev;
+            if (!initialized) {
+                if (missingFields == null) {
+                    missingFields = new ArrayList<>(1);
+                }
+                missingFields.add(fieldName);
+            }
+            return missingFields;
+        }
+
+        public SingleFieldNotStrict build() {
+            checkNotBuilt();
+            this._buildInvoked = true;
+            validatePrimitiveFieldsHaveBeenInitialized();
+            return new SingleFieldNotStrict(foo);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyObjectExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyObjectExample.java
@@ -1,10 +1,12 @@
 package test.prefix.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import javax.annotation.Generated;
 
 @JsonSerialize
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
 public final class EmptyObjectExample {
     private static final EmptyObjectExample INSTANCE = new EmptyObjectExample();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.types;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -136,6 +137,11 @@ public final class BeanGenerator {
             // serialize this class. Without this annotation no serializer will be set for this class, thus preventing
             // serialization.
             typeBuilder.addAnnotation(JsonSerialize.class).addField(createSingletonField(objectClass));
+            if (!options.strictObjects()) {
+                typeBuilder.addAnnotation(AnnotationSpec.builder(JsonIgnoreProperties.class)
+                        .addMember("ignoreUnknown", "$L", true)
+                        .build());
+            }
         } else {
             ImmutableList<EnrichedField> fieldsNeedingBuilderStage = fields.stream()
                     .filter(field -> !fieldShouldBeInFinalStage(field))

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
@@ -142,6 +142,21 @@ public final class ObjectGeneratorTests {
         assertThatFilesAreTheSame(files, REFERENCE_FILES_FOLDER);
     }
 
+    @Test
+    public void testStrictFalse() throws IOException {
+        ConjureDefinition def =
+                Conjure.parse(ImmutableList.of(new File("src/test/resources/example-types-strict-objects.yml")));
+        List<Path> files = new GenerationCoordinator(
+                        MoreExecutors.directExecutor(),
+                        ImmutableSet.of(new ObjectGenerator(Options.builder()
+                                .useImmutableBytes(true)
+                                .strictObjects(false)
+                                .build())))
+                .emit(def, tempDir);
+
+        assertThatFilesAreTheSame(files, REFERENCE_FILES_FOLDER);
+    }
+
     private void assertThatFilesAreTheSame(List<Path> files, String referenceFilesFolder) throws IOException {
         for (Path file : files) {
             Path relativized = tempDir.toPath().relativize(file);

--- a/conjure-java-core/src/test/resources/example-types-strict-objects.yml
+++ b/conjure-java-core/src/test/resources/example-types-strict-objects.yml
@@ -1,0 +1,10 @@
+types:
+  definitions:
+    default-package: com.palantir.strict
+    objects:
+      EmptyObjectNotStrict:
+        fields: {}
+      SingleFieldNotStrict:
+        fields:
+          foo: integer
+


### PR DESCRIPTION
… beans

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
When using strictObjects=false, generated code for empty beans does not include the @JsonIgnoreProperties annotation.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Objects with no fields correctly add the @JsonIgnoreProperties annotation when strictObjects is set to false
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

