### PR TITLE
Union unknown variant is defined with unknown safety

### DIFF
--- a/changelog/@unreleased/pr-1763.v2.yml
+++ b/changelog/@unreleased/pr-1763.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Union unknown variant is defined with unknown safety
+  links:
+  - https://github.com/palantir/conjure-java/pull/1763

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.Unsafe;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -20,7 +19,6 @@ import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
-@Unsafe
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class EmptyUnionTypeExample {
     private final Base value;
@@ -35,7 +33,7 @@ public final class EmptyUnionTypeExample {
         return value;
     }
 
-    public static EmptyUnionTypeExample unknown(@Safe String type, @Unsafe Object value) {
+    public static EmptyUnionTypeExample unknown(@Safe String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
             default:
                 return new EmptyUnionTypeExample(new UnknownWrapper(type, Collections.singletonMap(type, value)));
@@ -66,7 +64,7 @@ public final class EmptyUnionTypeExample {
     }
 
     public interface Visitor<T> {
-        T visitUnknown(@Safe String unknownType, @Unsafe Object unknownValue);
+        T visitUnknown(@Safe String unknownType, Object unknownValue);
 
         static <T> UnknownStageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
@@ -75,11 +73,10 @@ public final class EmptyUnionTypeExample {
 
     private static final class VisitorBuilder<T>
             implements UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
-        private BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor;
+        private BiFunction<@Safe String, Object, T> unknownVisitor;
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknown(
-                @Nonnull BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull BiFunction<@Safe String, Object, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -103,7 +100,7 @@ public final class EmptyUnionTypeExample {
 
         @Override
         public Visitor<T> build() {
-            final BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor = this.unknownVisitor;
+            final BiFunction<@Safe String, Object, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
                 public T visitUnknown(String unknownType, Object unknownValue) {
@@ -114,7 +111,7 @@ public final class EmptyUnionTypeExample {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        Completed_StageVisitorBuilder<T> unknown(@Nonnull BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull BiFunction<@Safe String, Object, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.Unsafe;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -23,7 +22,6 @@ import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
-@Unsafe
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class SingleUnion {
     private final Base value;
@@ -42,7 +40,7 @@ public final class SingleUnion {
         return new SingleUnion(new FooWrapper(value));
     }
 
-    public static SingleUnion unknown(@Safe String type, @Unsafe Object value) {
+    public static SingleUnion unknown(@Safe String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
             case "foo":
                 throw new SafeIllegalArgumentException(
@@ -78,7 +76,7 @@ public final class SingleUnion {
     public interface Visitor<T> {
         T visitFoo(@Safe String value);
 
-        T visitUnknown(@Safe String unknownType, @Unsafe Object unknownValue);
+        T visitUnknown(@Safe String unknownType, Object unknownValue);
 
         static <T> FooStageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
@@ -89,7 +87,7 @@ public final class SingleUnion {
             implements FooStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
         private Function<@Safe String, T> fooVisitor;
 
-        private BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor;
+        private BiFunction<@Safe String, Object, T> unknownVisitor;
 
         @Override
         public UnknownStageVisitorBuilder<T> foo(@Nonnull Function<@Safe String, T> fooVisitor) {
@@ -99,8 +97,7 @@ public final class SingleUnion {
         }
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknown(
-                @Nonnull BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull BiFunction<@Safe String, Object, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -125,7 +122,7 @@ public final class SingleUnion {
         @Override
         public Visitor<T> build() {
             final Function<@Safe String, T> fooVisitor = this.fooVisitor;
-            final BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor = this.unknownVisitor;
+            final BiFunction<@Safe String, Object, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
                 public T visitFoo(String value) {
@@ -145,7 +142,7 @@ public final class SingleUnion {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        Completed_StageVisitorBuilder<T> unknown(@Nonnull BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull BiFunction<@Safe String, Object, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.Unsafe;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -24,7 +23,6 @@ import java.util.function.IntFunction;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
-@Unsafe
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class Union {
     private final Base value;
@@ -60,7 +58,7 @@ public final class Union {
         return new Union(new BazWrapper(value));
     }
 
-    public static Union unknown(@Safe String type, @Unsafe Object value) {
+    public static Union unknown(@Safe String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
             case "foo":
                 throw new SafeIllegalArgumentException(
@@ -115,7 +113,7 @@ public final class Union {
         @Deprecated
         T visitBaz(long value);
 
-        T visitUnknown(@Safe String unknownType, @Unsafe Object unknownValue);
+        T visitUnknown(@Safe String unknownType, Object unknownValue);
 
         static <T> BarStageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
@@ -134,7 +132,7 @@ public final class Union {
 
         private Function<String, T> fooVisitor;
 
-        private BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor;
+        private BiFunction<@Safe String, Object, T> unknownVisitor;
 
         @Override
         public BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor) {
@@ -158,8 +156,7 @@ public final class Union {
         }
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknown(
-                @Nonnull BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull BiFunction<@Safe String, Object, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -186,7 +183,7 @@ public final class Union {
             final IntFunction<T> barVisitor = this.barVisitor;
             final Function<Long, T> bazVisitor = this.bazVisitor;
             final Function<String, T> fooVisitor = this.fooVisitor;
-            final BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor = this.unknownVisitor;
+            final BiFunction<@Safe String, Object, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
                 public T visitBar(int value) {
@@ -224,7 +221,7 @@ public final class Union {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        Completed_StageVisitorBuilder<T> unknown(@Nonnull BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull BiFunction<@Safe String, Object, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -14,7 +14,6 @@ import com.fasterxml.jackson.annotation.Nulls;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.Unsafe;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,7 +30,6 @@ import javax.annotation.Nonnull;
 /**
  * A type which can either be a StringExample, a set of strings, or an integer.
  */
-@Unsafe
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class UnionTypeExample {
     private final Base value;
@@ -113,7 +111,7 @@ public final class UnionTypeExample {
         return new UnionTypeExample(new MapAliasWrapper(value));
     }
 
-    public static UnionTypeExample unknown(@Safe String type, @Unsafe Object value) {
+    public static UnionTypeExample unknown(@Safe String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
             case "stringExample":
                 throw new SafeIllegalArgumentException(
@@ -227,7 +225,7 @@ public final class UnionTypeExample {
 
         T visitMapAlias(MapAliasExample value);
 
-        T visitUnknown(@Safe String unknownType, @Unsafe Object unknownValue);
+        T visitUnknown(@Safe String unknownType, Object unknownValue);
 
         static <T> AlsoAnIntegerStageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
@@ -285,7 +283,7 @@ public final class UnionTypeExample {
 
         private IntFunction<T> unknown_Visitor;
 
-        private BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor;
+        private BiFunction<@Safe String, Object, T> unknownVisitor;
 
         @Override
         public CompletedStageVisitorBuilder<T> alsoAnInteger(@Nonnull IntFunction<T> alsoAnIntegerVisitor) {
@@ -402,8 +400,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknown(
-                @Nonnull BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull BiFunction<@Safe String, Object, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -443,7 +440,7 @@ public final class UnionTypeExample {
             final Function<StringExample, T> stringExampleVisitor = this.stringExampleVisitor;
             final IntFunction<T> thisFieldIsAnIntegerVisitor = this.thisFieldIsAnIntegerVisitor;
             final IntFunction<T> unknown_Visitor = this.unknown_Visitor;
-            final BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor = this.unknownVisitor;
+            final BiFunction<@Safe String, Object, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
                 public T visitAlsoAnInteger(int value) {
@@ -599,7 +596,7 @@ public final class UnionTypeExample {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        Completed_StageVisitorBuilder<T> unknown(@Nonnull BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull BiFunction<@Safe String, Object, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.Unsafe;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -23,7 +22,6 @@ import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
-@Unsafe
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class UnionWithUnknownString {
     private final Base value;
@@ -42,7 +40,7 @@ public final class UnionWithUnknownString {
         return new UnionWithUnknownString(new Unknown_Wrapper(value));
     }
 
-    public static UnionWithUnknownString unknown(@Safe String type, @Unsafe Object value) {
+    public static UnionWithUnknownString unknown(@Safe String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
             case "unknown":
                 throw new SafeIllegalArgumentException(
@@ -78,7 +76,7 @@ public final class UnionWithUnknownString {
     public interface Visitor<T> {
         T visitUnknown_(String value);
 
-        T visitUnknown(@Safe String unknownType, @Unsafe Object unknownValue);
+        T visitUnknown(@Safe String unknownType, Object unknownValue);
 
         static <T> Unknown_StageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
@@ -89,7 +87,7 @@ public final class UnionWithUnknownString {
             implements Unknown_StageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
         private Function<String, T> unknown_Visitor;
 
-        private BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor;
+        private BiFunction<@Safe String, Object, T> unknownVisitor;
 
         @Override
         public UnknownStageVisitorBuilder<T> unknown_(@Nonnull Function<String, T> unknown_Visitor) {
@@ -99,8 +97,7 @@ public final class UnionWithUnknownString {
         }
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknown(
-                @Nonnull BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull BiFunction<@Safe String, Object, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -126,7 +123,7 @@ public final class UnionWithUnknownString {
         @Override
         public Visitor<T> build() {
             final Function<String, T> unknown_Visitor = this.unknown_Visitor;
-            final BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor = this.unknownVisitor;
+            final BiFunction<@Safe String, Object, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
                 public T visitUnknown_(String value) {
@@ -146,7 +143,7 @@ public final class UnionWithUnknownString {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        Completed_StageVisitorBuilder<T> unknown(@Nonnull BiFunction<@Safe String, @Unsafe Object, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull BiFunction<@Safe String, Object, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.Unsafe;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -19,7 +18,6 @@ import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
-@Unsafe
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class EmptyUnionTypeExample {
     private final Base value;
@@ -34,7 +32,7 @@ public final class EmptyUnionTypeExample {
         return value;
     }
 
-    public static EmptyUnionTypeExample unknown(@Safe String type, @Unsafe Object value) {
+    public static EmptyUnionTypeExample unknown(@Safe String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
             default:
                 return new EmptyUnionTypeExample(new UnknownWrapper(type, Collections.singletonMap(type, value)));
@@ -74,10 +72,10 @@ public final class EmptyUnionTypeExample {
 
     private static final class VisitorBuilder<T>
             implements UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
-        private Function<@Unsafe String, T> unknownVisitor;
+        private Function<String, T> unknownVisitor;
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<@Unsafe String, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -94,7 +92,7 @@ public final class EmptyUnionTypeExample {
 
         @Override
         public Visitor<T> build() {
-            final Function<@Unsafe String, T> unknownVisitor = this.unknownVisitor;
+            final Function<String, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
                 public T visitUnknown(String value) {
@@ -105,7 +103,7 @@ public final class EmptyUnionTypeExample {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<@Unsafe String, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.Unsafe;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -22,7 +21,6 @@ import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
-@Unsafe
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class SingleUnion {
     private final Base value;
@@ -41,7 +39,7 @@ public final class SingleUnion {
         return new SingleUnion(new FooWrapper(value));
     }
 
-    public static SingleUnion unknown(@Safe String type, @Unsafe Object value) {
+    public static SingleUnion unknown(@Safe String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
             case "foo":
                 throw new SafeIllegalArgumentException(
@@ -88,7 +86,7 @@ public final class SingleUnion {
             implements FooStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
         private Function<@Safe String, T> fooVisitor;
 
-        private Function<@Unsafe String, T> unknownVisitor;
+        private Function<String, T> unknownVisitor;
 
         @Override
         public UnknownStageVisitorBuilder<T> foo(@Nonnull Function<@Safe String, T> fooVisitor) {
@@ -98,7 +96,7 @@ public final class SingleUnion {
         }
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<@Unsafe String, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -116,7 +114,7 @@ public final class SingleUnion {
         @Override
         public Visitor<T> build() {
             final Function<@Safe String, T> fooVisitor = this.fooVisitor;
-            final Function<@Unsafe String, T> unknownVisitor = this.unknownVisitor;
+            final Function<String, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
                 public T visitFoo(String value) {
@@ -136,7 +134,7 @@ public final class SingleUnion {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<@Unsafe String, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.Unsafe;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -23,7 +22,6 @@ import java.util.function.IntFunction;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
-@Unsafe
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class Union {
     private final Base value;
@@ -59,7 +57,7 @@ public final class Union {
         return new Union(new BazWrapper(value));
     }
 
-    public static Union unknown(@Safe String type, @Unsafe Object value) {
+    public static Union unknown(@Safe String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
             case "foo":
                 throw new SafeIllegalArgumentException(
@@ -133,7 +131,7 @@ public final class Union {
 
         private Function<String, T> fooVisitor;
 
-        private Function<@Unsafe String, T> unknownVisitor;
+        private Function<String, T> unknownVisitor;
 
         @Override
         public BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor) {
@@ -157,7 +155,7 @@ public final class Union {
         }
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<@Unsafe String, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -177,7 +175,7 @@ public final class Union {
             final IntFunction<T> barVisitor = this.barVisitor;
             final Function<Long, T> bazVisitor = this.bazVisitor;
             final Function<String, T> fooVisitor = this.fooVisitor;
-            final Function<@Unsafe String, T> unknownVisitor = this.unknownVisitor;
+            final Function<String, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
                 public T visitBar(int value) {
@@ -215,7 +213,7 @@ public final class Union {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<@Unsafe String, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -14,7 +14,6 @@ import com.fasterxml.jackson.annotation.Nulls;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.Unsafe;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,7 +29,6 @@ import javax.annotation.Nonnull;
 /**
  * A type which can either be a StringExample, a set of strings, or an integer.
  */
-@Unsafe
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class UnionTypeExample {
     private final Base value;
@@ -112,7 +110,7 @@ public final class UnionTypeExample {
         return new UnionTypeExample(new MapAliasWrapper(value));
     }
 
-    public static UnionTypeExample unknown(@Safe String type, @Unsafe Object value) {
+    public static UnionTypeExample unknown(@Safe String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
             case "stringExample":
                 throw new SafeIllegalArgumentException(
@@ -284,7 +282,7 @@ public final class UnionTypeExample {
 
         private IntFunction<T> unknown_Visitor;
 
-        private Function<@Unsafe String, T> unknownVisitor;
+        private Function<String, T> unknownVisitor;
 
         @Override
         public CompletedStageVisitorBuilder<T> alsoAnInteger(@Nonnull IntFunction<T> alsoAnIntegerVisitor) {
@@ -401,7 +399,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<@Unsafe String, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -434,7 +432,7 @@ public final class UnionTypeExample {
             final Function<StringExample, T> stringExampleVisitor = this.stringExampleVisitor;
             final IntFunction<T> thisFieldIsAnIntegerVisitor = this.thisFieldIsAnIntegerVisitor;
             final IntFunction<T> unknown_Visitor = this.unknown_Visitor;
-            final Function<@Unsafe String, T> unknownVisitor = this.unknownVisitor;
+            final Function<String, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
                 public T visitAlsoAnInteger(int value) {
@@ -590,7 +588,7 @@ public final class UnionTypeExample {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<@Unsafe String, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.Unsafe;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -22,7 +21,6 @@ import java.util.function.Function;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
-@Unsafe
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class UnionWithUnknownString {
     private final Base value;
@@ -41,7 +39,7 @@ public final class UnionWithUnknownString {
         return new UnionWithUnknownString(new Unknown_Wrapper(value));
     }
 
-    public static UnionWithUnknownString unknown(@Safe String type, @Unsafe Object value) {
+    public static UnionWithUnknownString unknown(@Safe String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
             case "unknown":
                 throw new SafeIllegalArgumentException(
@@ -88,7 +86,7 @@ public final class UnionWithUnknownString {
             implements Unknown_StageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
         private Function<String, T> unknown_Visitor;
 
-        private Function<@Unsafe String, T> unknownVisitor;
+        private Function<String, T> unknownVisitor;
 
         @Override
         public UnknownStageVisitorBuilder<T> unknown_(@Nonnull Function<String, T> unknown_Visitor) {
@@ -98,7 +96,7 @@ public final class UnionWithUnknownString {
         }
 
         @Override
-        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<@Unsafe String, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownVisitor;
             return this;
@@ -117,7 +115,7 @@ public final class UnionWithUnknownString {
         @Override
         public Visitor<T> build() {
             final Function<String, T> unknown_Visitor = this.unknown_Visitor;
-            final Function<@Unsafe String, T> unknownVisitor = this.unknownVisitor;
+            final Function<String, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
                 public T visitUnknown_(String value) {
@@ -137,7 +135,7 @@ public final class UnionWithUnknownString {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<@Unsafe String, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/SafetyEvaluator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/SafetyEvaluator.java
@@ -47,8 +47,12 @@ public final class SafetyEvaluator {
      * for past and future values which are known at compile-time in that version.
      */
     public static final Optional<LogSafety> ENUM_SAFETY = Optional.of(LogSafety.SAFE);
-    /** Unknown variant is considered unsafe because we don't know what kind of data it may contain. */
-    public static final Optional<LogSafety> UNKNOWN_UNION_VARINT_SAFETY = Optional.of(LogSafety.UNSAFE);
+    /**
+     * Unknown variant should be considered unsafe because we don't know what kind of data it may contain,
+     * however this makes rollout much more challenging, so we will ratchet unknown safety once we have
+     * better tooling to extract safe components.
+     */
+    public static final Optional<LogSafety> UNKNOWN_UNION_VARINT_SAFETY = Optional.empty();
 
     private final Map<TypeName, TypeDefinition> definitionMap;
 


### PR DESCRIPTION
The unknown variant is frightening, and should be considered unsafe,
however we should not risk the rollout of this feature in its
entirety over the unknown-union detail.

==COMMIT_MSG==
Union unknown variant is defined with unknown safety
==COMMIT_MSG==

## Possible downsides?
we have no idea what could be in there. It's not very safe, but it may not necessarily always be unsafe either.

