### PR TITLE
conjure-undertow supports custom OPTIONS and PATCH endpoints

### DIFF
--- a/changelog/@unreleased/pr-1695.v2.yml
+++ b/changelog/@unreleased/pr-1695.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: conjure-undertow supports custom OPTIONS and PATCH endpoints
+  links:
+  - https://github.com/palantir/conjure-java/pull/1695

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureHandler.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureHandler.java
@@ -85,10 +85,14 @@ public final class ConjureHandler implements HttpHandler {
                 .collect(ImmutableSetMultimap.toImmutableSetMultimap(
                         endpoint -> normalizeTemplate(endpoint.template()), Endpoint::method))
                 .asMap()
-                .forEach((normalizedPath, methods) -> routingHandler.add(
-                        Methods.OPTIONS,
-                        normalizedPath,
-                        new WebSecurityHandler(new OptionsHandler(ImmutableSet.copyOf(methods)))));
+                .forEach((normalizedPath, methods) -> {
+                    if (!methods.contains(Methods.OPTIONS)) {
+                        routingHandler.add(
+                                Methods.OPTIONS,
+                                normalizedPath,
+                                new WebSecurityHandler(new OptionsHandler(ImmutableSet.copyOf(methods))));
+                    }
+                });
     }
 
     @Override
@@ -107,7 +111,7 @@ public final class ConjureHandler implements HttpHandler {
     public static final class Builder {
 
         private static final ImmutableSet<HttpString> ALLOWED_METHODS =
-                ImmutableSet.of(Methods.GET, Methods.PUT, Methods.POST, Methods.DELETE);
+                ImmutableSet.of(Methods.GET, Methods.PUT, Methods.POST, Methods.DELETE, Methods.OPTIONS, Methods.PATCH);
 
         private final List<EndpointHandlerWrapper> wrappersJustBeforeBlocking = new ArrayList<>();
 

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureHandlerBuilderTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureHandlerBuilderTest.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.java.undertow.runtime;
 
 import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
@@ -58,7 +59,7 @@ public class ConjureHandlerBuilderTest {
 
     @Test
     public void testAddEndpoint_options() {
-        assertThatLoggableExceptionThrownBy(() -> ConjureHandler.builder()
+        assertThatCode(() -> ConjureHandler.builder()
                         .services(EndpointService.of(Endpoint.builder()
                                 .name("name")
                                 .serviceName("service")
@@ -67,9 +68,8 @@ public class ConjureHandlerBuilderTest {
                                 .template("/template")
                                 .build()))
                         .build())
-                .isInstanceOf(SafeIllegalStateException.class)
-                .hasLogMessage("Endpoint method is not recognized")
-                .containsArgs(SafeArg.of("method", Methods.OPTIONS));
+                .as("OPTIONS may be handled by custom endpoints")
+                .doesNotThrowAnyException();
     }
 
     @Test


### PR DESCRIPTION
These methods are listed in the `HttpMethod` enum used by the
annotation processor. OPTIONS handlers are generated by default,
however now custom OPTIONS endpoints may be provided to opt out
of that functionality.

Known bug: We allow `HEAD` requests to be created using the
annotaiton processor, however these are not yet supported by
`ConjureHandler`.

==COMMIT_MSG==
conjure-undertow supports custom OPTIONS and PATCH endpoints
==COMMIT_MSG==

