### PR TITLE
Handle query/header/path `Optional<Long>` and `OptionalLong`

### DIFF
--- a/changelog/@unreleased/pr-1712.v2.yml
+++ b/changelog/@unreleased/pr-1712.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Handle query/header/path `Optional<Long>` and `OptionalLong`
+  links:
+  - https://github.com/palantir/conjure-java/pull/1712

--- a/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/ParamDecoders.java
+++ b/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/ParamDecoders.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.java.undertow.annotations;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.conjure.java.undertow.lib.PlainSerDe;
 import com.palantir.ri.ResourceIdentifier;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
@@ -229,6 +231,36 @@ public final class ParamDecoders {
         return DelegatingCollectionParamDecoder.of(serde::deserializeSafeLongSet);
     }
 
+    public static ParamDecoder<Long> longParamDecoder(PlainSerDe serde) {
+        return complexParamDecoder(serde, Long::parseLong);
+    }
+
+    public static ParamDecoder<OptionalLong> optionalLongParamDecoder(PlainSerDe serde) {
+        return DelegatingParamDecoder.of(
+                in -> OptionalLong.of(serde.deserializeComplex(in, Long::parseLong)), OptionalLong.empty());
+    }
+
+    public static CollectionParamDecoder<Long> longCollectionParamDecoder(PlainSerDe serde) {
+        return DelegatingCollectionParamDecoder.of(in -> serde.deserializeComplex(in, Long::parseLong));
+    }
+
+    public static CollectionParamDecoder<OptionalLong> optionalLongCollectionParamDecoder(PlainSerDe serde) {
+        return DelegatingCollectionParamDecoder.of(in -> {
+            if (in == null || Iterables.isEmpty(in)) {
+                return OptionalLong.empty();
+            }
+            return OptionalLong.of(serde.deserializeComplex(in, Long::parseLong));
+        });
+    }
+
+    public static CollectionParamDecoder<List<Long>> longListCollectionParamDecoder(PlainSerDe serde) {
+        return complexListCollectionParamDecoder(serde, Long::parseLong);
+    }
+
+    public static CollectionParamDecoder<Set<Long>> longSetCollectionParamDecoder(PlainSerDe serde) {
+        return complexSetCollectionParamDecoder(serde, Long::parseLong);
+    }
+
     public static ParamDecoder<UUID> uuidParamDecoder(PlainSerDe serde) {
         return DelegatingParamDecoder.of(serde::deserializeUuid);
     }
@@ -273,7 +305,7 @@ public final class ParamDecoders {
         return DelegatingCollectionParamDecoder.of(value -> serde.deserializeOptionalComplex(value, factory));
     }
 
-    public <T> CollectionParamDecoder<List<T>> complexListCollectionParamDecoder(
+    public static <T> CollectionParamDecoder<List<T>> complexListCollectionParamDecoder(
             PlainSerDe serde, Function<String, T> factory) {
         return DelegatingCollectionParamDecoder.of(value -> serde.deserializeComplexList(value, factory));
     }

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/DefaultDecoderNames.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/DefaultDecoderNames.java
@@ -33,6 +33,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.stream.Stream;
 import javax.lang.model.element.ElementKind;
@@ -56,7 +57,9 @@ final class DefaultDecoderNames {
             OptionalInt.class.getName(),
             ResourceIdentifier.class.getName(),
             SafeLong.class.getName(),
-            UUID.class.getName());
+            UUID.class.getName(),
+            Long.class.getName(),
+            OptionalLong.class.getName());
 
     private static final ImmutableSet<ContainerType> INPUT_TYPES =
             ImmutableSet.of(ContainerType.NONE, ContainerType.LIST);
@@ -82,7 +85,8 @@ final class DefaultDecoderNames {
                     // to construct Optional<Integer> and Optional<Double>.
                     boolean isOptionalBoxedConjureType = outType == ContainerType.OPTIONAL
                             && (Integer.class.getName().equals(className)
-                                    || Double.class.getName().equals(className));
+                                    || Double.class.getName().equals(className)
+                                    || Long.class.getName().equals(className));
                     return !isOptionalBoxedConjureType;
                 })
                 .map(className -> getDefaultDecoderMethodName(className, inputType, outType))

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/data/DefaultDecoderNamesTest.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/data/DefaultDecoderNamesTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -84,7 +85,8 @@ final class DefaultDecoderNamesTest {
                 // We handle these cases differently further down this method.
                 .filter(maybeName -> maybeName
                         .map(name -> !name.equals(OptionalDouble.class.getName())
-                                && !name.equals(OptionalInt.class.getName()))
+                                && !name.equals(OptionalInt.class.getName())
+                                && !name.equals(OptionalLong.class.getName()))
                         .orElse(true))
                 .collect(Collectors.toList());
 
@@ -108,19 +110,24 @@ final class DefaultDecoderNamesTest {
         return supportedClasses.stream()
                 .map(clazzName -> {
                     // For double and int, we use a separate optional type instead of wrapping it with Optional.
-                    if (outputContainer.equals(ContainerType.OPTIONAL)
-                            && clazzName.isPresent()
-                            && clazzName.get().equals(Double.class.getName())) {
-                        return Arguments.of(
-                                Optional.of(OptionalDouble.class.getName()), ContainerType.NONE, ContainerType.NONE);
-                    } else if (outputContainer.equals(ContainerType.OPTIONAL)
-                            && clazzName.isPresent()
-                            && clazzName.get().equals(Integer.class.getName())) {
-                        return Arguments.of(
-                                Optional.of(OptionalInt.class.getName()), ContainerType.NONE, ContainerType.NONE);
-                    } else {
-                        return Arguments.of(clazzName, inputContainer, outputContainer);
+                    if (outputContainer.equals(ContainerType.OPTIONAL) && clazzName.isPresent()) {
+                        String name = clazzName.get();
+                        if (name.equals(Double.class.getName())) {
+                            return Arguments.of(
+                                    Optional.of(OptionalDouble.class.getName()),
+                                    ContainerType.NONE,
+                                    ContainerType.NONE);
+                        }
+                        if (name.equals(Integer.class.getName())) {
+                            return Arguments.of(
+                                    Optional.of(OptionalInt.class.getName()), ContainerType.NONE, ContainerType.NONE);
+                        }
+                        if (name.equals(Long.class.getName())) {
+                            return Arguments.of(
+                                    Optional.of(OptionalLong.class.getName()), ContainerType.NONE, ContainerType.NONE);
+                        }
                     }
+                    return Arguments.of(clazzName, inputContainer, outputContainer);
                 })
                 .collect(Collectors.toList());
     }

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/OptionalPrimitives.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/OptionalPrimitives.java
@@ -22,6 +22,7 @@ import com.palantir.conjure.java.undertow.annotations.HttpMethod;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 
 public interface OptionalPrimitives {
 
@@ -30,4 +31,7 @@ public interface OptionalPrimitives {
 
     @Handle(method = HttpMethod.GET, path = "/double")
     void doubles(@QueryParam("one") OptionalDouble one, @QueryParam("two") Optional<Double> two);
+
+    @Handle(method = HttpMethod.GET, path = "/long")
+    void longs(@QueryParam("one") OptionalLong one, @QueryParam("two") Optional<Long> two);
 }

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/OptionalPrimitivesEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/OptionalPrimitivesEndpoints.java.generated
@@ -15,12 +15,14 @@ import io.undertow.util.StatusCodes;
 import java.lang.Double;
 import java.lang.Exception;
 import java.lang.Integer;
+import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.undertow.processor.generate.ConjureUndertowEndpointsGenerator")
@@ -37,7 +39,10 @@ public final class OptionalPrimitivesEndpoints implements UndertowService {
 
     @Override
     public List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return ImmutableList.of(new IntegersEndpoint(runtime, delegate), new DoublesEndpoint(runtime, delegate));
+        return ImmutableList.of(
+                new IntegersEndpoint(runtime, delegate),
+                new DoublesEndpoint(runtime, delegate),
+                new LongsEndpoint(runtime, delegate));
     }
 
     private static final class IntegersEndpoint implements HttpHandler, Endpoint {
@@ -136,6 +141,58 @@ public final class OptionalPrimitivesEndpoints implements UndertowService {
         @Override
         public String name() {
             return "doubles";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class LongsEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final OptionalPrimitives delegate;
+
+        private final Deserializer<OptionalLong> oneDeserializer;
+
+        private final Deserializer<Optional<Long>> twoDeserializer;
+
+        LongsEndpoint(UndertowRuntime runtime, OptionalPrimitives delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.oneDeserializer = new QueryParamDeserializer<>(
+                    "one", ParamDecoders.optionalLongCollectionParamDecoder(runtime.plainSerDe()));
+            this.twoDeserializer = new QueryParamDeserializer<>(
+                    "two", ParamDecoders.optionalComplexCollectionParamDecoder(runtime.plainSerDe(), Long::valueOf));
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            OptionalLong one = this.oneDeserializer.deserialize(exchange);
+            Optional<Long> two = this.twoDeserializer.deserialize(exchange);
+            this.delegate.longs(one, two);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/long";
+        }
+
+        @Override
+        public String serviceName() {
+            return "OptionalPrimitives";
+        }
+
+        @Override
+        public String name() {
+            return "longs";
         }
 
         @Override


### PR DESCRIPTION
This uses the same approach as conjure primitive types as opposed
to special methods, this is because there are only three special
optional types, the other two of which were already handled
using `ParamDecoders`.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Handle query/header/path `Optional<Long>` and `OptionalLong`
==COMMIT_MSG==

