### PR TITLE
Test coverage for missing annotations

### DIFF
--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/EndpointDefinitions.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/EndpointDefinitions.java
@@ -107,10 +107,10 @@ public final class EndpointDefinitions {
     }
 
     private Optional<ArgumentDefinition> getArgumentDefinition(VariableElement param) {
-        Optional<ArgumentType> argumentType = argumentTypesResolver.getArgumentType(param);
+        ArgumentType argumentType = argumentTypesResolver.getArgumentType(param);
         Optional<ParameterType> parameterType = paramTypesResolver.getParameterType(param);
 
-        if (argumentType.isEmpty() || parameterType.isEmpty()) {
+        if (parameterType.isEmpty()) {
             return Optional.empty();
         }
 
@@ -119,7 +119,7 @@ public final class EndpointDefinitions {
 
         return Optional.of(ImmutableArgumentDefinition.builder()
                 .argName(ImmutableArgumentName.of(param.getSimpleName().toString()))
-                .argType(argumentType.get())
+                .argType(argumentType)
                 .paramType(parameterType.get())
                 .build());
     }

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
@@ -28,6 +28,7 @@ import com.google.testing.compile.JavaFileObjects;
 import com.palantir.conjure.java.undertow.processor.sample.CookieParams;
 import com.palantir.conjure.java.undertow.processor.sample.DefaultDecoderService;
 import com.palantir.conjure.java.undertow.processor.sample.MultipleBodyInterface;
+import com.palantir.conjure.java.undertow.processor.sample.ParameterNotAnnotated;
 import com.palantir.conjure.java.undertow.processor.sample.PrimitiveBodyParam;
 import com.palantir.conjure.java.undertow.processor.sample.PrimitiveQueryParams;
 import com.palantir.conjure.java.undertow.processor.sample.PrivateMethodAnnotatedResource;
@@ -98,6 +99,12 @@ public class ConjureUndertowAnnotationProcessorTest {
     public void testStaticAnnotatedMethod() {
         assertThat(compileTestClass(TEST_CLASSES_BASE_DIR, StaticMethodAnnotatedResource.class))
                 .hadErrorContaining("The '@Handle' annotation does not support static methods");
+    }
+
+    @Test
+    public void testBodyIsNotAnnotated() {
+        assertThat(compileTestClass(TEST_CLASSES_BASE_DIR, ParameterNotAnnotated.class))
+                .hadErrorContaining("At least one annotation should be present");
     }
 
     private void assertTestFileCompileAndMatches(Path basePath, Class<?> clazz) {

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/ParameterNotAnnotated.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/ParameterNotAnnotated.java
@@ -1,0 +1,27 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.palantir.conjure.java.undertow.annotations.Handle;
+import com.palantir.conjure.java.undertow.annotations.HttpMethod;
+import java.util.List;
+
+public interface ParameterNotAnnotated {
+
+    @Handle(method = HttpMethod.POST, path = "/oops")
+    void parameterMissingAnnotation(List<String> body);
+}


### PR DESCRIPTION
Also removes `Optional` return type from implementation
methods which always return a present value.

==COMMIT_MSG==
Test coverage for missing annotations
==COMMIT_MSG==
