### PR TITLE
Support Intellij Gradle integration

### DIFF
--- a/conjure-java-core/build.gradle
+++ b/conjure-java-core/build.gradle
@@ -18,10 +18,6 @@ apply plugin: 'com.palantir.external-publish-jar'
 
 sourceSets {
     integrationInput
-    test {
-        compileClasspath += integrationInput.output
-        runtimeClasspath += integrationInput.output
-    }
 }
 
 spotless {
@@ -32,7 +28,7 @@ spotless {
 
 idea {
     module {
-        testSourceDirs += sourceSets.integrationInput.java.srcDirs
+        sourceDirs += sourceSets.integrationInput.java.srcDirs
     }
 }
 
@@ -64,6 +60,7 @@ dependencies {
     implementation 'com.palantir.safe-logging:logger'
     implementation 'com.palantir.human-readable-types:human-readable-types'
 
+    testImplementation sourceSets.integrationInput.output
     testImplementation 'com.palantir.conjure:conjure-core'
     testImplementation project(':conjure-java-undertow-runtime')
     testImplementation 'com.palantir.conjure.java.runtime:conjure-java-jackson-serialization'


### PR DESCRIPTION
## Before this PR
The configuration of the `integrationInput` source set does not work with the Intellij Gradle integration. Intellij fails to find `integrationInput` classes when imported in `test` classes.

![Screen Shot 2022-03-11 at 9 03 15 AM](https://user-images.githubusercontent.com/5273164/157921574-97559119-4759-47ce-ad92-f559854bf00a.png)

When using the IDEA plugin, each subproject is a single module. So the integrationInput and test source sets are in test source directories of the same module and everything works.

![Screen Shot 2022-03-11 at 9 46 48 AM](https://user-images.githubusercontent.com/5273164/157922003-c16883c2-4da7-4073-bcd9-997846f12c0a.png)

When using the Gradle integration, each sources set is a separate module.

![Screen Shot 2022-03-11 at 9 48 04 AM](https://user-images.githubusercontent.com/5273164/157922183-12f171c1-6a2d-4a0f-9316-1037b0085203.png)
![Screen Shot 2022-03-11 at 9 48 09 AM](https://user-images.githubusercontent.com/5273164/157922187-bb3c6ef4-d2c7-46a8-89cd-89070f703b13.png)

So although the `test` module depends on the `integrationInput` module, it's depending on the "sources" of the `integrationInput` module, not the "test sources".

![Screen Shot 2022-03-11 at 9 48 15 AM](https://user-images.githubusercontent.com/5273164/157922212-817cb609-09ef-4ae5-a278-6824dc60b668.png)

In my testing, it appears that the Intellij Gradle integration uses the IDEA plugin configuration to inform how the project is structured. Even when using the Gradle integration, changing `testSourceDirs` to `sourceDirs` changed how the integration input source directory was configured in Intellij.

## After this PR
- The `integrationInput` source is now marked as "sources" instead of "test sources".
- The `integrationInput` dependency is now declared using standard Gradle dependency declarations instead of manual classpath modifications.

## Possible downsides?
- When using the IDEA plugin it will now be possible to import `integrationInput` classes. But this will not compile in CI because there is no Gradle dependency.