### PR TITLE
Support more decoder factory method names

### DIFF
--- a/changelog/@unreleased/pr-1791.v2.yml
+++ b/changelog/@unreleased/pr-1791.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: conjure-undertow-annotations supports parameters with static factory
+    methods named `fromString` or `create`.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1791

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParamTypesResolver.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParamTypesResolver.java
@@ -384,7 +384,9 @@ public final class ParamTypesResolver {
                 DeclaredType declaredType = (DeclaredType) typeMirror;
                 return getFactoryDecoderFactoryFunction(declaredType, "valueOf")
                         .or(() -> getConstructorDecoderFactoryFunction(declaredType))
-                        .or(() -> getFactoryDecoderFactoryFunction(declaredType, "of"));
+                        .or(() -> getFactoryDecoderFactoryFunction(declaredType, "of"))
+                        .or(() -> getFactoryDecoderFactoryFunction(declaredType, "fromString"))
+                        .or(() -> getFactoryDecoderFactoryFunction(declaredType, "create"));
             default:
                 return Optional.empty();
         }

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
@@ -35,6 +35,8 @@ import com.palantir.conjure.java.undertow.processor.sample.NameClashExchangePara
 import com.palantir.conjure.java.undertow.processor.sample.OptionalPrimitives;
 import com.palantir.conjure.java.undertow.processor.sample.OverloadedResource;
 import com.palantir.conjure.java.undertow.processor.sample.ParameterConstructorThrows;
+import com.palantir.conjure.java.undertow.processor.sample.ParameterCreateFactoryThrows;
+import com.palantir.conjure.java.undertow.processor.sample.ParameterFromStringFactoryThrows;
 import com.palantir.conjure.java.undertow.processor.sample.ParameterNotAnnotated;
 import com.palantir.conjure.java.undertow.processor.sample.ParameterOfFactoryThrows;
 import com.palantir.conjure.java.undertow.processor.sample.ParameterValueOfFactoryThrows;
@@ -190,6 +192,18 @@ public class ConjureUndertowAnnotationProcessorTest {
     @Test
     public void testParameterValueOfFactoryThrows() {
         assertThat(compileTestClass(TEST_CLASSES_BASE_DIR, ParameterValueOfFactoryThrows.class))
+                .hadErrorContaining("No default decoder exists for parameter");
+    }
+
+    @Test
+    public void testParameterFromStringFactoryThrows() {
+        assertThat(compileTestClass(TEST_CLASSES_BASE_DIR, ParameterFromStringFactoryThrows.class))
+                .hadErrorContaining("No default decoder exists for parameter");
+    }
+
+    @Test
+    public void testParameterCreateFactoryThrows() {
+        assertThat(compileTestClass(TEST_CLASSES_BASE_DIR, ParameterCreateFactoryThrows.class))
                 .hadErrorContaining("No default decoder exists for parameter");
     }
 

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderService.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderService.java
@@ -51,7 +51,9 @@ public interface DefaultDecoderService {
             @Handle.QueryParam(value = "decoderParam", decoder = StringCollectionDecoder.class) String decoderParam,
             @Handle.QueryParam("constructor") Constructor constructor,
             @Handle.QueryParam("ofFactory") OfFactory ofFactory,
-            @Handle.QueryParam("valueOfFactory") ValueOfFactory valueOfFactory);
+            @Handle.QueryParam("valueOfFactory") ValueOfFactory valueOfFactory,
+            @Handle.QueryParam("fromStringFactory") FromStringFactory fromStringFactory,
+            @Handle.QueryParam("createFactory") CreateFactory createFactory);
 
     @Handle(method = HttpMethod.GET, path = "/headers")
     String headers(
@@ -65,7 +67,9 @@ public interface DefaultDecoderService {
             @Handle.Header(value = "decoderParam", decoder = StringCollectionDecoder.class) String decoderParam,
             @Handle.Header("constructor") Constructor constructor,
             @Handle.Header("ofFactory") OfFactory ofFactory,
-            @Handle.Header("valueOfFactory") ValueOfFactory valueOfFactory);
+            @Handle.Header("valueOfFactory") ValueOfFactory valueOfFactory,
+            @Handle.Header("fromStringFactory") FromStringFactory fromStringFactory,
+            @Handle.Header("createFactory") CreateFactory createFactory);
 
     @Handle(
             method = HttpMethod.GET,
@@ -79,7 +83,9 @@ public interface DefaultDecoderService {
             @Handle.PathParam float floatUnboxed,
             @Handle.PathParam Constructor constructor,
             @Handle.PathParam OfFactory ofFactory,
-            @Handle.PathParam ValueOfFactory valueOfFactory);
+            @Handle.PathParam ValueOfFactory valueOfFactory,
+            @Handle.PathParam FromStringFactory fromStringFactory,
+            @Handle.PathParam CreateFactory createFactory);
 
     enum StringCollectionDecoder implements CollectionParamDecoder<String> {
         INSTANCE;
@@ -119,6 +125,24 @@ public interface DefaultDecoderService {
 
         public static ValueOfFactory valueOf(String _value) {
             return new ValueOfFactory();
+        }
+    }
+
+    final class FromStringFactory {
+
+        private FromStringFactory() {}
+
+        public static FromStringFactory fromString(String _value) {
+            return new FromStringFactory();
+        }
+    }
+
+    final class CreateFactory {
+
+        private CreateFactory() {}
+
+        public static CreateFactory create(String _value) {
+            return new CreateFactory();
         }
     }
 }

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/ParameterCreateFactoryThrows.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/ParameterCreateFactoryThrows.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.palantir.conjure.java.undertow.annotations.Handle;
+import com.palantir.conjure.java.undertow.annotations.Handle.QueryParam;
+import com.palantir.conjure.java.undertow.annotations.HttpMethod;
+
+public interface ParameterCreateFactoryThrows {
+
+    @Handle(method = HttpMethod.GET, path = "/")
+    void parameterThrowingConstructor(@QueryParam("value") Value value);
+
+    final class Value {
+
+        private Value() {}
+
+        static Value create(String _value) throws Exception {
+            return new Value();
+        }
+    }
+}

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/ParameterFromStringFactoryThrows.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/ParameterFromStringFactoryThrows.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.palantir.conjure.java.undertow.annotations.Handle;
+import com.palantir.conjure.java.undertow.annotations.Handle.QueryParam;
+import com.palantir.conjure.java.undertow.annotations.HttpMethod;
+
+public interface ParameterFromStringFactoryThrows {
+
+    @Handle(method = HttpMethod.GET, path = "/")
+    void parameterThrowingConstructor(@QueryParam("value") Value value);
+
+    final class Value {
+
+        private Value() {}
+
+        static Value fromString(String _value) throws Exception {
+            return new Value();
+        }
+    }
+}

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderServiceEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderServiceEndpoints.java.generated
@@ -90,6 +90,10 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
 
         private final Deserializer<DefaultDecoderService.ValueOfFactory> valueOfFactoryDeserializer;
 
+        private final Deserializer<DefaultDecoderService.FromStringFactory> fromStringFactoryDeserializer;
+
+        private final Deserializer<DefaultDecoderService.CreateFactory> createFactoryDeserializer;
+
         private final Serializer<String> queryParamSerializer;
 
         QueryParamEndpoint(UndertowRuntime runtime, DefaultDecoderService delegate) {
@@ -135,6 +139,14 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                     "valueOfFactory",
                     ParamDecoders.complexCollectionParamDecoder(
                             runtime.plainSerDe(), DefaultDecoderService.ValueOfFactory::valueOf));
+            this.fromStringFactoryDeserializer = new QueryParamDeserializer<>(
+                    "fromStringFactory",
+                    ParamDecoders.complexCollectionParamDecoder(
+                            runtime.plainSerDe(), DefaultDecoderService.FromStringFactory::fromString));
+            this.createFactoryDeserializer = new QueryParamDeserializer<>(
+                    "createFactory",
+                    ParamDecoders.complexCollectionParamDecoder(
+                            runtime.plainSerDe(), DefaultDecoderService.CreateFactory::create));
             this.queryParamSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
         }
 
@@ -156,6 +168,9 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
             DefaultDecoderService.Constructor constructor = this.constructorDeserializer.deserialize(exchange);
             DefaultDecoderService.OfFactory ofFactory = this.ofFactoryDeserializer.deserialize(exchange);
             DefaultDecoderService.ValueOfFactory valueOfFactory = this.valueOfFactoryDeserializer.deserialize(exchange);
+            DefaultDecoderService.FromStringFactory fromStringFactory =
+                    this.fromStringFactoryDeserializer.deserialize(exchange);
+            DefaultDecoderService.CreateFactory createFactory = this.createFactoryDeserializer.deserialize(exchange);
             write(
                     this.delegate.queryParam(
                             stringParam,
@@ -173,7 +188,9 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                             decoderParam,
                             constructor,
                             ofFactory,
-                            valueOfFactory),
+                            valueOfFactory,
+                            fromStringFactory,
+                            createFactory),
                     exchange);
         }
 
@@ -235,6 +252,10 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
 
         private final Deserializer<DefaultDecoderService.ValueOfFactory> valueOfFactoryDeserializer;
 
+        private final Deserializer<DefaultDecoderService.FromStringFactory> fromStringFactoryDeserializer;
+
+        private final Deserializer<DefaultDecoderService.CreateFactory> createFactoryDeserializer;
+
         private final Serializer<String> headersSerializer;
 
         HeadersEndpoint(UndertowRuntime runtime, DefaultDecoderService delegate) {
@@ -269,6 +290,14 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                     "valueOfFactory",
                     ParamDecoders.complexCollectionParamDecoder(
                             runtime.plainSerDe(), DefaultDecoderService.ValueOfFactory::valueOf));
+            this.fromStringFactoryDeserializer = new HeaderParamDeserializer<>(
+                    "fromStringFactory",
+                    ParamDecoders.complexCollectionParamDecoder(
+                            runtime.plainSerDe(), DefaultDecoderService.FromStringFactory::fromString));
+            this.createFactoryDeserializer = new HeaderParamDeserializer<>(
+                    "createFactory",
+                    ParamDecoders.complexCollectionParamDecoder(
+                            runtime.plainSerDe(), DefaultDecoderService.CreateFactory::create));
             this.headersSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
         }
 
@@ -285,6 +314,9 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
             DefaultDecoderService.Constructor constructor = this.constructorDeserializer.deserialize(exchange);
             DefaultDecoderService.OfFactory ofFactory = this.ofFactoryDeserializer.deserialize(exchange);
             DefaultDecoderService.ValueOfFactory valueOfFactory = this.valueOfFactoryDeserializer.deserialize(exchange);
+            DefaultDecoderService.FromStringFactory fromStringFactory =
+                    this.fromStringFactoryDeserializer.deserialize(exchange);
+            DefaultDecoderService.CreateFactory createFactory = this.createFactoryDeserializer.deserialize(exchange);
             write(
                     this.delegate.headers(
                             stringParam,
@@ -297,7 +329,9 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                             decoderParam,
                             constructor,
                             ofFactory,
-                            valueOfFactory),
+                            valueOfFactory,
+                            fromStringFactory,
+                            createFactory),
                     exchange);
         }
 
@@ -353,6 +387,10 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
 
         private final Deserializer<DefaultDecoderService.ValueOfFactory> valueOfFactoryDeserializer;
 
+        private final Deserializer<DefaultDecoderService.FromStringFactory> fromStringFactoryDeserializer;
+
+        private final Deserializer<DefaultDecoderService.CreateFactory> createFactoryDeserializer;
+
         private final Serializer<String> pathParamSerializer;
 
         PathParamEndpoint(UndertowRuntime runtime, DefaultDecoderService delegate) {
@@ -378,6 +416,14 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                     "valueOfFactory",
                     ParamDecoders.complexParamDecoder(
                             runtime.plainSerDe(), DefaultDecoderService.ValueOfFactory::valueOf));
+            this.fromStringFactoryDeserializer = new PathParamDeserializer<>(
+                    "fromStringFactory",
+                    ParamDecoders.complexParamDecoder(
+                            runtime.plainSerDe(), DefaultDecoderService.FromStringFactory::fromString));
+            this.createFactoryDeserializer = new PathParamDeserializer<>(
+                    "createFactory",
+                    ParamDecoders.complexParamDecoder(
+                            runtime.plainSerDe(), DefaultDecoderService.CreateFactory::create));
             this.pathParamSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
         }
 
@@ -391,6 +437,9 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
             DefaultDecoderService.Constructor constructor = this.constructorDeserializer.deserialize(exchange);
             DefaultDecoderService.OfFactory ofFactory = this.ofFactoryDeserializer.deserialize(exchange);
             DefaultDecoderService.ValueOfFactory valueOfFactory = this.valueOfFactoryDeserializer.deserialize(exchange);
+            DefaultDecoderService.FromStringFactory fromStringFactory =
+                    this.fromStringFactoryDeserializer.deserialize(exchange);
+            DefaultDecoderService.CreateFactory createFactory = this.createFactoryDeserializer.deserialize(exchange);
             write(
                     this.delegate.pathParam(
                             stringParam,
@@ -400,7 +449,9 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                             floatUnboxed,
                             constructor,
                             ofFactory,
-                            valueOfFactory),
+                            valueOfFactory,
+                            fromStringFactory,
+                            createFactory),
                     exchange);
         }
 


### PR DESCRIPTION
## Before this PR
conjure-undertow-annotations supports parameters with static factory methods named `of` or `valueOf`.

## After this PR
conjure-undertow-annotations supports parameters with static factory methods named `fromString` or `create`.

This PR was motivated by my desire to use `URI` as a parameter.

## Possible downsides?
- Is this too much magic built-in behavior? It's not hard to define custom deserializer, but supporting these common factory names out of the box is a ergonomic improvement.