### PR TITLE
The conjure-undertow processor retains source element deprecation

### DIFF
--- a/conjure-undertow-processor-example/src/main/java/com/palantir/conjure/java/undertow/example/DeprecatedEndpointResource.java
+++ b/conjure-undertow-processor-example/src/main/java/com/palantir/conjure/java/undertow/example/DeprecatedEndpointResource.java
@@ -14,30 +14,21 @@
  * limitations under the License.
  */
 
-package com.palantir.conjure.java.undertow.processor.data;
+package com.palantir.conjure.java.undertow.example;
 
+import com.palantir.conjure.java.undertow.annotations.Handle;
 import com.palantir.conjure.java.undertow.annotations.HttpMethod;
-import java.util.List;
-import org.immutables.value.Value;
 
-@Value.Immutable
-@StagedBuilder
-public interface EndpointDefinition {
+public final class DeprecatedEndpointResource {
 
-    EndpointName endpointName();
-
-    ServiceName serviceName();
-
-    HttpMethod httpMethod();
-
-    HttpPath httpPath();
-
-    List<ArgumentDefinition> arguments();
-
-    ReturnType returns();
-
-    @Value.Default
-    default boolean deprecated() {
-        return false;
+    /**
+     * Deprecated endpoint.
+     *
+     * @deprecated deprecated
+     */
+    @Deprecated
+    @Handle(method = HttpMethod.GET, path = "/ping/deprecated")
+    public String ping() {
+        return "pong";
     }
 }

--- a/conjure-undertow-processor-example/src/main/java/com/palantir/conjure/java/undertow/example/DeprecatedResource.java
+++ b/conjure-undertow-processor-example/src/main/java/com/palantir/conjure/java/undertow/example/DeprecatedResource.java
@@ -14,30 +14,21 @@
  * limitations under the License.
  */
 
-package com.palantir.conjure.java.undertow.processor.data;
+package com.palantir.conjure.java.undertow.example;
 
+import com.palantir.conjure.java.undertow.annotations.Handle;
 import com.palantir.conjure.java.undertow.annotations.HttpMethod;
-import java.util.List;
-import org.immutables.value.Value;
 
-@Value.Immutable
-@StagedBuilder
-public interface EndpointDefinition {
+/**
+ * Deprecated resource.
+ *
+ * @deprecated deprecated
+ */
+@Deprecated
+public final class DeprecatedResource {
 
-    EndpointName endpointName();
-
-    ServiceName serviceName();
-
-    HttpMethod httpMethod();
-
-    HttpPath httpPath();
-
-    List<ArgumentDefinition> arguments();
-
-    ReturnType returns();
-
-    @Value.Default
-    default boolean deprecated() {
-        return false;
+    @Handle(method = HttpMethod.GET, path = "/deprecated/ping")
+    public String ping() {
+        return "pong";
     }
 }

--- a/conjure-undertow-processor-example/src/test/java/com/palantir/conjure/java/undertow/example/ExampleServiceTest.java
+++ b/conjure-undertow-processor-example/src/test/java/com/palantir/conjure/java/undertow/example/ExampleServiceTest.java
@@ -18,7 +18,10 @@ package com.palantir.conjure.java.undertow.example;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.Iterables;
 import com.google.common.net.HttpHeaders;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.runtime.ConjureUndertowRuntime;
 import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
 import io.undertow.Undertow;
@@ -27,6 +30,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
@@ -344,5 +348,24 @@ class ExampleServiceTest {
         } finally {
             server.stop();
         }
+    }
+
+    @Test
+    void testDeprecatedEndpoint() {
+        List<Endpoint> endpoints = DeprecatedEndpointResourceEndpoints.of(new DeprecatedEndpointResource())
+                .endpoints(ConjureUndertowRuntime.builder().build());
+        assertThat(endpoints).hasSize(1);
+        Endpoint endpoint = Iterables.getOnlyElement(endpoints);
+        assertThat(endpoint.deprecated()).isPresent();
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void testDeprecatedResource() {
+        List<Endpoint> endpoints = DeprecatedResourceEndpoints.of(new DeprecatedResource())
+                .endpoints(ConjureUndertowRuntime.builder().build());
+        assertThat(endpoints).hasSize(1);
+        Endpoint endpoint = Iterables.getOnlyElement(endpoints);
+        assertThat(endpoint.deprecated()).isPresent();
     }
 }

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessor.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessor.java
@@ -114,7 +114,7 @@ public final class ConjureUndertowAnnotationProcessor extends AbstractProcessor 
     }
 
     private JavaFile generateUndertowServiceEndpoints(
-            Element annotatedInterface, Collection<? extends Element> annotatedMethods) {
+            Element annotatedType, Collection<? extends Element> annotatedMethods) {
         validationStep(ctx -> {
             for (Element element : annotatedMethods) {
                 if (!element.getKind().equals(ElementKind.METHOD)) {
@@ -148,18 +148,18 @@ public final class ConjureUndertowAnnotationProcessor extends AbstractProcessor 
         });
 
         ClassName serviceInterface = ClassName.get(
-                MoreElements.getPackage(annotatedInterface).getQualifiedName().toString(),
-                annotatedInterface.getSimpleName().toString());
+                MoreElements.getPackage(annotatedType).getQualifiedName().toString(),
+                annotatedType.getSimpleName().toString());
 
         ServiceDefinition serviceDefinition = ImmutableServiceDefinition.builder()
                 .serviceInterface(serviceInterface)
                 .addAllEndpoints(endpoints)
+                .deprecated(MoreElements.isAnnotationPresent(annotatedType, Deprecated.class))
                 .build();
 
         TypeSpec generatedClass = new ConjureUndertowEndpointsGenerator(serviceDefinition).generate();
-        TypeSpec withOriginatingElement = generatedClass.toBuilder()
-                .addOriginatingElement(annotatedInterface)
-                .build();
+        TypeSpec withOriginatingElement =
+                generatedClass.toBuilder().addOriginatingElement(annotatedType).build();
 
         return JavaFile.builder(serviceInterface.packageName(), withOriginatingElement)
                 .build();

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/EndpointDefinitions.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/EndpointDefinitions.java
@@ -102,6 +102,8 @@ public final class EndpointDefinitions {
                 .httpPath(path)
                 .returns(maybeReturnType.get())
                 .addAllArguments(argumentDefinitions)
+                .deprecated(MoreElements.isAnnotationPresent(element, Deprecated.class)
+                        || MoreElements.isAnnotationPresent(element.getEnclosingElement(), Deprecated.class))
                 .build());
     }
 

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ServiceDefinition.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ServiceDefinition.java
@@ -37,4 +37,9 @@ public interface ServiceDefinition {
     }
 
     List<EndpointDefinition> endpoints();
+
+    @Value.Default
+    default boolean deprecated() {
+        return false;
+    }
 }

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
@@ -27,6 +27,8 @@ import com.google.testing.compile.Compiler;
 import com.google.testing.compile.JavaFileObjects;
 import com.palantir.conjure.java.undertow.processor.sample.CookieParams;
 import com.palantir.conjure.java.undertow.processor.sample.DefaultDecoderService;
+import com.palantir.conjure.java.undertow.processor.sample.DeprecatedEndpointResource;
+import com.palantir.conjure.java.undertow.processor.sample.DeprecatedResource;
 import com.palantir.conjure.java.undertow.processor.sample.MultipleBodyInterface;
 import com.palantir.conjure.java.undertow.processor.sample.NameClashContextParam;
 import com.palantir.conjure.java.undertow.processor.sample.NameClashExchangeParam;
@@ -91,6 +93,17 @@ public class ConjureUndertowAnnotationProcessorTest {
     @Test
     public void testSafeLoggableParams() {
         assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, SafeLoggableParams.class);
+    }
+
+    @Test
+    public void testDeprecatedEndpoint() {
+        assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, DeprecatedEndpointResource.class);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testDeprecatedResource() {
+        assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, DeprecatedResource.class);
     }
 
     @Test
@@ -160,7 +173,7 @@ public class ConjureUndertowAnnotationProcessorTest {
         try {
             return Compiler.javac()
                     // This is required because this tool does not know about our gradle setting.
-                    .withOptions("-source", "11")
+                    .withOptions("-source", "11", "-Werror", "-Xlint:deprecation")
                     .withProcessors(new ConjureUndertowAnnotationProcessor())
                     .compile(JavaFileObjects.forResource(clazzPath.toUri().toURL()));
         } catch (MalformedURLException e) {

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/DeprecatedEndpointResource.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/DeprecatedEndpointResource.java
@@ -14,30 +14,21 @@
  * limitations under the License.
  */
 
-package com.palantir.conjure.java.undertow.processor.data;
+package com.palantir.conjure.java.undertow.processor.sample;
 
+import com.palantir.conjure.java.undertow.annotations.Handle;
 import com.palantir.conjure.java.undertow.annotations.HttpMethod;
-import java.util.List;
-import org.immutables.value.Value;
 
-@Value.Immutable
-@StagedBuilder
-public interface EndpointDefinition {
+public final class DeprecatedEndpointResource {
 
-    EndpointName endpointName();
-
-    ServiceName serviceName();
-
-    HttpMethod httpMethod();
-
-    HttpPath httpPath();
-
-    List<ArgumentDefinition> arguments();
-
-    ReturnType returns();
-
-    @Value.Default
-    default boolean deprecated() {
-        return false;
+    /**
+     * Deprecated endpoint.
+     *
+     * @deprecated deprecated
+     */
+    @Deprecated
+    @Handle(method = HttpMethod.GET, path = "/ping/deprecated")
+    public String ping() {
+        return "pong";
     }
 }

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/DeprecatedResource.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/DeprecatedResource.java
@@ -14,30 +14,21 @@
  * limitations under the License.
  */
 
-package com.palantir.conjure.java.undertow.processor.data;
+package com.palantir.conjure.java.undertow.processor.sample;
 
+import com.palantir.conjure.java.undertow.annotations.Handle;
 import com.palantir.conjure.java.undertow.annotations.HttpMethod;
-import java.util.List;
-import org.immutables.value.Value;
 
-@Value.Immutable
-@StagedBuilder
-public interface EndpointDefinition {
+/**
+ * Deprecated resource.
+ *
+ * @deprecated deprecated
+ */
+@Deprecated
+public final class DeprecatedResource {
 
-    EndpointName endpointName();
-
-    ServiceName serviceName();
-
-    HttpMethod httpMethod();
-
-    HttpPath httpPath();
-
-    List<ArgumentDefinition> arguments();
-
-    ReturnType returns();
-
-    @Value.Default
-    default boolean deprecated() {
-        return false;
+    @Handle(method = HttpMethod.GET, path = "/deprecated/ping")
+    public String ping() {
+        return "pong";
     }
 }

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DeprecatedEndpointResourceEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DeprecatedEndpointResourceEndpoints.java.generated
@@ -1,0 +1,95 @@
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.java.undertow.annotations.DefaultSerDe;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.ReturnValueWriter;
+import com.palantir.conjure.java.undertow.lib.Serializer;
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import java.io.IOException;
+import java.lang.Deprecated;
+import java.lang.Exception;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.undertow.processor.generate.ConjureUndertowEndpointsGenerator")
+public final class DeprecatedEndpointResourceEndpoints implements UndertowService {
+    private final DeprecatedEndpointResource delegate;
+
+    private DeprecatedEndpointResourceEndpoints(DeprecatedEndpointResource delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(DeprecatedEndpointResource delegate) {
+        return new DeprecatedEndpointResourceEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return ImmutableList.of(new PingEndpoint(runtime, delegate));
+    }
+
+    private static final class PingEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<String> {
+        private final UndertowRuntime runtime;
+
+        private final DeprecatedEndpointResource delegate;
+
+        private final Serializer<String> pingSerializer;
+
+        PingEndpoint(UndertowRuntime runtime, DeprecatedEndpointResource delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.pingSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+        }
+
+        @Override
+        @Deprecated
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            write(this.delegate.ping(), exchange);
+        }
+
+        @Override
+        public void write(String returnValue, HttpServerExchange exchange) throws IOException {
+            this.pingSerializer.serialize(returnValue, exchange);
+        }
+
+        @Override
+        public Optional<String> deprecated() {
+            return Optional.of("deprecated");
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/ping/deprecated";
+        }
+
+        @Override
+        public String serviceName() {
+            return "DeprecatedEndpointResource";
+        }
+
+        @Override
+        public String name() {
+            return "ping";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DeprecatedResourceEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DeprecatedResourceEndpoints.java.generated
@@ -1,0 +1,95 @@
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.java.undertow.annotations.DefaultSerDe;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.ReturnValueWriter;
+import com.palantir.conjure.java.undertow.lib.Serializer;
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import java.io.IOException;
+import java.lang.Deprecated;
+import java.lang.Exception;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.undertow.processor.generate.ConjureUndertowEndpointsGenerator")
+@Deprecated
+public final class DeprecatedResourceEndpoints implements UndertowService {
+    private final DeprecatedResource delegate;
+
+    private DeprecatedResourceEndpoints(DeprecatedResource delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(DeprecatedResource delegate) {
+        return new DeprecatedResourceEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return ImmutableList.of(new PingEndpoint(runtime, delegate));
+    }
+
+    private static final class PingEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<String> {
+        private final UndertowRuntime runtime;
+
+        private final DeprecatedResource delegate;
+
+        private final Serializer<String> pingSerializer;
+
+        PingEndpoint(UndertowRuntime runtime, DeprecatedResource delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.pingSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            write(this.delegate.ping(), exchange);
+        }
+
+        @Override
+        public void write(String returnValue, HttpServerExchange exchange) throws IOException {
+            this.pingSerializer.serialize(returnValue, exchange);
+        }
+
+        @Override
+        public Optional<String> deprecated() {
+            return Optional.of("deprecated");
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/deprecated/ping";
+        }
+
+        @Override
+        public String serviceName() {
+            return "DeprecatedResource";
+        }
+
+        @Override
+        public String name() {
+            return "ping";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
This allows deprecation linting to work as expected without failing
due to non-deprecated generated code calling into deprecated
types.

==COMMIT_MSG==
The conjure-undertow processor retains source element deprecation
==COMMIT_MSG==

