### PR TITLE
Add safety annotations to toString methods

### DIFF
--- a/changelog/@unreleased/pr-1908.v2.yml
+++ b/changelog/@unreleased/pr-1908.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Declare safety annotations on generated toString methods
+  links:
+  - https://github.com/palantir/conjure-java/pull/1908

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasAsMapKeyExample.java
@@ -129,6 +129,7 @@ public final class AliasAsMapKeyExample {
     }
 
     @Override
+    @DoNotLog
     public String toString() {
         return "AliasAsMapKeyExample{strings: " + strings + ", rids: " + rids + ", bearertokens: " + bearertokens
                 + ", integers: " + integers + ", safelongs: " + safelongs + ", datetimes: " + datetimes + ", uuids: "

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenExample.java
@@ -45,6 +45,7 @@ public final class BearerTokenExample {
     }
 
     @Override
+    @DoNotLog
     public String toString() {
         return "BearerTokenExample{bearerTokenValue: " + bearerTokenValue + '}';
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyObjectExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyObjectExample.java
@@ -14,6 +14,7 @@ public final class EmptyObjectExample {
     private EmptyObjectExample() {}
 
     @Override
+    @Safe
     public String toString() {
         return "EmptyObjectExample{}";
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumFieldExample.java
@@ -44,6 +44,7 @@ public final class EnumFieldExample {
     }
 
     @Override
+    @Safe
     public String toString() {
         return "EnumFieldExample{enum: " + enum_ + '}';
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
@@ -120,6 +120,7 @@ public final class MultipleOrderedStages {
     }
 
     @Override
+    @DoNotLog
     public String toString() {
         return "MultipleOrderedStages{token: " + token + ", item: " + item + ", items: " + items + ", mappedRids: "
                 + mappedRids + ", optionalItem: " + optionalItem + '}';

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OneField.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OneField.java
@@ -46,6 +46,7 @@ public final class OneField {
     }
 
     @Override
+    @DoNotLog
     public String toString() {
         return "OneField{bearerTokenValue: " + bearerTokenValue + '}';
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAlias.java
@@ -31,6 +31,7 @@ public final class OptionalAlias {
     }
 
     @Override
+    @Safe
     public String toString() {
         return value.toString();
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAliasExample.java
@@ -47,6 +47,7 @@ public final class OptionalAliasExample {
     }
 
     @Override
+    @Safe
     public String toString() {
         return "OptionalAliasExample{optionalAlias: " + optionalAlias + '}';
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalExample.java
@@ -49,6 +49,7 @@ public final class OptionalExample {
     }
 
     @Override
+    @Safe
     public String toString() {
         return "OptionalExample{item: " + item + '}';
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveOptionalsExample.java
@@ -295,6 +295,7 @@ public final class PrimitiveOptionalsExample {
     }
 
     @Override
+    @DoNotLog
     public String toString() {
         return "PrimitiveOptionalsExample{num: " + num + ", bool: " + bool + ", integer: " + integer + ", safelong: "
                 + safelong + ", rid: " + rid + ", bearertoken: " + bearertoken + ", uuid: " + uuid + ", map: " + map

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasExample.java
@@ -24,6 +24,7 @@ public final class StringAliasExample implements Comparable<StringAliasExample> 
     }
 
     @Override
+    @Safe
     public String toString() {
         return value.toString();
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/strict/EmptyObjectNotStrict.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/strict/EmptyObjectNotStrict.java
@@ -16,6 +16,7 @@ public final class EmptyObjectNotStrict {
     private EmptyObjectNotStrict() {}
 
     @Override
+    @Safe
     public String toString() {
         return "EmptyObjectNotStrict{}";
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/AliasAsMapKeyExample.java
@@ -130,6 +130,7 @@ public final class AliasAsMapKeyExample {
     }
 
     @Override
+    @DoNotLog
     public String toString() {
         return "AliasAsMapKeyExample{strings: " + strings + ", rids: " + rids + ", bearertokens: " + bearertokens
                 + ", integers: " + integers + ", safelongs: " + safelongs + ", datetimes: " + datetimes + ", uuids: "

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BearerTokenExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BearerTokenExample.java
@@ -46,6 +46,7 @@ public final class BearerTokenExample {
     }
 
     @Override
+    @DoNotLog
     public String toString() {
         return "BearerTokenExample{bearerTokenValue: " + bearerTokenValue + '}';
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyObjectExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyObjectExample.java
@@ -16,6 +16,7 @@ public final class EmptyObjectExample {
     private EmptyObjectExample() {}
 
     @Override
+    @Safe
     public String toString() {
         return "EmptyObjectExample{}";
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumFieldExample.java
@@ -45,6 +45,7 @@ public final class EnumFieldExample {
     }
 
     @Override
+    @Safe
     public String toString() {
         return "EnumFieldExample{enum: " + enum_ + '}';
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAlias.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAlias.java
@@ -31,6 +31,7 @@ public final class OptionalAlias {
     }
 
     @Override
+    @Safe
     public String toString() {
         return value.toString();
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAliasExample.java
@@ -48,6 +48,7 @@ public final class OptionalAliasExample {
     }
 
     @Override
+    @Safe
     public String toString() {
         return "OptionalAliasExample{optionalAlias: " + optionalAlias + '}';
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalExample.java
@@ -50,6 +50,7 @@ public final class OptionalExample {
     }
 
     @Override
+    @Safe
     public String toString() {
         return "OptionalExample{item: " + item + '}';
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/PrimitiveOptionalsExample.java
@@ -296,6 +296,7 @@ public final class PrimitiveOptionalsExample {
     }
 
     @Override
+    @DoNotLog
     public String toString() {
         return "PrimitiveOptionalsExample{num: " + num + ", bool: " + bool + ", integer: " + integer + ", safelong: "
                 + safelong + ", rid: " + rid + ", bearertoken: " + bearertoken + ", uuid: " + uuid + ", map: " + map

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasExample.java
@@ -24,6 +24,7 @@ public final class StringAliasExample implements Comparable<StringAliasExample> 
     }
 
     @Override
+    @Safe
     public String toString() {
         return value.toString();
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -90,6 +90,7 @@ public final class AliasGenerator {
                 .addMethod(MethodSpec.methodBuilder("toString")
                         .addModifiers(Modifier.PUBLIC)
                         .addAnnotation(Override.class)
+                        .addAnnotations(safetyAnnotations)
                         .returns(String.class)
                         .addCode(primitiveSafeToString(aliasTypeName))
                         .build())

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -129,8 +129,11 @@ public final class BeanGenerator {
         }
 
         typeBuilder.addMethod(MethodSpecs.createToString(
-                prefixedName.getName(),
-                fields.stream().map(EnrichedField::fieldName).collect(Collectors.toList())));
+                        prefixedName.getName(),
+                        fields.stream().map(EnrichedField::fieldName).collect(Collectors.toList()))
+                .toBuilder()
+                .addAnnotations(safety)
+                .build());
 
         if (poetFields.size() <= MAX_NUM_PARAMS_FOR_FACTORY) {
             typeBuilder.addMethod(createStaticFactoryMethod(fields, objectClass));

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -108,10 +108,12 @@ public final class UnionGenerator {
         List<FieldSpec> fields =
                 ImmutableList.of(FieldSpec.builder(baseClass, VALUE_FIELD_NAME, Modifier.PRIVATE, Modifier.FINAL)
                         .build());
+        List<AnnotationSpec> safety =
+                ConjureAnnotations.safety(safetyEvaluator.evaluate(TypeDefinition.union(typeDef)));
 
         TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(
                         typeDef.getTypeName().getName())
-                .addAnnotations(ConjureAnnotations.safety(safetyEvaluator.evaluate(TypeDefinition.union(typeDef))))
+                .addAnnotations(safety)
                 .addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(UnionGenerator.class))
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                 .addFields(fields)
@@ -130,10 +132,13 @@ public final class UnionGenerator {
                 .addMethod(MethodSpecs.createEqualTo(unionClass, fields))
                 .addMethod(MethodSpecs.createHashCode(fields))
                 .addMethod(MethodSpecs.createToString(
-                        unionClass.simpleName(),
-                        fields.stream()
-                                .map(fieldSpec -> FieldName.of(fieldSpec.name))
-                                .collect(Collectors.toList())));
+                                unionClass.simpleName(),
+                                fields.stream()
+                                        .map(fieldSpec -> FieldName.of(fieldSpec.name))
+                                        .collect(Collectors.toList()))
+                        .toBuilder()
+                        .addAnnotations(safety)
+                        .build());
 
         typeDef.getDocs().ifPresent(docs -> typeBuilder.addJavadoc("$L", Javadoc.render(docs)));
 


### PR DESCRIPTION
## Before this PR
No change for static analysis, we already assume toString safety
is inferred from the type, however this aligns more closely with
our code style, and is clearer to readers.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Declare safety annotations on generated toString methods
==COMMIT_MSG==
