### PR TITLE
Simplify integer hashcode

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
@@ -35,7 +35,7 @@ public final class IntegerExample {
 
     @Override
     public int hashCode() {
-        return Integer.hashCode(this.integer);
+        return this.integer;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -153,7 +153,7 @@ public final class ManyFieldExample {
         if (result == 0) {
             int hash = 1;
             hash = 31 * hash + this.string.hashCode();
-            hash = 31 * hash + Integer.hashCode(this.integer);
+            hash = 31 * hash + this.integer;
             hash = 31 * hash + Double.hashCode(this.doubleValue);
             hash = 31 * hash + this.optionalItem.hashCode();
             hash = 31 * hash + this.items.hashCode();

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -96,9 +96,9 @@ public final class ReservedKeyExample {
             hash = 31 * hash + this.package_.hashCode();
             hash = 31 * hash + this.interface_.hashCode();
             hash = 31 * hash + this.fieldNameWithDashes.hashCode();
-            hash = 31 * hash + Integer.hashCode(this.primitveFieldNameWithDashes);
-            hash = 31 * hash + Integer.hashCode(this.memoizedHashCode_);
-            hash = 31 * hash + Integer.hashCode(this.result);
+            hash = 31 * hash + this.primitveFieldNameWithDashes;
+            hash = 31 * hash + this.memoizedHashCode_;
+            hash = 31 * hash + this.result;
             result = hash;
             memoizedHashCode = result;
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -329,7 +329,7 @@ public final class Union {
 
         @Override
         public int hashCode() {
-            return Integer.hashCode(this.value);
+            return this.value;
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -717,7 +717,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Integer.hashCode(this.value);
+            return this.value;
         }
 
         @Override
@@ -762,7 +762,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Integer.hashCode(this.value);
+            return this.value;
         }
 
         @Override
@@ -807,7 +807,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Integer.hashCode(this.value);
+            return this.value;
         }
 
         @Override
@@ -852,7 +852,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Integer.hashCode(this.value);
+            return this.value;
         }
 
         @Override
@@ -897,7 +897,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Integer.hashCode(this.value);
+            return this.value;
         }
 
         @Override
@@ -942,7 +942,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Integer.hashCode(this.value);
+            return this.value;
         }
 
         @Override
@@ -987,7 +987,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Integer.hashCode(this.value);
+            return this.value;
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/strict/SingleFieldNotStrict.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/strict/SingleFieldNotStrict.java
@@ -36,7 +36,7 @@ public final class SingleFieldNotStrict {
 
     @Override
     public int hashCode() {
-        return Integer.hashCode(this.foo);
+        return this.foo;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/IntegerExample.java
@@ -36,7 +36,7 @@ public final class IntegerExample {
 
     @Override
     public int hashCode() {
-        return Integer.hashCode(this.integer);
+        return this.integer;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
@@ -154,7 +154,7 @@ public final class ManyFieldExample {
         if (result == 0) {
             int hash = 1;
             hash = 31 * hash + this.string.hashCode();
-            hash = 31 * hash + Integer.hashCode(this.integer);
+            hash = 31 * hash + this.integer;
             hash = 31 * hash + Double.hashCode(this.doubleValue);
             hash = 31 * hash + this.optionalItem.hashCode();
             hash = 31 * hash + this.items.hashCode();

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReservedKeyExample.java
@@ -97,9 +97,9 @@ public final class ReservedKeyExample {
             hash = 31 * hash + this.package_.hashCode();
             hash = 31 * hash + this.interface_.hashCode();
             hash = 31 * hash + this.fieldNameWithDashes.hashCode();
-            hash = 31 * hash + Integer.hashCode(this.primitveFieldNameWithDashes);
-            hash = 31 * hash + Integer.hashCode(this.memoizedHashCode_);
-            hash = 31 * hash + Integer.hashCode(this.result);
+            hash = 31 * hash + this.primitveFieldNameWithDashes;
+            hash = 31 * hash + this.memoizedHashCode_;
+            hash = 31 * hash + this.result;
             result = hash;
             memoizedHashCode = result;
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
@@ -319,7 +319,7 @@ public final class Union {
 
         @Override
         public int hashCode() {
-            return Integer.hashCode(this.value);
+            return this.value;
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -707,7 +707,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Integer.hashCode(this.value);
+            return this.value;
         }
 
         @Override
@@ -752,7 +752,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Integer.hashCode(this.value);
+            return this.value;
         }
 
         @Override
@@ -797,7 +797,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Integer.hashCode(this.value);
+            return this.value;
         }
 
         @Override
@@ -842,7 +842,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Integer.hashCode(this.value);
+            return this.value;
         }
 
         @Override
@@ -887,7 +887,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Integer.hashCode(this.value);
+            return this.value;
         }
 
         @Override
@@ -932,7 +932,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Integer.hashCode(this.value);
+            return this.value;
         }
 
         @Override
@@ -977,7 +977,7 @@ public final class UnionTypeExample {
 
         @Override
         public int hashCode() {
-            return Integer.hashCode(this.value);
+            return this.value;
         }
 
         @Override

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/MethodSpecs.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/MethodSpecs.java
@@ -143,7 +143,11 @@ public final class MethodSpecs {
 
     private static CodeBlock computeHashCode(FieldSpec fieldSpec) {
         if (fieldSpec.type.isPrimitive()) {
-            return CodeBlock.of("$1T.$2N($3L)", fieldSpec.type.box(), "hashCode", createHashInput(fieldSpec));
+            if (TypeName.INT.equals(fieldSpec.type)) {
+                return createHashInput(fieldSpec);
+            } else {
+                return CodeBlock.of("$1T.$2N($3L)", fieldSpec.type.box(), "hashCode", createHashInput(fieldSpec));
+            }
         }
         return CodeBlock.of("$L.hashCode()", createHashInput(fieldSpec));
     }


### PR DESCRIPTION
Avoids an unnecessary method call returning the same value

==COMMIT_MSG==
Simplify integer hashcode
==COMMIT_MSG==

