### PR TITLE
conjure-undertow error responses are more concise

### DIFF
--- a/changelog/@unreleased/pr-1867.v2.yml
+++ b/changelog/@unreleased/pr-1867.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: conjure-undertow error responses are more concise
+  links:
+  - https://github.com/palantir/conjure-java/pull/1867


### PR DESCRIPTION
==COMMIT_MSG==
conjure-undertow error responses are more concise
==COMMIT_MSG==
