### PR TITLE
Use consistent name for auth parameters

### DIFF
--- a/changelog/@unreleased/pr-1840.v2.yml
+++ b/changelog/@unreleased/pr-1840.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use consistent name for auth parameters.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1840

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Auth.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Auth.java
@@ -26,7 +26,7 @@ import com.palantir.tokens.auth.BearerToken;
 import com.squareup.javapoet.ParameterSpec;
 
 public final class Auth {
-    // TODO(forozco): consolidate usage
+
     public static final String AUTH_HEADER_NAME = "Authorization";
     public static final String AUTH_HEADER_PARAM_NAME = "authHeader";
     public static final String COOKIE_AUTH_PARAM_NAME = "token";

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/JerseyServiceGenerator.java
@@ -319,18 +319,18 @@ public final class JerseyServiceGenerator implements Generator {
         ClassName annotationClassName;
         ClassName tokenClassName;
         String paramName;
-        String tokenName;
+        String value;
 
         if (auth.get().accept(AuthTypeVisitor.IS_HEADER)) {
             annotationClassName = ClassName.get("javax.ws.rs", "HeaderParam");
             tokenClassName = ClassName.get("com.palantir.tokens.auth", "AuthHeader");
             paramName = Auth.AUTH_HEADER_PARAM_NAME;
-            tokenName = "Authorization";
+            value = Auth.AUTH_HEADER_NAME;
         } else if (auth.get().accept(AuthTypeVisitor.IS_COOKIE)) {
             annotationClassName = ClassName.get("javax.ws.rs", "CookieParam");
             tokenClassName = ClassName.get("com.palantir.tokens.auth", "BearerToken");
             paramName = Auth.COOKIE_AUTH_PARAM_NAME;
-            tokenName = auth.get().accept(AuthTypeVisitor.COOKIE).getCookieName();
+            value = auth.get().accept(AuthTypeVisitor.COOKIE).getCookieName();
         } else {
             throw new IllegalStateException("Unrecognized auth type: " + auth.get());
         }
@@ -338,7 +338,7 @@ public final class JerseyServiceGenerator implements Generator {
         ParameterSpec.Builder paramSpec = ParameterSpec.builder(tokenClassName, paramName);
         if (withAnnotations) {
             paramSpec.addAnnotation(AnnotationSpec.builder(annotationClassName)
-                    .addMember("value", "$S", tokenName)
+                    .addMember("value", "$S", value)
                     .build());
             if (options.requireNotNullAuthAndBodyParams()) {
                 paramSpec.addAnnotation(AnnotationSpec.builder(NOT_NULL).build());

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/Retrofit2ServiceGenerator.java
@@ -45,6 +45,7 @@ import com.palantir.conjure.visitor.AuthTypeVisitor;
 import com.palantir.conjure.visitor.ParameterTypeVisitor;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.util.syntacticpath.Path;
 import com.palantir.util.syntacticpath.Paths;
 import com.squareup.javapoet.AnnotationSpec;
@@ -73,7 +74,6 @@ public final class Retrofit2ServiceGenerator implements Generator {
 
     private static final ClassName LISTENABLE_FUTURE_TYPE =
             ClassName.get("com.google.common.util.concurrent", "ListenableFuture");
-    private static final String AUTH_HEADER_NAME = "Authorization";
 
     private static final ClassName BINARY_ARGUMENT_TYPE = ClassName.get("okhttp3", "RequestBody");
     private static final ClassName BINARY_RETURN_TYPE = ClassName.get("okhttp3", "ResponseBody");
@@ -341,12 +341,11 @@ public final class Retrofit2ServiceGenerator implements Generator {
 
         AuthType authType = auth.get();
         if (authType.accept(AuthTypeVisitor.IS_HEADER)) {
-            return Optional.of(
-                    ParameterSpec.builder(ClassName.get("com.palantir.tokens.auth", "AuthHeader"), "authHeader")
-                            .addAnnotation(AnnotationSpec.builder(ClassName.get("retrofit2.http", "Header"))
-                                    .addMember("value", "$S", AUTH_HEADER_NAME)
-                                    .build())
-                            .build());
+            return Optional.of(ParameterSpec.builder(ClassName.get(AuthHeader.class), Auth.AUTH_HEADER_PARAM_NAME)
+                    .addAnnotation(AnnotationSpec.builder(ClassName.get("retrofit2.http", "Header"))
+                            .addMember("value", "$S", Auth.AUTH_HEADER_NAME)
+                            .build())
+                    .build());
         } else if (authType.accept(AuthTypeVisitor.IS_COOKIE)) {
             // TODO(melliot): generate required retrofit logic to support this
             log.error("Retrofit does not support Cookie arguments");

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -104,8 +104,6 @@ final class UndertowServiceHandlerGenerator {
     private static final String RUNTIME_VAR_NAME = "runtime";
     private static final String DESERIALIZER_VAR_NAME = "deserializer";
     private static final String SERIALIZER_VAR_NAME = "serializer";
-    private static final String AUTH_HEADER_VAR_NAME = "authHeader";
-    private static final String COOKIE_TOKEN_VAR_NAME = "cookieToken";
     private static final String RESULT_VAR_NAME = "result";
 
     private static final ImmutableSet<String> RESERVED_PARAM_NAMES = ImmutableSet.of(
@@ -661,10 +659,10 @@ final class UndertowServiceHandlerGenerator {
                 code.addStatement(
                         "$1T $2N = $3N.auth().header($4N)",
                         AuthHeader.class,
-                        AUTH_HEADER_VAR_NAME,
+                        Auth.AUTH_HEADER_PARAM_NAME,
                         RUNTIME_VAR_NAME,
                         EXCHANGE_VAR_NAME);
-                return Optional.of(AUTH_HEADER_VAR_NAME);
+                return Optional.of(Auth.AUTH_HEADER_PARAM_NAME);
             }
 
             @Override
@@ -672,7 +670,7 @@ final class UndertowServiceHandlerGenerator {
                 code.addStatement(
                         "$1T $2N = $3N.auth().cookie($4N, $5S)",
                         BearerToken.class,
-                        COOKIE_TOKEN_VAR_NAME,
+                        Auth.COOKIE_AUTH_PARAM_NAME,
                         RUNTIME_VAR_NAME,
                         EXCHANGE_VAR_NAME,
                         endpointDefinition
@@ -680,7 +678,7 @@ final class UndertowServiceHandlerGenerator {
                                 .get()
                                 .accept(AuthTypeVisitor.COOKIE)
                                 .getCookieName());
-                return Optional.of(COOKIE_TOKEN_VAR_NAME);
+                return Optional.of(Auth.COOKIE_AUTH_PARAM_NAME);
             }
 
             @Override

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceInterfaceGenerator.java
@@ -116,13 +116,13 @@ final class UndertowServiceInterfaceGenerator {
                 .ifPresent(authType -> parameterSpecs.add(authType.accept(new AuthType.Visitor<ParameterSpec>() {
                     @Override
                     public ParameterSpec visitHeader(HeaderAuthType _value) {
-                        return ParameterSpec.builder(ClassName.get(AuthHeader.class), "authHeader")
+                        return ParameterSpec.builder(ClassName.get(AuthHeader.class), Auth.AUTH_HEADER_PARAM_NAME)
                                 .build();
                     }
 
                     @Override
                     public ParameterSpec visitCookie(CookieAuthType _value) {
-                        return ParameterSpec.builder(ClassName.get(BearerToken.class), "cookieToken")
+                        return ParameterSpec.builder(ClassName.get(BearerToken.class), Auth.COOKIE_AUTH_PARAM_NAME)
                                 .build();
                     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/JavaNameSanitizer.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/JavaNameSanitizer.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.util;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.conjure.CaseConverter;
 import com.palantir.conjure.java.ConjureTags;
+import com.palantir.conjure.java.services.Auth;
 import com.palantir.conjure.spec.AuthType;
 import com.palantir.conjure.spec.CookieAuthType;
 import com.palantir.conjure.spec.EndpointDefinition;
@@ -64,12 +65,12 @@ public final class JavaNameSanitizer {
                 .map(authType -> authType.accept(new AuthType.Visitor<String>() {
                     @Override
                     public String visitHeader(HeaderAuthType _header) {
-                        return "authHeader";
+                        return Auth.AUTH_HEADER_PARAM_NAME;
                     }
 
                     @Override
                     public String visitCookie(CookieAuthType _cookie) {
-                        return "cookieToken";
+                        return Auth.COOKIE_AUTH_PARAM_NAME;
                     }
 
                     @Override

--- a/conjure-java-core/src/test/resources/test/api/CookieService.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/CookieService.java.undertow
@@ -8,5 +8,5 @@ public interface CookieService {
     /**
      * @apiNote {@code GET /cookies}
      */
-    void eatCookies(BearerToken cookieToken);
+    void eatCookies(BearerToken token);
 }

--- a/conjure-java-core/src/test/resources/test/api/CookieServiceEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/CookieServiceEndpoints.java.undertow
@@ -43,8 +43,8 @@ public final class CookieServiceEndpoints implements UndertowService {
 
         @Override
         public void handleRequest(HttpServerExchange exchange) throws IOException {
-            BearerToken cookieToken = runtime.auth().cookie(exchange, "PALANTIR_TOKEN");
-            delegate.eatCookies(cookieToken);
+            BearerToken token = runtime.auth().cookie(exchange, "PALANTIR_TOKEN");
+            delegate.eatCookies(token);
             exchange.setStatusCode(StatusCodes.NO_CONTENT);
         }
 


### PR DESCRIPTION
## Before this PR
- Different implementations used different names for auth parameters (Undertow uses `cookieToken` while Jersey uses `token`)
- We duplicate the parameter names in a couple places

## After this PR
- All implementations use `token` as the name for cookie auth parameters
- We use the `Auth` constants everywhere

