### PR TITLE
Allow customization of Jackson Undertow Encodings

### DIFF
--- a/changelog/@unreleased/pr-1848.v2.yml
+++ b/changelog/@unreleased/pr-1848.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Allow customization of the ObjectMapper used by Jackson based Undertow
+    encodings
+  links:
+  - https://github.com/palantir/conjure-java/pull/1848


### PR DESCRIPTION
## Before this PR
Some old endpoints can't easily be migrated to using Undertow because they feature response/request structures that require additional ObjectMapper modules to be registered.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow customization of the ObjectMapper used by Jackson based Undertow encodings
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

