### PR TITLE
Limit conjure codegen concurrency to the expected parallelism

### DIFF
--- a/changelog/@unreleased/pr-1749.v2.yml
+++ b/changelog/@unreleased/pr-1749.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Limit conjure codegen concurrency to the expected parallelism
+  links:
+  - https://github.com/palantir/conjure-java/pull/1749

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -221,7 +221,8 @@ public final class ConjureJavaCli implements Runnable {
                 System.err.println("[WARNING] Using deprecated ByteBuffer codegen, please enable the "
                         + "--useImmutableBytes feature flag to opt into the preferred implementation");
             }
-            ExecutorService executor = Executors.newCachedThreadPool(
+            ExecutorService executor = Executors.newFixedThreadPool(
+                    Runtime.getRuntime().availableProcessors(),
                     new ThreadFactoryBuilder().setDaemon(true).build());
             try {
                 ConjureDefinition conjureDefinition = OBJECT_MAPPER.readValue(config.input(), ConjureDefinition.class);


### PR DESCRIPTION
This was the expected behavior, however `MoreStreams` has a bug
which allows greater concurrency than expected when the underlying
stream is constructed using flatMap.

==COMMIT_MSG==
Limit conjure codegen concurrency to the expected parallelism
==COMMIT_MSG==

