### PR TITLE
annotation-processor uses `of(String)` factory methods by default

### DIFF
--- a/changelog/@unreleased/pr-1723.v2.yml
+++ b/changelog/@unreleased/pr-1723.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: annotation-processor uses `of(String)` factory methods by default
+  description: annotation-processor uses `of(String)` factory methods by default.
   links:
   - https://github.com/palantir/conjure-java/pull/1723

--- a/changelog/@unreleased/pr-1723.v2.yml
+++ b/changelog/@unreleased/pr-1723.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: annotation-processor uses `of(String)` factory methods by default
+  links:
+  - https://github.com/palantir/conjure-java/pull/1723

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
@@ -32,6 +32,7 @@ import com.palantir.conjure.java.undertow.processor.sample.DeprecatedResource;
 import com.palantir.conjure.java.undertow.processor.sample.MultipleBodyInterface;
 import com.palantir.conjure.java.undertow.processor.sample.NameClashContextParam;
 import com.palantir.conjure.java.undertow.processor.sample.NameClashExchangeParam;
+import com.palantir.conjure.java.undertow.processor.sample.OfFactory;
 import com.palantir.conjure.java.undertow.processor.sample.OptionalPrimitives;
 import com.palantir.conjure.java.undertow.processor.sample.OverloadedResource;
 import com.palantir.conjure.java.undertow.processor.sample.ParameterNotAnnotated;
@@ -75,6 +76,11 @@ public class ConjureUndertowAnnotationProcessorTest {
     @Test
     public void testMultipleBodies() {
         assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, MultipleBodyInterface.class);
+    }
+
+    @Test
+    public void testOfFactoryMethod() {
+        assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, OfFactory.class);
     }
 
     @Test

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/OfFactory.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/OfFactory.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.palantir.conjure.java.undertow.annotations.Handle;
+import com.palantir.conjure.java.undertow.annotations.HttpMethod;
+
+public interface OfFactory {
+
+    @Handle(method = HttpMethod.GET, path = "/{pathVar}")
+    void ping(@Handle.PathParam PathVariable pathVar);
+
+    final class PathVariable {
+        private final String value;
+
+        private PathVariable(String value) {
+            this.value = value;
+        }
+
+        public static PathVariable of(String value) {
+            return new PathVariable(value);
+        }
+
+        @Override
+        public String toString() {
+            return "PathVariable{value='" + value + '\'' + '}';
+        }
+    }
+}

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/OfFactoryEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/OfFactoryEndpoints.java.generated
@@ -1,0 +1,84 @@
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.java.undertow.annotations.ParamDecoders;
+import com.palantir.conjure.java.undertow.annotations.PathParamDeserializer;
+import com.palantir.conjure.java.undertow.lib.Deserializer;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import io.undertow.util.StatusCodes;
+import java.lang.Exception;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.undertow.processor.generate.ConjureUndertowEndpointsGenerator")
+public final class OfFactoryEndpoints implements UndertowService {
+    private final OfFactory delegate;
+
+    private OfFactoryEndpoints(OfFactory delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(OfFactory delegate) {
+        return new OfFactoryEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return ImmutableList.of(new PingEndpoint(runtime, delegate));
+    }
+
+    private static final class PingEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final OfFactory delegate;
+
+        private final Deserializer<OfFactory.PathVariable> pathVarDeserializer;
+
+        PingEndpoint(UndertowRuntime runtime, OfFactory delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.pathVarDeserializer = new PathParamDeserializer<>(
+                    "pathVar", ParamDecoders.complexParamDecoder(runtime.plainSerDe(), OfFactory.PathVariable::of));
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            OfFactory.PathVariable pathVar = this.pathVarDeserializer.deserialize(exchange);
+            this.delegate.ping(pathVar);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/{pathVar}";
+        }
+
+        @Override
+        public String serviceName() {
+            return "OfFactory";
+        }
+
+        @Override
+        public String name() {
+            return "ping";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
This is least preferred, after `valueOf(String)` and a single-string
constructor.

==COMMIT_MSG==
annotation-processor uses `of(String)` factory methods by default
==COMMIT_MSG==

