### PR TITLE
[processor] Support multiple body parameters

### DIFF
--- a/changelog/@unreleased/pr-1661.v2.yml
+++ b/changelog/@unreleased/pr-1661.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: '[processor] Support multiple body parameters to support multipart
+    use-cases'
+  links:
+  - https://github.com/palantir/conjure-java/pull/1661

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/EndpointDefinitions.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/EndpointDefinitions.java
@@ -65,7 +65,7 @@ public final class EndpointDefinitions {
         Optional<ReturnType> maybeReturnType =
                 returnTypesResolver.getReturnType(endpointName, element, requestAnnotationReflector);
         List<Optional<ArgumentDefinition>> args = element.getParameters().stream()
-                .map(arg -> getArgumentDefinition(endpointName, arg))
+                .map(this::getArgumentDefinition)
                 .collect(Collectors.toList());
 
         if (!args.stream()
@@ -106,9 +106,9 @@ public final class EndpointDefinitions {
                 .build());
     }
 
-    private Optional<ArgumentDefinition> getArgumentDefinition(EndpointName endpointName, VariableElement param) {
+    private Optional<ArgumentDefinition> getArgumentDefinition(VariableElement param) {
         Optional<ArgumentType> argumentType = argumentTypesResolver.getArgumentType(param);
-        Optional<ParameterType> parameterType = paramTypesResolver.getParameterType(endpointName, param);
+        Optional<ParameterType> parameterType = paramTypesResolver.getParameterType(param);
 
         if (argumentType.isEmpty() || parameterType.isEmpty()) {
             return Optional.empty();

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParamTypesResolver.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParamTypesResolver.java
@@ -58,7 +58,7 @@ public final class ParamTypesResolver {
     }
 
     @SuppressWarnings("CyclomaticComplexity")
-    public Optional<ParameterType> getParameterType(EndpointName endpointName, VariableElement variableElement) {
+    public Optional<ParameterType> getParameterType(VariableElement variableElement) {
         List<AnnotationMirror> paramAnnotationMirrors = new ArrayList<>();
         for (AnnotationMirror annotationMirror : variableElement.getAnnotationMirrors()) {
             TypeElement annotationTypeElement =
@@ -99,7 +99,7 @@ public final class ParamTypesResolver {
         AnnotationReflector annotationReflector =
                 ImmutableAnnotationReflector.of(Iterables.getOnlyElement(paramAnnotationMirrors));
         if (annotationReflector.isAnnotation(Handle.Body.class)) {
-            return Optional.of(bodyParameter(endpointName, annotationReflector));
+            return Optional.of(bodyParameter(variableElement, annotationReflector));
         } else if (annotationReflector.isAnnotation(Handle.Header.class)) {
             return Optional.of(headerParameter(variableElement, annotationReflector));
         } else if (annotationReflector.isAnnotation(Handle.PathParam.class)) {
@@ -115,8 +115,9 @@ public final class ParamTypesResolver {
         throw new SafeIllegalStateException("Not possible");
     }
 
-    private ParameterType bodyParameter(EndpointName endpointName, AnnotationReflector annotationReflector) {
-        String deserializerName = InstanceVariables.joinCamelCase(endpointName.get(), "Deserializer");
+    private ParameterType bodyParameter(VariableElement variableElement, AnnotationReflector annotationReflector) {
+        String javaParameterName = variableElement.getSimpleName().toString();
+        String deserializerName = InstanceVariables.joinCamelCase(javaParameterName, "Deserializer");
         TypeMirror deserializer = annotationReflector.getAnnotationValue(TypeMirror.class);
         return ParameterTypes.body(Instantiables.instantiate(deserializer), deserializerName);
     }

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
@@ -27,6 +27,7 @@ import com.google.testing.compile.Compiler;
 import com.google.testing.compile.JavaFileObjects;
 import com.palantir.conjure.java.undertow.processor.sample.CookieParams;
 import com.palantir.conjure.java.undertow.processor.sample.DefaultDecoderService;
+import com.palantir.conjure.java.undertow.processor.sample.MultipleBodyInterface;
 import com.palantir.conjure.java.undertow.processor.sample.PrimitiveBodyParam;
 import com.palantir.conjure.java.undertow.processor.sample.PrimitiveQueryParams;
 import com.palantir.conjure.java.undertow.processor.sample.PrivateMethodAnnotatedResource;
@@ -59,6 +60,11 @@ public class ConjureUndertowAnnotationProcessorTest {
     @Test
     public void testPrimitiveBodyParam() {
         assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, PrimitiveBodyParam.class);
+    }
+
+    @Test
+    public void testMultipleBodies() {
+        assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, MultipleBodyInterface.class);
     }
 
     @Test

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/MultipleBodyInterface.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/MultipleBodyInterface.java
@@ -1,0 +1,30 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.palantir.conjure.java.undertow.annotations.Handle;
+import com.palantir.conjure.java.undertow.annotations.HttpMethod;
+
+public interface MultipleBodyInterface {
+
+    // Just like that, we can solve the three body problem!
+    // This functionality is helpful for multipart form-data, as written it wouldn't be
+    // very useful because each default body deserializer would fully consume the request
+    // body.
+    @Handle(method = HttpMethod.POST, path = "/body")
+    void post(@Handle.Body String one, @Handle.Body String two, @Handle.Body String three);
+}

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/MultipleBodyInterfaceEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/MultipleBodyInterfaceEndpoints.java.generated
@@ -1,0 +1,91 @@
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.java.undertow.annotations.DefaultSerDe;
+import com.palantir.conjure.java.undertow.lib.Deserializer;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import io.undertow.util.StatusCodes;
+import java.lang.Exception;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.undertow.processor.generate.ConjureUndertowEndpointsGenerator")
+public final class MultipleBodyInterfaceEndpoints implements UndertowService {
+    private final MultipleBodyInterface delegate;
+
+    private MultipleBodyInterfaceEndpoints(MultipleBodyInterface delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(MultipleBodyInterface delegate) {
+        return new MultipleBodyInterfaceEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return ImmutableList.of(new PostEndpoint(runtime, delegate));
+    }
+
+    private static final class PostEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final MultipleBodyInterface delegate;
+
+        private final Deserializer<String> oneDeserializer;
+
+        private final Deserializer<String> twoDeserializer;
+
+        private final Deserializer<String> threeDeserializer;
+
+        PostEndpoint(UndertowRuntime runtime, MultipleBodyInterface delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.oneDeserializer = DefaultSerDe.INSTANCE.deserializer(new TypeMarker<String>() {}, runtime, this);
+            this.twoDeserializer = DefaultSerDe.INSTANCE.deserializer(new TypeMarker<String>() {}, runtime, this);
+            this.threeDeserializer = DefaultSerDe.INSTANCE.deserializer(new TypeMarker<String>() {}, runtime, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            this.delegate.post(
+                    oneDeserializer.deserialize(exchange),
+                    twoDeserializer.deserialize(exchange),
+                    threeDeserializer.deserialize(exchange));
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/body";
+        }
+
+        @Override
+        public String serviceName() {
+            return "MultipleBodyInterface";
+        }
+
+        @Override
+        public String name() {
+            return "post";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/PrimitiveBodyParamEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/PrimitiveBodyParamEndpoints.java.generated
@@ -40,18 +40,18 @@ public final class PrimitiveBodyParamEndpoints implements UndertowService {
 
         private final PrimitiveBodyParam delegate;
 
-        private final Deserializer<Integer> handlePrimitiveBodyDeserializer;
+        private final Deserializer<Integer> countDeserializer;
 
         HandlePrimitiveBodyEndpoint(UndertowRuntime runtime, PrimitiveBodyParam delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.handlePrimitiveBodyDeserializer = PrimitiveBodyParam.IntParamDeserializerFactory.INSTANCE.deserializer(
+            this.countDeserializer = PrimitiveBodyParam.IntParamDeserializerFactory.INSTANCE.deserializer(
                     new TypeMarker<Integer>() {}, runtime, this);
         }
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws Exception {
-            this.delegate.handlePrimitiveBody(handlePrimitiveBodyDeserializer.deserialize(exchange));
+            this.delegate.handlePrimitiveBody(countDeserializer.deserialize(exchange));
             exchange.setStatusCode(StatusCodes.NO_CONTENT);
         }
 


### PR DESCRIPTION
This is useful when dealing with Form data

==COMMIT_MSG==
[processor] Support multiple body parameters to support multipart use-cases
==COMMIT_MSG==

