### PR TITLE
Remove jaxrs dependency from conjure-lib

### DIFF
--- a/conjure-lib/build.gradle
+++ b/conjure-lib/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     api 'com.palantir.tokens:auth-tokens'
     api 'com.palantir.conjure.java.api:errors'
     api 'jakarta.annotation:jakarta.annotation-api'
-    api 'jakarta.ws.rs:jakarta.ws.rs-api'
     api 'com.google.errorprone:error_prone_annotations'
 
     testImplementation 'org.assertj:assertj-core'


### PR DESCRIPTION


## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
This only existed as a platform dependency

Another option is to switch this to the jakarta equivalent

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove jaxrs dependency from conjure-lib
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

