### PR TITLE
Validate safety agreement between existing arguments and types

### DIFF
--- a/changelog/@unreleased/pr-1756.v2.yml
+++ b/changelog/@unreleased/pr-1756.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Validate safety agreement between existing argument markers/tags and
+    types
+  links:
+  - https://github.com/palantir/conjure-java/pull/1756

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowNameCollisionService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowNameCollisionService.java
@@ -1,6 +1,7 @@
 package com.palantir.product;
 
 import com.palantir.conjure.java.undertow.lib.RequestContext;
+import com.palantir.logsafe.Safe;
 import com.palantir.tokens.auth.AuthHeader;
 import javax.annotation.Generated;
 
@@ -11,13 +12,13 @@ public interface UndertowNameCollisionService {
      */
     String int_(
             AuthHeader authHeader,
-            String serializer,
-            String runtime,
-            String authHeader_,
-            String long_,
-            String delegate,
-            String result,
-            String deserializer);
+            @Safe String serializer,
+            @Safe String runtime,
+            @Safe String authHeader_,
+            @Safe String long_,
+            @Safe String delegate,
+            @Safe String result,
+            @Safe String deserializer);
 
     /**
      * @apiNote {@code POST /no/context}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/ConjureMarkers.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/ConjureMarkers.java
@@ -1,0 +1,91 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.palantir.conjure.java.types.TypeMapper;
+import com.palantir.conjure.spec.ArgumentDefinition;
+import com.palantir.conjure.spec.LogSafety;
+import com.palantir.conjure.spec.Type;
+import com.palantir.conjure.spec.TypeName;
+import com.palantir.conjure.visitor.TypeVisitor;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.Unsafe;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/** The marker concept is deprecated in favor of tags, however the functionality has not been dropped yet. */
+public final class ConjureMarkers {
+
+    private static final ImmutableSet<ClassName> SAFETY_CLASS_NAMES =
+            ImmutableSet.of(ClassName.get(Safe.class), ClassName.get(Unsafe.class));
+
+    private static final TypeName SAFE_TYPE_NAME =
+            TypeName.of(Safe.class.getSimpleName(), Safe.class.getPackage().getName());
+    private static final TypeName UNSAFE_TYPE_NAME =
+            TypeName.of(Unsafe.class.getSimpleName(), Unsafe.class.getPackage().getName());
+
+    public static ImmutableList<AnnotationSpec> annotations(TypeMapper typeMapper, List<Type> markers) {
+        Preconditions.checkArgument(
+                markers.stream().allMatch(type -> type.accept(TypeVisitor.IS_REFERENCE)),
+                "Markers must refer to reference types.");
+        return markers.stream()
+                .map(typeMapper::getClassName)
+                .map(ClassName.class::cast)
+                // safety is handled separately by markerSafety
+                .filter(name -> !SAFETY_CLASS_NAMES.contains(name))
+                .map(AnnotationSpec::builder)
+                .map(AnnotationSpec.Builder::build)
+                .collect(ImmutableList.toImmutableList());
+    }
+
+    public static Optional<LogSafety> markerSafety(ArgumentDefinition argument) {
+        ImmutableList<LogSafety> markerSafety = argument.getMarkers().stream()
+                .map(type -> type.accept(TypeVisitor.IS_REFERENCE) ? type.accept(TypeVisitor.REFERENCE) : null)
+                .map(typeName -> {
+                    if (SAFE_TYPE_NAME.equals(typeName)) {
+                        return LogSafety.SAFE;
+                    }
+                    if (UNSAFE_TYPE_NAME.equals(typeName)) {
+                        return LogSafety.UNSAFE;
+                    }
+                    return null;
+                })
+                .filter(Objects::nonNull)
+                .collect(ImmutableList.toImmutableList());
+        if (markerSafety.isEmpty()) {
+            return Optional.empty();
+        }
+        if (markerSafety.size() > 1) {
+            throw new SafeIllegalStateException(
+                    "Markers may declare at most one safety value",
+                    SafeArg.of("argName", argument.getArgName()),
+                    SafeArg.of("markerSafety", markerSafety));
+        }
+        return Optional.of(Iterables.getOnlyElement(markerSafety));
+    }
+
+    private ConjureMarkers() {}
+}

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/SafetyEvaluatorTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/SafetyEvaluatorTest.java
@@ -87,6 +87,35 @@ class SafetyEvaluatorTest {
     }
 
     @Test
+    public void testAllows() {
+        assertThat(SafetyEvaluator.allows(Optional.empty(), Optional.empty())).isTrue();
+        assertThat(SafetyEvaluator.allows(Optional.of(LogSafety.SAFE), Optional.empty()))
+                .isTrue();
+        assertThat(SafetyEvaluator.allows(Optional.of(LogSafety.UNSAFE), Optional.empty()))
+                .isTrue();
+        assertThat(SafetyEvaluator.allows(Optional.of(LogSafety.DO_NOT_LOG), Optional.empty()))
+                .isTrue();
+        assertThat(SafetyEvaluator.allows(Optional.of(LogSafety.SAFE), Optional.of(LogSafety.SAFE)))
+                .isTrue();
+        assertThat(SafetyEvaluator.allows(Optional.of(LogSafety.SAFE), Optional.of(LogSafety.UNSAFE)))
+                .isFalse();
+        assertThat(SafetyEvaluator.allows(Optional.of(LogSafety.SAFE), Optional.of(LogSafety.DO_NOT_LOG)))
+                .isFalse();
+        assertThat(SafetyEvaluator.allows(Optional.of(LogSafety.UNSAFE), Optional.of(LogSafety.SAFE)))
+                .isTrue();
+        assertThat(SafetyEvaluator.allows(Optional.of(LogSafety.UNSAFE), Optional.of(LogSafety.UNSAFE)))
+                .isTrue();
+        assertThat(SafetyEvaluator.allows(Optional.of(LogSafety.UNSAFE), Optional.of(LogSafety.DO_NOT_LOG)))
+                .isFalse();
+        assertThat(SafetyEvaluator.allows(Optional.of(LogSafety.DO_NOT_LOG), Optional.of(LogSafety.SAFE)))
+                .isTrue();
+        assertThat(SafetyEvaluator.allows(Optional.of(LogSafety.DO_NOT_LOG), Optional.of(LogSafety.UNSAFE)))
+                .isTrue();
+        assertThat(SafetyEvaluator.allows(Optional.of(LogSafety.DO_NOT_LOG), Optional.of(LogSafety.DO_NOT_LOG)))
+                .isTrue();
+    }
+
+    @Test
     void testMapSafeKey() {
         TypeDefinition object = TypeDefinition.object(ObjectDefinition.builder()
                 .typeName(FOO)

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
@@ -55,7 +55,7 @@ public interface TestService {
     @ClientEndpoint(method = "POST", path = "/catalog/datasets")
     Dataset createDataset(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @HeaderParam("Test-Header") @Safe String testHeaderArg,
+            @Safe @HeaderParam("Test-Header") String testHeaderArg,
             @NotNull CreateDatasetRequest request);
 
     @GET
@@ -63,7 +63,7 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}")
     Optional<Dataset> getDataset(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/raw")
@@ -71,7 +71,7 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw")
     StreamingOutput getRawData(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/raw-aliased")
@@ -79,7 +79,7 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw-aliased")
     StreamingOutput getAliasedRawData(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/raw-maybe")
@@ -87,20 +87,20 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw-maybe")
     Optional<StreamingOutput> maybeGetRawData(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe @Nonnull ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") @Nonnull ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/string-aliased")
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/string-aliased")
     AliasedString getAliasedString(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @POST
     @Path("catalog/datasets/upload-raw")
     @Consumes(MediaType.APPLICATION_OCTET_STREAM)
     @ClientEndpoint(method = "POST", path = "/catalog/datasets/upload-raw")
-    void uploadRawData(@HeaderParam("Authorization") @NotNull AuthHeader authHeader, @NotNull @Safe InputStream input);
+    void uploadRawData(@HeaderParam("Authorization") @NotNull AuthHeader authHeader, @Safe @NotNull InputStream input);
 
     @POST
     @Path("catalog/datasets/upload-raw-aliased")
@@ -116,7 +116,7 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches")
     Set<String> getBranches(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     /**
      * Gets all branches of this dataset.
@@ -129,14 +129,14 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branchesDeprecated")
     Set<String> getBranchesDeprecated(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
     Optional<String> resolveBranch(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid,
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid,
             @PathParam("branch") String branch);
 
     @GET
@@ -144,14 +144,14 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/testParam")
     Optional<String> testParam(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @POST
     @Path("catalog/test-query-params")
     @ClientEndpoint(method = "POST", path = "/catalog/test-query-params")
     int testQueryParams(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @QueryParam("different") @Safe ResourceIdentifier something,
+            @Safe @QueryParam("different") ResourceIdentifier something,
             @QueryParam("implicit") ResourceIdentifier implicit,
             @QueryParam("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @QueryParam("setEnd") Set<String> setEnd,
@@ -204,13 +204,13 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/strings")
     void getForStrings(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid,
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid,
             @QueryParam("strings") Set<AliasedString> strings);
 
     @Deprecated
     @ClientEndpoint(method = "POST", path = "/catalog/test-query-params")
     default int testQueryParams(
-            AuthHeader authHeader, ResourceIdentifier something, ResourceIdentifier implicit, String query) {
+            AuthHeader authHeader, @Safe ResourceIdentifier something, ResourceIdentifier implicit, String query) {
         return testQueryParams(
                 authHeader, something, implicit, Optional.empty(), Collections.emptySet(), Optional.empty(), query);
     }
@@ -219,7 +219,7 @@ public interface TestService {
     @ClientEndpoint(method = "POST", path = "/catalog/test-query-params")
     default int testQueryParams(
             AuthHeader authHeader,
-            ResourceIdentifier something,
+            @Safe ResourceIdentifier something,
             ResourceIdentifier implicit,
             Optional<ResourceIdentifier> optionalMiddle,
             String query) {
@@ -231,7 +231,7 @@ public interface TestService {
     @ClientEndpoint(method = "POST", path = "/catalog/test-query-params")
     default int testQueryParams(
             AuthHeader authHeader,
-            ResourceIdentifier something,
+            @Safe ResourceIdentifier something,
             ResourceIdentifier implicit,
             Optional<ResourceIdentifier> optionalMiddle,
             Set<String> setEnd,
@@ -285,7 +285,7 @@ public interface TestService {
 
     @Deprecated
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/strings")
-    default void getForStrings(AuthHeader authHeader, ResourceIdentifier datasetRid) {
+    default void getForStrings(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid) {
         getForStrings(authHeader, datasetRid, Collections.emptySet());
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.prefix
@@ -54,7 +54,7 @@ public interface TestService {
     @ClientEndpoint(method = "POST", path = "/catalog/datasets")
     Dataset createDataset(
             @HeaderParam("Authorization") AuthHeader authHeader,
-            @HeaderParam("Test-Header") @Safe String testHeaderArg,
+            @Safe @HeaderParam("Test-Header") String testHeaderArg,
             CreateDatasetRequest request);
 
     @GET
@@ -62,7 +62,7 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}")
     Optional<Dataset> getDataset(
             @HeaderParam("Authorization") AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/raw")
@@ -70,7 +70,7 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw")
     StreamingOutput getRawData(
             @HeaderParam("Authorization") AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/raw-aliased")
@@ -78,7 +78,7 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw-aliased")
     StreamingOutput getAliasedRawData(
             @HeaderParam("Authorization") AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/raw-maybe")
@@ -86,14 +86,14 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw-maybe")
     Optional<StreamingOutput> maybeGetRawData(
             @HeaderParam("Authorization") AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe @Nonnull ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") @Nonnull ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/string-aliased")
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/string-aliased")
     AliasedString getAliasedString(
             @HeaderParam("Authorization") AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @POST
     @Path("catalog/datasets/upload-raw")
@@ -115,7 +115,7 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches")
     Set<String> getBranches(
             @HeaderParam("Authorization") AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     /**
      * Gets all branches of this dataset.
@@ -128,14 +128,14 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branchesDeprecated")
     Set<String> getBranchesDeprecated(
             @HeaderParam("Authorization") AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
     Optional<String> resolveBranch(
             @HeaderParam("Authorization") AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid,
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid,
             @PathParam("branch") String branch);
 
     @GET
@@ -143,14 +143,14 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/testParam")
     Optional<String> testParam(
             @HeaderParam("Authorization") AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @POST
     @Path("catalog/test-query-params")
     @ClientEndpoint(method = "POST", path = "/catalog/test-query-params")
     int testQueryParams(
             @HeaderParam("Authorization") AuthHeader authHeader,
-            @QueryParam("different") @Safe ResourceIdentifier something,
+            @Safe @QueryParam("different") ResourceIdentifier something,
             @QueryParam("implicit") ResourceIdentifier implicit,
             @QueryParam("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @QueryParam("setEnd") Set<String> setEnd,
@@ -203,13 +203,13 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/strings")
     void getForStrings(
             @HeaderParam("Authorization") AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid,
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid,
             @QueryParam("strings") Set<AliasedString> strings);
 
     @Deprecated
     @ClientEndpoint(method = "POST", path = "/catalog/test-query-params")
     default int testQueryParams(
-            AuthHeader authHeader, ResourceIdentifier something, ResourceIdentifier implicit, String query) {
+            AuthHeader authHeader, @Safe ResourceIdentifier something, ResourceIdentifier implicit, String query) {
         return testQueryParams(
                 authHeader, something, implicit, Optional.empty(), Collections.emptySet(), Optional.empty(), query);
     }
@@ -218,7 +218,7 @@ public interface TestService {
     @ClientEndpoint(method = "POST", path = "/catalog/test-query-params")
     default int testQueryParams(
             AuthHeader authHeader,
-            ResourceIdentifier something,
+            @Safe ResourceIdentifier something,
             ResourceIdentifier implicit,
             Optional<ResourceIdentifier> optionalMiddle,
             String query) {
@@ -230,7 +230,7 @@ public interface TestService {
     @ClientEndpoint(method = "POST", path = "/catalog/test-query-params")
     default int testQueryParams(
             AuthHeader authHeader,
-            ResourceIdentifier something,
+            @Safe ResourceIdentifier something,
             ResourceIdentifier implicit,
             Optional<ResourceIdentifier> optionalMiddle,
             Set<String> setEnd,
@@ -284,7 +284,7 @@ public interface TestService {
 
     @Deprecated
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/strings")
-    default void getForStrings(AuthHeader authHeader, ResourceIdentifier datasetRid) {
+    default void getForStrings(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid) {
         getForStrings(authHeader, datasetRid, Collections.emptySet());
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
@@ -55,7 +55,7 @@ public interface TestService {
     @ClientEndpoint(method = "POST", path = "/catalog/datasets")
     Dataset createDataset(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @HeaderParam("Test-Header") @Safe String testHeaderArg,
+            @Safe @HeaderParam("Test-Header") String testHeaderArg,
             @NotNull CreateDatasetRequest request);
 
     @GET
@@ -63,7 +63,7 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}")
     Optional<Dataset> getDataset(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/raw")
@@ -71,7 +71,7 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw")
     StreamingOutput getRawData(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/raw-aliased")
@@ -79,7 +79,7 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw-aliased")
     StreamingOutput getAliasedRawData(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/raw-maybe")
@@ -87,20 +87,20 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw-maybe")
     Optional<StreamingOutput> maybeGetRawData(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe @Nonnull ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") @Nonnull ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/string-aliased")
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/string-aliased")
     AliasedString getAliasedString(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @POST
     @Path("catalog/datasets/upload-raw")
     @Consumes(MediaType.APPLICATION_OCTET_STREAM)
     @ClientEndpoint(method = "POST", path = "/catalog/datasets/upload-raw")
-    void uploadRawData(@HeaderParam("Authorization") @NotNull AuthHeader authHeader, @NotNull @Safe InputStream input);
+    void uploadRawData(@HeaderParam("Authorization") @NotNull AuthHeader authHeader, @Safe @NotNull InputStream input);
 
     @POST
     @Path("catalog/datasets/upload-raw-aliased")
@@ -116,7 +116,7 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches")
     Set<String> getBranches(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     /**
      * Gets all branches of this dataset.
@@ -129,14 +129,14 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branchesDeprecated")
     Set<String> getBranchesDeprecated(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @GET
     @Path("catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
     Optional<String> resolveBranch(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid,
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid,
             @PathParam("branch") String branch);
 
     @GET
@@ -144,14 +144,14 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/testParam")
     Optional<String> testParam(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid);
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
     @POST
     @Path("catalog/test-query-params")
     @ClientEndpoint(method = "POST", path = "/catalog/test-query-params")
     int testQueryParams(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @QueryParam("different") @Safe ResourceIdentifier something,
+            @Safe @QueryParam("different") ResourceIdentifier something,
             @QueryParam("implicit") ResourceIdentifier implicit,
             @QueryParam("optionalMiddle") Optional<ResourceIdentifier> optionalMiddle,
             @QueryParam("setEnd") Set<String> setEnd,
@@ -204,13 +204,13 @@ public interface TestService {
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/strings")
     void getForStrings(
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
-            @PathParam("datasetRid") @Safe ResourceIdentifier datasetRid,
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid,
             @QueryParam("strings") Set<AliasedString> strings);
 
     @Deprecated
     @ClientEndpoint(method = "POST", path = "/catalog/test-query-params")
     default int testQueryParams(
-            AuthHeader authHeader, ResourceIdentifier something, ResourceIdentifier implicit, String query) {
+            AuthHeader authHeader, @Safe ResourceIdentifier something, ResourceIdentifier implicit, String query) {
         return testQueryParams(
                 authHeader, something, implicit, Optional.empty(), Collections.emptySet(), Optional.empty(), query);
     }
@@ -219,7 +219,7 @@ public interface TestService {
     @ClientEndpoint(method = "POST", path = "/catalog/test-query-params")
     default int testQueryParams(
             AuthHeader authHeader,
-            ResourceIdentifier something,
+            @Safe ResourceIdentifier something,
             ResourceIdentifier implicit,
             Optional<ResourceIdentifier> optionalMiddle,
             String query) {
@@ -231,7 +231,7 @@ public interface TestService {
     @ClientEndpoint(method = "POST", path = "/catalog/test-query-params")
     default int testQueryParams(
             AuthHeader authHeader,
-            ResourceIdentifier something,
+            @Safe ResourceIdentifier something,
             ResourceIdentifier implicit,
             Optional<ResourceIdentifier> optionalMiddle,
             Set<String> setEnd,
@@ -285,7 +285,7 @@ public interface TestService {
 
     @Deprecated
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/strings")
-    default void getForStrings(AuthHeader authHeader, ResourceIdentifier datasetRid) {
+    default void getForStrings(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid) {
         getForStrings(authHeader, datasetRid, Collections.emptySet());
     }
 }

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
@@ -33,27 +33,27 @@ public interface TestService {
      * foo $bar
      * @apiNote {@code POST /catalog/datasets}
      */
-    Dataset createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request);
+    Dataset createDataset(AuthHeader authHeader, @Safe String testHeaderArg, CreateDatasetRequest request);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}}
      */
-    Optional<Dataset> getDataset(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Optional<Dataset> getDataset(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/raw}
      */
-    BinaryResponseBody getRawData(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    BinaryResponseBody getRawData(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/raw-aliased}
      */
-    BinaryResponseBody getAliasedRawData(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    BinaryResponseBody getAliasedRawData(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/raw-maybe}
      */
-    Optional<BinaryResponseBody> maybeGetRawData(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Optional<BinaryResponseBody> maybeGetRawData(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/string-aliased}
@@ -63,7 +63,7 @@ public interface TestService {
     /**
      * @apiNote {@code POST /catalog/datasets/upload-raw}
      */
-    void uploadRawData(AuthHeader authHeader, InputStream input);
+    void uploadRawData(AuthHeader authHeader, @Safe InputStream input);
 
     /**
      * @apiNote {@code POST /catalog/datasets/upload-raw-aliased}
@@ -74,7 +74,7 @@ public interface TestService {
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/branches}
      * @param datasetRid A valid dataset resource identifier.
      */
-    Set<String> getBranches(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Set<String> getBranches(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * Gets all branches of this dataset.
@@ -83,24 +83,24 @@ public interface TestService {
      * @deprecated use getBranches instead
      */
     @Deprecated
-    Set<String> getBranchesDeprecated(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Set<String> getBranchesDeprecated(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve}
      */
-    Optional<String> resolveBranch(AuthHeader authHeader, ResourceIdentifier datasetRid, String branch);
+    Optional<String> resolveBranch(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid, String branch);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/testParam}
      */
-    Optional<String> testParam(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Optional<String> testParam(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code POST /catalog/test-query-params}
      */
     int testQueryParams(
             AuthHeader authHeader,
-            ResourceIdentifier something,
+            @Safe ResourceIdentifier something,
             ResourceIdentifier implicit,
             Optional<ResourceIdentifier> optionalMiddle,
             Set<String> setEnd,
@@ -147,5 +147,5 @@ public interface TestService {
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/strings}
      */
-    void getForStrings(AuthHeader authHeader, ResourceIdentifier datasetRid, Set<AliasedString> strings);
+    void getForStrings(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid, Set<AliasedString> strings);
 }

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.prefix
@@ -33,27 +33,27 @@ public interface TestService {
      * foo $bar
      * @apiNote {@code POST /catalog/datasets}
      */
-    Dataset createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request);
+    Dataset createDataset(AuthHeader authHeader, @Safe String testHeaderArg, CreateDatasetRequest request);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}}
      */
-    Optional<Dataset> getDataset(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Optional<Dataset> getDataset(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/raw}
      */
-    BinaryResponseBody getRawData(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    BinaryResponseBody getRawData(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/raw-aliased}
      */
-    BinaryResponseBody getAliasedRawData(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    BinaryResponseBody getAliasedRawData(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/raw-maybe}
      */
-    Optional<BinaryResponseBody> maybeGetRawData(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Optional<BinaryResponseBody> maybeGetRawData(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/string-aliased}
@@ -63,7 +63,7 @@ public interface TestService {
     /**
      * @apiNote {@code POST /catalog/datasets/upload-raw}
      */
-    void uploadRawData(AuthHeader authHeader, InputStream input);
+    void uploadRawData(AuthHeader authHeader, @Safe InputStream input);
 
     /**
      * @apiNote {@code POST /catalog/datasets/upload-raw-aliased}
@@ -74,7 +74,7 @@ public interface TestService {
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/branches}
      * @param datasetRid A valid dataset resource identifier.
      */
-    Set<String> getBranches(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Set<String> getBranches(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * Gets all branches of this dataset.
@@ -83,24 +83,24 @@ public interface TestService {
      * @deprecated use getBranches instead
      */
     @Deprecated
-    Set<String> getBranchesDeprecated(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Set<String> getBranchesDeprecated(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve}
      */
-    Optional<String> resolveBranch(AuthHeader authHeader, ResourceIdentifier datasetRid, String branch);
+    Optional<String> resolveBranch(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid, String branch);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/testParam}
      */
-    Optional<String> testParam(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Optional<String> testParam(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code POST /catalog/test-query-params}
      */
     int testQueryParams(
             AuthHeader authHeader,
-            ResourceIdentifier something,
+            @Safe ResourceIdentifier something,
             ResourceIdentifier implicit,
             Optional<ResourceIdentifier> optionalMiddle,
             Set<String> setEnd,
@@ -147,5 +147,5 @@ public interface TestService {
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/strings}
      */
-    void getForStrings(AuthHeader authHeader, ResourceIdentifier datasetRid, Set<AliasedString> strings);
+    void getForStrings(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid, Set<AliasedString> strings);
 }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
@@ -60,31 +60,32 @@ public interface TestServiceAsync {
      * @apiNote {@code POST /catalog/datasets}
      */
     @ClientEndpoint(method = "POST", path = "/catalog/datasets")
-    ListenableFuture<Dataset> createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request);
+    ListenableFuture<Dataset> createDataset(
+            AuthHeader authHeader, @Safe String testHeaderArg, CreateDatasetRequest request);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}")
-    ListenableFuture<Optional<Dataset>> getDataset(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    ListenableFuture<Optional<Dataset>> getDataset(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/raw}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw")
-    ListenableFuture<InputStream> getRawData(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    ListenableFuture<InputStream> getRawData(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/raw-aliased}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw-aliased")
-    ListenableFuture<InputStream> getAliasedRawData(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    ListenableFuture<InputStream> getAliasedRawData(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/raw-maybe}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw-maybe")
-    ListenableFuture<Optional<InputStream>> maybeGetRawData(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    ListenableFuture<Optional<InputStream>> maybeGetRawData(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/string-aliased}
@@ -96,7 +97,7 @@ public interface TestServiceAsync {
      * @apiNote {@code POST /catalog/datasets/upload-raw}
      */
     @ClientEndpoint(method = "POST", path = "/catalog/datasets/upload-raw")
-    ListenableFuture<Void> uploadRawData(AuthHeader authHeader, BinaryRequestBody input);
+    ListenableFuture<Void> uploadRawData(AuthHeader authHeader, @Safe BinaryRequestBody input);
 
     /**
      * @apiNote {@code POST /catalog/datasets/upload-raw-aliased}
@@ -109,7 +110,7 @@ public interface TestServiceAsync {
      * @param datasetRid A valid dataset resource identifier.
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches")
-    ListenableFuture<Set<String>> getBranches(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    ListenableFuture<Set<String>> getBranches(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * Gets all branches of this dataset.
@@ -119,20 +120,20 @@ public interface TestServiceAsync {
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branchesDeprecated")
     @Deprecated
-    ListenableFuture<Set<String>> getBranchesDeprecated(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    ListenableFuture<Set<String>> getBranchesDeprecated(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
     ListenableFuture<Optional<String>> resolveBranch(
-            AuthHeader authHeader, ResourceIdentifier datasetRid, String branch);
+            AuthHeader authHeader, @Safe ResourceIdentifier datasetRid, String branch);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/testParam}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/testParam")
-    ListenableFuture<Optional<String>> testParam(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    ListenableFuture<Optional<String>> testParam(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code POST /catalog/test-query-params}
@@ -140,7 +141,7 @@ public interface TestServiceAsync {
     @ClientEndpoint(method = "POST", path = "/catalog/test-query-params")
     ListenableFuture<Integer> testQueryParams(
             AuthHeader authHeader,
-            ResourceIdentifier something,
+            @Safe ResourceIdentifier something,
             ResourceIdentifier implicit,
             Optional<ResourceIdentifier> optionalMiddle,
             Set<String> setEnd,
@@ -196,7 +197,7 @@ public interface TestServiceAsync {
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/strings")
     ListenableFuture<Void> getForStrings(
-            AuthHeader authHeader, ResourceIdentifier datasetRid, Set<AliasedString> strings);
+            AuthHeader authHeader, @Safe ResourceIdentifier datasetRid, Set<AliasedString> strings);
 
     /**
      * Creates an asynchronous/non-blocking client for a TestService service.

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
@@ -60,31 +60,32 @@ public interface TestServiceAsync {
      * @apiNote {@code POST /catalog/datasets}
      */
     @ClientEndpoint(method = "POST", path = "/catalog/datasets")
-    ListenableFuture<Dataset> createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request);
+    ListenableFuture<Dataset> createDataset(
+            AuthHeader authHeader, @Safe String testHeaderArg, CreateDatasetRequest request);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}")
-    ListenableFuture<Optional<Dataset>> getDataset(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    ListenableFuture<Optional<Dataset>> getDataset(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/raw}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw")
-    ListenableFuture<InputStream> getRawData(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    ListenableFuture<InputStream> getRawData(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/raw-aliased}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw-aliased")
-    ListenableFuture<InputStream> getAliasedRawData(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    ListenableFuture<InputStream> getAliasedRawData(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/raw-maybe}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw-maybe")
-    ListenableFuture<Optional<InputStream>> maybeGetRawData(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    ListenableFuture<Optional<InputStream>> maybeGetRawData(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/string-aliased}
@@ -96,7 +97,7 @@ public interface TestServiceAsync {
      * @apiNote {@code POST /catalog/datasets/upload-raw}
      */
     @ClientEndpoint(method = "POST", path = "/catalog/datasets/upload-raw")
-    ListenableFuture<Void> uploadRawData(AuthHeader authHeader, BinaryRequestBody input);
+    ListenableFuture<Void> uploadRawData(AuthHeader authHeader, @Safe BinaryRequestBody input);
 
     /**
      * @apiNote {@code POST /catalog/datasets/upload-raw-aliased}
@@ -109,7 +110,7 @@ public interface TestServiceAsync {
      * @param datasetRid A valid dataset resource identifier.
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches")
-    ListenableFuture<Set<String>> getBranches(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    ListenableFuture<Set<String>> getBranches(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * Gets all branches of this dataset.
@@ -119,20 +120,20 @@ public interface TestServiceAsync {
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branchesDeprecated")
     @Deprecated
-    ListenableFuture<Set<String>> getBranchesDeprecated(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    ListenableFuture<Set<String>> getBranchesDeprecated(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
     ListenableFuture<Optional<String>> resolveBranch(
-            AuthHeader authHeader, ResourceIdentifier datasetRid, String branch);
+            AuthHeader authHeader, @Safe ResourceIdentifier datasetRid, String branch);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/testParam}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/testParam")
-    ListenableFuture<Optional<String>> testParam(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    ListenableFuture<Optional<String>> testParam(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code POST /catalog/test-query-params}
@@ -140,7 +141,7 @@ public interface TestServiceAsync {
     @ClientEndpoint(method = "POST", path = "/catalog/test-query-params")
     ListenableFuture<Integer> testQueryParams(
             AuthHeader authHeader,
-            ResourceIdentifier something,
+            @Safe ResourceIdentifier something,
             ResourceIdentifier implicit,
             Optional<ResourceIdentifier> optionalMiddle,
             Set<String> setEnd,
@@ -196,7 +197,7 @@ public interface TestServiceAsync {
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/strings")
     ListenableFuture<Void> getForStrings(
-            AuthHeader authHeader, ResourceIdentifier datasetRid, Set<AliasedString> strings);
+            AuthHeader authHeader, @Safe ResourceIdentifier datasetRid, Set<AliasedString> strings);
 
     /**
      * Creates an asynchronous/non-blocking client for a TestService service.

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
@@ -60,33 +60,33 @@ public interface TestServiceBlocking {
      * @apiNote {@code POST /catalog/datasets}
      */
     @ClientEndpoint(method = "POST", path = "/catalog/datasets")
-    Dataset createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request);
+    Dataset createDataset(AuthHeader authHeader, @Safe String testHeaderArg, CreateDatasetRequest request);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}")
-    Optional<Dataset> getDataset(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Optional<Dataset> getDataset(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/raw}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw")
     @MustBeClosed
-    InputStream getRawData(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    InputStream getRawData(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/raw-aliased}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw-aliased")
     @MustBeClosed
-    InputStream getAliasedRawData(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    InputStream getAliasedRawData(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/raw-maybe}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw-maybe")
-    Optional<InputStream> maybeGetRawData(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Optional<InputStream> maybeGetRawData(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/string-aliased}
@@ -98,7 +98,7 @@ public interface TestServiceBlocking {
      * @apiNote {@code POST /catalog/datasets/upload-raw}
      */
     @ClientEndpoint(method = "POST", path = "/catalog/datasets/upload-raw")
-    void uploadRawData(AuthHeader authHeader, BinaryRequestBody input);
+    void uploadRawData(AuthHeader authHeader, @Safe BinaryRequestBody input);
 
     /**
      * @apiNote {@code POST /catalog/datasets/upload-raw-aliased}
@@ -111,7 +111,7 @@ public interface TestServiceBlocking {
      * @param datasetRid A valid dataset resource identifier.
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches")
-    Set<String> getBranches(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Set<String> getBranches(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * Gets all branches of this dataset.
@@ -121,19 +121,19 @@ public interface TestServiceBlocking {
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branchesDeprecated")
     @Deprecated
-    Set<String> getBranchesDeprecated(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Set<String> getBranchesDeprecated(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
-    Optional<String> resolveBranch(AuthHeader authHeader, ResourceIdentifier datasetRid, String branch);
+    Optional<String> resolveBranch(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid, String branch);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/testParam}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/testParam")
-    Optional<String> testParam(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Optional<String> testParam(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code POST /catalog/test-query-params}
@@ -141,7 +141,7 @@ public interface TestServiceBlocking {
     @ClientEndpoint(method = "POST", path = "/catalog/test-query-params")
     int testQueryParams(
             AuthHeader authHeader,
-            ResourceIdentifier something,
+            @Safe ResourceIdentifier something,
             ResourceIdentifier implicit,
             Optional<ResourceIdentifier> optionalMiddle,
             Set<String> setEnd,
@@ -195,7 +195,7 @@ public interface TestServiceBlocking {
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/strings}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/strings")
-    void getForStrings(AuthHeader authHeader, ResourceIdentifier datasetRid, Set<AliasedString> strings);
+    void getForStrings(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid, Set<AliasedString> strings);
 
     /**
      * Creates a synchronous/blocking client for a TestService service.

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
@@ -60,33 +60,33 @@ public interface TestServiceBlocking {
      * @apiNote {@code POST /catalog/datasets}
      */
     @ClientEndpoint(method = "POST", path = "/catalog/datasets")
-    Dataset createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request);
+    Dataset createDataset(AuthHeader authHeader, @Safe String testHeaderArg, CreateDatasetRequest request);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}")
-    Optional<Dataset> getDataset(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Optional<Dataset> getDataset(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/raw}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw")
     @MustBeClosed
-    InputStream getRawData(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    InputStream getRawData(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/raw-aliased}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw-aliased")
     @MustBeClosed
-    InputStream getAliasedRawData(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    InputStream getAliasedRawData(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/raw-maybe}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/raw-maybe")
-    Optional<InputStream> maybeGetRawData(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Optional<InputStream> maybeGetRawData(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/string-aliased}
@@ -98,7 +98,7 @@ public interface TestServiceBlocking {
      * @apiNote {@code POST /catalog/datasets/upload-raw}
      */
     @ClientEndpoint(method = "POST", path = "/catalog/datasets/upload-raw")
-    void uploadRawData(AuthHeader authHeader, BinaryRequestBody input);
+    void uploadRawData(AuthHeader authHeader, @Safe BinaryRequestBody input);
 
     /**
      * @apiNote {@code POST /catalog/datasets/upload-raw-aliased}
@@ -111,7 +111,7 @@ public interface TestServiceBlocking {
      * @param datasetRid A valid dataset resource identifier.
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches")
-    Set<String> getBranches(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Set<String> getBranches(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * Gets all branches of this dataset.
@@ -121,19 +121,19 @@ public interface TestServiceBlocking {
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branchesDeprecated")
     @Deprecated
-    Set<String> getBranchesDeprecated(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Set<String> getBranchesDeprecated(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
-    Optional<String> resolveBranch(AuthHeader authHeader, ResourceIdentifier datasetRid, String branch);
+    Optional<String> resolveBranch(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid, String branch);
 
     /**
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/testParam}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/testParam")
-    Optional<String> testParam(AuthHeader authHeader, ResourceIdentifier datasetRid);
+    Optional<String> testParam(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
     /**
      * @apiNote {@code POST /catalog/test-query-params}
@@ -141,7 +141,7 @@ public interface TestServiceBlocking {
     @ClientEndpoint(method = "POST", path = "/catalog/test-query-params")
     int testQueryParams(
             AuthHeader authHeader,
-            ResourceIdentifier something,
+            @Safe ResourceIdentifier something,
             ResourceIdentifier implicit,
             Optional<ResourceIdentifier> optionalMiddle,
             Set<String> setEnd,
@@ -195,7 +195,7 @@ public interface TestServiceBlocking {
      * @apiNote {@code GET /catalog/datasets/{datasetRid}/strings}
      */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/strings")
-    void getForStrings(AuthHeader authHeader, ResourceIdentifier datasetRid, Set<AliasedString> strings);
+    void getForStrings(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid, Set<AliasedString> strings);
 
     /**
      * Creates a synchronous/blocking client for a TestService service.


### PR DESCRIPTION
Ideally validation would occur within the conjure parser, not
at codegen time, and it certainly will for new argument-specific
safety fields, however the marker and tag handling is older than
new safety features, and requires us to fully evaluate safety
of types.

## After this PR
==COMMIT_MSG==
Validate safety agreement between existing argument markers/tags and types
==COMMIT_MSG==

I've also included a change to consolidate handling of legacy `Marker` values with safety `tag` values, where weren't supported the same way across the board.

## Possible downsides?
Could fail to upgrade, but that's signal that something is very wrong.
