### PR TITLE
Fix processor codegen for `Optional<Integer>` and `Optional<Double>`

### DIFF
--- a/changelog/@unreleased/pr-1711.v2.yml
+++ b/changelog/@unreleased/pr-1711.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix processor codegen for `Optional<Integer>` and `Optional<Double>`
+  links:
+  - https://github.com/palantir/conjure-java/pull/1711

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/DefaultDecoderNames.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/DefaultDecoderNames.java
@@ -77,6 +77,14 @@ final class DefaultDecoderNames {
             TypeMirror type, ContainerType inputType, ContainerType outType) {
         return getClassNameForTypeMirror(type)
                 .filter(SUPPORTED_CLASSES::contains)
+                .filter(className -> {
+                    // Conjure uses OptionalInt and OptionalDouble, we cannot use these methods
+                    // to construct Optional<Integer> and Optional<Double>.
+                    boolean isOptionalBoxedConjureType = outType == ContainerType.OPTIONAL
+                            && (Integer.class.getName().equals(className)
+                                    || Double.class.getName().equals(className));
+                    return !isOptionalBoxedConjureType;
+                })
                 .map(className -> getDefaultDecoderMethodName(className, inputType, outType))
                 .map(decoderMethodName ->
                         CodeBlock.of("$T.$L(runtime.plainSerDe())", ParamDecoders.class, decoderMethodName))

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
@@ -32,6 +32,7 @@ import com.palantir.conjure.java.undertow.processor.sample.DeprecatedResource;
 import com.palantir.conjure.java.undertow.processor.sample.MultipleBodyInterface;
 import com.palantir.conjure.java.undertow.processor.sample.NameClashContextParam;
 import com.palantir.conjure.java.undertow.processor.sample.NameClashExchangeParam;
+import com.palantir.conjure.java.undertow.processor.sample.OptionalPrimitives;
 import com.palantir.conjure.java.undertow.processor.sample.OverloadedResource;
 import com.palantir.conjure.java.undertow.processor.sample.ParameterNotAnnotated;
 import com.palantir.conjure.java.undertow.processor.sample.PrimitiveBodyParam;
@@ -110,6 +111,11 @@ public class ConjureUndertowAnnotationProcessorTest {
     @Test
     public void testOverloadedEndpoint() {
         assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, OverloadedResource.class);
+    }
+
+    @Test
+    public void testQueryOptionals() {
+        assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, OptionalPrimitives.class);
     }
 
     @Test

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/OptionalPrimitives.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/OptionalPrimitives.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.palantir.conjure.java.undertow.annotations.Handle;
+import com.palantir.conjure.java.undertow.annotations.Handle.QueryParam;
+import com.palantir.conjure.java.undertow.annotations.HttpMethod;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+
+public interface OptionalPrimitives {
+
+    @Handle(method = HttpMethod.GET, path = "/integer")
+    void integers(@QueryParam("one") OptionalInt one, @QueryParam("two") Optional<Integer> two);
+
+    @Handle(method = HttpMethod.GET, path = "/double")
+    void doubles(@QueryParam("one") OptionalDouble one, @QueryParam("two") Optional<Double> two);
+}

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/OptionalPrimitivesEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/OptionalPrimitivesEndpoints.java.generated
@@ -1,0 +1,146 @@
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.java.undertow.annotations.ParamDecoders;
+import com.palantir.conjure.java.undertow.annotations.QueryParamDeserializer;
+import com.palantir.conjure.java.undertow.lib.Deserializer;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import io.undertow.util.StatusCodes;
+import java.lang.Double;
+import java.lang.Exception;
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.undertow.processor.generate.ConjureUndertowEndpointsGenerator")
+public final class OptionalPrimitivesEndpoints implements UndertowService {
+    private final OptionalPrimitives delegate;
+
+    private OptionalPrimitivesEndpoints(OptionalPrimitives delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(OptionalPrimitives delegate) {
+        return new OptionalPrimitivesEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return ImmutableList.of(new IntegersEndpoint(runtime, delegate), new DoublesEndpoint(runtime, delegate));
+    }
+
+    private static final class IntegersEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final OptionalPrimitives delegate;
+
+        private final Deserializer<OptionalInt> oneDeserializer;
+
+        private final Deserializer<Optional<Integer>> twoDeserializer;
+
+        IntegersEndpoint(UndertowRuntime runtime, OptionalPrimitives delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.oneDeserializer = new QueryParamDeserializer<>(
+                    "one", ParamDecoders.optionalIntegerCollectionParamDecoder(runtime.plainSerDe()));
+            this.twoDeserializer = new QueryParamDeserializer<>(
+                    "two", ParamDecoders.optionalComplexCollectionParamDecoder(runtime.plainSerDe(), Integer::valueOf));
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            OptionalInt one = this.oneDeserializer.deserialize(exchange);
+            Optional<Integer> two = this.twoDeserializer.deserialize(exchange);
+            this.delegate.integers(one, two);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/integer";
+        }
+
+        @Override
+        public String serviceName() {
+            return "OptionalPrimitives";
+        }
+
+        @Override
+        public String name() {
+            return "integers";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class DoublesEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final OptionalPrimitives delegate;
+
+        private final Deserializer<OptionalDouble> oneDeserializer;
+
+        private final Deserializer<Optional<Double>> twoDeserializer;
+
+        DoublesEndpoint(UndertowRuntime runtime, OptionalPrimitives delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.oneDeserializer = new QueryParamDeserializer<>(
+                    "one", ParamDecoders.optionalDoubleCollectionParamDecoder(runtime.plainSerDe()));
+            this.twoDeserializer = new QueryParamDeserializer<>(
+                    "two", ParamDecoders.optionalComplexCollectionParamDecoder(runtime.plainSerDe(), Double::valueOf));
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            OptionalDouble one = this.oneDeserializer.deserialize(exchange);
+            Optional<Double> two = this.twoDeserializer.deserialize(exchange);
+            this.delegate.doubles(one, two);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/double";
+        }
+
+        @Override
+        public String serviceName() {
+            return "OptionalPrimitives";
+        }
+
+        @Override
+        public String name() {
+            return "doubles";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
Previously these were generated using the codepath for `OptionalInt`
and `OptionalDouble`, failing to compile.

==COMMIT_MSG==
Fix processor codegen for `Optional<Integer>` and `Optional<Double>`
==COMMIT_MSG==

