### PR TITLE
The conjure-undertow annotation processor supports endpoint tags

### DIFF
--- a/changelog/@unreleased/pr-1835.v2.yml
+++ b/changelog/@unreleased/pr-1835.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: The conjure-undertow annotation processor supports endpoint tags
+  links:
+  - https://github.com/palantir/conjure-java/pull/1835

--- a/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/Handle.java
+++ b/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/Handle.java
@@ -55,8 +55,8 @@ public @interface Handle {
     // TODO(ckozak): Custom exception handling? Not sure it should be necessary if we support custom response status
     //  codes.
 
-    // TODO(ckozak): support conjure endpoint tags
-    // String[] tags()
+    /** Conjure endpoint tags. */
+    String[] tags() default {};
 
     @Retention(RetentionPolicy.SOURCE)
     @Target(ElementType.PARAMETER)

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/EndpointDefinitions.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/EndpointDefinitions.java
@@ -104,6 +104,7 @@ public final class EndpointDefinitions {
                 .addAllArguments(argumentDefinitions)
                 .deprecated(MoreElements.isAnnotationPresent(element, Deprecated.class)
                         || MoreElements.isAnnotationPresent(element.getEnclosingElement(), Deprecated.class))
+                .addTags(requestAnnotationReflector.getAnnotationValue("tags", String[].class))
                 .build());
     }
 

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
@@ -144,7 +144,7 @@ public final class ConjureUndertowEndpointsGenerator {
         return endpointClassName;
     }
 
-    @SuppressWarnings("checkstyle:MethodLength") // TODO(ckozak): refactor
+    @SuppressWarnings("checkstyle:MethodLength", "checkstyle:CyclomaticComplexity")
     private static TypeSpec endpoint(ServiceDefinition service, EndpointDefinition endpoint) {
         List<AdditionalField> additionalFields = new ArrayList<>();
         MethodSpec.Builder handlerBuilder = MethodSpec.methodBuilder("handleRequest")

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
@@ -144,7 +144,7 @@ public final class ConjureUndertowEndpointsGenerator {
         return endpointClassName;
     }
 
-    @SuppressWarnings("checkstyle:MethodLength", "checkstyle:CyclomaticComplexity")
+    @SuppressWarnings({"checkstyle:MethodLength", "checkstyle:CyclomaticComplexity"})
     private static TypeSpec endpoint(ServiceDefinition service, EndpointDefinition endpoint) {
         List<AdditionalField> additionalFields = new ArrayList<>();
         MethodSpec.Builder handlerBuilder = MethodSpec.methodBuilder("handleRequest")

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.java.undertow.processor.generate;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.palantir.conjure.java.undertow.annotations.BearerTokenCookieDeserializer;
 import com.palantir.conjure.java.undertow.annotations.CookieDeserializer;
 import com.palantir.conjure.java.undertow.annotations.HeaderParamDeserializer;
@@ -454,6 +455,28 @@ public final class ConjureUndertowEndpointsGenerator {
                     // Ideally we could scrape javadoc from the annotated method, but that's
                     // more trouble than it's worth for now.
                     .addStatement("return $T.of($S)", Optional.class, "deprecated")
+                    .build());
+        }
+
+        if (!endpoint.tags().isEmpty()) {
+            TypeName tagsType = ParameterizedTypeName.get(ImmutableSet.class, String.class);
+            String tagsField = "TAGS";
+            endpointBuilder.addField(FieldSpec.builder(tagsType, tagsField)
+                    .addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+                    .initializer(
+                            "$T.of($L)",
+                            ImmutableSet.class,
+                            endpoint.tags().stream()
+                                    .map(tagValue -> CodeBlock.of("$S", tagValue))
+                                    .collect(CodeBlock.joining(", ")))
+                    .build());
+            endpointBuilder.addMethod(MethodSpec.methodBuilder("tags")
+                    .addModifiers(Modifier.PUBLIC)
+                    .addAnnotation(Override.class)
+                    .returns(tagsType)
+                    // Ideally we could scrape javadoc from the annotated method, but that's
+                    // more trouble than it's worth for now.
+                    .addStatement("return $N", tagsField)
                     .build());
         }
 

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
@@ -49,6 +49,7 @@ import com.palantir.conjure.java.undertow.processor.sample.SafeLoggableAuthHeade
 import com.palantir.conjure.java.undertow.processor.sample.SafeLoggableParams;
 import com.palantir.conjure.java.undertow.processor.sample.SimpleInterface;
 import com.palantir.conjure.java.undertow.processor.sample.StaticMethodAnnotatedResource;
+import com.palantir.conjure.java.undertow.processor.sample.TaggedEndpoints;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -205,6 +206,11 @@ public class ConjureUndertowAnnotationProcessorTest {
     public void testParameterCreateFactoryThrows() {
         assertThat(compileTestClass(TEST_CLASSES_BASE_DIR, ParameterCreateFactoryThrows.class))
                 .hadErrorContaining("No default decoder exists for parameter");
+    }
+
+    @Test
+    public void testTaggedEndpoints() {
+        assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, TaggedEndpoints.class);
     }
 
     private void assertTestFileCompileAndMatches(Path basePath, Class<?> clazz) {

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/TaggedEndpoints.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/TaggedEndpoints.java
@@ -14,33 +14,22 @@
  * limitations under the License.
  */
 
-package com.palantir.conjure.java.undertow.processor.data;
+package com.palantir.conjure.java.undertow.processor.sample;
 
+import com.palantir.conjure.java.undertow.annotations.Handle;
 import com.palantir.conjure.java.undertow.annotations.HttpMethod;
-import java.util.List;
-import java.util.Set;
-import org.immutables.value.Value;
 
-@Value.Immutable
-@StagedBuilder
-public interface EndpointDefinition {
+public interface TaggedEndpoints {
 
-    EndpointName endpointName();
+    @Handle(method = HttpMethod.GET, path = "/zero")
+    void noTags();
 
-    ServiceName serviceName();
+    @Handle(method = HttpMethod.GET, path = "/one", tags = "one")
+    void oneTag();
 
-    HttpMethod httpMethod();
-
-    HttpPath httpPath();
-
-    List<ArgumentDefinition> arguments();
-
-    ReturnType returns();
-
-    @Value.Default
-    default boolean deprecated() {
-        return false;
-    }
-
-    Set<String> tags();
+    @Handle(
+            method = HttpMethod.GET,
+            path = "/two",
+            tags = {"one", "two"})
+    void twoTags();
 }

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/TaggedEndpointsEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/TaggedEndpointsEndpoints.java.generated
@@ -1,0 +1,178 @@
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import io.undertow.util.StatusCodes;
+import java.lang.Exception;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.undertow.processor.generate.ConjureUndertowEndpointsGenerator")
+public final class TaggedEndpointsEndpoints implements UndertowService {
+    private final TaggedEndpoints delegate;
+
+    private TaggedEndpointsEndpoints(TaggedEndpoints delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(TaggedEndpoints delegate) {
+        return new TaggedEndpointsEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return ImmutableList.of(
+                new NoTagsEndpoint(runtime, delegate),
+                new OneTagEndpoint(runtime, delegate),
+                new TwoTagsEndpoint(runtime, delegate));
+    }
+
+    private static final class NoTagsEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final TaggedEndpoints delegate;
+
+        NoTagsEndpoint(UndertowRuntime runtime, TaggedEndpoints delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            this.delegate.noTags();
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/zero";
+        }
+
+        @Override
+        public String serviceName() {
+            return "TaggedEndpoints";
+        }
+
+        @Override
+        public String name() {
+            return "noTags";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class OneTagEndpoint implements HttpHandler, Endpoint {
+        private static final ImmutableSet<String> TAGS = ImmutableSet.of("one");
+
+        private final UndertowRuntime runtime;
+
+        private final TaggedEndpoints delegate;
+
+        OneTagEndpoint(UndertowRuntime runtime, TaggedEndpoints delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            this.delegate.oneTag();
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public ImmutableSet<String> tags() {
+            return TAGS;
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/one";
+        }
+
+        @Override
+        public String serviceName() {
+            return "TaggedEndpoints";
+        }
+
+        @Override
+        public String name() {
+            return "oneTag";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class TwoTagsEndpoint implements HttpHandler, Endpoint {
+        private static final ImmutableSet<String> TAGS = ImmutableSet.of("one", "two");
+
+        private final UndertowRuntime runtime;
+
+        private final TaggedEndpoints delegate;
+
+        TwoTagsEndpoint(UndertowRuntime runtime, TaggedEndpoints delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            this.delegate.twoTags();
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public ImmutableSet<String> tags() {
+            return TAGS;
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/two";
+        }
+
+        @Override
+        public String serviceName() {
+            return "TaggedEndpoints";
+        }
+
+        @Override
+        public String name() {
+            return "twoTags";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
## Before this PR
No support for tags in the annotation processor as we hadn't captured a use-case where they were necessary. As we add support for opt-in metrics using endpoint tags, support is helpful.

## After this PR
==COMMIT_MSG==
The conjure-undertow annotation processor supports endpoint tags
==COMMIT_MSG==

