### PR TITLE
Add source address to request context

### DIFF
--- a/changelog/@unreleased/pr-1730.v2.yml
+++ b/changelog/@unreleased/pr-1730.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add source address to request context
+  links:
+    - https://github.com/palantir/conjure-java/pull/1730

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
@@ -26,6 +26,7 @@ import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderValues;
+import java.net.InetSocketAddress;
 import java.security.cert.Certificate;
 import java.util.Collections;
 import java.util.Deque;
@@ -97,6 +98,17 @@ final class ConjureContexts implements Contexts {
                 }
             }
             return ImmutableList.of();
+        }
+
+        @Override
+        public String sourceAddress() {
+            return formatSocketAddress(exchange.getSourceAddress());
+        }
+
+        private static String formatSocketAddress(InetSocketAddress socketAddress) {
+            return socketAddress.isUnresolved()
+                    ? socketAddress.getHostString()
+                    : socketAddress.getAddress().getHostAddress();
         }
 
         private ImmutableListMultimap<String, String> buildQueryParameters() {

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureContextsTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureContextsTest.java
@@ -1,0 +1,67 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.RequestContext;
+import io.undertow.server.HttpServerExchange;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ConjureContextsTest {
+
+    @Mock
+    private RequestArgHandler requestArgHandler;
+
+    @Mock
+    private HttpServerExchange exchange;
+
+    @Mock
+    private Endpoint endpoint;
+
+    private ConjureContexts conjureContexts;
+    private RequestContext requestContext;
+
+    @BeforeEach
+    private void beforeEach() {
+        conjureContexts = new ConjureContexts(requestArgHandler);
+        requestContext = conjureContexts.createContext(exchange, endpoint);
+    }
+
+    @Test
+    public void testSourceAddress() throws UnknownHostException {
+        // Should return an IP address for resolved addresses.
+        when(exchange.getSourceAddress()).thenReturn(new InetSocketAddress(InetAddress.getByName("172.18.0.1"), 8080));
+        assertThat(requestContext.sourceAddress()).isEqualTo("172.18.0.1");
+        when(exchange.getSourceAddress()).thenReturn(new InetSocketAddress(InetAddress.getByName("localhost"), 8080));
+        assertThat(requestContext.sourceAddress()).isEqualTo("127.0.0.1");
+
+        // Should return a hostname for unresolved addresses.
+        when(exchange.getSourceAddress()).thenReturn(InetSocketAddress.createUnresolved("localhost", 8080));
+        assertThat(requestContext.sourceAddress()).isEqualTo("localhost");
+    }
+}

--- a/conjure-java-undertow-runtime/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/conjure-java-undertow-runtime/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
@@ -61,4 +61,10 @@ public interface RequestContext {
      * @see javax.net.ssl.SSLSession#getPeerCertificates()
      */
     ImmutableList<Certificate> peerCertificates();
+
+    /**
+     * Returns the source address of the request, as an IP address (e.g. "172.18.0.1") if the source address can be
+     * resolved, or a hostname (e.g. "localhost") if it can not.
+     */
+    String sourceAddress();
 }


### PR DESCRIPTION
## Before this PR
`RequestContext` did not include the source address of the request.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add source address to request context
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

