### PR TITLE
Generated equals uses memoizedHashCode if available

### DIFF
--- a/changelog/@unreleased/pr-1842.v2.yml
+++ b/changelog/@unreleased/pr-1842.v2.yml
@@ -1,0 +1,15 @@
+type: improvement
+improvement:
+  description: |-
+    Generated equals uses memoizedHashCode if available
+
+    When we generate a memoizedHashCode field for a conjure object, the
+    equals & equalTo implementation now compare memoizedHashCode for objects
+    being compared, and will short circuit and return false if both objects
+    have already computed their hashCode and they do not match.
+
+    This is beneficial for complex conjure types that may be used as keys in
+    hash based collections, including graphs that rely on both hashCode and
+    equals.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1842

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
@@ -95,6 +95,11 @@ public final class AliasAsMapKeyExample {
     }
 
     private boolean equalTo(AliasAsMapKeyExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.strings.equals(other.strings)
                 && this.rids.equals(other.rids)
                 && this.bearertokens.equals(other.bearertokens)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
@@ -38,6 +38,11 @@ public final class AnyMapExample {
     }
 
     private boolean equalTo(AnyMapExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.items.equals(other.items);
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestObject.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestObject.java
@@ -105,6 +105,11 @@ public final class CollectionsTestObject {
     }
 
     private boolean equalTo(CollectionsTestObject other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.items.equals(other.items)
                 && this.itemsMap.equals(other.itemsMap)
                 && this.optionalItem.equals(other.optionalItem)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
@@ -46,6 +46,11 @@ public final class CovariantListExample {
     }
 
     private boolean equalTo(CovariantListExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.items.equals(other.items) && this.externalItems.equals(other.externalItems);
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
@@ -50,6 +50,11 @@ public final class CovariantOptionalExample {
     }
 
     private boolean equalTo(CovariantOptionalExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.item.equals(other.item) && this.setItem.equals(other.setItem);
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
@@ -35,6 +35,11 @@ public final class DateTimeExample {
     }
 
     private boolean equalTo(DateTimeExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.datetime.isEqual(other.datetime);
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -57,6 +57,11 @@ public final class ExternalLongExample {
     }
 
     private boolean equalTo(ExternalLongExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.externalLong == other.externalLong
                 && this.optionalExternalLong.equals(other.optionalExternalLong)
                 && this.listExternalLong.equals(other.listExternalLong);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
@@ -84,6 +84,11 @@ public final class ListExample {
     }
 
     private boolean equalTo(ListExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.items.equals(other.items)
                 && this.primitiveItems.equals(other.primitiveItems)
                 && this.doubleItems.equals(other.doubleItems)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -137,6 +137,11 @@ public final class ManyFieldExample {
     }
 
     private boolean equalTo(ManyFieldExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.string.equals(other.string)
                 && this.integer == other.integer
                 && Double.doubleToLongBits(this.doubleValue) == Double.doubleToLongBits(other.doubleValue)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
@@ -58,6 +58,11 @@ public final class MapExample {
     }
 
     private boolean equalTo(MapExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.items.equals(other.items)
                 && this.optionalItems.equals(other.optionalItems)
                 && this.aliasOptionalItems.equals(other.aliasOptionalItems);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleFieldsOnlyFinalStage.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleFieldsOnlyFinalStage.java
@@ -127,6 +127,11 @@ public final class MultipleFieldsOnlyFinalStage {
     }
 
     private boolean equalTo(MultipleFieldsOnlyFinalStage other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.items.equals(other.items)
                 && this.itemsMap.equals(other.itemsMap)
                 && this.optionalItem.equals(other.optionalItem)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
@@ -90,6 +90,11 @@ public final class MultipleOrderedStages {
     }
 
     private boolean equalTo(MultipleOrderedStages other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.token.equals(other.token)
                 && this.item.equals(other.item)
                 && this.items.equals(other.items)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
@@ -239,6 +239,11 @@ public final class PrimitiveOptionalsExample {
     }
 
     private boolean equalTo(PrimitiveOptionalsExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.num.equals(other.num)
                 && this.bool.equals(other.bool)
                 && this.integer.equals(other.integer)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -80,6 +80,11 @@ public final class ReservedKeyExample {
     }
 
     private boolean equalTo(ReservedKeyExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.package_.equals(other.package_)
                 && this.interface_.equals(other.interface_)
                 && this.fieldNameWithDashes.equals(other.fieldNameWithDashes)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RiskyNames.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RiskyNames.java
@@ -58,6 +58,11 @@ public final class RiskyNames {
     }
 
     private boolean equalTo(RiskyNames other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.var.equals(other.var)
                 && this.class_.equals(other.class_)
                 && this.int_.equals(other.int_)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
@@ -47,6 +47,11 @@ public final class SetExample {
     }
 
     private boolean equalTo(SetExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.items.equals(other.items) && this.doubleItems.equals(other.doubleItems);
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AliasAsMapKeyExample.java
@@ -96,6 +96,11 @@ public final class AliasAsMapKeyExample {
     }
 
     private boolean equalTo(AliasAsMapKeyExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.strings.equals(other.strings)
                 && this.rids.equals(other.rids)
                 && this.bearertokens.equals(other.bearertokens)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyMapExample.java
@@ -39,6 +39,11 @@ public final class AnyMapExample {
     }
 
     private boolean equalTo(AnyMapExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.items.equals(other.items);
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
@@ -47,6 +47,11 @@ public final class CovariantListExample {
     }
 
     private boolean equalTo(CovariantListExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.items.equals(other.items) && this.externalItems.equals(other.externalItems);
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantOptionalExample.java
@@ -51,6 +51,11 @@ public final class CovariantOptionalExample {
     }
 
     private boolean equalTo(CovariantOptionalExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.item.equals(other.item) && this.setItem.equals(other.setItem);
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeExample.java
@@ -36,6 +36,11 @@ public final class DateTimeExample {
     }
 
     private boolean equalTo(DateTimeExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.datetime.isEqual(other.datetime);
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
@@ -58,6 +58,11 @@ public final class ExternalLongExample {
     }
 
     private boolean equalTo(ExternalLongExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.externalLong == other.externalLong
                 && this.optionalExternalLong.equals(other.optionalExternalLong)
                 && this.listExternalLong.equals(other.listExternalLong);

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListExample.java
@@ -85,6 +85,11 @@ public final class ListExample {
     }
 
     private boolean equalTo(ListExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.items.equals(other.items)
                 && this.primitiveItems.equals(other.primitiveItems)
                 && this.doubleItems.equals(other.doubleItems)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
@@ -138,6 +138,11 @@ public final class ManyFieldExample {
     }
 
     private boolean equalTo(ManyFieldExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.string.equals(other.string)
                 && this.integer == other.integer
                 && Double.doubleToLongBits(this.doubleValue) == Double.doubleToLongBits(other.doubleValue)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapExample.java
@@ -59,6 +59,11 @@ public final class MapExample {
     }
 
     private boolean equalTo(MapExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.items.equals(other.items)
                 && this.optionalItems.equals(other.optionalItems)
                 && this.aliasOptionalItems.equals(other.aliasOptionalItems);

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
@@ -240,6 +240,11 @@ public final class PrimitiveOptionalsExample {
     }
 
     private boolean equalTo(PrimitiveOptionalsExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.num.equals(other.num)
                 && this.bool.equals(other.bool)
                 && this.integer.equals(other.integer)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReservedKeyExample.java
@@ -81,6 +81,11 @@ public final class ReservedKeyExample {
     }
 
     private boolean equalTo(ReservedKeyExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.package_.equals(other.package_)
                 && this.interface_.equals(other.interface_)
                 && this.fieldNameWithDashes.equals(other.fieldNameWithDashes)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RiskyNames.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RiskyNames.java
@@ -59,6 +59,11 @@ public final class RiskyNames {
     }
 
     private boolean equalTo(RiskyNames other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.var.equals(other.var)
                 && this.class_.equals(other.class_)
                 && this.int_.equals(other.int_)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetExample.java
@@ -48,6 +48,11 @@ public final class SetExample {
     }
 
     private boolean equalTo(SetExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
         return this.items.equals(other.items) && this.doubleItems.equals(other.doubleItems);
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -117,10 +117,11 @@ public final class BeanGenerator {
                 .addMethods(createGetters(fields, typesMap, options));
 
         if (!poetFields.isEmpty()) {
+            boolean useCachedHashCode = useCachedHashCode(fields);
             typeBuilder
                     .addMethod(MethodSpecs.createEquals(objectClass))
-                    .addMethod(MethodSpecs.createEqualTo(objectClass, poetFields));
-            if (useCachedHashCode(fields)) {
+                    .addMethod(MethodSpecs.createEqualTo(objectClass, poetFields, useCachedHashCode));
+            if (useCachedHashCode) {
                 MethodSpecs.addCachedHashCode(typeBuilder, poetFields);
             } else {
                 typeBuilder.addMethod(MethodSpecs.createHashCode(poetFields));

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectMethodsTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectMethodsTest.java
@@ -1,0 +1,103 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatComparable;
+
+import com.google.common.collect.ImmutableMap;
+import com.palantir.product.MapExample;
+import com.palantir.product.OptionalAlias;
+import com.palantir.product.StringExample;
+import java.util.Objects;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+public final class ObjectMethodsTest {
+    @Test
+    void equalsWithMemoizedHashCode() {
+        MapExample example = MapExample.builder()
+                .items("item1", "value1")
+                .optionalItems("optItem1", Optional.empty())
+                .aliasOptionalItems("aliasOpt1", OptionalAlias.of(Optional.of("alias1")))
+                .build();
+        checkEqualsHashCodeContractForDifferentInstances(
+                example, MapExample.builder().from(example).build());
+        checkEqualsHashCodeContractForDifferentInstances(
+                example,
+                MapExample.builder()
+                        .from(example)
+                        .putAllItems(ImmutableMap.of("item2", "value2"))
+                        .build());
+    }
+
+    @Test
+    void equalsWithMemoizedHashCodeCollision() {
+        MapExample hypoplankton =
+                MapExample.builder().items("hypoplankton", "test").build();
+        MapExample unheavenly = MapExample.builder().items("unheavenly", "test").build();
+        assertThat(hypoplankton).hasSameHashCodeAs(unheavenly);
+        checkEqualsHashCodeContractForDifferentInstances(hypoplankton, unheavenly);
+    }
+
+    @Test
+    void equalsWithNonMemoizedHashCode() {
+        checkEqualsHashCodeContractForDifferentInstances(StringExample.of("test"), StringExample.of("test"));
+        checkEqualsHashCodeContractForDifferentInstances(StringExample.of("test"), StringExample.of("test2"));
+    }
+
+    @Test
+    void equalsWithNonMemoizedHashCodeCollision() {
+        StringExample hypoplankton = StringExample.of("hypoplankton");
+        StringExample unheavenly = StringExample.of("unheavenly");
+        assertThat(hypoplankton).hasSameHashCodeAs(unheavenly);
+        checkEqualsHashCodeContractForDifferentInstances(hypoplankton, unheavenly);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void checkEqualsHashCodeContractForDifferentInstances(Object o1, Object o2) {
+        assertThat(o1).isNotSameAs(o2);
+        assertThat(o2).isNotSameAs(o1);
+
+        // memoize hash codes and ensure they are not default
+        assertThat(o1.hashCode()).isNotZero();
+        assertThat(o2.hashCode()).isNotZero();
+
+        if (Objects.equals(o1, o2)) {
+            assertThat(o1.getClass()).isEqualTo(o2.getClass()).isSameAs(o2.getClass());
+            assertThat(o1).hasSameHashCodeAs(o2);
+            assertThat(o1).describedAs("equals is not reflexive").isEqualTo(o1);
+            assertThat(o2).describedAs("equals is not reflexive").isEqualTo(o2);
+            assertThat(o2).describedAs("equals is not symmetric").isEqualTo(o1);
+            assertThat(o1).describedAs("equals is not consistent").isEqualTo(o2);
+            if (o1 instanceof Comparable) {
+                assertThat(o1.getClass()).isInstanceOf(Comparable.class);
+                assertThat(o2.getClass()).isInstanceOf(Comparable.class);
+                assertThatComparable((Comparable<Object>) o1).isEqualByComparingTo(o2);
+                assertThatComparable((Comparable<Object>) o2).isEqualByComparingTo(o1);
+            }
+        } else {
+            assertThat(o2).isNotEqualTo(o1);
+            if (o1 instanceof Comparable) {
+                assertThat(o1.getClass()).isInstanceOf(Comparable.class);
+                assertThat(o2.getClass()).isInstanceOf(Comparable.class);
+                assertThatComparable((Comparable<Object>) o1).isNotEqualByComparingTo(o2);
+                assertThatComparable((Comparable<Object>) o2).isNotEqualByComparingTo(o1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Before this PR
Conjure generated objects with `memoizedHashCode` field did not utilize this in `equals(Object)` comparison for short circuiting mismatches.

## After this PR
==COMMIT_MSG==
Generated equals uses memoizedHashCode if available

When we generate a memoizedHashCode field for a conjure object, the
equals & equalTo implementation now compare memoizedHashCode for objects
being compared, and will short circuit and return false if both objects
have already computed their hashCode and they do not match.

This is beneficial for complex conjure types that may be used as keys in
hash based collections, including graphs that rely on both hashCode and
equals.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

