### PR TITLE
Support exclusion of empty collections using `experimentalExcludeEmptyCollections`

### DIFF
--- a/changelog/@unreleased/pr-1670.v2.yml
+++ b/changelog/@unreleased/pr-1670.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Support exclusion of empty collections using `experimentalExcludeEmptyCollections`
+  links:
+  - https://github.com/palantir/conjure-java/pull/1670

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasOptionalDoubleAliasedBinaryResult.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasOptionalDoubleAliasedBinaryResult.java
@@ -9,6 +9,8 @@ import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class AliasOptionalDoubleAliasedBinaryResult {
+    private static final AliasOptionalDoubleAliasedBinaryResult EMPTY = new AliasOptionalDoubleAliasedBinaryResult();
+
     private final Optional<DoubleAliasedBinaryResult> value;
 
     private AliasOptionalDoubleAliasedBinaryResult(@Nonnull Optional<DoubleAliasedBinaryResult> value) {
@@ -44,5 +46,9 @@ public final class AliasOptionalDoubleAliasedBinaryResult {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static AliasOptionalDoubleAliasedBinaryResult of(@Nonnull Optional<DoubleAliasedBinaryResult> value) {
         return new AliasOptionalDoubleAliasedBinaryResult(value);
+    }
+
+    public static AliasOptionalDoubleAliasedBinaryResult empty() {
+        return EMPTY;
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestAliasList.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestAliasList.java
@@ -9,21 +9,21 @@ import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
-public final class ListAlias {
-    private static final ListAlias EMPTY = new ListAlias();
+public final class CollectionsTestAliasList {
+    private static final CollectionsTestAliasList EMPTY = new CollectionsTestAliasList();
 
-    private final List<String> value;
+    private final List<Integer> value;
 
-    private ListAlias(@Nonnull List<String> value) {
+    private CollectionsTestAliasList(@Nonnull List<Integer> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
-    private ListAlias() {
+    private CollectionsTestAliasList() {
         this(Collections.emptyList());
     }
 
     @JsonValue
-    public List<String> get() {
+    public List<Integer> get() {
         return value;
     }
 
@@ -34,7 +34,9 @@ public final class ListAlias {
 
     @Override
     public boolean equals(Object other) {
-        return this == other || (other instanceof ListAlias && this.value.equals(((ListAlias) other).value));
+        return this == other
+                || (other instanceof CollectionsTestAliasList
+                        && this.value.equals(((CollectionsTestAliasList) other).value));
     }
 
     @Override
@@ -43,11 +45,11 @@ public final class ListAlias {
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static ListAlias of(@Nonnull List<String> value) {
-        return new ListAlias(value);
+    public static CollectionsTestAliasList of(@Nonnull List<Integer> value) {
+        return new CollectionsTestAliasList(value);
     }
 
-    public static ListAlias empty() {
+    public static CollectionsTestAliasList empty() {
         return EMPTY;
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestAliasMap.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestAliasMap.java
@@ -4,26 +4,26 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.Collections;
-import java.util.List;
+import java.util.Map;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
-public final class ListAlias {
-    private static final ListAlias EMPTY = new ListAlias();
+public final class CollectionsTestAliasMap {
+    private static final CollectionsTestAliasMap EMPTY = new CollectionsTestAliasMap();
 
-    private final List<String> value;
+    private final Map<String, Integer> value;
 
-    private ListAlias(@Nonnull List<String> value) {
+    private CollectionsTestAliasMap(@Nonnull Map<String, Integer> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
-    private ListAlias() {
-        this(Collections.emptyList());
+    private CollectionsTestAliasMap() {
+        this(Collections.emptyMap());
     }
 
     @JsonValue
-    public List<String> get() {
+    public Map<String, Integer> get() {
         return value;
     }
 
@@ -34,7 +34,9 @@ public final class ListAlias {
 
     @Override
     public boolean equals(Object other) {
-        return this == other || (other instanceof ListAlias && this.value.equals(((ListAlias) other).value));
+        return this == other
+                || (other instanceof CollectionsTestAliasMap
+                        && this.value.equals(((CollectionsTestAliasMap) other).value));
     }
 
     @Override
@@ -43,11 +45,11 @@ public final class ListAlias {
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static ListAlias of(@Nonnull List<String> value) {
-        return new ListAlias(value);
+    public static CollectionsTestAliasMap of(@Nonnull Map<String, Integer> value) {
+        return new CollectionsTestAliasMap(value);
     }
 
-    public static ListAlias empty() {
+    public static CollectionsTestAliasMap empty() {
         return EMPTY;
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestAliasSet.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestAliasSet.java
@@ -4,26 +4,26 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.Collections;
-import java.util.List;
+import java.util.Set;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
-public final class ListAlias {
-    private static final ListAlias EMPTY = new ListAlias();
+public final class CollectionsTestAliasSet {
+    private static final CollectionsTestAliasSet EMPTY = new CollectionsTestAliasSet();
 
-    private final List<String> value;
+    private final Set<Integer> value;
 
-    private ListAlias(@Nonnull List<String> value) {
+    private CollectionsTestAliasSet(@Nonnull Set<Integer> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
 
-    private ListAlias() {
-        this(Collections.emptyList());
+    private CollectionsTestAliasSet() {
+        this(Collections.emptySet());
     }
 
     @JsonValue
-    public List<String> get() {
+    public Set<Integer> get() {
         return value;
     }
 
@@ -34,7 +34,9 @@ public final class ListAlias {
 
     @Override
     public boolean equals(Object other) {
-        return this == other || (other instanceof ListAlias && this.value.equals(((ListAlias) other).value));
+        return this == other
+                || (other instanceof CollectionsTestAliasSet
+                        && this.value.equals(((CollectionsTestAliasSet) other).value));
     }
 
     @Override
@@ -43,11 +45,11 @@ public final class ListAlias {
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static ListAlias of(@Nonnull List<String> value) {
-        return new ListAlias(value);
+    public static CollectionsTestAliasSet of(@Nonnull Set<Integer> value) {
+        return new CollectionsTestAliasSet(value);
     }
 
-    public static ListAlias empty() {
+    public static CollectionsTestAliasSet empty() {
         return EMPTY;
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestObject.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestObject.java
@@ -1,0 +1,315 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.palantir.conjure.java.lib.internal.ConjureCollections;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.Generated;
+import javax.annotation.Nonnull;
+
+@JsonDeserialize(builder = CollectionsTestObject.Builder.class)
+@Generated("com.palantir.conjure.java.types.BeanGenerator")
+public final class CollectionsTestObject {
+    private final List<String> items;
+
+    private final Map<String, Integer> itemsMap;
+
+    private final Optional<String> optionalItem;
+
+    private final Set<String> itemsSet;
+
+    private final CollectionsTestAliasList alist;
+
+    private final CollectionsTestAliasSet aset;
+
+    private final CollectionsTestAliasMap amap;
+
+    private int memoizedHashCode;
+
+    private CollectionsTestObject(
+            List<String> items,
+            Map<String, Integer> itemsMap,
+            Optional<String> optionalItem,
+            Set<String> itemsSet,
+            CollectionsTestAliasList alist,
+            CollectionsTestAliasSet aset,
+            CollectionsTestAliasMap amap) {
+        validateFields(items, itemsMap, optionalItem, itemsSet, alist, aset, amap);
+        this.items = Collections.unmodifiableList(items);
+        this.itemsMap = Collections.unmodifiableMap(itemsMap);
+        this.optionalItem = optionalItem;
+        this.itemsSet = Collections.unmodifiableSet(itemsSet);
+        this.alist = alist;
+        this.aset = aset;
+        this.amap = amap;
+    }
+
+    @JsonProperty("items")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<String> getItems() {
+        return this.items;
+    }
+
+    @JsonProperty("itemsMap")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, Integer> getItemsMap() {
+        return this.itemsMap;
+    }
+
+    @JsonProperty("optionalItem")
+    public Optional<String> getOptionalItem() {
+        return this.optionalItem;
+    }
+
+    @JsonProperty("itemsSet")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Set<String> getItemsSet() {
+        return this.itemsSet;
+    }
+
+    @JsonProperty("alist")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public CollectionsTestAliasList getAlist() {
+        return this.alist;
+    }
+
+    @JsonProperty("aset")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public CollectionsTestAliasSet getAset() {
+        return this.aset;
+    }
+
+    @JsonProperty("amap")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public CollectionsTestAliasMap getAmap() {
+        return this.amap;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other || (other instanceof CollectionsTestObject && equalTo((CollectionsTestObject) other));
+    }
+
+    private boolean equalTo(CollectionsTestObject other) {
+        return this.items.equals(other.items)
+                && this.itemsMap.equals(other.itemsMap)
+                && this.optionalItem.equals(other.optionalItem)
+                && this.itemsSet.equals(other.itemsSet)
+                && this.alist.equals(other.alist)
+                && this.aset.equals(other.aset)
+                && this.amap.equals(other.amap);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = memoizedHashCode;
+        if (result == 0) {
+            int hash = 1;
+            hash = 31 * hash + this.items.hashCode();
+            hash = 31 * hash + this.itemsMap.hashCode();
+            hash = 31 * hash + this.optionalItem.hashCode();
+            hash = 31 * hash + this.itemsSet.hashCode();
+            hash = 31 * hash + this.alist.hashCode();
+            hash = 31 * hash + this.aset.hashCode();
+            hash = 31 * hash + this.amap.hashCode();
+            result = hash;
+            memoizedHashCode = result;
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "CollectionsTestObject{items: " + items + ", itemsMap: " + itemsMap + ", optionalItem: " + optionalItem
+                + ", itemsSet: " + itemsSet + ", alist: " + alist + ", aset: " + aset + ", amap: " + amap + '}';
+    }
+
+    private static void validateFields(
+            List<String> items,
+            Map<String, Integer> itemsMap,
+            Optional<String> optionalItem,
+            Set<String> itemsSet,
+            CollectionsTestAliasList alist,
+            CollectionsTestAliasSet aset,
+            CollectionsTestAliasMap amap) {
+        List<String> missingFields = null;
+        missingFields = addFieldIfMissing(missingFields, items, "items");
+        missingFields = addFieldIfMissing(missingFields, itemsMap, "itemsMap");
+        missingFields = addFieldIfMissing(missingFields, optionalItem, "optionalItem");
+        missingFields = addFieldIfMissing(missingFields, itemsSet, "itemsSet");
+        missingFields = addFieldIfMissing(missingFields, alist, "alist");
+        missingFields = addFieldIfMissing(missingFields, aset, "aset");
+        missingFields = addFieldIfMissing(missingFields, amap, "amap");
+        if (missingFields != null) {
+            throw new SafeIllegalArgumentException(
+                    "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
+        }
+    }
+
+    private static List<String> addFieldIfMissing(List<String> prev, Object fieldValue, String fieldName) {
+        List<String> missingFields = prev;
+        if (fieldValue == null) {
+            if (missingFields == null) {
+                missingFields = new ArrayList<>(7);
+            }
+            missingFields.add(fieldName);
+        }
+        return missingFields;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder {
+        boolean _buildInvoked;
+
+        private List<String> items = new ArrayList<>();
+
+        private Map<String, Integer> itemsMap = new LinkedHashMap<>();
+
+        private Optional<String> optionalItem = Optional.empty();
+
+        private Set<String> itemsSet = new LinkedHashSet<>();
+
+        private CollectionsTestAliasList alist = CollectionsTestAliasList.empty();
+
+        private CollectionsTestAliasSet aset = CollectionsTestAliasSet.empty();
+
+        private CollectionsTestAliasMap amap = CollectionsTestAliasMap.empty();
+
+        private Builder() {}
+
+        public Builder from(CollectionsTestObject other) {
+            checkNotBuilt();
+            items(other.getItems());
+            itemsMap(other.getItemsMap());
+            optionalItem(other.getOptionalItem());
+            itemsSet(other.getItemsSet());
+            alist(other.getAlist());
+            aset(other.getAset());
+            amap(other.getAmap());
+            return this;
+        }
+
+        @JsonSetter(value = "items", nulls = Nulls.SKIP)
+        public Builder items(@Nonnull Iterable<String> items) {
+            checkNotBuilt();
+            this.items.clear();
+            ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            return this;
+        }
+
+        public Builder addAllItems(@Nonnull Iterable<String> items) {
+            checkNotBuilt();
+            ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            return this;
+        }
+
+        public Builder items(String items) {
+            checkNotBuilt();
+            this.items.add(items);
+            return this;
+        }
+
+        @JsonSetter(value = "itemsMap", nulls = Nulls.SKIP)
+        public Builder itemsMap(@Nonnull Map<String, Integer> itemsMap) {
+            checkNotBuilt();
+            this.itemsMap.clear();
+            this.itemsMap.putAll(Preconditions.checkNotNull(itemsMap, "itemsMap cannot be null"));
+            return this;
+        }
+
+        public Builder putAllItemsMap(@Nonnull Map<String, Integer> itemsMap) {
+            checkNotBuilt();
+            this.itemsMap.putAll(Preconditions.checkNotNull(itemsMap, "itemsMap cannot be null"));
+            return this;
+        }
+
+        public Builder itemsMap(String key, int value) {
+            checkNotBuilt();
+            this.itemsMap.put(key, value);
+            return this;
+        }
+
+        @JsonSetter(value = "optionalItem", nulls = Nulls.SKIP)
+        public Builder optionalItem(@Nonnull Optional<String> optionalItem) {
+            checkNotBuilt();
+            this.optionalItem = Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null");
+            return this;
+        }
+
+        public Builder optionalItem(@Nonnull String optionalItem) {
+            checkNotBuilt();
+            this.optionalItem = Optional.of(Preconditions.checkNotNull(optionalItem, "optionalItem cannot be null"));
+            return this;
+        }
+
+        @JsonSetter(value = "itemsSet", nulls = Nulls.SKIP)
+        public Builder itemsSet(@Nonnull Iterable<String> itemsSet) {
+            checkNotBuilt();
+            this.itemsSet.clear();
+            ConjureCollections.addAll(this.itemsSet, Preconditions.checkNotNull(itemsSet, "itemsSet cannot be null"));
+            return this;
+        }
+
+        public Builder addAllItemsSet(@Nonnull Iterable<String> itemsSet) {
+            checkNotBuilt();
+            ConjureCollections.addAll(this.itemsSet, Preconditions.checkNotNull(itemsSet, "itemsSet cannot be null"));
+            return this;
+        }
+
+        public Builder itemsSet(String itemsSet) {
+            checkNotBuilt();
+            this.itemsSet.add(itemsSet);
+            return this;
+        }
+
+        @JsonSetter(value = "alist", nulls = Nulls.AS_EMPTY)
+        public Builder alist(@Nonnull CollectionsTestAliasList alist) {
+            checkNotBuilt();
+            this.alist = Preconditions.checkNotNull(alist, "alist cannot be null");
+            return this;
+        }
+
+        @JsonSetter(value = "aset", nulls = Nulls.AS_EMPTY)
+        public Builder aset(@Nonnull CollectionsTestAliasSet aset) {
+            checkNotBuilt();
+            this.aset = Preconditions.checkNotNull(aset, "aset cannot be null");
+            return this;
+        }
+
+        @JsonSetter(value = "amap", nulls = Nulls.AS_EMPTY)
+        public Builder amap(@Nonnull CollectionsTestAliasMap amap) {
+            checkNotBuilt();
+            this.amap = Preconditions.checkNotNull(amap, "amap cannot be null");
+            return this;
+        }
+
+        public CollectionsTestObject build() {
+            checkNotBuilt();
+            this._buildInvoked = true;
+            return new CollectionsTestObject(items, itemsMap, optionalItem, itemsSet, alist, aset, amap);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapAliasExample.java
@@ -10,6 +10,8 @@ import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class MapAliasExample {
+    private static final MapAliasExample EMPTY = new MapAliasExample();
+
     private final Map<String, Object> value;
 
     private MapAliasExample(@Nonnull Map<String, Object> value) {
@@ -44,5 +46,9 @@ public final class MapAliasExample {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static MapAliasExample of(@Nonnull Map<String, Object> value) {
         return new MapAliasExample(value);
+    }
+
+    public static MapAliasExample empty() {
+        return EMPTY;
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAlias.java
@@ -9,6 +9,8 @@ import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class OptionalAlias {
+    private static final OptionalAlias EMPTY = new OptionalAlias();
+
     private final Optional<String> value;
 
     private OptionalAlias(@Nonnull Optional<String> value) {
@@ -42,5 +44,9 @@ public final class OptionalAlias {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static OptionalAlias of(@Nonnull Optional<String> value) {
         return new OptionalAlias(value);
+    }
+
+    public static OptionalAlias empty() {
+        return EMPTY;
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAliasExample.java
@@ -80,7 +80,7 @@ public final class OptionalAliasExample {
     public static final class Builder {
         boolean _buildInvoked;
 
-        private OptionalAlias optionalAlias;
+        private OptionalAlias optionalAlias = OptionalAlias.empty();
 
         private Builder() {}
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalListAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalListAliasExample.java
@@ -10,6 +10,8 @@ import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class OptionalListAliasExample {
+    private static final OptionalListAliasExample EMPTY = new OptionalListAliasExample();
+
     private final Optional<List<String>> value;
 
     private OptionalListAliasExample(@Nonnull Optional<List<String>> value) {
@@ -45,5 +47,9 @@ public final class OptionalListAliasExample {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static OptionalListAliasExample of(@Nonnull Optional<List<String>> value) {
         return new OptionalListAliasExample(value);
+    }
+
+    public static OptionalListAliasExample empty() {
+        return EMPTY;
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalMapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalMapAliasExample.java
@@ -10,6 +10,8 @@ import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class OptionalMapAliasExample {
+    private static final OptionalMapAliasExample EMPTY = new OptionalMapAliasExample();
+
     private final Optional<Map<String, Object>> value;
 
     private OptionalMapAliasExample(@Nonnull Optional<Map<String, Object>> value) {
@@ -45,5 +47,9 @@ public final class OptionalMapAliasExample {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static OptionalMapAliasExample of(@Nonnull Optional<Map<String, Object>> value) {
         return new OptionalMapAliasExample(value);
+    }
+
+    public static OptionalMapAliasExample empty() {
+        return EMPTY;
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalSetAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalSetAliasExample.java
@@ -10,6 +10,8 @@ import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class OptionalSetAliasExample {
+    private static final OptionalSetAliasExample EMPTY = new OptionalSetAliasExample();
+
     private final Optional<Set<String>> value;
 
     private OptionalSetAliasExample(@Nonnull Optional<Set<String>> value) {
@@ -45,5 +47,9 @@ public final class OptionalSetAliasExample {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static OptionalSetAliasExample of(@Nonnull Optional<Set<String>> value) {
         return new OptionalSetAliasExample(value);
+    }
+
+    public static OptionalSetAliasExample empty() {
+        return EMPTY;
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
@@ -381,19 +381,19 @@ public final class PrimitiveOptionalsExample {
 
         private Optional<StringAliasOne> aliasOne = Optional.empty();
 
-        private StringAliasTwo aliasTwo;
+        private StringAliasTwo aliasTwo = StringAliasTwo.empty();
 
         private Optional<ListAlias> aliasList = Optional.empty();
 
         private Optional<MapAliasExample> aliasMap = Optional.empty();
 
-        private OptionalAlias aliasOptional;
+        private OptionalAlias aliasOptional = OptionalAlias.empty();
 
-        private OptionalMapAliasExample aliasOptionalMap;
+        private OptionalMapAliasExample aliasOptionalMap = OptionalMapAliasExample.empty();
 
-        private OptionalListAliasExample aliasOptionalList;
+        private OptionalListAliasExample aliasOptionalList = OptionalListAliasExample.empty();
 
-        private OptionalSetAliasExample aliasOptionalSet;
+        private OptionalSetAliasExample aliasOptionalSet = OptionalSetAliasExample.empty();
 
         private Builder() {}
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetAlias.java
@@ -10,6 +10,8 @@ import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class SetAlias {
+    private static final SetAlias EMPTY = new SetAlias();
+
     private final Set<String> value;
 
     private SetAlias(@Nonnull Set<String> value) {
@@ -43,5 +45,9 @@ public final class SetAlias {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static SetAlias of(@Nonnull Set<String> value) {
         return new SetAlias(value);
+    }
+
+    public static SetAlias empty() {
+        return EMPTY;
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasTwo.java
@@ -9,6 +9,8 @@ import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class StringAliasTwo {
+    private static final StringAliasTwo EMPTY = new StringAliasTwo();
+
     private final Optional<StringAliasOne> value;
 
     private StringAliasTwo(@Nonnull Optional<StringAliasOne> value) {
@@ -42,5 +44,9 @@ public final class StringAliasTwo {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static StringAliasTwo of(@Nonnull Optional<StringAliasOne> value) {
         return new StringAliasTwo(value);
+    }
+
+    public static StringAliasTwo empty() {
+        return EMPTY;
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListAlias.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListAlias.java
@@ -10,6 +10,8 @@ import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class ListAlias {
+    private static final ListAlias EMPTY = new ListAlias();
+
     private final List<String> value;
 
     private ListAlias(@Nonnull List<String> value) {
@@ -43,5 +45,9 @@ public final class ListAlias {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static ListAlias of(@Nonnull List<String> value) {
         return new ListAlias(value);
+    }
+
+    public static ListAlias empty() {
+        return EMPTY;
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapAliasExample.java
@@ -10,6 +10,8 @@ import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class MapAliasExample {
+    private static final MapAliasExample EMPTY = new MapAliasExample();
+
     private final Map<String, Object> value;
 
     private MapAliasExample(@Nonnull Map<String, Object> value) {
@@ -44,5 +46,9 @@ public final class MapAliasExample {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static MapAliasExample of(@Nonnull Map<String, Object> value) {
         return new MapAliasExample(value);
+    }
+
+    public static MapAliasExample empty() {
+        return EMPTY;
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAlias.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAlias.java
@@ -9,6 +9,8 @@ import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class OptionalAlias {
+    private static final OptionalAlias EMPTY = new OptionalAlias();
+
     private final Optional<String> value;
 
     private OptionalAlias(@Nonnull Optional<String> value) {
@@ -42,5 +44,9 @@ public final class OptionalAlias {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static OptionalAlias of(@Nonnull Optional<String> value) {
         return new OptionalAlias(value);
+    }
+
+    public static OptionalAlias empty() {
+        return EMPTY;
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAliasExample.java
@@ -82,7 +82,7 @@ public final class OptionalAliasExample {
     public static final class Builder {
         boolean _buildInvoked;
 
-        private OptionalAlias optionalAlias;
+        private OptionalAlias optionalAlias = OptionalAlias.empty();
 
         private Builder() {}
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalListAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalListAliasExample.java
@@ -10,6 +10,8 @@ import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class OptionalListAliasExample {
+    private static final OptionalListAliasExample EMPTY = new OptionalListAliasExample();
+
     private final Optional<List<String>> value;
 
     private OptionalListAliasExample(@Nonnull Optional<List<String>> value) {
@@ -45,5 +47,9 @@ public final class OptionalListAliasExample {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static OptionalListAliasExample of(@Nonnull Optional<List<String>> value) {
         return new OptionalListAliasExample(value);
+    }
+
+    public static OptionalListAliasExample empty() {
+        return EMPTY;
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalMapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalMapAliasExample.java
@@ -10,6 +10,8 @@ import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class OptionalMapAliasExample {
+    private static final OptionalMapAliasExample EMPTY = new OptionalMapAliasExample();
+
     private final Optional<Map<String, Object>> value;
 
     private OptionalMapAliasExample(@Nonnull Optional<Map<String, Object>> value) {
@@ -45,5 +47,9 @@ public final class OptionalMapAliasExample {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static OptionalMapAliasExample of(@Nonnull Optional<Map<String, Object>> value) {
         return new OptionalMapAliasExample(value);
+    }
+
+    public static OptionalMapAliasExample empty() {
+        return EMPTY;
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalSetAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalSetAliasExample.java
@@ -10,6 +10,8 @@ import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class OptionalSetAliasExample {
+    private static final OptionalSetAliasExample EMPTY = new OptionalSetAliasExample();
+
     private final Optional<Set<String>> value;
 
     private OptionalSetAliasExample(@Nonnull Optional<Set<String>> value) {
@@ -45,5 +47,9 @@ public final class OptionalSetAliasExample {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static OptionalSetAliasExample of(@Nonnull Optional<Set<String>> value) {
         return new OptionalSetAliasExample(value);
+    }
+
+    public static OptionalSetAliasExample empty() {
+        return EMPTY;
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
@@ -383,19 +383,19 @@ public final class PrimitiveOptionalsExample {
 
         private Optional<StringAliasOne> aliasOne = Optional.empty();
 
-        private StringAliasTwo aliasTwo;
+        private StringAliasTwo aliasTwo = StringAliasTwo.empty();
 
         private Optional<ListAlias> aliasList = Optional.empty();
 
         private Optional<MapAliasExample> aliasMap = Optional.empty();
 
-        private OptionalAlias aliasOptional;
+        private OptionalAlias aliasOptional = OptionalAlias.empty();
 
-        private OptionalMapAliasExample aliasOptionalMap;
+        private OptionalMapAliasExample aliasOptionalMap = OptionalMapAliasExample.empty();
 
-        private OptionalListAliasExample aliasOptionalList;
+        private OptionalListAliasExample aliasOptionalList = OptionalListAliasExample.empty();
 
-        private OptionalSetAliasExample aliasOptionalSet;
+        private OptionalSetAliasExample aliasOptionalSet = OptionalSetAliasExample.empty();
 
         private Builder() {}
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetAlias.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetAlias.java
@@ -10,6 +10,8 @@ import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class SetAlias {
+    private static final SetAlias EMPTY = new SetAlias();
+
     private final Set<String> value;
 
     private SetAlias(@Nonnull Set<String> value) {
@@ -43,5 +45,9 @@ public final class SetAlias {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static SetAlias of(@Nonnull Set<String> value) {
         return new SetAlias(value);
+    }
+
+    public static SetAlias empty() {
+        return EMPTY;
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasTwo.java
@@ -9,6 +9,8 @@ import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class StringAliasTwo {
+    private static final StringAliasTwo EMPTY = new StringAliasTwo();
+
     private final Optional<StringAliasOne> value;
 
     private StringAliasTwo(@Nonnull Optional<StringAliasOne> value) {
@@ -42,5 +44,9 @@ public final class StringAliasTwo {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static StringAliasTwo of(@Nonnull Optional<StringAliasOne> value) {
         return new StringAliasTwo(value);
+    }
+
+    public static StringAliasTwo empty() {
+        return EMPTY;
     }
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
@@ -120,6 +120,14 @@ public interface Options {
     }
 
     /**
+     * Generated objects exclude fields with empty collection (list, set, and map) values.
+     */
+    @Value.Default
+    default boolean excludeEmptyCollections() {
+        return false;
+    }
+
+    /**
      * Instructs the object generator to generate union visitors that expose the values of unknowns in addition to their
      * types.
      */

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -121,14 +121,7 @@ public final class AliasGenerator {
         // Generate a default constructor so that Jackson can construct a default instance when coercing from null
         typeDef.getAlias().accept(new DefaultConstructorVisitor(aliasTypeName)).ifPresent(ctor -> {
             spec.addMethod(ctor);
-            spec.addField(FieldSpec.builder(thisClass, "EMPTY", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
-                    .initializer(CodeBlock.of("new $T()", thisClass))
-                    .build());
-            spec.addMethod(MethodSpec.methodBuilder("empty")
-                    .returns(thisClass)
-                    .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                    .addStatement("return $N", "EMPTY")
-                    .build());
+            addEmptyMethod(spec, thisClass);
         });
 
         if (isAliasOfDouble(typeDef)) {
@@ -205,6 +198,17 @@ public final class AliasGenerator {
                 .skipJavaLangImports(true)
                 .indent("    ")
                 .build();
+    }
+
+    private static void addEmptyMethod(TypeSpec.Builder spec, TypeName thisClass) {
+        spec.addField(FieldSpec.builder(thisClass, "EMPTY", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+                .initializer(CodeBlock.of("new $T()", thisClass))
+                .build());
+        spec.addMethod(MethodSpec.methodBuilder("empty")
+                .returns(thisClass)
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .addStatement("return $N", "EMPTY")
+                .build());
     }
 
     private static boolean isAliasOfDouble(AliasDefinition typeDef) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -37,6 +37,7 @@ import com.palantir.conjure.visitor.TypeVisitor;
 import com.palantir.logsafe.Preconditions;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
@@ -118,7 +119,17 @@ public final class AliasGenerator {
                 .build());
 
         // Generate a default constructor so that Jackson can construct a default instance when coercing from null
-        typeDef.getAlias().accept(new DefaultConstructorVisitor(aliasTypeName)).ifPresent(spec::addMethod);
+        typeDef.getAlias().accept(new DefaultConstructorVisitor(aliasTypeName)).ifPresent(ctor -> {
+            spec.addMethod(ctor);
+            spec.addField(FieldSpec.builder(thisClass, "EMPTY", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+                    .initializer(CodeBlock.of("new $T()", thisClass))
+                    .build());
+            spec.addMethod(MethodSpec.methodBuilder("empty")
+                    .returns(thisClass)
+                    .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                    .addStatement("return $N", "EMPTY")
+                    .build());
+        });
 
         if (isAliasOfDouble(typeDef)) {
             CodeBlock longCastCodeBlock = CodeBlock.builder()

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -109,7 +109,7 @@ public final class BeanBuilderGenerator {
             ObjectDefinition typeDef,
             Map<com.palantir.conjure.spec.TypeName, TypeDefinition> typesMap,
             Optional<ClassName> builderInterfaceClass) {
-        Collection<EnrichedField> enrichedFields = enrichFields(typeDef.getFields(), typesMap);
+        Collection<EnrichedField> enrichedFields = enrichFields(typeDef.getFields());
         Collection<FieldSpec> poetFields = EnrichedField.toPoetSpecs(enrichedFields);
         boolean override = builderInterfaceClass.isPresent();
         TypeSpec.Builder builder = TypeSpec.classBuilder(
@@ -215,11 +215,8 @@ public final class BeanBuilderGenerator {
         return "_" + JavaNameSanitizer.sanitize(field.conjureDef().getFieldName()) + "Initialized";
     }
 
-    private Collection<EnrichedField> enrichFields(
-            List<FieldDefinition> fields, Map<com.palantir.conjure.spec.TypeName, TypeDefinition> typesMap) {
-        return fields.stream()
-                .map(e -> createField(e.getFieldName(), e, typesMap))
-                .collect(Collectors.toList());
+    private Collection<EnrichedField> enrichFields(List<FieldDefinition> fields) {
+        return fields.stream().map(e -> createField(e.getFieldName(), e)).collect(Collectors.toList());
     }
 
     private static MethodSpec createConstructor() {
@@ -243,10 +240,7 @@ public final class BeanBuilderGenerator {
                 .build();
     }
 
-    private EnrichedField createField(
-            FieldName fieldName,
-            FieldDefinition field,
-            Map<com.palantir.conjure.spec.TypeName, TypeDefinition> typesMap) {
+    private EnrichedField createField(FieldName fieldName, FieldDefinition field) {
         FieldSpec.Builder spec = FieldSpec.builder(
                 typeMapper.getClassName(field.getType()), JavaNameSanitizer.sanitize(fieldName), Modifier.PRIVATE);
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -34,6 +34,7 @@ import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.java.util.Packages;
 import com.palantir.conjure.java.util.TypeFunctions;
 import com.palantir.conjure.java.visitor.DefaultTypeVisitor;
+import com.palantir.conjure.java.visitor.MoreVisitors;
 import com.palantir.conjure.spec.FieldDefinition;
 import com.palantir.conjure.spec.FieldName;
 import com.palantir.conjure.spec.ListType;
@@ -456,6 +457,17 @@ public final class BeanGenerator {
                             .accept(TypeVisitor.IS_OPTIONAL)) {
                 // Aliases are special, as usual. Inclusion cannot take advantage of the optional delegate types,
                 // however the default (hidden no-arg constructor) can be leveraged using NON_EMPTY.
+                getterBuilder.addAnnotation(AnnotationSpec.builder(JsonInclude.class)
+                        .addMember("value", "$T.NON_EMPTY", JsonInclude.Include.class)
+                        .build());
+            }
+        }
+
+        if (featureFlags.excludeEmptyCollections()) {
+            Type dealiased = conjureDefType.accept(TypeVisitor.IS_REFERENCE)
+                    ? TypeFunctions.toConjureTypeWithoutAliases(conjureDefType, typesMap)
+                    : conjureDefType;
+            if (dealiased.accept(MoreVisitors.IS_COLLECTION)) {
                 getterBuilder.addAnnotation(AnnotationSpec.builder(JsonInclude.class)
                         .addMember("value", "$T.NON_EMPTY", JsonInclude.Include.class)
                         .build());

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/visitor/MoreVisitors.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/visitor/MoreVisitors.java
@@ -31,6 +31,7 @@ public final class MoreVisitors {
     public static final IsExternalType IS_EXTERNAL = new IsExternalType();
     public static final ExternalType EXTERNAL = new ExternalType();
     public static final IsInternalReference IS_INTERNAL_REFERENCE = new IsInternalReference();
+    public static final IsCollection IS_COLLECTION = new IsCollection();
 
     private static final class IsExternalType extends IsTypeVisitor {
         @Override
@@ -93,6 +94,23 @@ public final class MoreVisitors {
         @Override
         public Boolean visitUnknown(String _unknownType) {
             return false;
+        }
+    }
+
+    private static final class IsCollection extends IsTypeVisitor {
+        @Override
+        public Boolean visitList(ListType _value) {
+            return true;
+        }
+
+        @Override
+        public Boolean visitSet(SetType _value) {
+            return true;
+        }
+
+        @Override
+        public Boolean visitMap(MapType _value) {
+            return true;
         }
     }
 }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
@@ -102,6 +102,19 @@ public final class ObjectGeneratorTests {
     }
 
     @Test
+    public void testObjectGenerator_excludeEmptyCollections() throws IOException {
+        ConjureDefinition def =
+                Conjure.parse(ImmutableList.of(new File("src/test/resources/exclude-empty-collections.yml")));
+        List<Path> files = new GenerationCoordinator(
+                        MoreExecutors.directExecutor(),
+                        ImmutableSet.of(new ObjectGenerator(
+                                Options.builder().excludeEmptyCollections(true).build())))
+                .emit(def, tempDir);
+
+        assertThatFilesAreTheSame(files, REFERENCE_FILES_FOLDER);
+    }
+
+    @Test
     public void testConjureImports() throws IOException {
         ConjureDefinition conjure = Conjure.parse(ImmutableList.of(
                 new File("src/test/resources/example-conjure-imports.yml"),

--- a/conjure-java-core/src/test/resources/exclude-empty-collections.yml
+++ b/conjure-java-core/src/test/resources/exclude-empty-collections.yml
@@ -1,0 +1,19 @@
+types:
+  definitions:
+    default-package: com.palantir.product
+    objects:
+      CollectionsTestAliasList:
+        alias: list<integer>
+      CollectionsTestAliasSet:
+        alias: set<integer>
+      CollectionsTestAliasMap:
+        alias: map<string, integer>
+      CollectionsTestObject:
+        fields:
+          items: list<string>
+          itemsMap: map<string, integer>
+          optionalItem: optional<string>
+          itemsSet: set<string>
+          alist: CollectionsTestAliasList
+          aset: CollectionsTestAliasSet
+          amap: CollectionsTestAliasMap

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -196,6 +196,14 @@ public final class ConjureJavaCli implements Runnable {
         private boolean excludeEmptyOptionals;
 
         @CommandLine.Option(
+                names = "--experimentalExcludeEmptyCollections",
+                defaultValue = "false",
+                description = "Objects exclude empty collections in serialization based on the conjure spec. Note "
+                        + "that this should not be enabled on servers due to shortcomings in the "
+                        + "typescript implementation, and should only be used for clients with local codegen.")
+        private boolean excludeEmptyCollections;
+
+        @CommandLine.Option(
                 names = "--unionsWithUnknownValues",
                 defaultValue = "false",
                 description = "Union visitors expose the values of unknowns in addition to their types.")
@@ -267,6 +275,7 @@ public final class ConjureJavaCli implements Runnable {
                             .apiVersion(Optional.ofNullable(apiVersion))
                             .useStagedBuilders(useStagedBuilders)
                             .excludeEmptyOptionals(excludeEmptyOptionals)
+                            .excludeEmptyCollections(excludeEmptyCollections)
                             .unionsWithUnknownValues(unionsWithUnknownValues)
                             .build())
                     .build();


### PR DESCRIPTION
This matches empty optional exclusion, including discovery
and remediation of a bug:

Aliases may be excluded, however they were not handled correctly
in the other direction, where null values were handled correctly.
Now we initialize builder instances with a reference to an empty
instance of alias types. This includes a new `public static T empty()`
method on aliases which can handle defaults.

The current implementation only checks one level of alias indirection,
so alias-of-alias-of-optional/collection still won't do quite what we
want, but it's a start. Eventually we should consolidate this code.

### Staged Builders

Note that this change could impact staged builders which consider `alias<optional/collection>` a required field, however such a change would be an abi break. Staged builders are not impacted by this change.

Non-staged builders will no longer throw when `alias<optional/collection>` are not explicitly set, matching the behavior of an optional/collection field.

## After this PR
==COMMIT_MSG==
Support exclusion of empty collections using `experimentalExcludeEmptyCollections`
==COMMIT_MSG==

## Possible downsides?
Super duper dangerous if this is set on servers because our typescript clients do not fully implement conjure.

