### PR TITLE
Expose `AuthorizationExtractor.setRequestToken` for alternative sources

### DIFF
--- a/changelog/@unreleased/pr-1692.v2.yml
+++ b/changelog/@unreleased/pr-1692.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Expose `AuthorizationExtractor.setRequestToken` for alternative sources
+  links:
+  - https://github.com/palantir/conjure-java/pull/1692

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureAuthorizationExtractor.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureAuthorizationExtractor.java
@@ -83,13 +83,8 @@ final class ConjureAuthorizationExtractor implements AuthorizationExtractor {
         }
     }
 
-    /**
-     * Attempts to extract a {@link UnverifiedJsonWebToken JSON Web Token} from the {@link BearerToken} value, and
-     * populates the SLF4J {@link MDC} with user id, session id, and token id extracted from the JWT. This is
-     * best-effort and does not throw an exception in case any of these steps fail.
-     */
-    private static BearerToken setState(HttpServerExchange exchange, BearerToken token) {
-        Optional<UnverifiedJsonWebToken> parsedJwt = UnverifiedJsonWebToken.tryParse(token.getToken());
+    @Override
+    public void setRequestToken(HttpServerExchange exchange, Optional<UnverifiedJsonWebToken> parsedJwt) {
         exchange.putAttachment(Attachments.UNVERIFIED_JWT, parsedJwt);
         if (parsedJwt.isPresent()) {
             UnverifiedJsonWebToken jwt = parsedJwt.get();
@@ -97,10 +92,20 @@ final class ConjureAuthorizationExtractor implements AuthorizationExtractor {
             jwt.getUnverifiedSessionId().ifPresent(sessionIdSetter);
             jwt.getUnverifiedTokenId().ifPresent(tokenIdSetter);
         }
+    }
+
+    /**
+     * Attempts to extract a {@link UnverifiedJsonWebToken JSON Web Token} from the {@link BearerToken} value, and
+     * populates the SLF4J {@link MDC} with user id, session id, and token id extracted from the JWT. This is
+     * best-effort and does not throw an exception in case any of these steps fail.
+     */
+    private BearerToken setState(HttpServerExchange exchange, BearerToken token) {
+        Optional<UnverifiedJsonWebToken> parsedJwt = UnverifiedJsonWebToken.tryParse(token.getToken());
+        setRequestToken(exchange, parsedJwt);
         return token;
     }
 
-    private static AuthHeader setState(HttpServerExchange exchange, AuthHeader authHeader) {
+    private AuthHeader setState(HttpServerExchange exchange, AuthHeader authHeader) {
         setState(exchange, authHeader.getBearerToken());
         return authHeader;
     }

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/AuthorizationExtractor.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/AuthorizationExtractor.java
@@ -18,14 +18,33 @@ package com.palantir.conjure.java.undertow.lib;
 
 import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
+import com.palantir.tokens.auth.UnverifiedJsonWebToken;
 import io.undertow.server.HttpServerExchange;
+import java.util.Optional;
 
 /** Provides auth functionality for generated code. */
 public interface AuthorizationExtractor {
 
-    /** Parses an {@link AuthHeader} from the provided {@link HttpServerExchange}. */
+    /**
+     * Parses an {@link AuthHeader} from the provided {@link HttpServerExchange}.
+     * Implementations are responsible for calling {@link #setRequestToken(HttpServerExchange, Optional)} before
+     * returning the result.
+     */
     AuthHeader header(HttpServerExchange exchange);
 
-    /** Parses a {@link BearerToken} from the provided {@link HttpServerExchange}. */
+    /**
+     * Parses a {@link BearerToken} from the provided {@link HttpServerExchange}.
+     * Implementations are responsible for calling {@link #setRequestToken(HttpServerExchange, Optional)} before
+     * returning the result.
+     */
     BearerToken cookie(HttpServerExchange exchange, String cookieName);
+
+    /**
+     * Set the {@link HttpServerExchange request} {@link UnverifiedJsonWebToken} for observability information.
+     * Implementations may choose to set logging context data and track the token value for request logging.
+     * This data is never used for auth and is not guaranteed to be verified.
+     */
+    default void setRequestToken(HttpServerExchange exchange, Optional<UnverifiedJsonWebToken> token) {
+        // no-op default implementation for cross-version compatibility.
+    }
 }


### PR DESCRIPTION
This provides additional surface for users of the conjure-undertow
annotation processor to handle custom code while reusing standard
tooling.

==COMMIT_MSG==
Expose `AuthorizationExtractor.setRequestToken` for alternative sources
==COMMIT_MSG==

Based on a request from @pkoenig10 