### PR TITLE
Make .equals accept null values

### DIFF
--- a/changelog/@unreleased/pr-1883.v2.yml
+++ b/changelog/@unreleased/pr-1883.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Mark the argument to .equals on a conjure bean as @Nullable
+  description: Mark the argument to .equals on a conjure bean as `@Nullable`
   links:
   - https://github.com/palantir/conjure-java/pull/1883

--- a/changelog/@unreleased/pr-1883.v2.yml
+++ b/changelog/@unreleased/pr-1883.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Mark the argument to .equals on a conjure bean as @Nullable
+  links:
+  - https://github.com/palantir/conjure-java/pull/1883

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryExample.java
@@ -12,6 +12,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = BinaryExample.Builder.class)
@@ -30,7 +31,7 @@ public final class BinaryExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof BinaryExample && equalTo((BinaryExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/OptionalExample.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = OptionalExample.Builder.class)
@@ -33,7 +34,7 @@ public final class OptionalExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof OptionalExample && equalTo((OptionalExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
@@ -14,6 +14,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @DoNotLog
@@ -90,7 +91,7 @@ public final class AliasAsMapKeyExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof AliasAsMapKeyExample && equalTo((AliasAsMapKeyExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyExample.java
@@ -9,6 +9,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = AnyExample.Builder.class)
@@ -27,7 +28,7 @@ public final class AnyExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof AnyExample && equalTo((AnyExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AnyMapExample.java
@@ -13,6 +13,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = AnyMapExample.Builder.class)
@@ -33,7 +34,7 @@ public final class AnyMapExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof AnyMapExample && equalTo((AnyMapExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
@@ -11,6 +11,7 @@ import com.palantir.tokens.auth.BearerToken;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @DoNotLog
@@ -30,7 +31,7 @@ public final class BearerTokenExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof BearerTokenExample && equalTo((BearerTokenExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryExample.java
@@ -10,6 +10,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = BinaryExample.Builder.class)
@@ -28,7 +29,7 @@ public final class BinaryExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof BinaryExample && equalTo((BinaryExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanExample.java
@@ -8,6 +8,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = BooleanExample.Builder.class)
@@ -25,7 +26,7 @@ public final class BooleanExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof BooleanExample && equalTo((BooleanExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestObject.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestObject.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = CollectionsTestObject.Builder.class)
@@ -100,7 +101,7 @@ public final class CollectionsTestObject {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof CollectionsTestObject && equalTo((CollectionsTestObject) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 import test.api.ExampleExternalReference;
 
@@ -41,7 +42,7 @@ public final class CovariantListExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof CovariantListExample && equalTo((CovariantListExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantOptionalExample.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = CovariantOptionalExample.Builder.class)
@@ -44,7 +45,7 @@ public final class CovariantOptionalExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof CovariantOptionalExample && equalTo((CovariantOptionalExample) other));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeExample.java
@@ -10,6 +10,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = DateTimeExample.Builder.class)
@@ -30,7 +31,7 @@ public final class DateTimeExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof DateTimeExample && equalTo((DateTimeExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleExample.java
@@ -8,6 +8,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = DoubleExample.Builder.class)
@@ -25,7 +26,7 @@ public final class DoubleExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof DoubleExample && equalTo((DoubleExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
@@ -171,7 +172,7 @@ public final class EmptyUnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof UnknownWrapper && equalTo((UnknownWrapper) other));
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
@@ -10,6 +10,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Safe
@@ -29,7 +30,7 @@ public final class EnumFieldExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof EnumFieldExample && equalTo((EnumFieldExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = ExternalLongExample.Builder.class)
@@ -52,7 +53,7 @@ public final class ExternalLongExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof ExternalLongExample && equalTo((ExternalLongExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerExample.java
@@ -8,6 +8,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = IntegerExample.Builder.class)
@@ -25,7 +26,7 @@ public final class IntegerExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof IntegerExample && equalTo((IntegerExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = ListExample.Builder.class)
@@ -79,7 +80,7 @@ public final class ListExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof ListExample && equalTo((ListExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = ManyFieldExample.Builder.class)
@@ -132,7 +133,7 @@ public final class ManyFieldExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof ManyFieldExample && equalTo((ManyFieldExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapExample.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = MapExample.Builder.class)
@@ -53,7 +54,7 @@ public final class MapExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof MapExample && equalTo((MapExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleFieldsOnlyFinalStage.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleFieldsOnlyFinalStage.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = MultipleFieldsOnlyFinalStage.Builder.class)
@@ -121,7 +122,7 @@ public final class MultipleFieldsOnlyFinalStage {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof MultipleFieldsOnlyFinalStage && equalTo((MultipleFieldsOnlyFinalStage) other));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @DoNotLog
@@ -85,7 +86,7 @@ public final class MultipleOrderedStages {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof MultipleOrderedStages && equalTo((MultipleOrderedStages) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OneField.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OneField.java
@@ -12,6 +12,7 @@ import com.palantir.tokens.auth.BearerToken;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @DoNotLog
@@ -31,7 +32,7 @@ public final class OneField {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof OneField && equalTo((OneField) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OneFieldOnlyFinalStage.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OneFieldOnlyFinalStage.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = OneFieldOnlyFinalStage.Builder.class)
@@ -32,7 +33,7 @@ public final class OneFieldOnlyFinalStage {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof OneFieldOnlyFinalStage && equalTo((OneFieldOnlyFinalStage) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAliasExample.java
@@ -12,6 +12,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Safe
@@ -32,7 +33,7 @@ public final class OptionalAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof OptionalAliasExample && equalTo((OptionalAliasExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Safe
@@ -34,7 +35,7 @@ public final class OptionalExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof OptionalExample && equalTo((OptionalExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @DoNotLog
@@ -233,7 +234,7 @@ public final class PrimitiveOptionalsExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof PrimitiveOptionalsExample && equalTo((PrimitiveOptionalsExample) other));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReservedKeyExample.java
@@ -9,6 +9,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = ReservedKeyExample.Builder.class)
@@ -75,7 +76,7 @@ public final class ReservedKeyExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof ReservedKeyExample && equalTo((ReservedKeyExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RidExample.java
@@ -10,6 +10,7 @@ import com.palantir.ri.ResourceIdentifier;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = RidExample.Builder.class)
@@ -28,7 +29,7 @@ public final class RidExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof RidExample && equalTo((RidExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RiskyNames.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RiskyNames.java
@@ -9,6 +9,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = RiskyNames.Builder.class)
@@ -53,7 +54,7 @@ public final class RiskyNames {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof RiskyNames && equalTo((RiskyNames) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
@@ -10,6 +10,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = SafeLongExample.Builder.class)
@@ -28,7 +29,7 @@ public final class SafeLongExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof SafeLongExample && equalTo((SafeLongExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetExample.java
@@ -14,6 +14,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = SetExample.Builder.class)
@@ -42,7 +43,7 @@ public final class SetExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof SetExample && equalTo((SetExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
@@ -191,7 +192,7 @@ public final class SingleUnion {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof FooWrapper && equalTo((FooWrapper) other));
         }
 
@@ -248,7 +249,7 @@ public final class SingleUnion {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof UnknownWrapper && equalTo((UnknownWrapper) other));
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringExample.java
@@ -9,6 +9,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = StringExample.Builder.class)
@@ -27,7 +28,7 @@ public final class StringExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof StringExample && equalTo((StringExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -21,6 +21,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
@@ -274,7 +275,7 @@ public final class Union {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof FooWrapper && equalTo((FooWrapper) other));
         }
 
@@ -320,7 +321,7 @@ public final class Union {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof BarWrapper && equalTo((BarWrapper) other));
         }
 
@@ -366,7 +367,7 @@ public final class Union {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof BazWrapper && equalTo((BazWrapper) other));
         }
 
@@ -423,7 +424,7 @@ public final class Union {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof UnknownWrapper && equalTo((UnknownWrapper) other));
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -25,6 +25,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 /**
@@ -662,7 +663,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof StringExampleWrapper && equalTo((StringExampleWrapper) other));
         }
 
@@ -707,7 +708,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other
                     || (other instanceof ThisFieldIsAnIntegerWrapper && equalTo((ThisFieldIsAnIntegerWrapper) other));
         }
@@ -753,7 +754,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof AlsoAnIntegerWrapper && equalTo((AlsoAnIntegerWrapper) other));
         }
 
@@ -798,7 +799,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof IfWrapper && equalTo((IfWrapper) other));
         }
 
@@ -843,7 +844,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof NewWrapper && equalTo((NewWrapper) other));
         }
 
@@ -888,7 +889,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof InterfaceWrapper && equalTo((InterfaceWrapper) other));
         }
 
@@ -933,7 +934,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof CompletedWrapper && equalTo((CompletedWrapper) other));
         }
 
@@ -978,7 +979,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof Unknown_Wrapper && equalTo((Unknown_Wrapper) other));
         }
 
@@ -1024,7 +1025,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof OptionalWrapper && equalTo((OptionalWrapper) other));
         }
 
@@ -1069,7 +1070,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof ListWrapper && equalTo((ListWrapper) other));
         }
 
@@ -1114,7 +1115,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof SetWrapper && equalTo((SetWrapper) other));
         }
 
@@ -1159,7 +1160,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof MapWrapper && equalTo((MapWrapper) other));
         }
 
@@ -1205,7 +1206,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof OptionalAliasWrapper && equalTo((OptionalAliasWrapper) other));
         }
 
@@ -1250,7 +1251,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof ListAliasWrapper && equalTo((ListAliasWrapper) other));
         }
 
@@ -1295,7 +1296,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof SetAliasWrapper && equalTo((SetAliasWrapper) other));
         }
 
@@ -1341,7 +1342,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof MapAliasWrapper && equalTo((MapAliasWrapper) other));
         }
 
@@ -1398,7 +1399,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof UnknownWrapper && equalTo((UnknownWrapper) other));
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
@@ -192,7 +193,7 @@ public final class UnionWithUnknownString {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof Unknown_Wrapper && equalTo((Unknown_Wrapper) other));
         }
 
@@ -249,7 +250,7 @@ public final class UnionWithUnknownString {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof UnknownWrapper && equalTo((UnknownWrapper) other));
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidExample.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = UuidExample.Builder.class)
@@ -28,7 +29,7 @@ public final class UuidExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof UuidExample && equalTo((UuidExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/strict/SingleFieldNotStrict.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/strict/SingleFieldNotStrict.java
@@ -9,6 +9,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = SingleFieldNotStrict.Builder.class)
@@ -26,7 +27,7 @@ public final class SingleFieldNotStrict {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof SingleFieldNotStrict && equalTo((SingleFieldNotStrict) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AliasAsMapKeyExample.java
@@ -15,6 +15,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @DoNotLog
@@ -91,7 +92,7 @@ public final class AliasAsMapKeyExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof AliasAsMapKeyExample && equalTo((AliasAsMapKeyExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyExample.java
@@ -10,6 +10,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = AnyExample.Builder.class)
@@ -28,7 +29,7 @@ public final class AnyExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof AnyExample && equalTo((AnyExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyMapExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AnyMapExample.java
@@ -14,6 +14,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = AnyMapExample.Builder.class)
@@ -34,7 +35,7 @@ public final class AnyMapExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof AnyMapExample && equalTo((AnyMapExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BearerTokenExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BearerTokenExample.java
@@ -12,6 +12,7 @@ import com.palantir.tokens.auth.BearerToken;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @DoNotLog
@@ -31,7 +32,7 @@ public final class BearerTokenExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof BearerTokenExample && equalTo((BearerTokenExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryExample.java
@@ -12,6 +12,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = BinaryExample.Builder.class)
@@ -30,7 +31,7 @@ public final class BinaryExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof BinaryExample && equalTo((BinaryExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BooleanExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BooleanExample.java
@@ -9,6 +9,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = BooleanExample.Builder.class)
@@ -26,7 +27,7 @@ public final class BooleanExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof BooleanExample && equalTo((BooleanExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 import test.api.ExampleExternalReference;
 
@@ -42,7 +43,7 @@ public final class CovariantListExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof CovariantListExample && equalTo((CovariantListExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantOptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantOptionalExample.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = CovariantOptionalExample.Builder.class)
@@ -45,7 +46,7 @@ public final class CovariantOptionalExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof CovariantOptionalExample && equalTo((CovariantOptionalExample) other));
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeExample.java
@@ -11,6 +11,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = DateTimeExample.Builder.class)
@@ -31,7 +32,7 @@ public final class DateTimeExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof DateTimeExample && equalTo((DateTimeExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleExample.java
@@ -9,6 +9,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = DoubleExample.Builder.class)
@@ -26,7 +27,7 @@ public final class DoubleExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof DoubleExample && equalTo((DoubleExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
@@ -161,7 +162,7 @@ public final class EmptyUnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof UnknownWrapper && equalTo((UnknownWrapper) other));
         }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumFieldExample.java
@@ -11,6 +11,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Safe
@@ -30,7 +31,7 @@ public final class EnumFieldExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof EnumFieldExample && equalTo((EnumFieldExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = ExternalLongExample.Builder.class)
@@ -53,7 +54,7 @@ public final class ExternalLongExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof ExternalLongExample && equalTo((ExternalLongExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/IntegerExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/IntegerExample.java
@@ -9,6 +9,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = IntegerExample.Builder.class)
@@ -26,7 +27,7 @@ public final class IntegerExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof IntegerExample && equalTo((IntegerExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListExample.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = ListExample.Builder.class)
@@ -80,7 +81,7 @@ public final class ListExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof ListExample && equalTo((ListExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = ManyFieldExample.Builder.class)
@@ -133,7 +134,7 @@ public final class ManyFieldExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof ManyFieldExample && equalTo((ManyFieldExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapExample.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = MapExample.Builder.class)
@@ -54,7 +55,7 @@ public final class MapExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof MapExample && equalTo((MapExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAliasExample.java
@@ -13,6 +13,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Safe
@@ -33,7 +34,7 @@ public final class OptionalAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof OptionalAliasExample && equalTo((OptionalAliasExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalExample.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Safe
@@ -35,7 +36,7 @@ public final class OptionalExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof OptionalExample && equalTo((OptionalExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @DoNotLog
@@ -234,7 +235,7 @@ public final class PrimitiveOptionalsExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof PrimitiveOptionalsExample && equalTo((PrimitiveOptionalsExample) other));
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReservedKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReservedKeyExample.java
@@ -10,6 +10,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = ReservedKeyExample.Builder.class)
@@ -76,7 +77,7 @@ public final class ReservedKeyExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof ReservedKeyExample && equalTo((ReservedKeyExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RidExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RidExample.java
@@ -11,6 +11,7 @@ import com.palantir.ri.ResourceIdentifier;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = RidExample.Builder.class)
@@ -29,7 +30,7 @@ public final class RidExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof RidExample && equalTo((RidExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RiskyNames.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RiskyNames.java
@@ -10,6 +10,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = RiskyNames.Builder.class)
@@ -54,7 +55,7 @@ public final class RiskyNames {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof RiskyNames && equalTo((RiskyNames) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeLongExample.java
@@ -11,6 +11,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = SafeLongExample.Builder.class)
@@ -29,7 +30,7 @@ public final class SafeLongExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof SafeLongExample && equalTo((SafeLongExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetExample.java
@@ -15,6 +15,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = SetExample.Builder.class)
@@ -43,7 +44,7 @@ public final class SetExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof SetExample && equalTo((SetExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
@@ -181,7 +182,7 @@ public final class SingleUnion {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof FooWrapper && equalTo((FooWrapper) other));
         }
 
@@ -238,7 +239,7 @@ public final class SingleUnion {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof UnknownWrapper && equalTo((UnknownWrapper) other));
         }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringExample.java
@@ -10,6 +10,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = StringExample.Builder.class)
@@ -28,7 +29,7 @@ public final class StringExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof StringExample && equalTo((StringExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
@@ -264,7 +265,7 @@ public final class Union {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof FooWrapper && equalTo((FooWrapper) other));
         }
 
@@ -310,7 +311,7 @@ public final class Union {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof BarWrapper && equalTo((BarWrapper) other));
         }
 
@@ -356,7 +357,7 @@ public final class Union {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof BazWrapper && equalTo((BazWrapper) other));
         }
 
@@ -413,7 +414,7 @@ public final class Union {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof UnknownWrapper && equalTo((UnknownWrapper) other));
         }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 /**
@@ -652,7 +653,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof StringExampleWrapper && equalTo((StringExampleWrapper) other));
         }
 
@@ -697,7 +698,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other
                     || (other instanceof ThisFieldIsAnIntegerWrapper && equalTo((ThisFieldIsAnIntegerWrapper) other));
         }
@@ -743,7 +744,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof AlsoAnIntegerWrapper && equalTo((AlsoAnIntegerWrapper) other));
         }
 
@@ -788,7 +789,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof IfWrapper && equalTo((IfWrapper) other));
         }
 
@@ -833,7 +834,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof NewWrapper && equalTo((NewWrapper) other));
         }
 
@@ -878,7 +879,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof InterfaceWrapper && equalTo((InterfaceWrapper) other));
         }
 
@@ -923,7 +924,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof CompletedWrapper && equalTo((CompletedWrapper) other));
         }
 
@@ -968,7 +969,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof Unknown_Wrapper && equalTo((Unknown_Wrapper) other));
         }
 
@@ -1014,7 +1015,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof OptionalWrapper && equalTo((OptionalWrapper) other));
         }
 
@@ -1059,7 +1060,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof ListWrapper && equalTo((ListWrapper) other));
         }
 
@@ -1104,7 +1105,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof SetWrapper && equalTo((SetWrapper) other));
         }
 
@@ -1149,7 +1150,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof MapWrapper && equalTo((MapWrapper) other));
         }
 
@@ -1195,7 +1196,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof OptionalAliasWrapper && equalTo((OptionalAliasWrapper) other));
         }
 
@@ -1240,7 +1241,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof ListAliasWrapper && equalTo((ListAliasWrapper) other));
         }
 
@@ -1285,7 +1286,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof SetAliasWrapper && equalTo((SetAliasWrapper) other));
         }
 
@@ -1331,7 +1332,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof MapAliasWrapper && equalTo((MapAliasWrapper) other));
         }
 
@@ -1388,7 +1389,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof UnknownWrapper && equalTo((UnknownWrapper) other));
         }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
@@ -182,7 +183,7 @@ public final class UnionWithUnknownString {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof Unknown_Wrapper && equalTo((Unknown_Wrapper) other));
         }
 
@@ -239,7 +240,7 @@ public final class UnionWithUnknownString {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return this == other || (other instanceof UnknownWrapper && equalTo((UnknownWrapper) other));
         }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UuidExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UuidExample.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @JsonDeserialize(builder = UuidExample.Builder.class)
@@ -29,7 +30,7 @@ public final class UuidExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof UuidExample && equalTo((UuidExample) other));
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/MethodSpecs.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/MethodSpecs.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collector;
+import javax.annotation.Nullable;
 import javax.lang.model.element.Modifier;
 
 public final class MethodSpecs {
@@ -41,7 +42,9 @@ public final class MethodSpecs {
     private static final String MEMOIZED_HASH_CODE = "memoizedHashCode";
 
     public static MethodSpec createEquals(TypeName thisClass) {
-        ParameterSpec other = ParameterSpec.builder(ClassName.OBJECT, "other").build();
+        ParameterSpec other = ParameterSpec.builder(ClassName.OBJECT, "other")
+                .addAnnotation(Nullable.class)
+                .build();
         return MethodSpec.methodBuilder("equals")
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(Override.class)


### PR DESCRIPTION
This solves a bunch of nullaway warnings

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
passing a nullable value to .equals causes nullaway warnings
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Mark the argument to .equals on a conjure bean as `@Nullable`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

