### PR TITLE
conjure-undertow processor supports specializing generic interfaces

### DIFF
--- a/changelog/@unreleased/pr-1873.v2.yml
+++ b/changelog/@unreleased/pr-1873.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: conjure-undertow processor supports specializing generic interfaces
+  links:
+  - https://github.com/palantir/conjure-java/pull/1873

--- a/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/Handle.java
+++ b/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/Handle.java
@@ -25,13 +25,22 @@ import java.lang.annotation.Target;
 
 /**
  * Annotates an RPC endpoint.
- *
- * This annotation provides namespace for annotations for dialogue client generation.
  */
 @Documented
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 @Target(ElementType.METHOD)
 public @interface Handle {
+
+    /**
+     * Generate annotation which is implied by default, however may be applied to an interface to
+     * opt out of codegen using <code>@Handle.Generate(false)</code>, for instance to allow a subclass/implementor
+     * to opt into code-generation. Implementors may annotate themselves with <code>@Handle.Generate</code>.
+     */
+    @Retention(RetentionPolicy.SOURCE)
+    @Target(ElementType.TYPE)
+    @interface Generate {
+        boolean value() default true;
+    }
 
     HttpMethod method();
 
@@ -58,7 +67,7 @@ public @interface Handle {
     /** Conjure endpoint tags. */
     String[] tags() default {};
 
-    @Retention(RetentionPolicy.SOURCE)
+    @Retention(RetentionPolicy.CLASS)
     @Target(ElementType.PARAMETER)
     @interface Body {
 
@@ -71,7 +80,7 @@ public @interface Handle {
         Class<? extends DeserializerFactory> value() default DefaultSerDe.class;
     }
 
-    @Retention(RetentionPolicy.SOURCE)
+    @Retention(RetentionPolicy.CLASS)
     @Target(ElementType.PARAMETER)
     @interface Header {
         String value();
@@ -83,7 +92,7 @@ public @interface Handle {
         Class<? extends CollectionParamDecoder<?>> decoder() default DefaultParamDecoder.class;
     }
 
-    @Retention(RetentionPolicy.SOURCE)
+    @Retention(RetentionPolicy.CLASS)
     @Target(ElementType.PARAMETER)
     @interface PathParam {
         /**
@@ -100,7 +109,7 @@ public @interface Handle {
      * is surfaced as {@code ['foo', 'bar']} while {@code /foo%2Fbar} is surfaced as {@code ['foo/bar']}.
      */
     @Beta
-    @Retention(RetentionPolicy.SOURCE)
+    @Retention(RetentionPolicy.CLASS)
     @Target(ElementType.PARAMETER)
     @interface PathMultiParam {
         /**
@@ -110,7 +119,7 @@ public @interface Handle {
         Class<? extends CollectionParamDecoder<?>> decoder() default DefaultParamDecoder.class;
     }
 
-    @Retention(RetentionPolicy.SOURCE)
+    @Retention(RetentionPolicy.CLASS)
     @Target(ElementType.PARAMETER)
     @interface QueryParam {
         String value();
@@ -122,7 +131,7 @@ public @interface Handle {
         Class<? extends CollectionParamDecoder<?>> decoder() default DefaultParamDecoder.class;
     }
 
-    @Retention(RetentionPolicy.SOURCE)
+    @Retention(RetentionPolicy.CLASS)
     @Target(ElementType.PARAMETER)
     @interface Cookie {
         String value();

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ArgumentTypesResolver.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ArgumentTypesResolver.java
@@ -74,8 +74,8 @@ public final class ArgumentTypesResolver {
                 ArgumentTypes.primitive(integerType, planSerDeMethodName(integerType), Optional.empty());
     }
 
-    public ArgumentType getArgumentType(VariableElement param) {
-        return getArgumentTypeImpl(param, param.asType());
+    public ArgumentType getArgumentType(VariableElement param, TypeMirror paramType) {
+        return getArgumentTypeImpl(param, paramType);
     }
 
     @SuppressWarnings("CyclomaticComplexity")

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParamTypesResolver.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParamTypesResolver.java
@@ -102,7 +102,7 @@ public final class ParamTypesResolver {
     }
 
     @SuppressWarnings("CyclomaticComplexity")
-    public Optional<ParameterType> getParameterType(VariableElement variableElement) {
+    public Optional<ParameterType> getParameterType(VariableElement variableElement, TypeMirror parameterType) {
         List<AnnotationMirror> paramAnnotationMirrors = new ArrayList<>();
         for (AnnotationMirror annotationMirror : variableElement.getAnnotationMirrors()) {
             TypeElement annotationTypeElement =
@@ -132,16 +132,16 @@ public final class ParamTypesResolver {
                 context.reportError(
                         "Parameter type cannot be annotated with safe logging annotations",
                         variableElement,
-                        SafeArg.of("type", variableElement.asType()));
+                        SafeArg.of("type", parameterType));
                 return Optional.empty();
             }
 
-            if (context.isSameTypes(variableElement.asType(), AuthHeader.class)) {
+            if (context.isSameTypes(parameterType, AuthHeader.class)) {
                 return Optional.of(ParameterTypes.authHeader(
                         variableElement.getSimpleName().toString()));
-            } else if (context.isSameTypes(variableElement.asType(), HttpServerExchange.class)) {
+            } else if (context.isSameTypes(parameterType, HttpServerExchange.class)) {
                 return Optional.of(ParameterTypes.exchange());
-            } else if (context.isSameTypes(variableElement.asType(), RequestContext.class)) {
+            } else if (context.isSameTypes(parameterType, RequestContext.class)) {
                 return Optional.of(ParameterTypes.context());
             } else {
                 context.reportError(

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ResolverContext.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ResolverContext.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.undertow.processor.data;
 
+import com.google.auto.common.MoreTypes;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.conjure.java.undertow.processor.ErrorContext;
@@ -23,8 +24,10 @@ import com.palantir.logsafe.Arg;
 import com.squareup.javapoet.TypeName;
 import java.util.Optional;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.SimpleTypeVisitor9;
@@ -81,6 +84,10 @@ public final class ResolverContext implements ErrorContext {
                 return Optional.empty();
             }
         });
+    }
+
+    public ExecutableType asMemberOf(DeclaredType owner, ExecutableElement method) {
+        return MoreTypes.asExecutable(types.asMemberOf(owner, method));
     }
 
     @Override

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ReturnTypesResolver.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ReturnTypesResolver.java
@@ -21,6 +21,7 @@ import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.TypeName;
 import java.util.Optional;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 
 public final class ReturnTypesResolver {
@@ -32,8 +33,11 @@ public final class ReturnTypesResolver {
     }
 
     public Optional<ReturnType> getReturnType(
-            EndpointName endpointName, ExecutableElement element, AnnotationReflector handleAnnotation) {
-        TypeMirror returnType = element.getReturnType();
+            EndpointName endpointName,
+            DeclaredType annotatedType,
+            ExecutableElement element,
+            AnnotationReflector handleAnnotation) {
+        TypeMirror returnType = context.asMemberOf(annotatedType, element).getReturnType();
 
         Optional<TypeMirror> maybeListenableFutureInnerType = getListenableFutureInnerType(returnType);
         // TODO(ckozak): Validate deserializer types match

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
@@ -29,6 +29,8 @@ import com.palantir.conjure.java.undertow.processor.sample.CookieParams;
 import com.palantir.conjure.java.undertow.processor.sample.DefaultDecoderService;
 import com.palantir.conjure.java.undertow.processor.sample.DeprecatedEndpointResource;
 import com.palantir.conjure.java.undertow.processor.sample.DeprecatedResource;
+import com.palantir.conjure.java.undertow.processor.sample.ExtendsNested;
+import com.palantir.conjure.java.undertow.processor.sample.ExtendsSimpleInterface;
 import com.palantir.conjure.java.undertow.processor.sample.MultipleBodyInterface;
 import com.palantir.conjure.java.undertow.processor.sample.NameClashContextParam;
 import com.palantir.conjure.java.undertow.processor.sample.NameClashExchangeParam;
@@ -127,6 +129,16 @@ public class ConjureUndertowAnnotationProcessorTest {
     @Test
     public void testPackagePrivateInterface() {
         assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, PackagePrivateInterface.class);
+    }
+
+    @Test
+    public void testExtendsSimpleInterface() {
+        assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, ExtendsSimpleInterface.class);
+    }
+
+    @Test
+    public void testExtendsNested() {
+        assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, ExtendsNested.class);
     }
 
     @Test

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
@@ -31,6 +31,7 @@ import com.palantir.conjure.java.undertow.processor.sample.DeprecatedEndpointRes
 import com.palantir.conjure.java.undertow.processor.sample.DeprecatedResource;
 import com.palantir.conjure.java.undertow.processor.sample.ExtendsNested;
 import com.palantir.conjure.java.undertow.processor.sample.ExtendsSimpleInterface;
+import com.palantir.conjure.java.undertow.processor.sample.GenericImpl;
 import com.palantir.conjure.java.undertow.processor.sample.MultipleBodyInterface;
 import com.palantir.conjure.java.undertow.processor.sample.NameClashContextParam;
 import com.palantir.conjure.java.undertow.processor.sample.NameClashExchangeParam;
@@ -139,6 +140,11 @@ public class ConjureUndertowAnnotationProcessorTest {
     @Test
     public void testExtendsNested() {
         assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, ExtendsNested.class);
+    }
+
+    @Test
+    public void testBindsGeneric() {
+        assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, GenericImpl.class);
     }
 
     @Test

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/ExtendsNested.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/ExtendsNested.java
@@ -1,0 +1,22 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.palantir.conjure.java.undertow.annotations.Handle;
+
+@Handle.Generate
+public interface ExtendsNested extends ExtendsSimpleInterface {}

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/ExtendsSimpleInterface.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/ExtendsSimpleInterface.java
@@ -1,0 +1,26 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.palantir.conjure.java.undertow.annotations.Handle;
+import com.palantir.conjure.java.undertow.annotations.HttpMethod;
+
+public interface ExtendsSimpleInterface extends SimpleInterface {
+
+    @Handle(method = HttpMethod.GET, path = "/greet")
+    String greet();
+}

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/GenericIface.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/GenericIface.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.palantir.conjure.java.undertow.annotations.Handle;
+import com.palantir.conjure.java.undertow.annotations.Handle.Body;
+import com.palantir.conjure.java.undertow.annotations.HttpMethod;
+
+@Handle.Generate(false)
+public interface GenericIface<I, O> {
+
+    @Handle(method = HttpMethod.POST, path = "/generic")
+    O generic(@Body I input);
+}

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/GenericImpl.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/GenericImpl.java
@@ -1,0 +1,22 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.palantir.conjure.java.undertow.annotations.Handle;
+
+@Handle.Generate
+public interface GenericImpl extends GenericIface<String, Integer> {}

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/ExtendsNestedEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/ExtendsNestedEndpoints.java.generated
@@ -1,0 +1,130 @@
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.java.undertow.annotations.DefaultSerDe;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.ReturnValueWriter;
+import com.palantir.conjure.java.undertow.lib.Serializer;
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import io.undertow.util.StatusCodes;
+import java.io.IOException;
+import java.lang.Exception;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.undertow.processor.generate.ConjureUndertowEndpointsGenerator")
+public final class ExtendsNestedEndpoints implements UndertowService {
+    private final ExtendsNested delegate;
+
+    private ExtendsNestedEndpoints(ExtendsNested delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(ExtendsNested delegate) {
+        return new ExtendsNestedEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return ImmutableList.of(new PingEndpoint(runtime, delegate), new GreetEndpoint(runtime, delegate));
+    }
+
+    private static final class PingEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final ExtendsNested delegate;
+
+        PingEndpoint(UndertowRuntime runtime, ExtendsNested delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            this.delegate.ping();
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/ping";
+        }
+
+        @Override
+        public String serviceName() {
+            return "SimpleInterface";
+        }
+
+        @Override
+        public String name() {
+            return "ping";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class GreetEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<String> {
+        private final UndertowRuntime runtime;
+
+        private final ExtendsNested delegate;
+
+        private final Serializer<String> greetSerializer;
+
+        GreetEndpoint(UndertowRuntime runtime, ExtendsNested delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.greetSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            write(this.delegate.greet(), exchange);
+        }
+
+        @Override
+        public void write(String returnValue, HttpServerExchange exchange) throws IOException {
+            this.greetSerializer.serialize(returnValue, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/greet";
+        }
+
+        @Override
+        public String serviceName() {
+            return "ExtendsSimpleInterface";
+        }
+
+        @Override
+        public String name() {
+            return "greet";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/ExtendsSimpleInterfaceEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/ExtendsSimpleInterfaceEndpoints.java.generated
@@ -1,0 +1,130 @@
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.java.undertow.annotations.DefaultSerDe;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.ReturnValueWriter;
+import com.palantir.conjure.java.undertow.lib.Serializer;
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import io.undertow.util.StatusCodes;
+import java.io.IOException;
+import java.lang.Exception;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.undertow.processor.generate.ConjureUndertowEndpointsGenerator")
+public final class ExtendsSimpleInterfaceEndpoints implements UndertowService {
+    private final ExtendsSimpleInterface delegate;
+
+    private ExtendsSimpleInterfaceEndpoints(ExtendsSimpleInterface delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(ExtendsSimpleInterface delegate) {
+        return new ExtendsSimpleInterfaceEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return ImmutableList.of(new PingEndpoint(runtime, delegate), new GreetEndpoint(runtime, delegate));
+    }
+
+    private static final class PingEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final ExtendsSimpleInterface delegate;
+
+        PingEndpoint(UndertowRuntime runtime, ExtendsSimpleInterface delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            this.delegate.ping();
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/ping";
+        }
+
+        @Override
+        public String serviceName() {
+            return "SimpleInterface";
+        }
+
+        @Override
+        public String name() {
+            return "ping";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class GreetEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<String> {
+        private final UndertowRuntime runtime;
+
+        private final ExtendsSimpleInterface delegate;
+
+        private final Serializer<String> greetSerializer;
+
+        GreetEndpoint(UndertowRuntime runtime, ExtendsSimpleInterface delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.greetSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            write(this.delegate.greet(), exchange);
+        }
+
+        @Override
+        public void write(String returnValue, HttpServerExchange exchange) throws IOException {
+            this.greetSerializer.serialize(returnValue, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/greet";
+        }
+
+        @Override
+        public String serviceName() {
+            return "ExtendsSimpleInterface";
+        }
+
+        @Override
+        public String name() {
+            return "greet";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/GenericImplEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/GenericImplEndpoints.java.generated
@@ -1,0 +1,93 @@
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.java.undertow.annotations.DefaultSerDe;
+import com.palantir.conjure.java.undertow.lib.Deserializer;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.ReturnValueWriter;
+import com.palantir.conjure.java.undertow.lib.Serializer;
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import java.io.IOException;
+import java.lang.Exception;
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.undertow.processor.generate.ConjureUndertowEndpointsGenerator")
+public final class GenericImplEndpoints implements UndertowService {
+    private final GenericImpl delegate;
+
+    private GenericImplEndpoints(GenericImpl delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(GenericImpl delegate) {
+        return new GenericImplEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return ImmutableList.of(new GenericEndpoint(runtime, delegate));
+    }
+
+    private static final class GenericEndpoint implements HttpHandler, Endpoint, ReturnValueWriter<Integer> {
+        private final UndertowRuntime runtime;
+
+        private final GenericImpl delegate;
+
+        private final Deserializer<String> inputDeserializer;
+
+        private final Serializer<Integer> genericSerializer;
+
+        GenericEndpoint(UndertowRuntime runtime, GenericImpl delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.inputDeserializer = DefaultSerDe.INSTANCE.deserializer(new TypeMarker<String>() {}, runtime, this);
+            this.genericSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<Integer>() {}, runtime, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            String input = inputDeserializer.deserialize(exchange);
+            write(this.delegate.generic(input), exchange);
+        }
+
+        @Override
+        public void write(Integer returnValue, HttpServerExchange exchange) throws IOException {
+            this.genericSerializer.serialize(returnValue, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/generic";
+        }
+
+        @Override
+        public String serviceName() {
+            return "GenericIface";
+        }
+
+        @Override
+        public String name() {
+            return "generic";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
## Before this PR
No way to specialize generic interfaces.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
conjure-undertow processor supports specializing generic interfaces
==COMMIT_MSG==

This provides an annotation to opt out of codegen for an interface meant to be extended using class-level `@Handle.Generate(false)`. Similarly, an interface which extends such an interface may be annotated `@Handle.Generate` to opt into codegen without any `@Handle(...` methods.

## Possible downsides?
conjure-undertow annotations are retained by classes as opposed to source-only. This may result in compiler warnings when they aren't present.

