### PR TITLE
Test coverage for FrameworkException diagnostic info

### DIFF
--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -235,6 +235,9 @@ public final class UndertowServiceEteTest extends TestBase {
             SerializableError error = CLIENT_OBJECT_MAPPER.readValue(responseBody, SerializableError.class);
             assertThat(error.errorCode()).isEqualTo("INVALID_ARGUMENT");
             assertThat(error.errorName()).isEqualTo("Conjure:UnprocessableEntity");
+            assertThat(error.parameters())
+                    .as("Diagnostic data is logged, not transmitted")
+                    .isEmpty();
         }
     }
 


### PR DESCRIPTION
==COMMIT_MSG==
Test coverage for FrameworkException diagnostic info
==COMMIT_MSG==

