### PR TITLE
Compare content-type case insensitive

### DIFF
--- a/changelog/@unreleased/pr-1854.v2.yml
+++ b/changelog/@unreleased/pr-1854.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Compare content-type case insensitive
+  links:
+  - https://github.com/palantir/conjure-java/pull/1854

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
@@ -100,7 +100,7 @@ final class ConjureBodySerDe implements BodySerDe {
     @Override
     public InputStream deserializeInputStream(HttpServerExchange exchange) {
         String contentType = getContentType(exchange);
-        if (!contentType.startsWith(BINARY_CONTENT_TYPE)) {
+        if (!contentType.toLowerCase().startsWith(BINARY_CONTENT_TYPE)) {
             throw FrameworkException.unsupportedMediaType(
                     "Unsupported Content-Type", SafeArg.of("Content-Type", contentType));
         }

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PushbackInputStream;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import org.xnio.IoUtils;
 
@@ -100,7 +101,7 @@ final class ConjureBodySerDe implements BodySerDe {
     @Override
     public InputStream deserializeInputStream(HttpServerExchange exchange) {
         String contentType = getContentType(exchange);
-        if (!contentType.toLowerCase().startsWith(BINARY_CONTENT_TYPE)) {
+        if (!contentType.toLowerCase(Locale.ROOT).startsWith(BINARY_CONTENT_TYPE)) {
             throw FrameworkException.unsupportedMediaType(
                     "Unsupported Content-Type", SafeArg.of("Content-Type", contentType));
         }

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
@@ -40,7 +40,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PushbackInputStream;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import org.xnio.IoUtils;
 
@@ -101,7 +100,10 @@ final class ConjureBodySerDe implements BodySerDe {
     @Override
     public InputStream deserializeInputStream(HttpServerExchange exchange) {
         String contentType = getContentType(exchange);
-        if (!contentType.toLowerCase(Locale.ROOT).startsWith(BINARY_CONTENT_TYPE)) {
+        // Compare using 'String#regionMatches' to avoid allocation
+        if (contentType.length() < BINARY_CONTENT_TYPE.length()
+                || !contentType.regionMatches(
+                        /* ignoreCase = */ true, 0, BINARY_CONTENT_TYPE, 0, BINARY_CONTENT_TYPE.length())) {
             throw FrameworkException.unsupportedMediaType(
                     "Unsupported Content-Type", SafeArg.of("Content-Type", contentType));
         }
@@ -272,6 +274,8 @@ final class ConjureBodySerDe implements BodySerDe {
      * a warning. This notifies us in the unexpected case when multiple
      * content-type headers are incorrectly sent to the server, it's not clear which should
      * be used.
+     * <p>
+     * Note that the returned content-type needs to be compared case-insensitive.
      */
     private static String getContentType(HttpServerExchange exchange) {
         HeaderValues contentTypeValues = exchange.getRequestHeaders().get(Headers.CONTENT_TYPE);

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDeTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDeTest.java
@@ -76,6 +76,15 @@ public class ConjureBodySerDeTest {
     }
 
     @Test
+    public void testBinaryRequestContentType_caseInsensitive() {
+        HttpServerExchange exchange = HttpServerExchanges.createStub();
+        exchange.getRequestHeaders().put(Headers.CONTENT_TYPE, "Application/Octet-Stream");
+        BodySerDe serializers = new ConjureBodySerDe(ImmutableList.of(new StubEncoding("application/octet-stream")));
+        // Test that no "Unsupported Content-Type" exception is thrown
+        serializers.deserializeInputStream(exchange);
+    }
+
+    @Test
     public void testResponseContentType() throws IOException {
         Encoding json = new StubEncoding("application/json");
         Encoding plain = new StubEncoding("text/plain");


### PR DESCRIPTION
## Before this PR
Small drivy-by fix, but I think we should match content types case insensitive. We do the same when determining a decoding: [example](https://github.com/palantir/conjure-java/blob/8afc1c6c92a33c03eff4d308ee31f855fe017e8b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encodings.java#L61) added in https://github.com/palantir/conjure-java/pull/686.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Compare content-type case insensitive
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

