### PR TITLE
Don't rewrite query parameters

### DIFF
--- a/changelog/@unreleased/pr-1817.v2.yml
+++ b/changelog/@unreleased/pr-1817.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: conjure-undertow does not unnecessarily rewrite path match variables
+    into query parameters
+  links:
+  - https://github.com/palantir/conjure-java/pull/1817

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureHandler.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureHandler.java
@@ -52,7 +52,7 @@ public final class ConjureHandler implements HttpHandler {
     private final RoutingHandler routingHandler;
 
     private ConjureHandler(HttpHandler fallback, List<Endpoint> endpoints) {
-        this.routingHandler = Handlers.routing()
+        this.routingHandler = Handlers.routing(false)
                 .setFallbackHandler(fallback)
                 // The method may be valid for another handlers, the
                 // fallback handler will be used instead of 405 status.


### PR DESCRIPTION
## Before this PR
Path parameters are put into the `HttpServerExchange` query parameters map.

## After this PR
Path parameters are not put into the `HttpServerExchange` query parameters map.