### PR TITLE
Add docs for visitor builders to README

### DIFF
--- a/changelog/@unreleased/pr-1897.v2.yml
+++ b/changelog/@unreleased/pr-1897.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add docs for visitor builders to README
+  links:
+  - https://github.com/palantir/conjure-java/pull/1897

--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,17 @@ Conjure-java objects are always immutable and thread-safe.  Fields are never nul
     ```
 
     Visitors may seem clunky in Java, but they have the upside of compile-time assurance that you've handled all the possible variants.  If you upgrade an API dependency and the API author added a new variant, the Java compiler will force you to explicitly deal with this new variant.  We intentionally avoid `switch` statements and `instanceof` checks for this exact reason.
+    
+    There is also a more concise visitor builders pattern that can be used to create a visitor:
+    
+    ```java
+    Foo output = unionTypeExample.accept(Visitor.<Foo>builder()
+        .stringExample(value -> ...)
+        .set(value -> ...)
+        .throwOnUnknown()
+        .build());
+    });
+    ```
 
 - **Conjure enum: [EnumExample](./conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java)**
 


### PR DESCRIPTION
Fixes https://github.com/palantir/conjure-java/issues/1896

## Before this PR
No mention in README for visitor builders

## After this PR
==COMMIT_MSG==
Add docs for visitor builders to README
==COMMIT_MSG==

## Possible downsides?
This README code isn't compiled as part of CI so could have compile errors or other errors that aren't caught in CI, potentially misleading readers.