### PR TITLE
Collection setters use constructor when clearing

### DIFF
--- a/changelog/@unreleased/pr-1852.v2.yml
+++ b/changelog/@unreleased/pr-1852.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Collection setters use constructor when clearing
+  links:
+  - https://github.com/palantir/conjure-java/pull/1852

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
@@ -206,8 +206,7 @@ public final class AliasAsMapKeyExample {
         @JsonSetter(value = "strings", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder strings(@Nonnull Map<StringAliasExample, ManyFieldExample> strings) {
             checkNotBuilt();
-            this.strings.clear();
-            this.strings.putAll(Preconditions.checkNotNull(strings, "strings cannot be null"));
+            this.strings = new LinkedHashMap<>(Preconditions.checkNotNull(strings, "strings cannot be null"));
             return this;
         }
 
@@ -226,8 +225,7 @@ public final class AliasAsMapKeyExample {
         @JsonSetter(value = "rids", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder rids(@Nonnull Map<RidAliasExample, ManyFieldExample> rids) {
             checkNotBuilt();
-            this.rids.clear();
-            this.rids.putAll(Preconditions.checkNotNull(rids, "rids cannot be null"));
+            this.rids = new LinkedHashMap<>(Preconditions.checkNotNull(rids, "rids cannot be null"));
             return this;
         }
 
@@ -246,8 +244,8 @@ public final class AliasAsMapKeyExample {
         @JsonSetter(value = "bearertokens", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder bearertokens(@Nonnull Map<BearerTokenAliasExample, ManyFieldExample> bearertokens) {
             checkNotBuilt();
-            this.bearertokens.clear();
-            this.bearertokens.putAll(Preconditions.checkNotNull(bearertokens, "bearertokens cannot be null"));
+            this.bearertokens =
+                    new LinkedHashMap<>(Preconditions.checkNotNull(bearertokens, "bearertokens cannot be null"));
             return this;
         }
 
@@ -266,8 +264,7 @@ public final class AliasAsMapKeyExample {
         @JsonSetter(value = "integers", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder integers(@Nonnull Map<IntegerAliasExample, ManyFieldExample> integers) {
             checkNotBuilt();
-            this.integers.clear();
-            this.integers.putAll(Preconditions.checkNotNull(integers, "integers cannot be null"));
+            this.integers = new LinkedHashMap<>(Preconditions.checkNotNull(integers, "integers cannot be null"));
             return this;
         }
 
@@ -286,8 +283,7 @@ public final class AliasAsMapKeyExample {
         @JsonSetter(value = "safelongs", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder safelongs(@Nonnull Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
             checkNotBuilt();
-            this.safelongs.clear();
-            this.safelongs.putAll(Preconditions.checkNotNull(safelongs, "safelongs cannot be null"));
+            this.safelongs = new LinkedHashMap<>(Preconditions.checkNotNull(safelongs, "safelongs cannot be null"));
             return this;
         }
 
@@ -306,8 +302,7 @@ public final class AliasAsMapKeyExample {
         @JsonSetter(value = "datetimes", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder datetimes(@Nonnull Map<DateTimeAliasExample, ManyFieldExample> datetimes) {
             checkNotBuilt();
-            this.datetimes.clear();
-            this.datetimes.putAll(Preconditions.checkNotNull(datetimes, "datetimes cannot be null"));
+            this.datetimes = new LinkedHashMap<>(Preconditions.checkNotNull(datetimes, "datetimes cannot be null"));
             return this;
         }
 
@@ -326,8 +321,7 @@ public final class AliasAsMapKeyExample {
         @JsonSetter(value = "uuids", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder uuids(@Nonnull Map<UuidAliasExample, ManyFieldExample> uuids) {
             checkNotBuilt();
-            this.uuids.clear();
-            this.uuids.putAll(Preconditions.checkNotNull(uuids, "uuids cannot be null"));
+            this.uuids = new LinkedHashMap<>(Preconditions.checkNotNull(uuids, "uuids cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
@@ -106,8 +106,7 @@ public final class AnyMapExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Map<String, Object> items) {
             checkNotBuilt();
-            this.items.clear();
-            this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
+            this.items = new LinkedHashMap<>(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestObject.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestObject.java
@@ -11,6 +11,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -216,8 +217,12 @@ public final class CollectionsTestObject {
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<String> items) {
             checkNotBuilt();
-            this.items.clear();
-            ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            if (items instanceof Collection) {
+                this.items = new ArrayList<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
+            } else {
+                this.items.clear();
+                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            }
             return this;
         }
 
@@ -236,8 +241,7 @@ public final class CollectionsTestObject {
         @JsonSetter(value = "itemsMap", nulls = Nulls.SKIP)
         public Builder itemsMap(@Nonnull Map<String, Integer> itemsMap) {
             checkNotBuilt();
-            this.itemsMap.clear();
-            this.itemsMap.putAll(Preconditions.checkNotNull(itemsMap, "itemsMap cannot be null"));
+            this.itemsMap = new LinkedHashMap<>(Preconditions.checkNotNull(itemsMap, "itemsMap cannot be null"));
             return this;
         }
 
@@ -269,8 +273,14 @@ public final class CollectionsTestObject {
         @JsonSetter(value = "itemsSet", nulls = Nulls.SKIP)
         public Builder itemsSet(@Nonnull Iterable<String> itemsSet) {
             checkNotBuilt();
-            this.itemsSet.clear();
-            ConjureCollections.addAll(this.itemsSet, Preconditions.checkNotNull(itemsSet, "itemsSet cannot be null"));
+            if (itemsSet instanceof Collection) {
+                this.itemsSet = new LinkedHashSet<>(
+                        (Collection) Preconditions.checkNotNull(itemsSet, "itemsSet cannot be null"));
+            } else {
+                this.itemsSet.clear();
+                ConjureCollections.addAll(
+                        this.itemsSet, Preconditions.checkNotNull(itemsSet, "itemsSet cannot be null"));
+            }
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestObject.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestObject.java
@@ -11,7 +11,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -217,12 +216,7 @@ public final class CollectionsTestObject {
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<String> items) {
             checkNotBuilt();
-            if (items instanceof Collection) {
-                this.items = new ArrayList<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
-            } else {
-                this.items.clear();
-                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
-            }
+            this.items = ConjureCollections.newArrayList(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
@@ -273,14 +267,8 @@ public final class CollectionsTestObject {
         @JsonSetter(value = "itemsSet", nulls = Nulls.SKIP)
         public Builder itemsSet(@Nonnull Iterable<String> itemsSet) {
             checkNotBuilt();
-            if (itemsSet instanceof Collection) {
-                this.itemsSet = new LinkedHashSet<>(
-                        (Collection) Preconditions.checkNotNull(itemsSet, "itemsSet cannot be null"));
-            } else {
-                this.itemsSet.clear();
-                ConjureCollections.addAll(
-                        this.itemsSet, Preconditions.checkNotNull(itemsSet, "itemsSet cannot be null"));
-            }
+            this.itemsSet = ConjureCollections.newLinkedHashSet(
+                    Preconditions.checkNotNull(itemsSet, "itemsSet cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
@@ -9,6 +9,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Generated;
@@ -121,8 +122,12 @@ public final class CovariantListExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Iterable<?> items) {
             checkNotBuilt();
-            this.items.clear();
-            ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            if (items instanceof Collection) {
+                this.items = new ArrayList<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
+            } else {
+                this.items.clear();
+                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            }
             return this;
         }
 
@@ -141,9 +146,14 @@ public final class CovariantListExample {
         @JsonSetter(value = "externalItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder externalItems(@Nonnull Iterable<? extends ExampleExternalReference> externalItems) {
             checkNotBuilt();
-            this.externalItems.clear();
-            ConjureCollections.addAll(
-                    this.externalItems, Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
+            if (externalItems instanceof Collection) {
+                this.externalItems = new ArrayList<>(
+                        (Collection) Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
+            } else {
+                this.externalItems.clear();
+                ConjureCollections.addAll(
+                        this.externalItems, Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
+            }
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
@@ -9,7 +9,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Generated;
@@ -122,12 +121,7 @@ public final class CovariantListExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Iterable<?> items) {
             checkNotBuilt();
-            if (items instanceof Collection) {
-                this.items = new ArrayList<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
-            } else {
-                this.items.clear();
-                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
-            }
+            this.items = ConjureCollections.newArrayList(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
@@ -146,14 +140,8 @@ public final class CovariantListExample {
         @JsonSetter(value = "externalItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder externalItems(@Nonnull Iterable<? extends ExampleExternalReference> externalItems) {
             checkNotBuilt();
-            if (externalItems instanceof Collection) {
-                this.externalItems = new ArrayList<>(
-                        (Collection) Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
-            } else {
-                this.externalItems.clear();
-                ConjureCollections.addAll(
-                        this.externalItems, Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
-            }
+            this.externalItems = ConjureCollections.newArrayList(
+                    Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -10,7 +10,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -170,15 +169,8 @@ public final class ExternalLongExample {
         @JsonSetter(value = "listExternalLong", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder listExternalLong(@Nonnull Iterable<? extends Long> listExternalLong) {
             checkNotBuilt();
-            if (listExternalLong instanceof Collection) {
-                this.listExternalLong = new ArrayList<>(
-                        (Collection) Preconditions.checkNotNull(listExternalLong, "listExternalLong cannot be null"));
-            } else {
-                this.listExternalLong.clear();
-                ConjureCollections.addAll(
-                        this.listExternalLong,
-                        Preconditions.checkNotNull(listExternalLong, "listExternalLong cannot be null"));
-            }
+            this.listExternalLong = ConjureCollections.newArrayList(
+                    Preconditions.checkNotNull(listExternalLong, "listExternalLong cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -10,6 +10,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -169,10 +170,15 @@ public final class ExternalLongExample {
         @JsonSetter(value = "listExternalLong", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder listExternalLong(@Nonnull Iterable<? extends Long> listExternalLong) {
             checkNotBuilt();
-            this.listExternalLong.clear();
-            ConjureCollections.addAll(
-                    this.listExternalLong,
-                    Preconditions.checkNotNull(listExternalLong, "listExternalLong cannot be null"));
+            if (listExternalLong instanceof Collection) {
+                this.listExternalLong = new ArrayList<>(
+                        (Collection) Preconditions.checkNotNull(listExternalLong, "listExternalLong cannot be null"));
+            } else {
+                this.listExternalLong.clear();
+                ConjureCollections.addAll(
+                        this.listExternalLong,
+                        Preconditions.checkNotNull(listExternalLong, "listExternalLong cannot be null"));
+            }
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
@@ -9,7 +9,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -189,12 +188,7 @@ public final class ListExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Iterable<String> items) {
             checkNotBuilt();
-            if (items instanceof Collection) {
-                this.items = new ArrayList<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
-            } else {
-                this.items.clear();
-                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
-            }
+            this.items = ConjureCollections.newArrayList(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
@@ -213,15 +207,8 @@ public final class ListExample {
         @JsonSetter(value = "primitiveItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder primitiveItems(@Nonnull Iterable<Integer> primitiveItems) {
             checkNotBuilt();
-            if (primitiveItems instanceof Collection) {
-                this.primitiveItems = new ArrayList<>(
-                        (Collection) Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
-            } else {
-                this.primitiveItems.clear();
-                ConjureCollections.addAll(
-                        this.primitiveItems,
-                        Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
-            }
+            this.primitiveItems = ConjureCollections.newArrayList(
+                    Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
             return this;
         }
 
@@ -241,14 +228,8 @@ public final class ListExample {
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
             checkNotBuilt();
-            if (doubleItems instanceof Collection) {
-                this.doubleItems = new ArrayList<>(
-                        (Collection) Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
-            } else {
-                this.doubleItems.clear();
-                ConjureCollections.addAll(
-                        this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
-            }
+            this.doubleItems = ConjureCollections.newArrayList(
+                    Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
             return this;
         }
 
@@ -268,14 +249,8 @@ public final class ListExample {
         @JsonSetter(value = "optionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder optionalItems(@Nonnull Iterable<Optional<String>> optionalItems) {
             checkNotBuilt();
-            if (optionalItems instanceof Collection) {
-                this.optionalItems = new ArrayList<>(
-                        (Collection) Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
-            } else {
-                this.optionalItems.clear();
-                ConjureCollections.addAll(
-                        this.optionalItems, Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
-            }
+            this.optionalItems = ConjureCollections.newArrayList(
+                    Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
         }
 
@@ -295,15 +270,8 @@ public final class ListExample {
         @JsonSetter(value = "aliasOptionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalItems(@Nonnull Iterable<OptionalAlias> aliasOptionalItems) {
             checkNotBuilt();
-            if (aliasOptionalItems instanceof Collection) {
-                this.aliasOptionalItems = new ArrayList<>((Collection)
-                        Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
-            } else {
-                this.aliasOptionalItems.clear();
-                ConjureCollections.addAll(
-                        this.aliasOptionalItems,
-                        Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
-            }
+            this.aliasOptionalItems = ConjureCollections.newArrayList(
+                    Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
             return this;
         }
 
@@ -324,14 +292,8 @@ public final class ListExample {
         @JsonSetter(value = "nestedItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder nestedItems(@Nonnull Iterable<? extends List<String>> nestedItems) {
             checkNotBuilt();
-            if (nestedItems instanceof Collection) {
-                this.nestedItems = new ArrayList<>(
-                        (Collection) Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
-            } else {
-                this.nestedItems.clear();
-                ConjureCollections.addAll(
-                        this.nestedItems, Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
-            }
+            this.nestedItems = ConjureCollections.newArrayList(
+                    Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
@@ -9,6 +9,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -188,8 +189,12 @@ public final class ListExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Iterable<String> items) {
             checkNotBuilt();
-            this.items.clear();
-            ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            if (items instanceof Collection) {
+                this.items = new ArrayList<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
+            } else {
+                this.items.clear();
+                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            }
             return this;
         }
 
@@ -208,9 +213,15 @@ public final class ListExample {
         @JsonSetter(value = "primitiveItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder primitiveItems(@Nonnull Iterable<Integer> primitiveItems) {
             checkNotBuilt();
-            this.primitiveItems.clear();
-            ConjureCollections.addAll(
-                    this.primitiveItems, Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
+            if (primitiveItems instanceof Collection) {
+                this.primitiveItems = new ArrayList<>(
+                        (Collection) Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
+            } else {
+                this.primitiveItems.clear();
+                ConjureCollections.addAll(
+                        this.primitiveItems,
+                        Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
+            }
             return this;
         }
 
@@ -230,9 +241,14 @@ public final class ListExample {
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
             checkNotBuilt();
-            this.doubleItems.clear();
-            ConjureCollections.addAll(
-                    this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
+            if (doubleItems instanceof Collection) {
+                this.doubleItems = new ArrayList<>(
+                        (Collection) Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
+            } else {
+                this.doubleItems.clear();
+                ConjureCollections.addAll(
+                        this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
+            }
             return this;
         }
 
@@ -252,9 +268,14 @@ public final class ListExample {
         @JsonSetter(value = "optionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder optionalItems(@Nonnull Iterable<Optional<String>> optionalItems) {
             checkNotBuilt();
-            this.optionalItems.clear();
-            ConjureCollections.addAll(
-                    this.optionalItems, Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
+            if (optionalItems instanceof Collection) {
+                this.optionalItems = new ArrayList<>(
+                        (Collection) Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
+            } else {
+                this.optionalItems.clear();
+                ConjureCollections.addAll(
+                        this.optionalItems, Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
+            }
             return this;
         }
 
@@ -274,10 +295,15 @@ public final class ListExample {
         @JsonSetter(value = "aliasOptionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalItems(@Nonnull Iterable<OptionalAlias> aliasOptionalItems) {
             checkNotBuilt();
-            this.aliasOptionalItems.clear();
-            ConjureCollections.addAll(
-                    this.aliasOptionalItems,
-                    Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
+            if (aliasOptionalItems instanceof Collection) {
+                this.aliasOptionalItems = new ArrayList<>((Collection)
+                        Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
+            } else {
+                this.aliasOptionalItems.clear();
+                ConjureCollections.addAll(
+                        this.aliasOptionalItems,
+                        Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
+            }
             return this;
         }
 
@@ -298,9 +324,14 @@ public final class ListExample {
         @JsonSetter(value = "nestedItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder nestedItems(@Nonnull Iterable<? extends List<String>> nestedItems) {
             checkNotBuilt();
-            this.nestedItems.clear();
-            ConjureCollections.addAll(
-                    this.nestedItems, Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
+            if (nestedItems instanceof Collection) {
+                this.nestedItems = new ArrayList<>(
+                        (Collection) Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
+            } else {
+                this.nestedItems.clear();
+                ConjureCollections.addAll(
+                        this.nestedItems, Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
+            }
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -10,6 +10,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -313,8 +314,12 @@ public final class ManyFieldExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Iterable<String> items) {
             checkNotBuilt();
-            this.items.clear();
-            ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            if (items instanceof Collection) {
+                this.items = new ArrayList<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
+            } else {
+                this.items.clear();
+                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            }
             return this;
         }
 
@@ -342,8 +347,12 @@ public final class ManyFieldExample {
         @JsonSetter(value = "set", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder set(@Nonnull Iterable<String> set) {
             checkNotBuilt();
-            this.set.clear();
-            ConjureCollections.addAll(this.set, Preconditions.checkNotNull(set, "set cannot be null"));
+            if (set instanceof Collection) {
+                this.set = new LinkedHashSet<>((Collection) Preconditions.checkNotNull(set, "set cannot be null"));
+            } else {
+                this.set.clear();
+                ConjureCollections.addAll(this.set, Preconditions.checkNotNull(set, "set cannot be null"));
+            }
             return this;
         }
 
@@ -372,8 +381,7 @@ public final class ManyFieldExample {
         @JsonSetter(value = "map", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder map(@Nonnull Map<String, String> map) {
             checkNotBuilt();
-            this.map.clear();
-            this.map.putAll(Preconditions.checkNotNull(map, "map cannot be null"));
+            this.map = new LinkedHashMap<>(Preconditions.checkNotNull(map, "map cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -10,7 +10,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -314,12 +313,7 @@ public final class ManyFieldExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Iterable<String> items) {
             checkNotBuilt();
-            if (items instanceof Collection) {
-                this.items = new ArrayList<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
-            } else {
-                this.items.clear();
-                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
-            }
+            this.items = ConjureCollections.newArrayList(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
@@ -347,12 +341,7 @@ public final class ManyFieldExample {
         @JsonSetter(value = "set", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder set(@Nonnull Iterable<String> set) {
             checkNotBuilt();
-            if (set instanceof Collection) {
-                this.set = new LinkedHashSet<>((Collection) Preconditions.checkNotNull(set, "set cannot be null"));
-            } else {
-                this.set.clear();
-                ConjureCollections.addAll(this.set, Preconditions.checkNotNull(set, "set cannot be null"));
-            }
+            this.set = ConjureCollections.newLinkedHashSet(Preconditions.checkNotNull(set, "set cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
@@ -151,8 +151,7 @@ public final class MapExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Map<String, String> items) {
             checkNotBuilt();
-            this.items.clear();
-            this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
+            this.items = new LinkedHashMap<>(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
@@ -171,8 +170,8 @@ public final class MapExample {
         @JsonSetter(value = "optionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder optionalItems(@Nonnull Map<String, Optional<String>> optionalItems) {
             checkNotBuilt();
-            this.optionalItems.clear();
-            this.optionalItems.putAll(Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
+            this.optionalItems =
+                    new LinkedHashMap<>(Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
         }
 
@@ -191,8 +190,7 @@ public final class MapExample {
         @JsonSetter(value = "aliasOptionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalItems(@Nonnull Map<String, OptionalAlias> aliasOptionalItems) {
             checkNotBuilt();
-            this.aliasOptionalItems.clear();
-            this.aliasOptionalItems.putAll(
+            this.aliasOptionalItems = new LinkedHashMap<>(
                     Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleFieldsOnlyFinalStage.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleFieldsOnlyFinalStage.java
@@ -11,7 +11,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -247,12 +246,7 @@ public final class MultipleFieldsOnlyFinalStage {
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<String> items) {
             checkNotBuilt();
-            if (items instanceof Collection) {
-                this.items = new ArrayList<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
-            } else {
-                this.items.clear();
-                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
-            }
+            this.items = ConjureCollections.newArrayList(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
@@ -303,14 +297,8 @@ public final class MultipleFieldsOnlyFinalStage {
         @JsonSetter(value = "itemsSet", nulls = Nulls.SKIP)
         public Builder itemsSet(@Nonnull Iterable<String> itemsSet) {
             checkNotBuilt();
-            if (itemsSet instanceof Collection) {
-                this.itemsSet = new LinkedHashSet<>(
-                        (Collection) Preconditions.checkNotNull(itemsSet, "itemsSet cannot be null"));
-            } else {
-                this.itemsSet.clear();
-                ConjureCollections.addAll(
-                        this.itemsSet, Preconditions.checkNotNull(itemsSet, "itemsSet cannot be null"));
-            }
+            this.itemsSet = ConjureCollections.newLinkedHashSet(
+                    Preconditions.checkNotNull(itemsSet, "itemsSet cannot be null"));
             return this;
         }
 
@@ -333,14 +321,8 @@ public final class MultipleFieldsOnlyFinalStage {
         @JsonSetter(value = "itemsOld", nulls = Nulls.SKIP)
         public Builder itemsOld(@Nonnull Iterable<String> itemsOld) {
             checkNotBuilt();
-            if (itemsOld instanceof Collection) {
-                this.itemsOld =
-                        new ArrayList<>((Collection) Preconditions.checkNotNull(itemsOld, "itemsOld cannot be null"));
-            } else {
-                this.itemsOld.clear();
-                ConjureCollections.addAll(
-                        this.itemsOld, Preconditions.checkNotNull(itemsOld, "itemsOld cannot be null"));
-            }
+            this.itemsOld =
+                    ConjureCollections.newArrayList(Preconditions.checkNotNull(itemsOld, "itemsOld cannot be null"));
             return this;
         }
 
@@ -425,14 +407,8 @@ public final class MultipleFieldsOnlyFinalStage {
         @JsonSetter(value = "itemsSetOld", nulls = Nulls.SKIP)
         public Builder itemsSetOld(@Nonnull Iterable<String> itemsSetOld) {
             checkNotBuilt();
-            if (itemsSetOld instanceof Collection) {
-                this.itemsSetOld = new LinkedHashSet<>(
-                        (Collection) Preconditions.checkNotNull(itemsSetOld, "itemsSetOld cannot be null"));
-            } else {
-                this.itemsSetOld.clear();
-                ConjureCollections.addAll(
-                        this.itemsSetOld, Preconditions.checkNotNull(itemsSetOld, "itemsSetOld cannot be null"));
-            }
+            this.itemsSetOld = ConjureCollections.newLinkedHashSet(
+                    Preconditions.checkNotNull(itemsSetOld, "itemsSetOld cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleFieldsOnlyFinalStage.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleFieldsOnlyFinalStage.java
@@ -11,6 +11,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -246,8 +247,12 @@ public final class MultipleFieldsOnlyFinalStage {
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<String> items) {
             checkNotBuilt();
-            this.items.clear();
-            ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            if (items instanceof Collection) {
+                this.items = new ArrayList<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
+            } else {
+                this.items.clear();
+                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            }
             return this;
         }
 
@@ -266,8 +271,7 @@ public final class MultipleFieldsOnlyFinalStage {
         @JsonSetter(value = "itemsMap", nulls = Nulls.SKIP)
         public Builder itemsMap(@Nonnull Map<String, Integer> itemsMap) {
             checkNotBuilt();
-            this.itemsMap.clear();
-            this.itemsMap.putAll(Preconditions.checkNotNull(itemsMap, "itemsMap cannot be null"));
+            this.itemsMap = new LinkedHashMap<>(Preconditions.checkNotNull(itemsMap, "itemsMap cannot be null"));
             return this;
         }
 
@@ -299,8 +303,14 @@ public final class MultipleFieldsOnlyFinalStage {
         @JsonSetter(value = "itemsSet", nulls = Nulls.SKIP)
         public Builder itemsSet(@Nonnull Iterable<String> itemsSet) {
             checkNotBuilt();
-            this.itemsSet.clear();
-            ConjureCollections.addAll(this.itemsSet, Preconditions.checkNotNull(itemsSet, "itemsSet cannot be null"));
+            if (itemsSet instanceof Collection) {
+                this.itemsSet = new LinkedHashSet<>(
+                        (Collection) Preconditions.checkNotNull(itemsSet, "itemsSet cannot be null"));
+            } else {
+                this.itemsSet.clear();
+                ConjureCollections.addAll(
+                        this.itemsSet, Preconditions.checkNotNull(itemsSet, "itemsSet cannot be null"));
+            }
             return this;
         }
 
@@ -323,8 +333,14 @@ public final class MultipleFieldsOnlyFinalStage {
         @JsonSetter(value = "itemsOld", nulls = Nulls.SKIP)
         public Builder itemsOld(@Nonnull Iterable<String> itemsOld) {
             checkNotBuilt();
-            this.itemsOld.clear();
-            ConjureCollections.addAll(this.itemsOld, Preconditions.checkNotNull(itemsOld, "itemsOld cannot be null"));
+            if (itemsOld instanceof Collection) {
+                this.itemsOld =
+                        new ArrayList<>((Collection) Preconditions.checkNotNull(itemsOld, "itemsOld cannot be null"));
+            } else {
+                this.itemsOld.clear();
+                ConjureCollections.addAll(
+                        this.itemsOld, Preconditions.checkNotNull(itemsOld, "itemsOld cannot be null"));
+            }
             return this;
         }
 
@@ -355,8 +371,8 @@ public final class MultipleFieldsOnlyFinalStage {
         @JsonSetter(value = "itemsMapOld", nulls = Nulls.SKIP)
         public Builder itemsMapOld(@Nonnull Map<String, Integer> itemsMapOld) {
             checkNotBuilt();
-            this.itemsMapOld.clear();
-            this.itemsMapOld.putAll(Preconditions.checkNotNull(itemsMapOld, "itemsMapOld cannot be null"));
+            this.itemsMapOld =
+                    new LinkedHashMap<>(Preconditions.checkNotNull(itemsMapOld, "itemsMapOld cannot be null"));
             return this;
         }
 
@@ -409,9 +425,14 @@ public final class MultipleFieldsOnlyFinalStage {
         @JsonSetter(value = "itemsSetOld", nulls = Nulls.SKIP)
         public Builder itemsSetOld(@Nonnull Iterable<String> itemsSetOld) {
             checkNotBuilt();
-            this.itemsSetOld.clear();
-            ConjureCollections.addAll(
-                    this.itemsSetOld, Preconditions.checkNotNull(itemsSetOld, "itemsSetOld cannot be null"));
+            if (itemsSetOld instanceof Collection) {
+                this.itemsSetOld = new LinkedHashSet<>(
+                        (Collection) Preconditions.checkNotNull(itemsSetOld, "itemsSetOld cannot be null"));
+            } else {
+                this.itemsSetOld.clear();
+                ConjureCollections.addAll(
+                        this.itemsSetOld, Preconditions.checkNotNull(itemsSetOld, "itemsSetOld cannot be null"));
+            }
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
@@ -14,6 +14,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.ri.ResourceIdentifier;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -289,8 +290,13 @@ public final class MultipleOrderedStages {
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<SafeLong> items) {
             checkNotBuilt();
-            this.items.clear();
-            ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            if (items instanceof Collection) {
+                this.items =
+                        new LinkedHashSet<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
+            } else {
+                this.items.clear();
+                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            }
             return this;
         }
 
@@ -312,8 +318,7 @@ public final class MultipleOrderedStages {
         @JsonSetter(value = "mappedRids", nulls = Nulls.SKIP)
         public Builder mappedRids(@Nonnull Map<ResourceIdentifier, String> mappedRids) {
             checkNotBuilt();
-            this.mappedRids.clear();
-            this.mappedRids.putAll(Preconditions.checkNotNull(mappedRids, "mappedRids cannot be null"));
+            this.mappedRids = new LinkedHashMap<>(Preconditions.checkNotNull(mappedRids, "mappedRids cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
@@ -14,7 +14,6 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.ri.ResourceIdentifier;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -290,13 +289,7 @@ public final class MultipleOrderedStages {
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<SafeLong> items) {
             checkNotBuilt();
-            if (items instanceof Collection) {
-                this.items =
-                        new LinkedHashSet<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
-            } else {
-                this.items.clear();
-                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
-            }
+            this.items = ConjureCollections.newLinkedHashSet(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
@@ -9,6 +9,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -122,8 +123,13 @@ public final class SetExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Iterable<String> items) {
             checkNotBuilt();
-            this.items.clear();
-            ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            if (items instanceof Collection) {
+                this.items =
+                        new LinkedHashSet<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
+            } else {
+                this.items.clear();
+                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            }
             return this;
         }
 
@@ -142,9 +148,14 @@ public final class SetExample {
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
             checkNotBuilt();
-            this.doubleItems.clear();
-            ConjureCollections.addAll(
-                    this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
+            if (doubleItems instanceof Collection) {
+                this.doubleItems = new LinkedHashSet<>(
+                        (Collection) Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
+            } else {
+                this.doubleItems.clear();
+                ConjureCollections.addAll(
+                        this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
+            }
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
@@ -9,7 +9,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -123,13 +122,7 @@ public final class SetExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder items(@Nonnull Iterable<String> items) {
             checkNotBuilt();
-            if (items instanceof Collection) {
-                this.items =
-                        new LinkedHashSet<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
-            } else {
-                this.items.clear();
-                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
-            }
+            this.items = ConjureCollections.newLinkedHashSet(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
@@ -148,14 +141,8 @@ public final class SetExample {
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
             checkNotBuilt();
-            if (doubleItems instanceof Collection) {
-                this.doubleItems = new LinkedHashSet<>(
-                        (Collection) Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
-            } else {
-                this.doubleItems.clear();
-                ConjureCollections.addAll(
-                        this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
-            }
+            this.doubleItems = ConjureCollections.newLinkedHashSet(
+                    Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AliasAsMapKeyExample.java
@@ -208,8 +208,7 @@ public final class AliasAsMapKeyExample {
         @JsonSetter(value = "strings", nulls = Nulls.SKIP)
         public Builder strings(@Nonnull Map<StringAliasExample, ManyFieldExample> strings) {
             checkNotBuilt();
-            this.strings.clear();
-            this.strings.putAll(Preconditions.checkNotNull(strings, "strings cannot be null"));
+            this.strings = new LinkedHashMap<>(Preconditions.checkNotNull(strings, "strings cannot be null"));
             return this;
         }
 
@@ -228,8 +227,7 @@ public final class AliasAsMapKeyExample {
         @JsonSetter(value = "rids", nulls = Nulls.SKIP)
         public Builder rids(@Nonnull Map<RidAliasExample, ManyFieldExample> rids) {
             checkNotBuilt();
-            this.rids.clear();
-            this.rids.putAll(Preconditions.checkNotNull(rids, "rids cannot be null"));
+            this.rids = new LinkedHashMap<>(Preconditions.checkNotNull(rids, "rids cannot be null"));
             return this;
         }
 
@@ -248,8 +246,8 @@ public final class AliasAsMapKeyExample {
         @JsonSetter(value = "bearertokens", nulls = Nulls.SKIP)
         public Builder bearertokens(@Nonnull Map<BearerTokenAliasExample, ManyFieldExample> bearertokens) {
             checkNotBuilt();
-            this.bearertokens.clear();
-            this.bearertokens.putAll(Preconditions.checkNotNull(bearertokens, "bearertokens cannot be null"));
+            this.bearertokens =
+                    new LinkedHashMap<>(Preconditions.checkNotNull(bearertokens, "bearertokens cannot be null"));
             return this;
         }
 
@@ -268,8 +266,7 @@ public final class AliasAsMapKeyExample {
         @JsonSetter(value = "integers", nulls = Nulls.SKIP)
         public Builder integers(@Nonnull Map<IntegerAliasExample, ManyFieldExample> integers) {
             checkNotBuilt();
-            this.integers.clear();
-            this.integers.putAll(Preconditions.checkNotNull(integers, "integers cannot be null"));
+            this.integers = new LinkedHashMap<>(Preconditions.checkNotNull(integers, "integers cannot be null"));
             return this;
         }
 
@@ -288,8 +285,7 @@ public final class AliasAsMapKeyExample {
         @JsonSetter(value = "safelongs", nulls = Nulls.SKIP)
         public Builder safelongs(@Nonnull Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
             checkNotBuilt();
-            this.safelongs.clear();
-            this.safelongs.putAll(Preconditions.checkNotNull(safelongs, "safelongs cannot be null"));
+            this.safelongs = new LinkedHashMap<>(Preconditions.checkNotNull(safelongs, "safelongs cannot be null"));
             return this;
         }
 
@@ -308,8 +304,7 @@ public final class AliasAsMapKeyExample {
         @JsonSetter(value = "datetimes", nulls = Nulls.SKIP)
         public Builder datetimes(@Nonnull Map<DateTimeAliasExample, ManyFieldExample> datetimes) {
             checkNotBuilt();
-            this.datetimes.clear();
-            this.datetimes.putAll(Preconditions.checkNotNull(datetimes, "datetimes cannot be null"));
+            this.datetimes = new LinkedHashMap<>(Preconditions.checkNotNull(datetimes, "datetimes cannot be null"));
             return this;
         }
 
@@ -328,8 +323,7 @@ public final class AliasAsMapKeyExample {
         @JsonSetter(value = "uuids", nulls = Nulls.SKIP)
         public Builder uuids(@Nonnull Map<UuidAliasExample, ManyFieldExample> uuids) {
             checkNotBuilt();
-            this.uuids.clear();
-            this.uuids.putAll(Preconditions.checkNotNull(uuids, "uuids cannot be null"));
+            this.uuids = new LinkedHashMap<>(Preconditions.checkNotNull(uuids, "uuids cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyMapExample.java
@@ -108,8 +108,7 @@ public final class AnyMapExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Map<String, Object> items) {
             checkNotBuilt();
-            this.items.clear();
-            this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
+            this.items = new LinkedHashMap<>(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
@@ -10,6 +10,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Generated;
@@ -123,8 +124,12 @@ public final class CovariantListExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<?> items) {
             checkNotBuilt();
-            this.items.clear();
-            ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            if (items instanceof Collection) {
+                this.items = new ArrayList<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
+            } else {
+                this.items.clear();
+                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            }
             return this;
         }
 
@@ -143,9 +148,14 @@ public final class CovariantListExample {
         @JsonSetter(value = "externalItems", nulls = Nulls.SKIP)
         public Builder externalItems(@Nonnull Iterable<? extends ExampleExternalReference> externalItems) {
             checkNotBuilt();
-            this.externalItems.clear();
-            ConjureCollections.addAll(
-                    this.externalItems, Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
+            if (externalItems instanceof Collection) {
+                this.externalItems = new ArrayList<>(
+                        (Collection) Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
+            } else {
+                this.externalItems.clear();
+                ConjureCollections.addAll(
+                        this.externalItems, Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
+            }
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
@@ -10,7 +10,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Generated;
@@ -124,12 +123,7 @@ public final class CovariantListExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<?> items) {
             checkNotBuilt();
-            if (items instanceof Collection) {
-                this.items = new ArrayList<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
-            } else {
-                this.items.clear();
-                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
-            }
+            this.items = ConjureCollections.newArrayList(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
@@ -148,14 +142,8 @@ public final class CovariantListExample {
         @JsonSetter(value = "externalItems", nulls = Nulls.SKIP)
         public Builder externalItems(@Nonnull Iterable<? extends ExampleExternalReference> externalItems) {
             checkNotBuilt();
-            if (externalItems instanceof Collection) {
-                this.externalItems = new ArrayList<>(
-                        (Collection) Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
-            } else {
-                this.externalItems.clear();
-                ConjureCollections.addAll(
-                        this.externalItems, Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
-            }
+            this.externalItems = ConjureCollections.newArrayList(
+                    Preconditions.checkNotNull(externalItems, "externalItems cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
@@ -11,6 +11,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -171,10 +172,15 @@ public final class ExternalLongExample {
         @JsonSetter(value = "listExternalLong", nulls = Nulls.SKIP)
         public Builder listExternalLong(@Nonnull Iterable<? extends Long> listExternalLong) {
             checkNotBuilt();
-            this.listExternalLong.clear();
-            ConjureCollections.addAll(
-                    this.listExternalLong,
-                    Preconditions.checkNotNull(listExternalLong, "listExternalLong cannot be null"));
+            if (listExternalLong instanceof Collection) {
+                this.listExternalLong = new ArrayList<>(
+                        (Collection) Preconditions.checkNotNull(listExternalLong, "listExternalLong cannot be null"));
+            } else {
+                this.listExternalLong.clear();
+                ConjureCollections.addAll(
+                        this.listExternalLong,
+                        Preconditions.checkNotNull(listExternalLong, "listExternalLong cannot be null"));
+            }
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
@@ -11,7 +11,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -172,15 +171,8 @@ public final class ExternalLongExample {
         @JsonSetter(value = "listExternalLong", nulls = Nulls.SKIP)
         public Builder listExternalLong(@Nonnull Iterable<? extends Long> listExternalLong) {
             checkNotBuilt();
-            if (listExternalLong instanceof Collection) {
-                this.listExternalLong = new ArrayList<>(
-                        (Collection) Preconditions.checkNotNull(listExternalLong, "listExternalLong cannot be null"));
-            } else {
-                this.listExternalLong.clear();
-                ConjureCollections.addAll(
-                        this.listExternalLong,
-                        Preconditions.checkNotNull(listExternalLong, "listExternalLong cannot be null"));
-            }
+            this.listExternalLong = ConjureCollections.newArrayList(
+                    Preconditions.checkNotNull(listExternalLong, "listExternalLong cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListExample.java
@@ -10,7 +10,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -191,12 +190,7 @@ public final class ListExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<String> items) {
             checkNotBuilt();
-            if (items instanceof Collection) {
-                this.items = new ArrayList<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
-            } else {
-                this.items.clear();
-                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
-            }
+            this.items = ConjureCollections.newArrayList(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
@@ -215,15 +209,8 @@ public final class ListExample {
         @JsonSetter(value = "primitiveItems", nulls = Nulls.SKIP)
         public Builder primitiveItems(@Nonnull Iterable<Integer> primitiveItems) {
             checkNotBuilt();
-            if (primitiveItems instanceof Collection) {
-                this.primitiveItems = new ArrayList<>(
-                        (Collection) Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
-            } else {
-                this.primitiveItems.clear();
-                ConjureCollections.addAll(
-                        this.primitiveItems,
-                        Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
-            }
+            this.primitiveItems = ConjureCollections.newArrayList(
+                    Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
             return this;
         }
 
@@ -243,14 +230,8 @@ public final class ListExample {
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP)
         public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
             checkNotBuilt();
-            if (doubleItems instanceof Collection) {
-                this.doubleItems = new ArrayList<>(
-                        (Collection) Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
-            } else {
-                this.doubleItems.clear();
-                ConjureCollections.addAll(
-                        this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
-            }
+            this.doubleItems = ConjureCollections.newArrayList(
+                    Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
             return this;
         }
 
@@ -270,14 +251,8 @@ public final class ListExample {
         @JsonSetter(value = "optionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder optionalItems(@Nonnull Iterable<Optional<String>> optionalItems) {
             checkNotBuilt();
-            if (optionalItems instanceof Collection) {
-                this.optionalItems = new ArrayList<>(
-                        (Collection) Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
-            } else {
-                this.optionalItems.clear();
-                ConjureCollections.addAll(
-                        this.optionalItems, Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
-            }
+            this.optionalItems = ConjureCollections.newArrayList(
+                    Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
         }
 
@@ -297,15 +272,8 @@ public final class ListExample {
         @JsonSetter(value = "aliasOptionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalItems(@Nonnull Iterable<OptionalAlias> aliasOptionalItems) {
             checkNotBuilt();
-            if (aliasOptionalItems instanceof Collection) {
-                this.aliasOptionalItems = new ArrayList<>((Collection)
-                        Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
-            } else {
-                this.aliasOptionalItems.clear();
-                ConjureCollections.addAll(
-                        this.aliasOptionalItems,
-                        Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
-            }
+            this.aliasOptionalItems = ConjureCollections.newArrayList(
+                    Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
             return this;
         }
 
@@ -326,14 +294,8 @@ public final class ListExample {
         @JsonSetter(value = "nestedItems", nulls = Nulls.SKIP)
         public Builder nestedItems(@Nonnull Iterable<? extends List<String>> nestedItems) {
             checkNotBuilt();
-            if (nestedItems instanceof Collection) {
-                this.nestedItems = new ArrayList<>(
-                        (Collection) Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
-            } else {
-                this.nestedItems.clear();
-                ConjureCollections.addAll(
-                        this.nestedItems, Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
-            }
+            this.nestedItems = ConjureCollections.newArrayList(
+                    Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListExample.java
@@ -10,6 +10,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -190,8 +191,12 @@ public final class ListExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<String> items) {
             checkNotBuilt();
-            this.items.clear();
-            ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            if (items instanceof Collection) {
+                this.items = new ArrayList<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
+            } else {
+                this.items.clear();
+                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            }
             return this;
         }
 
@@ -210,9 +215,15 @@ public final class ListExample {
         @JsonSetter(value = "primitiveItems", nulls = Nulls.SKIP)
         public Builder primitiveItems(@Nonnull Iterable<Integer> primitiveItems) {
             checkNotBuilt();
-            this.primitiveItems.clear();
-            ConjureCollections.addAll(
-                    this.primitiveItems, Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
+            if (primitiveItems instanceof Collection) {
+                this.primitiveItems = new ArrayList<>(
+                        (Collection) Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
+            } else {
+                this.primitiveItems.clear();
+                ConjureCollections.addAll(
+                        this.primitiveItems,
+                        Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
+            }
             return this;
         }
 
@@ -232,9 +243,14 @@ public final class ListExample {
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP)
         public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
             checkNotBuilt();
-            this.doubleItems.clear();
-            ConjureCollections.addAll(
-                    this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
+            if (doubleItems instanceof Collection) {
+                this.doubleItems = new ArrayList<>(
+                        (Collection) Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
+            } else {
+                this.doubleItems.clear();
+                ConjureCollections.addAll(
+                        this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
+            }
             return this;
         }
 
@@ -254,9 +270,14 @@ public final class ListExample {
         @JsonSetter(value = "optionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder optionalItems(@Nonnull Iterable<Optional<String>> optionalItems) {
             checkNotBuilt();
-            this.optionalItems.clear();
-            ConjureCollections.addAll(
-                    this.optionalItems, Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
+            if (optionalItems instanceof Collection) {
+                this.optionalItems = new ArrayList<>(
+                        (Collection) Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
+            } else {
+                this.optionalItems.clear();
+                ConjureCollections.addAll(
+                        this.optionalItems, Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
+            }
             return this;
         }
 
@@ -276,10 +297,15 @@ public final class ListExample {
         @JsonSetter(value = "aliasOptionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalItems(@Nonnull Iterable<OptionalAlias> aliasOptionalItems) {
             checkNotBuilt();
-            this.aliasOptionalItems.clear();
-            ConjureCollections.addAll(
-                    this.aliasOptionalItems,
-                    Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
+            if (aliasOptionalItems instanceof Collection) {
+                this.aliasOptionalItems = new ArrayList<>((Collection)
+                        Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
+            } else {
+                this.aliasOptionalItems.clear();
+                ConjureCollections.addAll(
+                        this.aliasOptionalItems,
+                        Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
+            }
             return this;
         }
 
@@ -300,9 +326,14 @@ public final class ListExample {
         @JsonSetter(value = "nestedItems", nulls = Nulls.SKIP)
         public Builder nestedItems(@Nonnull Iterable<? extends List<String>> nestedItems) {
             checkNotBuilt();
-            this.nestedItems.clear();
-            ConjureCollections.addAll(
-                    this.nestedItems, Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
+            if (nestedItems instanceof Collection) {
+                this.nestedItems = new ArrayList<>(
+                        (Collection) Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
+            } else {
+                this.nestedItems.clear();
+                ConjureCollections.addAll(
+                        this.nestedItems, Preconditions.checkNotNull(nestedItems, "nestedItems cannot be null"));
+            }
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
@@ -11,6 +11,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -315,8 +316,12 @@ public final class ManyFieldExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<String> items) {
             checkNotBuilt();
-            this.items.clear();
-            ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            if (items instanceof Collection) {
+                this.items = new ArrayList<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
+            } else {
+                this.items.clear();
+                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            }
             return this;
         }
 
@@ -344,8 +349,12 @@ public final class ManyFieldExample {
         @JsonSetter(value = "set", nulls = Nulls.SKIP)
         public Builder set(@Nonnull Iterable<String> set) {
             checkNotBuilt();
-            this.set.clear();
-            ConjureCollections.addAll(this.set, Preconditions.checkNotNull(set, "set cannot be null"));
+            if (set instanceof Collection) {
+                this.set = new LinkedHashSet<>((Collection) Preconditions.checkNotNull(set, "set cannot be null"));
+            } else {
+                this.set.clear();
+                ConjureCollections.addAll(this.set, Preconditions.checkNotNull(set, "set cannot be null"));
+            }
             return this;
         }
 
@@ -374,8 +383,7 @@ public final class ManyFieldExample {
         @JsonSetter(value = "map", nulls = Nulls.SKIP)
         public Builder map(@Nonnull Map<String, String> map) {
             checkNotBuilt();
-            this.map.clear();
-            this.map.putAll(Preconditions.checkNotNull(map, "map cannot be null"));
+            this.map = new LinkedHashMap<>(Preconditions.checkNotNull(map, "map cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
@@ -11,7 +11,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -316,12 +315,7 @@ public final class ManyFieldExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<String> items) {
             checkNotBuilt();
-            if (items instanceof Collection) {
-                this.items = new ArrayList<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
-            } else {
-                this.items.clear();
-                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
-            }
+            this.items = ConjureCollections.newArrayList(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
@@ -349,12 +343,7 @@ public final class ManyFieldExample {
         @JsonSetter(value = "set", nulls = Nulls.SKIP)
         public Builder set(@Nonnull Iterable<String> set) {
             checkNotBuilt();
-            if (set instanceof Collection) {
-                this.set = new LinkedHashSet<>((Collection) Preconditions.checkNotNull(set, "set cannot be null"));
-            } else {
-                this.set.clear();
-                ConjureCollections.addAll(this.set, Preconditions.checkNotNull(set, "set cannot be null"));
-            }
+            this.set = ConjureCollections.newLinkedHashSet(Preconditions.checkNotNull(set, "set cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapExample.java
@@ -153,8 +153,7 @@ public final class MapExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Map<String, String> items) {
             checkNotBuilt();
-            this.items.clear();
-            this.items.putAll(Preconditions.checkNotNull(items, "items cannot be null"));
+            this.items = new LinkedHashMap<>(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
@@ -173,8 +172,8 @@ public final class MapExample {
         @JsonSetter(value = "optionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder optionalItems(@Nonnull Map<String, Optional<String>> optionalItems) {
             checkNotBuilt();
-            this.optionalItems.clear();
-            this.optionalItems.putAll(Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
+            this.optionalItems =
+                    new LinkedHashMap<>(Preconditions.checkNotNull(optionalItems, "optionalItems cannot be null"));
             return this;
         }
 
@@ -193,8 +192,7 @@ public final class MapExample {
         @JsonSetter(value = "aliasOptionalItems", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
         public Builder aliasOptionalItems(@Nonnull Map<String, OptionalAlias> aliasOptionalItems) {
             checkNotBuilt();
-            this.aliasOptionalItems.clear();
-            this.aliasOptionalItems.putAll(
+            this.aliasOptionalItems = new LinkedHashMap<>(
                     Preconditions.checkNotNull(aliasOptionalItems, "aliasOptionalItems cannot be null"));
             return this;
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetExample.java
@@ -10,7 +10,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -125,13 +124,7 @@ public final class SetExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<String> items) {
             checkNotBuilt();
-            if (items instanceof Collection) {
-                this.items =
-                        new LinkedHashSet<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
-            } else {
-                this.items.clear();
-                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
-            }
+            this.items = ConjureCollections.newLinkedHashSet(Preconditions.checkNotNull(items, "items cannot be null"));
             return this;
         }
 
@@ -150,14 +143,8 @@ public final class SetExample {
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP)
         public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
             checkNotBuilt();
-            if (doubleItems instanceof Collection) {
-                this.doubleItems = new LinkedHashSet<>(
-                        (Collection) Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
-            } else {
-                this.doubleItems.clear();
-                ConjureCollections.addAll(
-                        this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
-            }
+            this.doubleItems = ConjureCollections.newLinkedHashSet(
+                    Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetExample.java
@@ -10,6 +10,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -124,8 +125,13 @@ public final class SetExample {
         @JsonSetter(value = "items", nulls = Nulls.SKIP)
         public Builder items(@Nonnull Iterable<String> items) {
             checkNotBuilt();
-            this.items.clear();
-            ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            if (items instanceof Collection) {
+                this.items =
+                        new LinkedHashSet<>((Collection) Preconditions.checkNotNull(items, "items cannot be null"));
+            } else {
+                this.items.clear();
+                ConjureCollections.addAll(this.items, Preconditions.checkNotNull(items, "items cannot be null"));
+            }
             return this;
         }
 
@@ -144,9 +150,14 @@ public final class SetExample {
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP)
         public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
             checkNotBuilt();
-            this.doubleItems.clear();
-            ConjureCollections.addAll(
-                    this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
+            if (doubleItems instanceof Collection) {
+                this.doubleItems = new LinkedHashSet<>(
+                        (Collection) Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
+            } else {
+                this.doubleItems.clear();
+                ConjureCollections.addAll(
+                        this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
+            }
             return this;
         }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -387,11 +387,11 @@ public final class BeanBuilderGenerator {
         } else if (type.accept(TypeVisitor.IS_MAP)) {
             if (shouldClearFirst) {
                 return CodeBlocks.statement(
-                                "this.$1N = new $2T<>($3L)",
-                                spec.name,
-                                type.accept(COLLECTION_CONCRETE_TYPE),
-                                Expressions.requireNonNull(
-                                        spec.name, enriched.fieldName().get() + " cannot be null"));
+                        "this.$1N = new $2T<>($3L)",
+                        spec.name,
+                        type.accept(COLLECTION_CONCRETE_TYPE),
+                        Expressions.requireNonNull(
+                                spec.name, enriched.fieldName().get() + " cannot be null"));
             }
             return CodeBlocks.statement(
                     "this.$1N.putAll($2L)",

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
@@ -16,7 +16,10 @@
 
 package com.palantir.conjure.java.lib.internal;
 
+import com.palantir.logsafe.Preconditions;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 
 /**
  * Utility functions for conjure. Consumers should prefer to use something like guava instead of using these functions
@@ -30,6 +33,7 @@ public final class ConjureCollections {
 
     @SuppressWarnings("unchecked")
     public static <T> void addAll(Collection<T> addTo, Iterable<? extends T> elementsToAdd) {
+        Preconditions.checkNotNull(elementsToAdd, "elementsToAdd cannot be null");
         if (elementsToAdd instanceof Collection) {
             // This special-casing allows us to take advantage of the more performant
             // ArrayList#addAll method which does a single System.arraycopy.
@@ -39,5 +43,31 @@ public final class ConjureCollections {
                 addTo.add(element);
             }
         }
+    }
+
+    @SuppressWarnings({"IllegalType", "unchecked"}) // explicitly need to return mutable list for generated builders
+    public static <T> ArrayList<T> newArrayList(Iterable<? extends T> iterable) {
+        Preconditions.checkNotNull(iterable, "iterable cannot be null");
+        if (iterable instanceof Collection) {
+            return new ArrayList<>((Collection<T>) iterable);
+        }
+        ArrayList<T> list = new ArrayList<>();
+        for (T item : iterable) {
+            list.add(item);
+        }
+        return list;
+    }
+
+    @SuppressWarnings("IllegalType") // explicitly need to return mutable list for generated builders
+    public static <T> LinkedHashSet<T> newLinkedHashSet(Iterable<? extends T> iterable) {
+        Preconditions.checkNotNull(iterable, "iterable cannot be null");
+        if (iterable instanceof Collection) {
+            return new LinkedHashSet<>((Collection<T>) iterable);
+        }
+        LinkedHashSet<T> set = new LinkedHashSet<>();
+        for (T item : iterable) {
+            set.add(item);
+        }
+        return set;
     }
 }


### PR DESCRIPTION
## Before this PR
Passing a `Collection` to the generated builder method for `set` fields did not benefit from the presizing estimate logic in [`LinkedHashSet(Collection)`](https://github.com/openjdk/jdk/blob/c79baaa811971c43fbdbc251482d0e40903588cc/src/java.base/share/classes/java/util/LinkedHashSet.java#L177) 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Collection setters use constructor when clearing
==COMMIT_MSG==

## Possible downsides?
This adds a couple methods to `ConjureCollections` that return concrete `ArrayList` and `LinkedHashSet` implementations that ideally we wouldn't expose, but we need these to avoid Guava dependency.

We might also want to (separately?) consider generating builder methods that take a `Stream` and/or `Iterator` of elements to be added to Conjure objects as we have many places using Guava `Collections2`/`Lists`/`Maps`.`transform` or `Stream`s unnecessarily collecting to intermediate collection (or `Stream.forEach(builder::addFoo)`) which makes concise builder transformations slightly more difficult.