### PR TITLE
Allow cross-origin requests

### DIFF
--- a/changelog/@unreleased/pr-1698.v2.yml
+++ b/changelog/@unreleased/pr-1698.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Conjure Undertow endpoints now support cross-origin requests.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1698

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/OptionsRequestTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/OptionsRequestTest.java
@@ -75,6 +75,15 @@ public final class OptionsRequestTest {
         try (Response response = execute("/first")) {
             assertThat(response.code()).isEqualTo(204);
             assertThat(response.header(HttpHeaders.ALLOW)).isEqualTo("OPTIONS, GET, HEAD, POST");
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS))
+                    .isNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS))
+                    .isEqualTo("Authorization");
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
+                    .isEqualTo("OPTIONS, GET, HEAD, POST");
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS))
+                    .isNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_MAX_AGE)).isEqualTo("600");
         }
     }
 
@@ -83,6 +92,8 @@ public final class OptionsRequestTest {
         try (Response response = execute("/first")) {
             assertThat(response.code()).isEqualTo(204);
             assertThat(response.header(HttpHeaders.CONTENT_SECURITY_POLICY)).isNotNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo("origin.com");
+            assertThat(response.header(HttpHeaders.VARY)).isEqualTo("Origin");
         }
     }
 
@@ -91,6 +102,15 @@ public final class OptionsRequestTest {
         try (Response response = execute("/second/paramValue/and/secondParam")) {
             assertThat(response.code()).isEqualTo(204);
             assertThat(response.header(HttpHeaders.ALLOW)).isEqualTo("OPTIONS, PUT");
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS))
+                    .isNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS))
+                    .isEqualTo("Authorization");
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
+                    .isEqualTo("OPTIONS, PUT");
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS))
+                    .isNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_MAX_AGE)).isEqualTo("600");
         }
     }
 
@@ -99,10 +119,28 @@ public final class OptionsRequestTest {
         try (Response response = execute("GET", "/third")) {
             assertThat(response.code()).isEqualTo(200);
             assertThat(response.header(HttpHeaders.ALLOW)).isNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS))
+                    .isNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS))
+                    .isNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
+                    .isNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS))
+                    .isNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_MAX_AGE)).isNull();
         }
         try (Response response = execute("OPTIONS", "/third")) {
             assertThat(response.code()).isEqualTo(418);
             assertThat(response.header(HttpHeaders.ALLOW)).isNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS))
+                    .isNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS))
+                    .isNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
+                    .isNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS))
+                    .isNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_MAX_AGE)).isNull();
         }
     }
 
@@ -111,6 +149,15 @@ public final class OptionsRequestTest {
         try (Response response = execute("OPTIONS", "/fourth")) {
             assertThat(response.code()).isEqualTo(418);
             assertThat(response.header(HttpHeaders.ALLOW)).isNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS))
+                    .isNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS))
+                    .isNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
+                    .isNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS))
+                    .isNull();
+            assertThat(response.header(HttpHeaders.ACCESS_CONTROL_MAX_AGE)).isNull();
         }
     }
 
@@ -124,6 +171,7 @@ public final class OptionsRequestTest {
         Request request = new Request.Builder()
                 .method(method, null)
                 .url("http://localhost:" + port + path)
+                .header(HttpHeaders.ORIGIN, "origin.com")
                 .build();
         try {
             return client.newCall(request).execute();

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/WebSecurityHandlerTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/WebSecurityHandlerTest.java
@@ -55,6 +55,7 @@ public class WebSecurityHandlerTest {
         try (Response response = client.newCall(new Request.Builder()
                         .get()
                         .url("http://localhost:12345")
+                        .header(HttpHeaders.ORIGIN, "origin.com")
                         .build())
                 .execute()) {
             validateCommonResponseHeaders(response);
@@ -76,6 +77,7 @@ public class WebSecurityHandlerTest {
         try (Response response = client.newCall(new Request.Builder()
                         .get()
                         .url("http://localhost:12345")
+                        .header(HttpHeaders.ORIGIN, "origin.com")
                         .header(HttpHeaders.USER_AGENT, userAgent)
                         .build())
                 .execute()) {
@@ -94,5 +96,7 @@ public class WebSecurityHandlerTest {
         assertThat(response.header(HttpHeaders.X_CONTENT_TYPE_OPTIONS)).isEqualTo("nosniff");
         assertThat(response.header(HttpHeaders.X_FRAME_OPTIONS)).isEqualTo("sameorigin");
         assertThat(response.header(HttpHeaders.X_XSS_PROTECTION)).isEqualTo("1; mode=block");
+        assertThat(response.header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo("origin.com");
+        assertThat(response.header(HttpHeaders.VARY)).isEqualTo("Origin");
     }
 }


### PR DESCRIPTION
## Before this PR
Conjure endpoints do not support cross-origin requests.

## After this PR
Conjure endpoints do not support cross-origin requests. Supporting cross origin requests OOTB feels like a reasonable design choice for an API server.

When a CORS preflight request is made, the response now includes the following response headers:
- [`Access-Control-Allow-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers.html) is set to `Authorization`
- [`Access-Control-Allow-Methods`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods.html) is set to the list of methods supported for that path
- [`Access-Control-Allow-Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin.html) is set to the value of the `Origin` request header, if present
- [`Access-Control-Max-Age`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age.html) is set to 600 seconds
- [`Vary`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary.html) is set to `Origin` because the `Access-Control-Allow-Origin` response header varies based on the origin

For details see the [MDN documentation for CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS).

## Security considerations

- What about [`Access-Control-Expose-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers.html)?

    API endpoints generally do not return headers that need to be read by clients. If this changes in the future, we can revisit this decision.

- What about [`Access-Control-Allow-Credentials`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials.html)?

    We definitely do not want to allow credentials to be sent in cross-origin requests. If we do, endpoints that use cookie authentication will be vulnerable to CSRF.

    An explicitly set `Authorization` request header is still allowed even without `Access-Control-Allow-Credentials`. `Access-Control-Allow-Credentials` controls [request credentials](https://fetch.spec.whatwg.org/#credentials), which only includes things that send credentials _implicitly_,  such as cookies, TLS client certificates, and [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication) (which may use the `Authorization` request header). An _explicitly_ set `Authorization` request header doesn't have the same CSRF risks and is not blocked by CORS.

- What about request headers other than the `Authorization` header?

    Request headers other than the `Authorization` header are not supported.

    We could support arbitrary request headers by setting the `Access-Control-Allow-Headers` response header to the value of the `Access-Control-Request-Headers` value. I don't see any obvious security concerns with doing so ([this SO answer](https://stackoverflow.com/a/45045181) seems to confirm that there's no specific security-related reason for restricting request headers), but I biased towards security in this initial attempt.

    Most API endpoints do not use custom request headers, especially those that should be exposed to third-party developers making cross-origin requests. So the cost of not supporting custom header parameters is likely small. As always, we can revisit this decision in the future.