### PR TITLE
conjure-undertow processor allows overloaded `@Handle` methods

### DIFF
--- a/changelog/@unreleased/pr-1708.v2.yml
+++ b/changelog/@unreleased/pr-1708.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: conjure-undertow processor allows overloaded `@Handle` methods
+  links:
+  - https://github.com/palantir/conjure-java/pull/1708

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
@@ -60,6 +60,7 @@ import io.undertow.util.StatusCodes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.processing.Generated;
 import javax.lang.model.element.Modifier;
@@ -124,9 +125,22 @@ public final class ConjureUndertowEndpointsGenerator {
         return builder.build();
     }
 
-    private static String endpointClassName(EndpointName endpointName) {
+    private static String endpointClassName(EndpointDefinition endpoint, ServiceDefinition service) {
+        EndpointName endpointName = endpoint.endpointName();
         String name = endpointName.get();
-        return Character.toUpperCase(name.charAt(0)) + name.substring(1) + "Endpoint";
+        String endpointClassName = Character.toUpperCase(name.charAt(0)) + name.substring(1) + "Endpoint";
+        ImmutableList<EndpointDefinition> overloads = service.endpoints().stream()
+                .filter(item -> Objects.equals(endpointName, item.endpointName()))
+                .collect(ImmutableList.toImmutableList());
+        if (overloads.size() > 1) {
+            int overloadIndex = overloads.indexOf(endpoint);
+            if (overloadIndex < 0) {
+                throw new SafeIllegalStateException("Unknown endpoint", SafeArg.of("endpoint", endpoint));
+            }
+            endpointClassName = endpointClassName + "_" + overloadIndex;
+        }
+
+        return endpointClassName;
     }
 
     @SuppressWarnings("checkstyle:MethodLength") // TODO(ckozak): refactor
@@ -393,7 +407,7 @@ public final class ConjureUndertowEndpointsGenerator {
             }
         }
 
-        TypeSpec.Builder endpointBuilder = TypeSpec.classBuilder(endpointClassName(endpoint.endpointName()))
+        TypeSpec.Builder endpointBuilder = TypeSpec.classBuilder(endpointClassName(endpoint, service))
                 .addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
                 .addSuperinterface(HttpHandler.class)
                 .addSuperinterface(Endpoint.class)

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
@@ -32,6 +32,7 @@ import com.palantir.conjure.java.undertow.processor.sample.DeprecatedResource;
 import com.palantir.conjure.java.undertow.processor.sample.MultipleBodyInterface;
 import com.palantir.conjure.java.undertow.processor.sample.NameClashContextParam;
 import com.palantir.conjure.java.undertow.processor.sample.NameClashExchangeParam;
+import com.palantir.conjure.java.undertow.processor.sample.OverloadedResource;
 import com.palantir.conjure.java.undertow.processor.sample.ParameterNotAnnotated;
 import com.palantir.conjure.java.undertow.processor.sample.PrimitiveBodyParam;
 import com.palantir.conjure.java.undertow.processor.sample.PrimitiveQueryParams;
@@ -104,6 +105,11 @@ public class ConjureUndertowAnnotationProcessorTest {
     @SuppressWarnings("deprecation")
     public void testDeprecatedResource() {
         assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, DeprecatedResource.class);
+    }
+
+    @Test
+    public void testOverloadedEndpoint() {
+        assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, OverloadedResource.class);
     }
 
     @Test

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/OverloadedResource.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/OverloadedResource.java
@@ -1,5 +1,17 @@
 /*
- * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License.
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.palantir.conjure.java.undertow.processor.sample;

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/OverloadedResource.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/OverloadedResource.java
@@ -1,0 +1,21 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.palantir.conjure.java.undertow.annotations.Handle;
+import com.palantir.conjure.java.undertow.annotations.HttpMethod;
+
+public final class OverloadedResource {
+
+    @Handle(method = HttpMethod.GET, path = "/ping")
+    public String endpoint() {
+        return "pong";
+    }
+
+    @Handle(method = HttpMethod.DELETE, path = "/foo")
+    public String endpoint(@Handle.QueryParam("q") String value) {
+        return value;
+    }
+}

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/OverloadedResourceEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/OverloadedResourceEndpoints.java.generated
@@ -1,0 +1,144 @@
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.java.undertow.annotations.DefaultSerDe;
+import com.palantir.conjure.java.undertow.annotations.ParamDecoders;
+import com.palantir.conjure.java.undertow.annotations.QueryParamDeserializer;
+import com.palantir.conjure.java.undertow.lib.Deserializer;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.ReturnValueWriter;
+import com.palantir.conjure.java.undertow.lib.Serializer;
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import java.io.IOException;
+import java.lang.Exception;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.undertow.processor.generate.ConjureUndertowEndpointsGenerator")
+public final class OverloadedResourceEndpoints implements UndertowService {
+    private final OverloadedResource delegate;
+
+    private OverloadedResourceEndpoints(OverloadedResource delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(OverloadedResource delegate) {
+        return new OverloadedResourceEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return ImmutableList.of(new EndpointEndpoint_0(runtime, delegate), new EndpointEndpoint_1(runtime, delegate));
+    }
+
+    private static final class EndpointEndpoint_0 implements HttpHandler, Endpoint, ReturnValueWriter<String> {
+        private final UndertowRuntime runtime;
+
+        private final OverloadedResource delegate;
+
+        private final Serializer<String> endpointSerializer;
+
+        EndpointEndpoint_0(UndertowRuntime runtime, OverloadedResource delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.endpointSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            write(this.delegate.endpoint(), exchange);
+        }
+
+        @Override
+        public void write(String returnValue, HttpServerExchange exchange) throws IOException {
+            this.endpointSerializer.serialize(returnValue, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/ping";
+        }
+
+        @Override
+        public String serviceName() {
+            return "OverloadedResource";
+        }
+
+        @Override
+        public String name() {
+            return "endpoint";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class EndpointEndpoint_1 implements HttpHandler, Endpoint, ReturnValueWriter<String> {
+        private final UndertowRuntime runtime;
+
+        private final OverloadedResource delegate;
+
+        private final Deserializer<String> valueDeserializer;
+
+        private final Serializer<String> endpointSerializer;
+
+        EndpointEndpoint_1(UndertowRuntime runtime, OverloadedResource delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.valueDeserializer =
+                    new QueryParamDeserializer<>("q", ParamDecoders.stringCollectionParamDecoder(runtime.plainSerDe()));
+            this.endpointSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            String value = this.valueDeserializer.deserialize(exchange);
+            write(this.delegate.endpoint(value), exchange);
+        }
+
+        @Override
+        public void write(String returnValue, HttpServerExchange exchange) throws IOException {
+            this.endpointSerializer.serialize(returnValue, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.DELETE;
+        }
+
+        @Override
+        public String template() {
+            return "/foo";
+        }
+
+        @Override
+        public String serviceName() {
+            return "OverloadedResource";
+        }
+
+        @Override
+        public String name() {
+            return "endpoint";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
==COMMIT_MSG==
conjure-undertow processor allows overloaded `@Handle` methods
==COMMIT_MSG==

## Possible downsides?
This will simplify migration from Jersey, however our metrics often
assume service-name + endpoint-name pairs are unique, so per-endpoint
metric data may not be as nice as it could be. It's probably fair
to assume overloaded methods should be analyzed together though.

