### PR TITLE
conjure-undertow processor supports response binary InputStreams

### DIFF
--- a/changelog/@unreleased/pr-1710.v2.yml
+++ b/changelog/@unreleased/pr-1710.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: conjure-undertow processor supports response binary InputStreams by
+    default to overlap with Jersey
+  links:
+  - https://github.com/palantir/conjure-java/pull/1710

--- a/conjure-undertow-processor-example/src/main/java/com/palantir/conjure/java/undertow/example/ExampleService.java
+++ b/conjure-undertow-processor-example/src/main/java/com/palantir/conjure/java/undertow/example/ExampleService.java
@@ -29,6 +29,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
 import io.undertow.server.HttpServerExchange;
+import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.math.BigInteger;
 import java.util.Collection;
@@ -62,6 +63,9 @@ public interface ExampleService {
 
     @Handle(method = HttpMethod.GET, path = "/optionalNamedBinary")
     Optional<CustomBinaryResponseBody> optionalNamedBinary();
+
+    @Handle(method = HttpMethod.GET, path = "/optionalWildStream")
+    Optional<? extends ByteArrayInputStream> optionalWildStream();
 
     @Handle(method = HttpMethod.POST, path = "/post")
     String post(@Handle.Body String body);

--- a/conjure-undertow-processor-example/src/test/java/com/palantir/conjure/java/undertow/example/ExampleResource.java
+++ b/conjure-undertow-processor-example/src/test/java/com/palantir/conjure/java/undertow/example/ExampleResource.java
@@ -24,6 +24,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
 import io.undertow.server.HttpServerExchange;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigInteger;
@@ -72,6 +73,11 @@ final class ExampleResource implements ExampleService {
     @Override
     public Optional<CustomBinaryResponseBody> optionalNamedBinary() {
         return Optional.of(namedBinary());
+    }
+
+    @Override
+    public Optional<? extends ByteArrayInputStream> optionalWildStream() {
+        return Optional.of(new ByteArrayInputStream("binary".getBytes(StandardCharsets.UTF_8)));
     }
 
     @Override

--- a/conjure-undertow-processor-example/src/test/java/com/palantir/conjure/java/undertow/example/ExampleServiceTest.java
+++ b/conjure-undertow-processor-example/src/test/java/com/palantir/conjure/java/undertow/example/ExampleServiceTest.java
@@ -168,6 +168,21 @@ class ExampleServiceTest {
     }
 
     @Test
+    void testOptionalInputStreamWildcardBinary() throws IOException {
+        Undertow server = TestHelper.started(ExampleServiceEndpoints.of(new ExampleResource()));
+        try {
+            int port = TestHelper.getPort(server);
+            HttpURLConnection connection =
+                    (HttpURLConnection) new URL("http://localhost:" + port + "/optionalWildStream").openConnection();
+            assertThat(connection.getResponseCode()).isEqualTo(200);
+            assertThat(connection.getContentType()).startsWith("application/octet-stream");
+            assertThat(connection.getInputStream()).hasBinaryContent("binary".getBytes(StandardCharsets.UTF_8));
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
     void testPostRequest() throws IOException {
         Undertow server = TestHelper.started(ExampleServiceEndpoints.of(new ExampleResource()));
         try {


### PR DESCRIPTION
==COMMIT_MSG==
conjure-undertow processor supports response binary InputStreams by default to overlap with Jersey
==COMMIT_MSG==
