### PR TITLE
Ignore decoder factory functions that throw checked exceptions

### DIFF
--- a/changelog/@unreleased/pr-1790.v2.yml
+++ b/changelog/@unreleased/pr-1790.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Ignore parameter factory methods that throw checked exceptions.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1790

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
@@ -32,10 +32,12 @@ import com.palantir.conjure.java.undertow.processor.sample.DeprecatedResource;
 import com.palantir.conjure.java.undertow.processor.sample.MultipleBodyInterface;
 import com.palantir.conjure.java.undertow.processor.sample.NameClashContextParam;
 import com.palantir.conjure.java.undertow.processor.sample.NameClashExchangeParam;
-import com.palantir.conjure.java.undertow.processor.sample.OfFactory;
 import com.palantir.conjure.java.undertow.processor.sample.OptionalPrimitives;
 import com.palantir.conjure.java.undertow.processor.sample.OverloadedResource;
+import com.palantir.conjure.java.undertow.processor.sample.ParameterConstructorThrows;
 import com.palantir.conjure.java.undertow.processor.sample.ParameterNotAnnotated;
+import com.palantir.conjure.java.undertow.processor.sample.ParameterOfFactoryThrows;
+import com.palantir.conjure.java.undertow.processor.sample.ParameterValueOfFactoryThrows;
 import com.palantir.conjure.java.undertow.processor.sample.PrimitiveBodyParam;
 import com.palantir.conjure.java.undertow.processor.sample.PrimitiveQueryParams;
 import com.palantir.conjure.java.undertow.processor.sample.PrivateMethodAnnotatedResource;
@@ -76,11 +78,6 @@ public class ConjureUndertowAnnotationProcessorTest {
     @Test
     public void testMultipleBodies() {
         assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, MultipleBodyInterface.class);
-    }
-
-    @Test
-    public void testOfFactoryMethod() {
-        assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, OfFactory.class);
     }
 
     @Test
@@ -176,6 +173,24 @@ public class ConjureUndertowAnnotationProcessorTest {
     public void testBodyIsNotAnnotated() {
         assertThat(compileTestClass(TEST_CLASSES_BASE_DIR, ParameterNotAnnotated.class))
                 .hadErrorContaining("At least one annotation should be present");
+    }
+
+    @Test
+    public void testParameterConstructorThrows() {
+        assertThat(compileTestClass(TEST_CLASSES_BASE_DIR, ParameterConstructorThrows.class))
+                .hadErrorContaining("No default decoder exists for parameter");
+    }
+
+    @Test
+    public void testParameterOfFactoryThrows() {
+        assertThat(compileTestClass(TEST_CLASSES_BASE_DIR, ParameterOfFactoryThrows.class))
+                .hadErrorContaining("No default decoder exists for parameter");
+    }
+
+    @Test
+    public void testParameterValueOfFactoryThrows() {
+        assertThat(compileTestClass(TEST_CLASSES_BASE_DIR, ParameterValueOfFactoryThrows.class))
+                .hadErrorContaining("No default decoder exists for parameter");
     }
 
     private void assertTestFileCompileAndMatches(Path basePath, Class<?> clazz) {

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderService.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderService.java
@@ -23,7 +23,6 @@ import com.palantir.conjure.java.undertow.annotations.Handle;
 import com.palantir.conjure.java.undertow.annotations.HttpMethod;
 import com.palantir.conjure.java.undertow.annotations.ParamDecoder;
 import com.palantir.ri.ResourceIdentifier;
-import java.math.BigInteger;
 import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.List;
@@ -32,49 +31,55 @@ import java.util.OptionalInt;
 import java.util.Set;
 import java.util.UUID;
 
+@SuppressWarnings("TooManyArguments")
 public interface DefaultDecoderService {
 
     @Handle(method = HttpMethod.GET, path = "/queryParam")
     String queryParam(
-            @Handle.QueryParam(value = "stringParam") String stringParam,
-            @Handle.QueryParam(value = "booleanParam") Boolean booleanParam,
-            @Handle.QueryParam(value = "stringSetParam") Set<String> stringSetParam,
-            @Handle.QueryParam(value = "stringListParam") List<String> stringListParam,
-            @Handle.QueryParam(value = "optionalStringParam") Optional<String> optionalStringParam,
-            @Handle.QueryParam(value = "decoderParam", decoder = StringCollectionDecoder.class) String decoderParam);
-
-    @Handle(method = HttpMethod.GET, path = "/moreQueryParams")
-    String moreQueryParams(
-            @Handle.QueryParam(value = "optionalInt") OptionalInt optionalIntParam,
-            @Handle.QueryParam(value = "dateTime") OffsetDateTime dateTimeParam,
-            @Handle.QueryParam(value = "ridSetParam") Set<ResourceIdentifier> ridSetParam,
-            @Handle.QueryParam(value = "optionalSafeLongParam") Optional<SafeLong> optionalSafeLongParam,
-            @Handle.QueryParam(value = "uuidParam") UUID uuidParam,
-            @Handle.QueryParam("floatParamBoxed") Float floatHeaderBoxed,
-            @Handle.QueryParam("floatParamUnboxed") float floatHeaderUnboxed);
+            @Handle.QueryParam("stringParam") String stringParam,
+            @Handle.QueryParam("booleanParam") Boolean booleanParam,
+            @Handle.QueryParam("stringSetParam") Set<String> stringSetParam,
+            @Handle.QueryParam("stringListParam") List<String> stringListParam,
+            @Handle.QueryParam("optionalStringParam") Optional<String> optionalStringParam,
+            @Handle.QueryParam("floatBoxed") Float floatBoxed,
+            @Handle.QueryParam("floatUnboxed") float floatUnboxed,
+            @Handle.QueryParam("optionalInt") OptionalInt optionalIntParam,
+            @Handle.QueryParam("dateTime") OffsetDateTime dateTimeParam,
+            @Handle.QueryParam("ridSetParam") Set<ResourceIdentifier> ridSetParam,
+            @Handle.QueryParam("optionalSafeLongParam") Optional<SafeLong> optionalSafeLongParam,
+            @Handle.QueryParam("uuidParam") UUID uuidParam,
+            @Handle.QueryParam(value = "decoderParam", decoder = StringCollectionDecoder.class) String decoderParam,
+            @Handle.QueryParam("constructor") Constructor constructor,
+            @Handle.QueryParam("ofFactory") OfFactory ofFactory,
+            @Handle.QueryParam("valueOfFactory") ValueOfFactory valueOfFactory);
 
     @Handle(method = HttpMethod.GET, path = "/headers")
     String headers(
-            @Handle.Header(value = "stringParam") String stringParam,
-            @Handle.Header(value = "booleanParam") Boolean booleanParam,
-            @Handle.Header(value = "stringSetParam") Set<String> stringSetParam,
-            @Handle.Header(value = "stringListParam") List<String> stringListParam,
-            @Handle.Header(value = "optionalStringParam") Optional<String> optionalStringParam,
+            @Handle.Header("stringParam") String stringParam,
+            @Handle.Header("booleanParam") Boolean booleanParam,
+            @Handle.Header("stringSetParam") Set<String> stringSetParam,
+            @Handle.Header("stringListParam") List<String> stringListParam,
+            @Handle.Header("optionalStringParam") Optional<String> optionalStringParam,
+            @Handle.Header("floatBoxed") Float floatBoxed,
+            @Handle.Header("floatUnboxed") float floatUnboxed,
             @Handle.Header(value = "decoderParam", decoder = StringCollectionDecoder.class) String decoderParam,
-            @Handle.Header("floatHeaderBoxed") Float floatHeaderBoxed,
-            @Handle.Header("floatHeaderUnboxed") float floatHeaderUnboxed,
-            @Handle.Header("bigInteger") BigInteger bigInteger);
+            @Handle.Header("constructor") Constructor constructor,
+            @Handle.Header("ofFactory") OfFactory ofFactory,
+            @Handle.Header("valueOfFactory") ValueOfFactory valueOfFactory);
 
     @Handle(
             method = HttpMethod.GET,
-            path = "/pathParam/{stringParam}/{booleanParam}/{decoderParam}/{floatBoxed}/{floatUnboxed}/{bigInt}")
+            path = "/pathParam/{stringParam}/{booleanParam}/{decoderParam}/{floatBoxed}/{floatUnboxed}/{bigInt}"
+                    + "/{constructor}/{ofFactory}/{valueOfFactory}")
     String pathParam(
             @Handle.PathParam String stringParam,
             @Handle.PathParam Boolean booleanParam,
             @Handle.PathParam(decoder = StringDecoder.class) String decoderParam,
             @Handle.PathParam Float floatBoxed,
             @Handle.PathParam float floatUnboxed,
-            @Handle.PathParam BigInteger bigInt);
+            @Handle.PathParam Constructor constructor,
+            @Handle.PathParam OfFactory ofFactory,
+            @Handle.PathParam ValueOfFactory valueOfFactory);
 
     enum StringCollectionDecoder implements CollectionParamDecoder<String> {
         INSTANCE;
@@ -91,6 +96,29 @@ public interface DefaultDecoderService {
         @Override
         public String decode(String value) {
             return value;
+        }
+    }
+
+    final class Constructor {
+
+        public Constructor(String _value) {}
+    }
+
+    final class OfFactory {
+
+        private OfFactory() {}
+
+        public static OfFactory of(String _value) {
+            return new OfFactory();
+        }
+    }
+
+    final class ValueOfFactory {
+
+        private ValueOfFactory() {}
+
+        public static ValueOfFactory valueOf(String _value) {
+            return new ValueOfFactory();
         }
     }
 }

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/ParameterConstructorThrows.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/ParameterConstructorThrows.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.palantir.conjure.java.undertow.annotations.Handle;
+import com.palantir.conjure.java.undertow.annotations.Handle.QueryParam;
+import com.palantir.conjure.java.undertow.annotations.HttpMethod;
+
+public interface ParameterConstructorThrows {
+
+    @Handle(method = HttpMethod.GET, path = "/")
+    void parameterThrowingConstructor(@QueryParam("value") Value value);
+
+    final class Value {
+
+        public Value(String _value) throws Exception {}
+    }
+}

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/ParameterOfFactoryThrows.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/ParameterOfFactoryThrows.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.palantir.conjure.java.undertow.annotations.Handle;
+import com.palantir.conjure.java.undertow.annotations.Handle.QueryParam;
+import com.palantir.conjure.java.undertow.annotations.HttpMethod;
+
+public interface ParameterOfFactoryThrows {
+
+    @Handle(method = HttpMethod.GET, path = "/")
+    void parameterThrowingOfFactory(@QueryParam("value") Value _value);
+
+    final class Value {
+
+        private Value() {}
+
+        public static Value valueOf(String _value) throws Exception {
+            return new Value();
+        }
+    }
+}

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/ParameterValueOfFactoryThrows.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/ParameterValueOfFactoryThrows.java
@@ -17,27 +17,20 @@
 package com.palantir.conjure.java.undertow.processor.sample;
 
 import com.palantir.conjure.java.undertow.annotations.Handle;
+import com.palantir.conjure.java.undertow.annotations.Handle.QueryParam;
 import com.palantir.conjure.java.undertow.annotations.HttpMethod;
 
-public interface OfFactory {
+public interface ParameterValueOfFactoryThrows {
 
-    @Handle(method = HttpMethod.GET, path = "/{pathVar}")
-    void ping(@Handle.PathParam PathVariable pathVar);
+    @Handle(method = HttpMethod.GET, path = "/")
+    void parameterThrowingConstructor(@QueryParam("value") Value value);
 
-    final class PathVariable {
-        private final String value;
+    final class Value {
 
-        private PathVariable(String value) {
-            this.value = value;
-        }
+        private Value() {}
 
-        public static PathVariable of(String value) {
-            return new PathVariable(value);
-        }
-
-        @Override
-        public String toString() {
-            return "PathVariable{value='" + value + '\'' + '}';
+        static Value of(String _value) throws Exception {
+            return new Value();
         }
     }
 }

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderServiceEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderServiceEndpoints.java.generated
@@ -25,7 +25,6 @@ import java.lang.Exception;
 import java.lang.Float;
 import java.lang.Override;
 import java.lang.String;
-import java.math.BigInteger;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -50,7 +49,6 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
     public List<Endpoint> endpoints(UndertowRuntime runtime) {
         return ImmutableList.of(
                 new QueryParamEndpoint(runtime, delegate),
-                new MoreQueryParamsEndpoint(runtime, delegate),
                 new HeadersEndpoint(runtime, delegate),
                 new PathParamEndpoint(runtime, delegate));
     }
@@ -70,7 +68,27 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
 
         private final Deserializer<Optional<String>> optionalStringParamDeserializer;
 
+        private final Deserializer<Float> floatBoxedDeserializer;
+
+        private final Deserializer<Float> floatUnboxedDeserializer;
+
+        private final Deserializer<OptionalInt> optionalIntParamDeserializer;
+
+        private final Deserializer<OffsetDateTime> dateTimeParamDeserializer;
+
+        private final Deserializer<Set<ResourceIdentifier>> ridSetParamDeserializer;
+
+        private final Deserializer<Optional<SafeLong>> optionalSafeLongParamDeserializer;
+
+        private final Deserializer<UUID> uuidParamDeserializer;
+
         private final Deserializer<String> decoderParamDeserializer;
+
+        private final Deserializer<DefaultDecoderService.Constructor> constructorDeserializer;
+
+        private final Deserializer<DefaultDecoderService.OfFactory> ofFactoryDeserializer;
+
+        private final Deserializer<DefaultDecoderService.ValueOfFactory> valueOfFactoryDeserializer;
 
         private final Serializer<String> queryParamSerializer;
 
@@ -87,8 +105,36 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                     "stringListParam", ParamDecoders.stringListCollectionParamDecoder(runtime.plainSerDe()));
             this.optionalStringParamDeserializer = new QueryParamDeserializer<>(
                     "optionalStringParam", ParamDecoders.optionalStringCollectionParamDecoder(runtime.plainSerDe()));
+            this.floatBoxedDeserializer = new QueryParamDeserializer<>(
+                    "floatBoxed", ParamDecoders.complexCollectionParamDecoder(runtime.plainSerDe(), Float::valueOf));
+            this.floatUnboxedDeserializer = new QueryParamDeserializer<>(
+                    "floatUnboxed",
+                    ParamDecoders.complexCollectionParamDecoder(runtime.plainSerDe(), Float::parseFloat));
+            this.optionalIntParamDeserializer = new QueryParamDeserializer<>(
+                    "optionalInt", ParamDecoders.optionalIntegerCollectionParamDecoder(runtime.plainSerDe()));
+            this.dateTimeParamDeserializer = new QueryParamDeserializer<>(
+                    "dateTime", ParamDecoders.dateTimeCollectionParamDecoder(runtime.plainSerDe()));
+            this.ridSetParamDeserializer = new QueryParamDeserializer<>(
+                    "ridSetParam", ParamDecoders.ridSetCollectionParamDecoder(runtime.plainSerDe()));
+            this.optionalSafeLongParamDeserializer = new QueryParamDeserializer<>(
+                    "optionalSafeLongParam",
+                    ParamDecoders.optionalSafeLongCollectionParamDecoder(runtime.plainSerDe()));
+            this.uuidParamDeserializer = new QueryParamDeserializer<>(
+                    "uuidParam", ParamDecoders.uuidCollectionParamDecoder(runtime.plainSerDe()));
             this.decoderParamDeserializer = new QueryParamDeserializer<>(
                     "decoderParam", DefaultDecoderService.StringCollectionDecoder.INSTANCE);
+            this.constructorDeserializer = new QueryParamDeserializer<>(
+                    "constructor",
+                    ParamDecoders.complexCollectionParamDecoder(
+                            runtime.plainSerDe(), DefaultDecoderService.Constructor::new));
+            this.ofFactoryDeserializer = new QueryParamDeserializer<>(
+                    "ofFactory",
+                    ParamDecoders.complexCollectionParamDecoder(
+                            runtime.plainSerDe(), DefaultDecoderService.OfFactory::of));
+            this.valueOfFactoryDeserializer = new QueryParamDeserializer<>(
+                    "valueOfFactory",
+                    ParamDecoders.complexCollectionParamDecoder(
+                            runtime.plainSerDe(), DefaultDecoderService.ValueOfFactory::valueOf));
             this.queryParamSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
         }
 
@@ -99,7 +145,17 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
             Set<String> stringSetParam = this.stringSetParamDeserializer.deserialize(exchange);
             List<String> stringListParam = this.stringListParamDeserializer.deserialize(exchange);
             Optional<String> optionalStringParam = this.optionalStringParamDeserializer.deserialize(exchange);
+            Float floatBoxed = this.floatBoxedDeserializer.deserialize(exchange);
+            float floatUnboxed = this.floatUnboxedDeserializer.deserialize(exchange);
+            OptionalInt optionalIntParam = this.optionalIntParamDeserializer.deserialize(exchange);
+            OffsetDateTime dateTimeParam = this.dateTimeParamDeserializer.deserialize(exchange);
+            Set<ResourceIdentifier> ridSetParam = this.ridSetParamDeserializer.deserialize(exchange);
+            Optional<SafeLong> optionalSafeLongParam = this.optionalSafeLongParamDeserializer.deserialize(exchange);
+            UUID uuidParam = this.uuidParamDeserializer.deserialize(exchange);
             String decoderParam = this.decoderParamDeserializer.deserialize(exchange);
+            DefaultDecoderService.Constructor constructor = this.constructorDeserializer.deserialize(exchange);
+            DefaultDecoderService.OfFactory ofFactory = this.ofFactoryDeserializer.deserialize(exchange);
+            DefaultDecoderService.ValueOfFactory valueOfFactory = this.valueOfFactoryDeserializer.deserialize(exchange);
             write(
                     this.delegate.queryParam(
                             stringParam,
@@ -107,7 +163,17 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                             stringSetParam,
                             stringListParam,
                             optionalStringParam,
-                            decoderParam),
+                            floatBoxed,
+                            floatUnboxed,
+                            optionalIntParam,
+                            dateTimeParam,
+                            ridSetParam,
+                            optionalSafeLongParam,
+                            uuidParam,
+                            decoderParam,
+                            constructor,
+                            ofFactory,
+                            valueOfFactory),
                     exchange);
         }
 
@@ -142,103 +208,6 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
         }
     }
 
-    private static final class MoreQueryParamsEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<String> {
-        private final UndertowRuntime runtime;
-
-        private final DefaultDecoderService delegate;
-
-        private final Deserializer<OptionalInt> optionalIntParamDeserializer;
-
-        private final Deserializer<OffsetDateTime> dateTimeParamDeserializer;
-
-        private final Deserializer<Set<ResourceIdentifier>> ridSetParamDeserializer;
-
-        private final Deserializer<Optional<SafeLong>> optionalSafeLongParamDeserializer;
-
-        private final Deserializer<UUID> uuidParamDeserializer;
-
-        private final Deserializer<Float> floatHeaderBoxedDeserializer;
-
-        private final Deserializer<Float> floatHeaderUnboxedDeserializer;
-
-        private final Serializer<String> moreQueryParamsSerializer;
-
-        MoreQueryParamsEndpoint(UndertowRuntime runtime, DefaultDecoderService delegate) {
-            this.runtime = runtime;
-            this.delegate = delegate;
-            this.optionalIntParamDeserializer = new QueryParamDeserializer<>(
-                    "optionalInt", ParamDecoders.optionalIntegerCollectionParamDecoder(runtime.plainSerDe()));
-            this.dateTimeParamDeserializer = new QueryParamDeserializer<>(
-                    "dateTime", ParamDecoders.dateTimeCollectionParamDecoder(runtime.plainSerDe()));
-            this.ridSetParamDeserializer = new QueryParamDeserializer<>(
-                    "ridSetParam", ParamDecoders.ridSetCollectionParamDecoder(runtime.plainSerDe()));
-            this.optionalSafeLongParamDeserializer = new QueryParamDeserializer<>(
-                    "optionalSafeLongParam",
-                    ParamDecoders.optionalSafeLongCollectionParamDecoder(runtime.plainSerDe()));
-            this.uuidParamDeserializer = new QueryParamDeserializer<>(
-                    "uuidParam", ParamDecoders.uuidCollectionParamDecoder(runtime.plainSerDe()));
-            this.floatHeaderBoxedDeserializer = new QueryParamDeserializer<>(
-                    "floatParamBoxed",
-                    ParamDecoders.complexCollectionParamDecoder(runtime.plainSerDe(), Float::valueOf));
-            this.floatHeaderUnboxedDeserializer = new QueryParamDeserializer<>(
-                    "floatParamUnboxed",
-                    ParamDecoders.complexCollectionParamDecoder(runtime.plainSerDe(), Float::parseFloat));
-            this.moreQueryParamsSerializer =
-                    DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
-        }
-
-        @Override
-        public void handleRequest(HttpServerExchange exchange) throws Exception {
-            OptionalInt optionalIntParam = this.optionalIntParamDeserializer.deserialize(exchange);
-            OffsetDateTime dateTimeParam = this.dateTimeParamDeserializer.deserialize(exchange);
-            Set<ResourceIdentifier> ridSetParam = this.ridSetParamDeserializer.deserialize(exchange);
-            Optional<SafeLong> optionalSafeLongParam = this.optionalSafeLongParamDeserializer.deserialize(exchange);
-            UUID uuidParam = this.uuidParamDeserializer.deserialize(exchange);
-            Float floatHeaderBoxed = this.floatHeaderBoxedDeserializer.deserialize(exchange);
-            float floatHeaderUnboxed = this.floatHeaderUnboxedDeserializer.deserialize(exchange);
-            write(
-                    this.delegate.moreQueryParams(
-                            optionalIntParam,
-                            dateTimeParam,
-                            ridSetParam,
-                            optionalSafeLongParam,
-                            uuidParam,
-                            floatHeaderBoxed,
-                            floatHeaderUnboxed),
-                    exchange);
-        }
-
-        @Override
-        public void write(String returnValue, HttpServerExchange exchange) throws IOException {
-            this.moreQueryParamsSerializer.serialize(returnValue, exchange);
-        }
-
-        @Override
-        public HttpString method() {
-            return Methods.GET;
-        }
-
-        @Override
-        public String template() {
-            return "/moreQueryParams";
-        }
-
-        @Override
-        public String serviceName() {
-            return "DefaultDecoderService";
-        }
-
-        @Override
-        public String name() {
-            return "moreQueryParams";
-        }
-
-        @Override
-        public HttpHandler handler() {
-            return this;
-        }
-    }
-
     private static final class HeadersEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<String> {
         private final UndertowRuntime runtime;
 
@@ -254,13 +223,17 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
 
         private final Deserializer<Optional<String>> optionalStringParamDeserializer;
 
+        private final Deserializer<Float> floatBoxedDeserializer;
+
+        private final Deserializer<Float> floatUnboxedDeserializer;
+
         private final Deserializer<String> decoderParamDeserializer;
 
-        private final Deserializer<Float> floatHeaderBoxedDeserializer;
+        private final Deserializer<DefaultDecoderService.Constructor> constructorDeserializer;
 
-        private final Deserializer<Float> floatHeaderUnboxedDeserializer;
+        private final Deserializer<DefaultDecoderService.OfFactory> ofFactoryDeserializer;
 
-        private final Deserializer<BigInteger> bigIntegerDeserializer;
+        private final Deserializer<DefaultDecoderService.ValueOfFactory> valueOfFactoryDeserializer;
 
         private final Serializer<String> headersSerializer;
 
@@ -277,16 +250,25 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                     "stringListParam", ParamDecoders.stringListCollectionParamDecoder(runtime.plainSerDe()));
             this.optionalStringParamDeserializer = new HeaderParamDeserializer<>(
                     "optionalStringParam", ParamDecoders.optionalStringCollectionParamDecoder(runtime.plainSerDe()));
+            this.floatBoxedDeserializer = new HeaderParamDeserializer<>(
+                    "floatBoxed", ParamDecoders.complexCollectionParamDecoder(runtime.plainSerDe(), Float::valueOf));
+            this.floatUnboxedDeserializer = new HeaderParamDeserializer<>(
+                    "floatUnboxed",
+                    ParamDecoders.complexCollectionParamDecoder(runtime.plainSerDe(), Float::parseFloat));
             this.decoderParamDeserializer = new HeaderParamDeserializer<>(
                     "decoderParam", DefaultDecoderService.StringCollectionDecoder.INSTANCE);
-            this.floatHeaderBoxedDeserializer = new HeaderParamDeserializer<>(
-                    "floatHeaderBoxed",
-                    ParamDecoders.complexCollectionParamDecoder(runtime.plainSerDe(), Float::valueOf));
-            this.floatHeaderUnboxedDeserializer = new HeaderParamDeserializer<>(
-                    "floatHeaderUnboxed",
-                    ParamDecoders.complexCollectionParamDecoder(runtime.plainSerDe(), Float::parseFloat));
-            this.bigIntegerDeserializer = new HeaderParamDeserializer<>(
-                    "bigInteger", ParamDecoders.complexCollectionParamDecoder(runtime.plainSerDe(), BigInteger::new));
+            this.constructorDeserializer = new HeaderParamDeserializer<>(
+                    "constructor",
+                    ParamDecoders.complexCollectionParamDecoder(
+                            runtime.plainSerDe(), DefaultDecoderService.Constructor::new));
+            this.ofFactoryDeserializer = new HeaderParamDeserializer<>(
+                    "ofFactory",
+                    ParamDecoders.complexCollectionParamDecoder(
+                            runtime.plainSerDe(), DefaultDecoderService.OfFactory::of));
+            this.valueOfFactoryDeserializer = new HeaderParamDeserializer<>(
+                    "valueOfFactory",
+                    ParamDecoders.complexCollectionParamDecoder(
+                            runtime.plainSerDe(), DefaultDecoderService.ValueOfFactory::valueOf));
             this.headersSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
         }
 
@@ -297,10 +279,12 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
             Set<String> stringSetParam = this.stringSetParamDeserializer.deserialize(exchange);
             List<String> stringListParam = this.stringListParamDeserializer.deserialize(exchange);
             Optional<String> optionalStringParam = this.optionalStringParamDeserializer.deserialize(exchange);
+            Float floatBoxed = this.floatBoxedDeserializer.deserialize(exchange);
+            float floatUnboxed = this.floatUnboxedDeserializer.deserialize(exchange);
             String decoderParam = this.decoderParamDeserializer.deserialize(exchange);
-            Float floatHeaderBoxed = this.floatHeaderBoxedDeserializer.deserialize(exchange);
-            float floatHeaderUnboxed = this.floatHeaderUnboxedDeserializer.deserialize(exchange);
-            BigInteger bigInteger = this.bigIntegerDeserializer.deserialize(exchange);
+            DefaultDecoderService.Constructor constructor = this.constructorDeserializer.deserialize(exchange);
+            DefaultDecoderService.OfFactory ofFactory = this.ofFactoryDeserializer.deserialize(exchange);
+            DefaultDecoderService.ValueOfFactory valueOfFactory = this.valueOfFactoryDeserializer.deserialize(exchange);
             write(
                     this.delegate.headers(
                             stringParam,
@@ -308,10 +292,12 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                             stringSetParam,
                             stringListParam,
                             optionalStringParam,
+                            floatBoxed,
+                            floatUnboxed,
                             decoderParam,
-                            floatHeaderBoxed,
-                            floatHeaderUnboxed,
-                            bigInteger),
+                            constructor,
+                            ofFactory,
+                            valueOfFactory),
                     exchange);
         }
 
@@ -361,7 +347,11 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
 
         private final Deserializer<Float> floatUnboxedDeserializer;
 
-        private final Deserializer<BigInteger> bigIntDeserializer;
+        private final Deserializer<DefaultDecoderService.Constructor> constructorDeserializer;
+
+        private final Deserializer<DefaultDecoderService.OfFactory> ofFactoryDeserializer;
+
+        private final Deserializer<DefaultDecoderService.ValueOfFactory> valueOfFactoryDeserializer;
 
         private final Serializer<String> pathParamSerializer;
 
@@ -378,8 +368,16 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                     "floatBoxed", ParamDecoders.complexParamDecoder(runtime.plainSerDe(), Float::valueOf));
             this.floatUnboxedDeserializer = new PathParamDeserializer<>(
                     "floatUnboxed", ParamDecoders.complexParamDecoder(runtime.plainSerDe(), Float::parseFloat));
-            this.bigIntDeserializer = new PathParamDeserializer<>(
-                    "bigInt", ParamDecoders.complexParamDecoder(runtime.plainSerDe(), BigInteger::new));
+            this.constructorDeserializer = new PathParamDeserializer<>(
+                    "constructor",
+                    ParamDecoders.complexParamDecoder(runtime.plainSerDe(), DefaultDecoderService.Constructor::new));
+            this.ofFactoryDeserializer = new PathParamDeserializer<>(
+                    "ofFactory",
+                    ParamDecoders.complexParamDecoder(runtime.plainSerDe(), DefaultDecoderService.OfFactory::of));
+            this.valueOfFactoryDeserializer = new PathParamDeserializer<>(
+                    "valueOfFactory",
+                    ParamDecoders.complexParamDecoder(
+                            runtime.plainSerDe(), DefaultDecoderService.ValueOfFactory::valueOf));
             this.pathParamSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
         }
 
@@ -390,9 +388,19 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
             String decoderParam = this.decoderParamDeserializer.deserialize(exchange);
             Float floatBoxed = this.floatBoxedDeserializer.deserialize(exchange);
             float floatUnboxed = this.floatUnboxedDeserializer.deserialize(exchange);
-            BigInteger bigInt = this.bigIntDeserializer.deserialize(exchange);
+            DefaultDecoderService.Constructor constructor = this.constructorDeserializer.deserialize(exchange);
+            DefaultDecoderService.OfFactory ofFactory = this.ofFactoryDeserializer.deserialize(exchange);
+            DefaultDecoderService.ValueOfFactory valueOfFactory = this.valueOfFactoryDeserializer.deserialize(exchange);
             write(
-                    this.delegate.pathParam(stringParam, booleanParam, decoderParam, floatBoxed, floatUnboxed, bigInt),
+                    this.delegate.pathParam(
+                            stringParam,
+                            booleanParam,
+                            decoderParam,
+                            floatBoxed,
+                            floatUnboxed,
+                            constructor,
+                            ofFactory,
+                            valueOfFactory),
                     exchange);
         }
 
@@ -408,7 +416,7 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
 
         @Override
         public String template() {
-            return "/pathParam/{stringParam}/{booleanParam}/{decoderParam}/{floatBoxed}/{floatUnboxed}/{bigInt}";
+            return "/pathParam/{stringParam}/{booleanParam}/{decoderParam}/{floatBoxed}/{floatUnboxed}/{bigInt}/{constructor}/{ofFactory}/{valueOfFactory}";
         }
 
         @Override


### PR DESCRIPTION
## Before this PR
If I attempt to declare an endpoint with a parameter that has a constructor/static factory method that throws a checked exception, the generated code will use that constructor/static factory method but the generated code will fail to compile.

```java
final class MyService {

    @Handle(method = HttpMethod.GET, path = "/uri")
    public void uri(@QueryParam("uri") URI uri) {}
}
```

```
MyServiceEndpoints.java:50: error: incompatible thrown types URISyntaxException in functional expression
                    "uri", ParamDecoders.complexCollectionParamDecoder(runtime.plainSerDe(), URI::new));
```

## After this PR
When finding decoders for unknown types, constructors and static factory methods are only considered if they do not throw checked exceptions.

