### PR TITLE
conjure-undertow argument safety is evaluated taking tags into account

### DIFF
--- a/changelog/@unreleased/pr-1787.v2.yml
+++ b/changelog/@unreleased/pr-1787.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: conjure-undertow argument safety is evaluated taking tags into account
+  links:
+  - https://github.com/palantir/conjure-java/pull/1787

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
@@ -145,9 +145,11 @@ public final class TestServiceEndpoints implements UndertowService {
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
             AuthHeader authHeader = runtime.auth().header(exchange);
+            RequestContext requestContext = runtime.contexts().createContext(exchange, this);
             CreateDatasetRequest request = deserializer.deserialize(exchange);
             HeaderMap headerParams = exchange.getRequestHeaders();
             String testHeaderArg = runtime.plainSerDe().deserializeString(headerParams.get("Test-Header"));
+            requestContext.requestArg(SafeArg.of("testHeaderArg", testHeaderArg));
             Dataset result = delegate.createDataset(authHeader, testHeaderArg, request);
             serializer.serialize(result, exchange);
         }
@@ -194,9 +196,11 @@ public final class TestServiceEndpoints implements UndertowService {
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
             AuthHeader authHeader = runtime.auth().header(exchange);
+            RequestContext requestContext = runtime.contexts().createContext(exchange, this);
             Map<String, String> pathParams =
                     exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
             ResourceIdentifier datasetRid = runtime.plainSerDe().deserializeRid(pathParams.get("datasetRid"));
+            requestContext.requestArg(SafeArg.of("datasetRid", datasetRid));
             Optional<Dataset> result = delegate.getDataset(authHeader, datasetRid);
             if (result.isPresent()) {
                 serializer.serialize(result, exchange);
@@ -396,9 +400,11 @@ public final class TestServiceEndpoints implements UndertowService {
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
             AuthHeader authHeader = runtime.auth().header(exchange);
+            RequestContext requestContext = runtime.contexts().createContext(exchange, this);
             Map<String, String> pathParams =
                     exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
             ResourceIdentifier datasetRid = runtime.plainSerDe().deserializeRid(pathParams.get("datasetRid"));
+            requestContext.requestArg(SafeArg.of("datasetRid", datasetRid));
             AliasedString result = delegate.getAliasedString(authHeader, datasetRid);
             serializer.serialize(result, exchange);
         }

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.prefix
@@ -145,9 +145,11 @@ public final class TestServiceEndpoints implements UndertowService {
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
             AuthHeader authHeader = runtime.auth().header(exchange);
+            RequestContext requestContext = runtime.contexts().createContext(exchange, this);
             CreateDatasetRequest request = deserializer.deserialize(exchange);
             HeaderMap headerParams = exchange.getRequestHeaders();
             String testHeaderArg = runtime.plainSerDe().deserializeString(headerParams.get("Test-Header"));
+            requestContext.requestArg(SafeArg.of("testHeaderArg", testHeaderArg));
             Dataset result = delegate.createDataset(authHeader, testHeaderArg, request);
             serializer.serialize(result, exchange);
         }
@@ -194,9 +196,11 @@ public final class TestServiceEndpoints implements UndertowService {
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
             AuthHeader authHeader = runtime.auth().header(exchange);
+            RequestContext requestContext = runtime.contexts().createContext(exchange, this);
             Map<String, String> pathParams =
                     exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
             ResourceIdentifier datasetRid = runtime.plainSerDe().deserializeRid(pathParams.get("datasetRid"));
+            requestContext.requestArg(SafeArg.of("datasetRid", datasetRid));
             Optional<Dataset> result = delegate.getDataset(authHeader, datasetRid);
             if (result.isPresent()) {
                 serializer.serialize(result, exchange);
@@ -396,9 +400,11 @@ public final class TestServiceEndpoints implements UndertowService {
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
             AuthHeader authHeader = runtime.auth().header(exchange);
+            RequestContext requestContext = runtime.contexts().createContext(exchange, this);
             Map<String, String> pathParams =
                     exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
             ResourceIdentifier datasetRid = runtime.plainSerDe().deserializeRid(pathParams.get("datasetRid"));
+            requestContext.requestArg(SafeArg.of("datasetRid", datasetRid));
             AliasedString result = delegate.getAliasedString(authHeader, datasetRid);
             serializer.serialize(result, exchange);
         }


### PR DESCRIPTION
## Before this PR
This fixes a regression in which the argument declared safety and marker safety were used, but tag safety was ignored.

## After this PR
==COMMIT_MSG==
conjure-undertow argument safety is evaluated taking tags into account
==COMMIT_MSG==
