### PR TITLE
Conjure errors may provide Jetbrains annotations

### DIFF
--- a/changelog/@unreleased/pr-1884.v2.yml
+++ b/changelog/@unreleased/pr-1884.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Conjure errors may provide Jetbrains annotations when the `--jetbrainsContractAnnotations`
+    flag is provided
+  links:
+  - https://github.com/palantir/conjure-java/pull/1884

--- a/conjure-java-core/build.gradle
+++ b/conjure-java-core/build.gradle
@@ -86,6 +86,7 @@ dependencies {
     integrationInputImplementation 'jakarta.validation:jakarta.validation-api'
     integrationInputImplementation 'jakarta.ws.rs:jakarta.ws.rs-api'
     integrationInputImplementation 'com.palantir.dialogue:dialogue-target'
+    integrationInputImplementation 'org.jetbrains:annotations'
 
     annotationProcessor 'org.immutables:value'
     compileOnly 'org.immutables:value::annotations'

--- a/conjure-java-core/src/integrationInput/java/com/palantir/another/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/another/ConjureErrors.java
@@ -5,6 +5,7 @@ import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.processing.Generated;
+import org.jetbrains.annotations.Contract;
 
 @Generated("com.palantir.conjure.java.types.ErrorGenerator")
 public final class ConjureErrors {
@@ -26,8 +27,10 @@ public final class ConjureErrors {
 
     /**
      * Throws a {@link ServiceException} of type DifferentPackage when {@code shouldThrow} is true.
+     *
      * @param shouldThrow Cause the method to throw when true
      */
+    @Contract("true -> fail")
     public static void throwIfDifferentPackage(boolean shouldThrow) {
         if (shouldThrow) {
             throw differentPackage();

--- a/conjure-java-core/src/integrationInput/java/com/palantir/another/ConjureJavaOtherErrors.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/another/ConjureJavaOtherErrors.java
@@ -5,6 +5,7 @@ import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.processing.Generated;
+import org.jetbrains.annotations.Contract;
 
 @Generated("com.palantir.conjure.java.types.ErrorGenerator")
 public final class ConjureJavaOtherErrors {
@@ -26,8 +27,10 @@ public final class ConjureJavaOtherErrors {
 
     /**
      * Throws a {@link ServiceException} of type JavaCompilationFailed when {@code shouldThrow} is true.
+     *
      * @param shouldThrow Cause the method to throw when true
      */
+    @Contract("true -> fail")
     public static void throwIfJavaCompilationFailed(boolean shouldThrow) {
         if (shouldThrow) {
             throw javaCompilationFailed();

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ConjureErrors.java
@@ -9,6 +9,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.Unsafe;
 import com.palantir.logsafe.UnsafeArg;
 import javax.annotation.processing.Generated;
+import org.jetbrains.annotations.Contract;
 
 @Generated("com.palantir.conjure.java.types.ErrorGenerator")
 public final class ConjureErrors {
@@ -63,10 +64,12 @@ public final class ConjureErrors {
 
     /**
      * Throws a {@link ServiceException} of type InvalidServiceDefinition when {@code shouldThrow} is true.
+     *
      * @param shouldThrow Cause the method to throw when true
      * @param serviceName Name of the invalid service definition.
      * @param serviceDef Details of the invalid service definition.
      */
+    @Contract("true, _, _ -> fail")
     public static void throwIfInvalidServiceDefinition(
             boolean shouldThrow, @Safe String serviceName, @Unsafe Object serviceDef) {
         if (shouldThrow) {
@@ -76,10 +79,12 @@ public final class ConjureErrors {
 
     /**
      * Throws a {@link ServiceException} of type InvalidTypeDefinition when {@code shouldThrow} is true.
+     *
      * @param shouldThrow Cause the method to throw when true
      * @param typeName
      * @param typeDef
      */
+    @Contract("true, _, _ -> fail")
     public static void throwIfInvalidTypeDefinition(
             boolean shouldThrow, @Safe String typeName, @Unsafe Object typeDef) {
         if (shouldThrow) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ConjureJavaErrors.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ConjureJavaErrors.java
@@ -5,6 +5,7 @@ import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.processing.Generated;
+import org.jetbrains.annotations.Contract;
 
 @Generated("com.palantir.conjure.java.types.ErrorGenerator")
 public final class ConjureJavaErrors {
@@ -26,8 +27,10 @@ public final class ConjureJavaErrors {
 
     /**
      * Throws a {@link ServiceException} of type JavaCompilationFailed when {@code shouldThrow} is true.
+     *
      * @param shouldThrow Cause the method to throw when true
      */
+    @Contract("true -> fail")
     public static void throwIfJavaCompilationFailed(boolean shouldThrow) {
         if (shouldThrow) {
             throw javaCompilationFailed();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
@@ -147,6 +147,15 @@ public interface Options {
         return false;
     }
 
+    /**
+     * Instructs the {@link com.palantir.conjure.java.types.ErrorGenerator} to add {@code Contract} annotations
+     * to check methods for stronger static analysis.
+     */
+    @Value.Default
+    default boolean jetbrainsContractAnnotations() {
+        return false;
+    }
+
     Optional<String> packagePrefix();
 
     Optional<String> apiVersion();

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -574,6 +574,7 @@ public final class UndertowServiceEteTest extends TestBase {
                 .undertowServicePrefix(true)
                 .nonNullCollections(true)
                 .excludeEmptyOptionals(true)
+                .jetbrainsContractAnnotations(true)
                 .build();
         List<Path> files = new GenerationCoordinator(
                         MoreExecutors.directExecutor(),

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
@@ -65,6 +65,7 @@ public final class ObjectGeneratorTests {
                                 .nonNullCollections(true)
                                 .excludeEmptyOptionals(true)
                                 .unionsWithUnknownValues(true)
+                                .jetbrainsContractAnnotations(true)
                                 .build())))
                 .emit(def, tempDir);
 
@@ -77,8 +78,10 @@ public final class ObjectGeneratorTests {
                 Conjure.parse(ImmutableList.of(new File("src/test/resources/example-binary-types.yml")));
         List<Path> files = new GenerationCoordinator(
                         MoreExecutors.directExecutor(),
-                        ImmutableSet.of(new ObjectGenerator(
-                                Options.builder().excludeEmptyOptionals(true).build())))
+                        ImmutableSet.of(new ObjectGenerator(Options.builder()
+                                .excludeEmptyOptionals(true)
+                                .jetbrainsContractAnnotations(true)
+                                .build())))
                 .emit(def, tempDir);
 
         assertThatFilesAreTheSame(files, REFERENCE_FILES_FOLDER);
@@ -92,6 +95,7 @@ public final class ObjectGeneratorTests {
                         ImmutableSet.of(new ObjectGenerator(Options.builder()
                                 .packagePrefix("test.prefix")
                                 .excludeEmptyOptionals(true)
+                                .jetbrainsContractAnnotations(true)
                                 .build())))
                 .emit(def, tempDir);
 
@@ -107,6 +111,7 @@ public final class ObjectGeneratorTests {
                         ImmutableSet.of(new ObjectGenerator(Options.builder()
                                 .useStagedBuilders(true)
                                 .excludeEmptyOptionals(true)
+                                .jetbrainsContractAnnotations(true)
                                 .build())))
                 .emit(def, tempDir);
 
@@ -119,8 +124,10 @@ public final class ObjectGeneratorTests {
                 Conjure.parse(ImmutableList.of(new File("src/test/resources/exclude-empty-collections.yml")));
         List<Path> files = new GenerationCoordinator(
                         MoreExecutors.directExecutor(),
-                        ImmutableSet.of(new ObjectGenerator(
-                                Options.builder().excludeEmptyCollections(true).build())))
+                        ImmutableSet.of(new ObjectGenerator(Options.builder()
+                                .excludeEmptyCollections(true)
+                                .jetbrainsContractAnnotations(true)
+                                .build())))
                 .emit(def, tempDir);
 
         assertThatFilesAreTheSame(files, REFERENCE_FILES_FOLDER);
@@ -138,6 +145,7 @@ public final class ObjectGeneratorTests {
                         ImmutableSet.of(new ObjectGenerator(Options.builder()
                                 .useImmutableBytes(true)
                                 .excludeEmptyOptionals(true)
+                                .jetbrainsContractAnnotations(true)
                                 .build())))
                 .emit(conjure, src);
 
@@ -161,6 +169,7 @@ public final class ObjectGeneratorTests {
                         ImmutableSet.of(new ErrorGenerator(Options.builder()
                                 .useImmutableBytes(true)
                                 .excludeEmptyOptionals(true)
+                                .jetbrainsContractAnnotations(true)
                                 .build())))
                 .emit(def, tempDir);
 
@@ -172,6 +181,7 @@ public final class ObjectGeneratorTests {
         ErrorGenerator errorGenerator = new ErrorGenerator(Options.builder()
                 .useImmutableBytes(true)
                 .excludeEmptyOptionals(true)
+                .jetbrainsContractAnnotations(true)
                 .build());
         TypeName unsafeAliasName = TypeName.of("UnsafeAlias", "com.palantir.product");
         TypeDefinition unsafeAlias = TypeDefinition.alias(AliasDefinition.builder()
@@ -207,6 +217,7 @@ public final class ObjectGeneratorTests {
                         ImmutableSet.of(new ObjectGenerator(Options.builder()
                                 .useImmutableBytes(true)
                                 .strictObjects(false)
+                                .jetbrainsContractAnnotations(true)
                                 .build())))
                 .emit(def, tempDir);
 

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -102,6 +102,12 @@ public final class ConjureJavaCli implements Runnable {
         private boolean jakartaPackages;
 
         @CommandLine.Option(
+                names = "--jetbrainsContractAnnotations",
+                defaultValue = "false",
+                description = "When generating conjure errors, use the newer Jetbrains contract annotations")
+        private boolean jetbrainsContractAnnotations;
+
+        @CommandLine.Option(
                 names = "--undertow",
                 defaultValue = "false",
                 description = "Generate undertow service interfaces and endpoint wrappers for server usage")
@@ -275,6 +281,7 @@ public final class ConjureJavaCli implements Runnable {
                             .undertowListenableFutures(undertowListenableFutures)
                             .experimentalUndertowAsyncMarkers(experimentalUndertowAsyncMarkers)
                             .jakartaPackages(jakartaPackages)
+                            .jetbrainsContractAnnotations(jetbrainsContractAnnotations)
                             .strictObjects(strictObjects)
                             .nonNullCollections(nonNullCollections)
                             .nonNullTopLevelCollectionValues(nonNullCollections || nonNullTopLevelCollectionValues)

--- a/versions.props
+++ b/versions.props
@@ -31,6 +31,7 @@ org.glassfish.jersey.*:* = 2.34
 org.hamcrest:hamcrest-core = 2.2
 org.immutables:value = 2.8.8
 org.javassist:javassist = 3.22.0-GA
+org.jetbrains:annotations = 23.0.0
 org.junit.jupiter:* = 5.8.2
 org.junit.vintage:* = 5.8.2
 org.mockito:* = 4.6.1


### PR DESCRIPTION
This adds a new `--jetbrainsContractAnnotations` parameter which opts into the new feature. The gradle plugin will be updated to both add the jetbrains annotations dependency and add this parameter.

## Before this PR
No way to let static analysis tools understand that these methods are preconditions checks.

## After this PR
==COMMIT_MSG==
Conjure errors may provide Jetbrains annotations when the `--jetbrainsContractAnnotations` flag is provided
==COMMIT_MSG==

## Possible downsides?
Breadth of feature-set.

