### PR TITLE
Make alias .equals nullable too

### DIFF
--- a/changelog/@unreleased/pr-1894.v2.yml
+++ b/changelog/@unreleased/pr-1894.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Mark the argument to .equals on a conjure alias as `@Nullable`
+  links:
+  - https://github.com/palantir/conjure-java/pull/1894

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryAliasExample.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.nio.ByteBuffer;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -26,7 +27,7 @@ public final class BinaryAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof BinaryAliasExample && this.value.equals(((BinaryAliasExample) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasOptionalDoubleAliasedBinaryResult.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasOptionalDoubleAliasedBinaryResult.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -32,7 +33,7 @@ public final class AliasOptionalDoubleAliasedBinaryResult {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof AliasOptionalDoubleAliasedBinaryResult
                         && this.value.equals(((AliasOptionalDoubleAliasedBinaryResult) other).value));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedBinaryResult.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedBinaryResult.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.nio.ByteBuffer;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -26,7 +27,7 @@ public final class AliasedBinaryResult {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof AliasedBinaryResult && this.value.equals(((AliasedBinaryResult) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedBoolean.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedBoolean.java
@@ -2,6 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -23,7 +24,7 @@ public final class AliasedBoolean {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof AliasedBoolean && this.value == ((AliasedBoolean) other).value);
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedDouble.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedDouble.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.SafeLong;
 import java.math.BigDecimal;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -25,7 +26,7 @@ public final class AliasedDouble implements Comparable<AliasedDouble> {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof AliasedDouble
                         && Double.doubleToLongBits(this.value)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedInteger.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedInteger.java
@@ -2,6 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -23,7 +24,7 @@ public final class AliasedInteger implements Comparable<AliasedInteger> {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof AliasedInteger && this.value == ((AliasedInteger) other).value);
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedSafeLong.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedSafeLong.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -26,7 +27,7 @@ public final class AliasedSafeLong implements Comparable<AliasedSafeLong> {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof AliasedSafeLong && this.value.equals(((AliasedSafeLong) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenAliasExample.java
@@ -6,6 +6,7 @@ import com.palantir.logsafe.DoNotLog;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.tokens.auth.BearerToken;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @DoNotLog
@@ -28,7 +29,7 @@ public final class BearerTokenAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof BearerTokenAliasExample
                         && this.value.equals(((BearerTokenAliasExample) other).value));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasExample.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.Bytes;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -26,7 +27,7 @@ public final class BinaryAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof BinaryAliasExample && this.value.equals(((BinaryAliasExample) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasOne.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.Bytes;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -26,7 +27,7 @@ public final class BinaryAliasOne {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof BinaryAliasOne && this.value.equals(((BinaryAliasOne) other).value));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasTwo.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -25,7 +26,7 @@ public final class BinaryAliasTwo {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof BinaryAliasTwo && this.value.equals(((BinaryAliasTwo) other).value));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanAliasExample.java
@@ -2,6 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -23,7 +24,7 @@ public final class BooleanAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof BooleanAliasExample && this.value == ((BooleanAliasExample) other).value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestAliasList.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestAliasList.java
@@ -6,6 +6,7 @@ import com.palantir.logsafe.Preconditions;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -33,7 +34,7 @@ public final class CollectionsTestAliasList {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof CollectionsTestAliasList
                         && this.value.equals(((CollectionsTestAliasList) other).value));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestAliasMap.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestAliasMap.java
@@ -6,6 +6,7 @@ import com.palantir.logsafe.Preconditions;
 import java.util.Collections;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -33,7 +34,7 @@ public final class CollectionsTestAliasMap {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof CollectionsTestAliasMap
                         && this.value.equals(((CollectionsTestAliasMap) other).value));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestAliasSet.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestAliasSet.java
@@ -6,6 +6,7 @@ import com.palantir.logsafe.Preconditions;
 import java.util.Collections;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -33,7 +34,7 @@ public final class CollectionsTestAliasSet {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof CollectionsTestAliasSet
                         && this.value.equals(((CollectionsTestAliasSet) other).value));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeAliasExample.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.time.OffsetDateTime;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -26,7 +27,7 @@ public final class DateTimeAliasExample implements Comparable<DateTimeAliasExamp
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof DateTimeAliasExample && this.value.equals(((DateTimeAliasExample) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.SafeLong;
 import java.math.BigDecimal;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -25,7 +26,7 @@ public final class DoubleAliasExample implements Comparable<DoubleAliasExample> 
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof DoubleAliasExample
                         && Double.doubleToLongBits(this.value)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasedBinaryResult.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasedBinaryResult.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -25,7 +26,7 @@ public final class DoubleAliasedBinaryResult {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof DoubleAliasedBinaryResult
                         && this.value.equals(((DoubleAliasedBinaryResult) other).value));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasExample.java
@@ -2,6 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -23,7 +24,7 @@ public final class ExternalLongAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof ExternalLongAliasExample
                         && this.value == ((ExternalLongAliasExample) other).value);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasOne.java
@@ -2,6 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -23,7 +24,7 @@ public final class ExternalLongAliasOne {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof ExternalLongAliasOne && this.value == ((ExternalLongAliasOne) other).value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasTwo.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -25,7 +26,7 @@ public final class ExternalLongAliasTwo {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof ExternalLongAliasTwo && this.value.equals(((ExternalLongAliasTwo) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalStringAliasExample.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -25,7 +26,7 @@ public final class ExternalStringAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof ExternalStringAliasExample
                         && this.value.equals(((ExternalStringAliasExample) other).value));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerAliasExample.java
@@ -2,6 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -23,7 +24,7 @@ public final class IntegerAliasExample implements Comparable<IntegerAliasExample
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof IntegerAliasExample && this.value == ((IntegerAliasExample) other).value);
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListAlias.java
@@ -6,6 +6,7 @@ import com.palantir.logsafe.Preconditions;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -33,7 +34,7 @@ public final class ListAlias {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof ListAlias && this.value.equals(((ListAlias) other).value));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/LongAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/LongAlias.java
@@ -2,6 +2,7 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -23,7 +24,7 @@ public final class LongAlias {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof LongAlias && this.value == ((LongAlias) other).value);
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapAliasExample.java
@@ -6,6 +6,7 @@ import com.palantir.logsafe.Preconditions;
 import java.util.Collections;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -33,7 +34,7 @@ public final class MapAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof MapAliasExample && this.value.equals(((MapAliasExample) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/NestedStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/NestedStringAliasExample.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Safe
@@ -27,7 +28,7 @@ public final class NestedStringAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof NestedStringAliasExample
                         && this.value.equals(((NestedStringAliasExample) other).value));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAlias.java
@@ -6,6 +6,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Safe
@@ -35,7 +36,7 @@ public final class OptionalAlias {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof OptionalAlias && this.value.equals(((OptionalAlias) other).value));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalListAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalListAliasExample.java
@@ -6,6 +6,7 @@ import com.palantir.logsafe.Preconditions;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -33,7 +34,7 @@ public final class OptionalListAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof OptionalListAliasExample
                         && this.value.equals(((OptionalListAliasExample) other).value));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalMapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalMapAliasExample.java
@@ -6,6 +6,7 @@ import com.palantir.logsafe.Preconditions;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -33,7 +34,7 @@ public final class OptionalMapAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof OptionalMapAliasExample
                         && this.value.equals(((OptionalMapAliasExample) other).value));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalSetAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalSetAliasExample.java
@@ -6,6 +6,7 @@ import com.palantir.logsafe.Preconditions;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -33,7 +34,7 @@ public final class OptionalSetAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof OptionalSetAliasExample
                         && this.value.equals(((OptionalSetAliasExample) other).value));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReferenceAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReferenceAliasExample.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -25,7 +26,7 @@ public final class ReferenceAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof ReferenceAliasExample && this.value.equals(((ReferenceAliasExample) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RidAliasExample.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.ri.ResourceIdentifier;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -26,7 +27,7 @@ public final class RidAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof RidAliasExample && this.value.equals(((RidAliasExample) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongAliasExample.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -26,7 +27,7 @@ public final class SafeLongAliasExample implements Comparable<SafeLongAliasExamp
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof SafeLongAliasExample && this.value.equals(((SafeLongAliasExample) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetAlias.java
@@ -6,6 +6,7 @@ import com.palantir.logsafe.Preconditions;
 import java.util.Collections;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -33,7 +34,7 @@ public final class SetAlias {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof SetAlias && this.value.equals(((SetAlias) other).value));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasExample.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Safe
@@ -28,7 +29,7 @@ public final class StringAliasExample implements Comparable<StringAliasExample> 
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof StringAliasExample && this.value.equals(((StringAliasExample) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasOne.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -25,7 +26,7 @@ public final class StringAliasOne implements Comparable<StringAliasOne> {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof StringAliasOne && this.value.equals(((StringAliasOne) other).value));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasThree.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasThree.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -25,7 +26,7 @@ public final class StringAliasThree {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof StringAliasThree && this.value.equals(((StringAliasThree) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasTwo.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -32,7 +33,7 @@ public final class StringAliasTwo {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof StringAliasTwo && this.value.equals(((StringAliasTwo) other).value));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidAliasExample.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.UUID;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -26,7 +27,7 @@ public final class UuidAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof UuidAliasExample && this.value.equals(((UuidAliasExample) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BearerTokenAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BearerTokenAliasExample.java
@@ -6,6 +6,7 @@ import com.palantir.logsafe.DoNotLog;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.tokens.auth.BearerToken;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @DoNotLog
@@ -28,7 +29,7 @@ public final class BearerTokenAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof BearerTokenAliasExample
                         && this.value.equals(((BearerTokenAliasExample) other).value));

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasExample.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.nio.ByteBuffer;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -26,7 +27,7 @@ public final class BinaryAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof BinaryAliasExample && this.value.equals(((BinaryAliasExample) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasOne.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.nio.ByteBuffer;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -26,7 +27,7 @@ public final class BinaryAliasOne {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof BinaryAliasOne && this.value.equals(((BinaryAliasOne) other).value));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasTwo.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -25,7 +26,7 @@ public final class BinaryAliasTwo {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof BinaryAliasTwo && this.value.equals(((BinaryAliasTwo) other).value));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BooleanAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BooleanAliasExample.java
@@ -2,6 +2,7 @@ package test.prefix.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -23,7 +24,7 @@ public final class BooleanAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof BooleanAliasExample && this.value == ((BooleanAliasExample) other).value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeAliasExample.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.time.OffsetDateTime;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -26,7 +27,7 @@ public final class DateTimeAliasExample implements Comparable<DateTimeAliasExamp
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof DateTimeAliasExample && this.value.equals(((DateTimeAliasExample) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleAliasExample.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.SafeLong;
 import java.math.BigDecimal;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -25,7 +26,7 @@ public final class DoubleAliasExample implements Comparable<DoubleAliasExample> 
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof DoubleAliasExample
                         && Double.doubleToLongBits(this.value)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasExample.java
@@ -2,6 +2,7 @@ package test.prefix.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -23,7 +24,7 @@ public final class ExternalLongAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof ExternalLongAliasExample
                         && this.value == ((ExternalLongAliasExample) other).value);

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasOne.java
@@ -2,6 +2,7 @@ package test.prefix.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -23,7 +24,7 @@ public final class ExternalLongAliasOne {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof ExternalLongAliasOne && this.value == ((ExternalLongAliasOne) other).value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasTwo.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -25,7 +26,7 @@ public final class ExternalLongAliasTwo {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof ExternalLongAliasTwo && this.value.equals(((ExternalLongAliasTwo) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalStringAliasExample.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -25,7 +26,7 @@ public final class ExternalStringAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof ExternalStringAliasExample
                         && this.value.equals(((ExternalStringAliasExample) other).value));

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/IntegerAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/IntegerAliasExample.java
@@ -2,6 +2,7 @@ package test.prefix.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -23,7 +24,7 @@ public final class IntegerAliasExample implements Comparable<IntegerAliasExample
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof IntegerAliasExample && this.value == ((IntegerAliasExample) other).value);
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListAlias.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListAlias.java
@@ -6,6 +6,7 @@ import com.palantir.logsafe.Preconditions;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -33,7 +34,7 @@ public final class ListAlias {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof ListAlias && this.value.equals(((ListAlias) other).value));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapAliasExample.java
@@ -6,6 +6,7 @@ import com.palantir.logsafe.Preconditions;
 import java.util.Collections;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -33,7 +34,7 @@ public final class MapAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof MapAliasExample && this.value.equals(((MapAliasExample) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/NestedStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/NestedStringAliasExample.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Safe
@@ -27,7 +28,7 @@ public final class NestedStringAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof NestedStringAliasExample
                         && this.value.equals(((NestedStringAliasExample) other).value));

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAlias.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAlias.java
@@ -6,6 +6,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Safe
@@ -35,7 +36,7 @@ public final class OptionalAlias {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof OptionalAlias && this.value.equals(((OptionalAlias) other).value));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalListAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalListAliasExample.java
@@ -6,6 +6,7 @@ import com.palantir.logsafe.Preconditions;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -33,7 +34,7 @@ public final class OptionalListAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof OptionalListAliasExample
                         && this.value.equals(((OptionalListAliasExample) other).value));

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalMapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalMapAliasExample.java
@@ -6,6 +6,7 @@ import com.palantir.logsafe.Preconditions;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -33,7 +34,7 @@ public final class OptionalMapAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof OptionalMapAliasExample
                         && this.value.equals(((OptionalMapAliasExample) other).value));

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalSetAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalSetAliasExample.java
@@ -6,6 +6,7 @@ import com.palantir.logsafe.Preconditions;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -33,7 +34,7 @@ public final class OptionalSetAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof OptionalSetAliasExample
                         && this.value.equals(((OptionalSetAliasExample) other).value));

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReferenceAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReferenceAliasExample.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -25,7 +26,7 @@ public final class ReferenceAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof ReferenceAliasExample && this.value.equals(((ReferenceAliasExample) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RidAliasExample.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.ri.ResourceIdentifier;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -26,7 +27,7 @@ public final class RidAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof RidAliasExample && this.value.equals(((RidAliasExample) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeLongAliasExample.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -26,7 +27,7 @@ public final class SafeLongAliasExample implements Comparable<SafeLongAliasExamp
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof SafeLongAliasExample && this.value.equals(((SafeLongAliasExample) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetAlias.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetAlias.java
@@ -6,6 +6,7 @@ import com.palantir.logsafe.Preconditions;
 import java.util.Collections;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -33,7 +34,7 @@ public final class SetAlias {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof SetAlias && this.value.equals(((SetAlias) other).value));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasExample.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Safe
@@ -28,7 +29,7 @@ public final class StringAliasExample implements Comparable<StringAliasExample> 
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof StringAliasExample && this.value.equals(((StringAliasExample) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasOne.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -25,7 +26,7 @@ public final class StringAliasOne implements Comparable<StringAliasOne> {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof StringAliasOne && this.value.equals(((StringAliasOne) other).value));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasThree.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasThree.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -25,7 +26,7 @@ public final class StringAliasThree {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof StringAliasThree && this.value.equals(((StringAliasThree) other).value));
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasTwo.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -32,7 +33,7 @@ public final class StringAliasTwo {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof StringAliasTwo && this.value.equals(((StringAliasTwo) other).value));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UuidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UuidAliasExample.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
 import java.util.UUID;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
@@ -26,7 +27,7 @@ public final class UuidAliasExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof UuidAliasExample && this.value.equals(((UuidAliasExample) other).value));
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -53,6 +53,7 @@ import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.function.BiFunction;
+import javax.annotation.Nullable;
 import javax.lang.model.element.Modifier;
 
 public final class AliasGenerator {
@@ -95,7 +96,9 @@ public final class AliasGenerator {
                 .addMethod(MethodSpec.methodBuilder("equals")
                         .addModifiers(Modifier.PUBLIC)
                         .addAnnotation(Override.class)
-                        .addParameter(ClassName.OBJECT, "other")
+                        .addParameter(ParameterSpec.builder(ClassName.OBJECT, "other")
+                                .addAnnotation(Nullable.class)
+                                .build())
                         .returns(TypeName.BOOLEAN)
                         .addCode(primitiveSafeEquality(thisClass, aliasTypeName, typeDef))
                         .build())


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
#1883 missed alias .equals methods
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Mark the argument to .equals on a conjure alias as `@Nullable`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

