### PR TITLE
Add FormParam annotation

### DIFF
--- a/changelog/@unreleased/pr-1872.v2.yml
+++ b/changelog/@unreleased/pr-1872.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Add a `@FormParam` annotation for easily declaring endpoints that use
+    form data.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1872

--- a/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/FormParamDeserializer.java
+++ b/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/FormParamDeserializer.java
@@ -62,7 +62,7 @@ public final class FormParamDeserializer<T> implements Deserializer<T> {
             return Collections.emptyList();
         }
 
-        Collection<String> values = new ArrayList<>();
+        Collection<String> values = new ArrayList<>(maybeValues.size());
 
         for (FormValue value : maybeValues) {
             Preconditions.checkArgument(!value.isFileItem(), "Form value was a file item");

--- a/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/FormParamDeserializer.java
+++ b/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/FormParamDeserializer.java
@@ -1,0 +1,76 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.annotations;
+
+import com.google.common.collect.Collections2;
+import com.palantir.conjure.java.undertow.lib.Deserializer;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.handlers.form.FormData.FormValue;
+import io.undertow.server.handlers.form.FormDataParser;
+import io.undertow.server.handlers.form.FormParserFactory;
+import io.undertow.util.Headers;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+
+public final class FormParamDeserializer<T> implements Deserializer<T> {
+
+    private static final FormParserFactory FORM_PARSER_FACTORY =
+            FormParserFactory.builder().build();
+
+    private final String parameter;
+    private final CollectionParamDecoder<? extends T> decoder;
+
+    public FormParamDeserializer(String parameter, CollectionParamDecoder<? extends T> decoder) {
+        this.parameter = Preconditions.checkNotNull(parameter, "Form parameter name is required");
+        this.decoder = Preconditions.checkNotNull(decoder, "Decoder is required");
+    }
+
+    @Override
+    public T deserialize(HttpServerExchange exchange) throws IOException {
+        FormDataParser parser = FORM_PARSER_FACTORY.createParser(exchange);
+        if (parser == null) {
+            throw new SafeIllegalArgumentException(
+                    "Failed to create form data parser",
+                    SafeArg.of("contentType", exchange.getRequestHeaders().getFirst(Headers.CONTENT_TYPE)));
+        }
+
+        Deque<FormValue> maybeValues = parser.parseBlocking().get(parameter);
+        return Preconditions.checkNotNull(decoder.decode(getValues(maybeValues)), "Decoder produced a null value");
+    }
+
+    private Collection<String> getValues(Deque<FormValue> maybeValues) {
+        if (maybeValues == null) {
+            return Collections.emptyList();
+        }
+
+        for (FormValue value : maybeValues) {
+            Preconditions.checkArgument(!value.isFileItem(), "Form value was a file item");
+        }
+
+        return Collections.unmodifiableCollection(Collections2.transform(maybeValues, FormValue::getValue));
+    }
+
+    @Override
+    public String toString() {
+        return "QueryParamDeserializer{parameter='" + parameter + '\'' + ", decoder=" + decoder + '}';
+    }
+}

--- a/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/FormParamDeserializer.java
+++ b/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/FormParamDeserializer.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.java.undertow.annotations;
 
-import com.google.common.collect.Collections2;
 import com.palantir.conjure.java.undertow.lib.Deserializer;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
@@ -27,6 +26,7 @@ import io.undertow.server.handlers.form.FormDataParser;
 import io.undertow.server.handlers.form.FormParserFactory;
 import io.undertow.util.Headers;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
@@ -62,11 +62,14 @@ public final class FormParamDeserializer<T> implements Deserializer<T> {
             return Collections.emptyList();
         }
 
+        Collection<String> values = new ArrayList<>();
+
         for (FormValue value : maybeValues) {
             Preconditions.checkArgument(!value.isFileItem(), "Form value was a file item");
+            values.add(value.getValue());
         }
 
-        return Collections.unmodifiableCollection(Collections2.transform(maybeValues, FormValue::getValue));
+        return Collections.unmodifiableCollection(values);
     }
 
     @Override

--- a/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/Handle.java
+++ b/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/Handle.java
@@ -133,6 +133,18 @@ public @interface Handle {
 
     @Retention(RetentionPolicy.CLASS)
     @Target(ElementType.PARAMETER)
+    @interface FormParam {
+        String value();
+
+        /**
+         * Decoder for deserializing form parameter value. If omitted, tries to use a default decoder in
+         * {@link ParamDecoders}.
+         */
+        Class<? extends CollectionParamDecoder<?>> decoder() default DefaultParamDecoder.class;
+    }
+
+    @Retention(RetentionPolicy.CLASS)
+    @Target(ElementType.PARAMETER)
     @interface Cookie {
         String value();
 

--- a/conjure-undertow-processor-example/src/main/java/com/palantir/conjure/java/undertow/example/ExampleService.java
+++ b/conjure-undertow-processor-example/src/main/java/com/palantir/conjure/java/undertow/example/ExampleService.java
@@ -74,6 +74,10 @@ public interface ExampleService {
     String queryParam(
             @Handle.QueryParam(value = "q", decoder = StringCollectionParameterDecoder.class) String queryParameter);
 
+    @Handle(method = HttpMethod.POST, path = "/formParam")
+    String formParam(
+            @Handle.FormParam(value = "f", decoder = StringCollectionParameterDecoder.class) String formParameter);
+
     @Handle(method = HttpMethod.GET, path = "/path/{param}")
     String pathParam(@Handle.PathParam(decoder = StringParameterDecoder.class) String param);
 

--- a/conjure-undertow-processor-example/src/test/java/com/palantir/conjure/java/undertow/example/ExampleResource.java
+++ b/conjure-undertow-processor-example/src/test/java/com/palantir/conjure/java/undertow/example/ExampleResource.java
@@ -92,7 +92,7 @@ final class ExampleResource implements ExampleService {
 
     @Override
     public String formParam(String formParameter) {
-        return Preconditions.checkNotNull(formParameter, "Query parameter is required");
+        return Preconditions.checkNotNull(formParameter, "Form parameter is required");
     }
 
     @Override

--- a/conjure-undertow-processor-example/src/test/java/com/palantir/conjure/java/undertow/example/ExampleResource.java
+++ b/conjure-undertow-processor-example/src/test/java/com/palantir/conjure/java/undertow/example/ExampleResource.java
@@ -91,6 +91,11 @@ final class ExampleResource implements ExampleService {
     }
 
     @Override
+    public String formParam(String formParameter) {
+        return Preconditions.checkNotNull(formParameter, "Query parameter is required");
+    }
+
+    @Override
     public String pathParam(String param) {
         return Preconditions.checkNotNull(param, "Path parameter is required");
     }

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParamTypesResolver.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParamTypesResolver.java
@@ -65,10 +65,11 @@ public final class ParamTypesResolver {
 
     private static final ImmutableSet<Class<?>> PARAM_ANNOTATION_CLASSES = ImmutableSet.of(
             Handle.Body.class,
+            Handle.Header.class,
             Handle.PathParam.class,
             Handle.PathMultiParam.class,
             Handle.QueryParam.class,
-            Handle.Header.class,
+            Handle.FormParam.class,
             Handle.Cookie.class);
     private static final ImmutableSet<String> SUPPORTED_ANNOTATIONS = Stream.concat(
                     Stream.of(Safe.class, Unsafe.class), PARAM_ANNOTATION_CLASSES.stream())
@@ -174,6 +175,8 @@ public final class ParamTypesResolver {
             return Optional.of(pathMultiParameter(variableElement, parameterType, annotationReflector, safeLoggable));
         } else if (annotationReflector.isAnnotation(Handle.QueryParam.class)) {
             return Optional.of(queryParameter(variableElement, parameterType, annotationReflector, safeLoggable));
+        } else if (annotationReflector.isAnnotation(Handle.FormParam.class)) {
+            return Optional.of(formParameter(variableElement, parameterType, annotationReflector, safeLoggable));
         } else if (annotationReflector.isAnnotation(Handle.Cookie.class)) {
             return cookieParameter(variableElement, parameterType, annotationReflector, safeLoggable);
         }
@@ -244,6 +247,22 @@ public final class ParamTypesResolver {
         String deserializerName =
                 InstanceVariables.joinCamelCase(variableElement.getSimpleName().toString(), "Deserializer");
         return ParameterTypes.query(
+                javaParameterName,
+                annotationReflector.getAnnotationValue(String.class),
+                deserializerName,
+                getCollectionParamDecoder(variableElement, parameterType, annotationReflector),
+                safeLoggable);
+    }
+
+    private ParameterType formParameter(
+            VariableElement variableElement,
+            TypeMirror parameterType,
+            AnnotationReflector annotationReflector,
+            SafeLoggingAnnotation safeLoggable) {
+        String javaParameterName = variableElement.getSimpleName().toString();
+        String deserializerName =
+                InstanceVariables.joinCamelCase(variableElement.getSimpleName().toString(), "Deserializer");
+        return ParameterTypes.form(
                 javaParameterName,
                 annotationReflector.getAnnotationValue(String.class),
                 deserializerName,

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParameterType.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParameterType.java
@@ -55,6 +55,13 @@ public interface ParameterType {
                 CodeBlock deserializerFactory,
                 SafeLoggingAnnotation safeLoggable);
 
+        R form(
+                String variableName,
+                String paramName,
+                String deserializerFieldName,
+                CodeBlock deserializerFactory,
+                SafeLoggingAnnotation safeLoggable);
+
         R cookie(
                 String variableName,
                 String cookieName,

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParameterTypeVisitors.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParameterTypeVisitors.java
@@ -73,6 +73,16 @@ public final class ParameterTypeVisitors {
         }
 
         @Override
+        public Boolean form(
+                String _variableName,
+                String _paramName,
+                String _deserializerFieldName,
+                CodeBlock _deserializerFactory,
+                SafeLoggingAnnotation safeLoggable) {
+            return !safeLoggable.equals(SafeLoggingAnnotation.UNKNOWN);
+        }
+
+        @Override
         public Boolean cookie(
                 String _variableName,
                 String _cookieName,
@@ -145,6 +155,16 @@ public final class ParameterTypeVisitors {
 
         @Override
         public Boolean query(
+                String _variableName,
+                String _paramName,
+                String _deserializerFieldName,
+                CodeBlock _deserializerFactory,
+                SafeLoggingAnnotation _safeLoggable) {
+            return false;
+        }
+
+        @Override
+        public Boolean form(
                 String _variableName,
                 String _paramName,
                 String _deserializerFieldName,

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderService.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderService.java
@@ -55,6 +55,27 @@ public interface DefaultDecoderService {
             @Handle.QueryParam("fromStringFactory") FromStringFactory fromStringFactory,
             @Handle.QueryParam("createFactory") CreateFactory createFactory);
 
+    @Handle(method = HttpMethod.POST, path = "/formParam")
+    String formParam(
+            @Handle.FormParam("stringParam") String stringParam,
+            @Handle.FormParam("booleanParam") Boolean booleanParam,
+            @Handle.FormParam("stringSetParam") Set<String> stringSetParam,
+            @Handle.FormParam("stringListParam") List<String> stringListParam,
+            @Handle.FormParam("optionalStringParam") Optional<String> optionalStringParam,
+            @Handle.FormParam("floatBoxed") Float floatBoxed,
+            @Handle.FormParam("floatUnboxed") float floatUnboxed,
+            @Handle.FormParam("optionalInt") OptionalInt optionalIntParam,
+            @Handle.FormParam("dateTime") OffsetDateTime dateTimeParam,
+            @Handle.FormParam("ridSetParam") Set<ResourceIdentifier> ridSetParam,
+            @Handle.FormParam("optionalSafeLongParam") Optional<SafeLong> optionalSafeLongParam,
+            @Handle.FormParam("uuidParam") UUID uuidParam,
+            @Handle.FormParam(value = "decoderParam", decoder = StringCollectionDecoder.class) String decoderParam,
+            @Handle.FormParam("constructor") Constructor constructor,
+            @Handle.FormParam("ofFactory") OfFactory ofFactory,
+            @Handle.FormParam("valueOfFactory") ValueOfFactory valueOfFactory,
+            @Handle.FormParam("fromStringFactory") FromStringFactory fromStringFactory,
+            @Handle.FormParam("createFactory") CreateFactory createFactory);
+
     @Handle(method = HttpMethod.GET, path = "/headers")
     String headers(
             @Handle.Header("stringParam") String stringParam,

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/SafeLoggableParams.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/SafeLoggableParams.java
@@ -37,6 +37,12 @@ public interface SafeLoggableParams {
             @Safe @Handle.QueryParam("safeParam") String safeParam,
             @Unsafe @Handle.QueryParam("unsafeParam") String unsafeParam);
 
+    @Handle(method = HttpMethod.POST, path = "/formParams")
+    void formParams(
+            @Handle.FormParam("noAnnotation") String noAnnotationParam,
+            @Safe @Handle.FormParam("safeParam") String safeParam,
+            @Unsafe @Handle.FormParam("unsafeParam") String unsafeParam);
+
     @Handle(method = HttpMethod.GET, path = "/headerParams")
     void headerParams(
             @Handle.Header("noAnnotation") String noAnnotationParam,

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderServiceEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderServiceEndpoints.java.generated
@@ -3,6 +3,7 @@ package com.palantir.conjure.java.undertow.processor.sample;
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.conjure.java.undertow.annotations.DefaultSerDe;
+import com.palantir.conjure.java.undertow.annotations.FormParamDeserializer;
 import com.palantir.conjure.java.undertow.annotations.HeaderParamDeserializer;
 import com.palantir.conjure.java.undertow.annotations.ParamDecoders;
 import com.palantir.conjure.java.undertow.annotations.PathParamDeserializer;
@@ -49,6 +50,7 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
     public List<Endpoint> endpoints(UndertowRuntime runtime) {
         return ImmutableList.of(
                 new QueryParamEndpoint(runtime, delegate),
+                new FormParamEndpoint(runtime, delegate),
                 new HeadersEndpoint(runtime, delegate),
                 new PathParamEndpoint(runtime, delegate));
     }
@@ -217,6 +219,178 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
         @Override
         public String name() {
             return "queryParam";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class FormParamEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<String> {
+        private final UndertowRuntime runtime;
+
+        private final DefaultDecoderService delegate;
+
+        private final Deserializer<String> stringParamDeserializer;
+
+        private final Deserializer<Boolean> booleanParamDeserializer;
+
+        private final Deserializer<Set<String>> stringSetParamDeserializer;
+
+        private final Deserializer<List<String>> stringListParamDeserializer;
+
+        private final Deserializer<Optional<String>> optionalStringParamDeserializer;
+
+        private final Deserializer<Float> floatBoxedDeserializer;
+
+        private final Deserializer<Float> floatUnboxedDeserializer;
+
+        private final Deserializer<OptionalInt> optionalIntParamDeserializer;
+
+        private final Deserializer<OffsetDateTime> dateTimeParamDeserializer;
+
+        private final Deserializer<Set<ResourceIdentifier>> ridSetParamDeserializer;
+
+        private final Deserializer<Optional<SafeLong>> optionalSafeLongParamDeserializer;
+
+        private final Deserializer<UUID> uuidParamDeserializer;
+
+        private final Deserializer<String> decoderParamDeserializer;
+
+        private final Deserializer<DefaultDecoderService.Constructor> constructorDeserializer;
+
+        private final Deserializer<DefaultDecoderService.OfFactory> ofFactoryDeserializer;
+
+        private final Deserializer<DefaultDecoderService.ValueOfFactory> valueOfFactoryDeserializer;
+
+        private final Deserializer<DefaultDecoderService.FromStringFactory> fromStringFactoryDeserializer;
+
+        private final Deserializer<DefaultDecoderService.CreateFactory> createFactoryDeserializer;
+
+        private final Serializer<String> formParamSerializer;
+
+        FormParamEndpoint(UndertowRuntime runtime, DefaultDecoderService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.stringParamDeserializer = new FormParamDeserializer<>(
+                    "stringParam", ParamDecoders.stringCollectionParamDecoder(runtime.plainSerDe()));
+            this.booleanParamDeserializer = new FormParamDeserializer<>(
+                    "booleanParam", ParamDecoders.booleanCollectionParamDecoder(runtime.plainSerDe()));
+            this.stringSetParamDeserializer = new FormParamDeserializer<>(
+                    "stringSetParam", ParamDecoders.stringSetCollectionParamDecoder(runtime.plainSerDe()));
+            this.stringListParamDeserializer = new FormParamDeserializer<>(
+                    "stringListParam", ParamDecoders.stringListCollectionParamDecoder(runtime.plainSerDe()));
+            this.optionalStringParamDeserializer = new FormParamDeserializer<>(
+                    "optionalStringParam", ParamDecoders.optionalStringCollectionParamDecoder(runtime.plainSerDe()));
+            this.floatBoxedDeserializer = new FormParamDeserializer<>(
+                    "floatBoxed", ParamDecoders.complexCollectionParamDecoder(runtime.plainSerDe(), Float::valueOf));
+            this.floatUnboxedDeserializer = new FormParamDeserializer<>(
+                    "floatUnboxed",
+                    ParamDecoders.complexCollectionParamDecoder(runtime.plainSerDe(), Float::parseFloat));
+            this.optionalIntParamDeserializer = new FormParamDeserializer<>(
+                    "optionalInt", ParamDecoders.optionalIntegerCollectionParamDecoder(runtime.plainSerDe()));
+            this.dateTimeParamDeserializer = new FormParamDeserializer<>(
+                    "dateTime", ParamDecoders.dateTimeCollectionParamDecoder(runtime.plainSerDe()));
+            this.ridSetParamDeserializer = new FormParamDeserializer<>(
+                    "ridSetParam", ParamDecoders.ridSetCollectionParamDecoder(runtime.plainSerDe()));
+            this.optionalSafeLongParamDeserializer = new FormParamDeserializer<>(
+                    "optionalSafeLongParam",
+                    ParamDecoders.optionalSafeLongCollectionParamDecoder(runtime.plainSerDe()));
+            this.uuidParamDeserializer = new FormParamDeserializer<>(
+                    "uuidParam", ParamDecoders.uuidCollectionParamDecoder(runtime.plainSerDe()));
+            this.decoderParamDeserializer =
+                    new FormParamDeserializer<>("decoderParam", DefaultDecoderService.StringCollectionDecoder.INSTANCE);
+            this.constructorDeserializer = new FormParamDeserializer<>(
+                    "constructor",
+                    ParamDecoders.complexCollectionParamDecoder(
+                            runtime.plainSerDe(), DefaultDecoderService.Constructor::new));
+            this.ofFactoryDeserializer = new FormParamDeserializer<>(
+                    "ofFactory",
+                    ParamDecoders.complexCollectionParamDecoder(
+                            runtime.plainSerDe(), DefaultDecoderService.OfFactory::of));
+            this.valueOfFactoryDeserializer = new FormParamDeserializer<>(
+                    "valueOfFactory",
+                    ParamDecoders.complexCollectionParamDecoder(
+                            runtime.plainSerDe(), DefaultDecoderService.ValueOfFactory::valueOf));
+            this.fromStringFactoryDeserializer = new FormParamDeserializer<>(
+                    "fromStringFactory",
+                    ParamDecoders.complexCollectionParamDecoder(
+                            runtime.plainSerDe(), DefaultDecoderService.FromStringFactory::fromString));
+            this.createFactoryDeserializer = new FormParamDeserializer<>(
+                    "createFactory",
+                    ParamDecoders.complexCollectionParamDecoder(
+                            runtime.plainSerDe(), DefaultDecoderService.CreateFactory::create));
+            this.formParamSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            String stringParam = this.stringParamDeserializer.deserialize(exchange);
+            Boolean booleanParam = this.booleanParamDeserializer.deserialize(exchange);
+            Set<String> stringSetParam = this.stringSetParamDeserializer.deserialize(exchange);
+            List<String> stringListParam = this.stringListParamDeserializer.deserialize(exchange);
+            Optional<String> optionalStringParam = this.optionalStringParamDeserializer.deserialize(exchange);
+            Float floatBoxed = this.floatBoxedDeserializer.deserialize(exchange);
+            float floatUnboxed = this.floatUnboxedDeserializer.deserialize(exchange);
+            OptionalInt optionalIntParam = this.optionalIntParamDeserializer.deserialize(exchange);
+            OffsetDateTime dateTimeParam = this.dateTimeParamDeserializer.deserialize(exchange);
+            Set<ResourceIdentifier> ridSetParam = this.ridSetParamDeserializer.deserialize(exchange);
+            Optional<SafeLong> optionalSafeLongParam = this.optionalSafeLongParamDeserializer.deserialize(exchange);
+            UUID uuidParam = this.uuidParamDeserializer.deserialize(exchange);
+            String decoderParam = this.decoderParamDeserializer.deserialize(exchange);
+            DefaultDecoderService.Constructor constructor = this.constructorDeserializer.deserialize(exchange);
+            DefaultDecoderService.OfFactory ofFactory = this.ofFactoryDeserializer.deserialize(exchange);
+            DefaultDecoderService.ValueOfFactory valueOfFactory = this.valueOfFactoryDeserializer.deserialize(exchange);
+            DefaultDecoderService.FromStringFactory fromStringFactory =
+                    this.fromStringFactoryDeserializer.deserialize(exchange);
+            DefaultDecoderService.CreateFactory createFactory = this.createFactoryDeserializer.deserialize(exchange);
+            write(
+                    this.delegate.formParam(
+                            stringParam,
+                            booleanParam,
+                            stringSetParam,
+                            stringListParam,
+                            optionalStringParam,
+                            floatBoxed,
+                            floatUnboxed,
+                            optionalIntParam,
+                            dateTimeParam,
+                            ridSetParam,
+                            optionalSafeLongParam,
+                            uuidParam,
+                            decoderParam,
+                            constructor,
+                            ofFactory,
+                            valueOfFactory,
+                            fromStringFactory,
+                            createFactory),
+                    exchange);
+        }
+
+        @Override
+        public void write(String returnValue, HttpServerExchange exchange) throws IOException {
+            this.formParamSerializer.serialize(returnValue, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/formParam";
+        }
+
+        @Override
+        public String serviceName() {
+            return "DefaultDecoderService";
+        }
+
+        @Override
+        public String name() {
+            return "formParam";
         }
 
         @Override

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/SafeLoggableParamsEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/SafeLoggableParamsEndpoints.java.generated
@@ -3,6 +3,7 @@ package com.palantir.conjure.java.undertow.processor.sample;
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.undertow.annotations.CookieDeserializer;
 import com.palantir.conjure.java.undertow.annotations.DefaultSerDe;
+import com.palantir.conjure.java.undertow.annotations.FormParamDeserializer;
 import com.palantir.conjure.java.undertow.annotations.HeaderParamDeserializer;
 import com.palantir.conjure.java.undertow.annotations.ParamDecoders;
 import com.palantir.conjure.java.undertow.annotations.PathMultiParamDeserializer;
@@ -47,6 +48,7 @@ public final class SafeLoggableParamsEndpoints implements UndertowService {
         return ImmutableList.of(
                 new PathParamsEndpoint(runtime, delegate),
                 new QueryParamsEndpoint(runtime, delegate),
+                new FormParamsEndpoint(runtime, delegate),
                 new HeaderParamsEndpoint(runtime, delegate),
                 new CookieParamsEndpoint(runtime, delegate),
                 new SafeLoggingReusesContextEndpoint(runtime, delegate),
@@ -171,6 +173,66 @@ public final class SafeLoggableParamsEndpoints implements UndertowService {
         @Override
         public String name() {
             return "queryParams";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class FormParamsEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final SafeLoggableParams delegate;
+
+        private final Deserializer<String> noAnnotationParamDeserializer;
+
+        private final Deserializer<String> safeParamDeserializer;
+
+        private final Deserializer<String> unsafeParamDeserializer;
+
+        FormParamsEndpoint(UndertowRuntime runtime, SafeLoggableParams delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.noAnnotationParamDeserializer = new FormParamDeserializer<>(
+                    "noAnnotation", ParamDecoders.stringCollectionParamDecoder(runtime.plainSerDe()));
+            this.safeParamDeserializer = new FormParamDeserializer<>(
+                    "safeParam", ParamDecoders.stringCollectionParamDecoder(runtime.plainSerDe()));
+            this.unsafeParamDeserializer = new FormParamDeserializer<>(
+                    "unsafeParam", ParamDecoders.stringCollectionParamDecoder(runtime.plainSerDe()));
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            RequestContext requestContext = this.runtime.contexts().createContext(exchange, this);
+            String noAnnotationParam = this.noAnnotationParamDeserializer.deserialize(exchange);
+            String safeParam = this.safeParamDeserializer.deserialize(exchange);
+            requestContext.requestArg(SafeArg.of("safeParam", safeParam));
+            String unsafeParam = this.unsafeParamDeserializer.deserialize(exchange);
+            requestContext.requestArg(UnsafeArg.of("unsafeParam", unsafeParam));
+            this.delegate.formParams(noAnnotationParam, safeParam, unsafeParam);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/formParams";
+        }
+
+        @Override
+        public String serviceName() {
+            return "SafeLoggableParams";
+        }
+
+        @Override
+        public String name() {
+            return "formParams";
         }
 
         @Override


### PR DESCRIPTION
Adds a `@FormParam` annotation for easily declaring endpoints that use form data.

The implementation in this PR does not support file form parameters. Supporting files doesn't fit as neatly into the existing structure and is a more niche feature. We can consider adding support in the future, but it might be better for consumers who need file form parameters to just implement it themselves.