### PR TITLE
fix eclipse deprecation warnings

### DIFF
--- a/changelog/@unreleased/pr-1917.v2.yml
+++ b/changelog/@unreleased/pr-1917.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Generated code does not produce deprecation warnings in eclipse by
+    default
+  links:
+  - https://github.com/palantir/conjure-java/pull/1917

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -315,7 +315,6 @@ public final class Union {
         }
 
         @Override
-        @SuppressWarnings("deprecation")
         public <T> T accept(Visitor<T> visitor) {
             return visitor.visitBar(value);
         }
@@ -361,7 +360,6 @@ public final class Union {
         }
 
         @Override
-        @SuppressWarnings("deprecation")
         public <T> T accept(Visitor<T> visitor) {
             return visitor.visitBaz(value);
         }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
@@ -305,7 +305,6 @@ public final class Union {
         }
 
         @Override
-        @SuppressWarnings("deprecation")
         public <T> T accept(Visitor<T> visitor) {
             return visitor.visitBar(value);
         }
@@ -351,7 +350,6 @@ public final class Union {
         }
 
         @Override
-        @SuppressWarnings("deprecation")
         public <T> T accept(Visitor<T> visitor) {
             return visitor.visitBaz(value);
         }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DefaultStaticFactoryMethodGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DefaultStaticFactoryMethodGenerator.java
@@ -52,7 +52,6 @@ import com.palantir.dialogue.Serializer;
 import com.palantir.dialogue.TypeMarker;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
-import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.FieldSpec;

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DefaultStaticFactoryMethodGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DefaultStaticFactoryMethodGenerator.java
@@ -200,12 +200,6 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
                 .addParameters(params)
                 .addAnnotation(Override.class);
 
-        if (def.getDeprecated().isPresent()) {
-            methodBuilder.addAnnotation(AnnotationSpec.builder(SuppressWarnings.class)
-                    .addMember("value", "$S", "deprecation")
-                    .build());
-        }
-
         TypeName returnType =
                 methodType.switchBy(returnTypes.baseType(def.getReturns()), returnTypes.async(def.getReturns()));
         methodBuilder.returns(returnType);

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -910,11 +910,6 @@ public final class UnionGenerator {
         } else {
             methodBuilder.addStatement("return $N.$N($N)", visitor, visitMethodName, valueName);
         }
-        if (isDeprecated) {
-            methodBuilder.addAnnotation(AnnotationSpec.builder(SuppressWarnings.class)
-                    .addMember("value", "$S", "deprecation")
-                    .build());
-        }
         return methodBuilder.build();
     }
 

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
@@ -30,7 +30,6 @@ import java.lang.Double;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.SuppressWarnings;
 import java.lang.Void;
 import java.util.Map;
 import java.util.Optional;
@@ -437,7 +436,6 @@ public interface TestServiceAsync {
             }
 
             @Override
-            @SuppressWarnings("deprecation")
             public ListenableFuture<Set<String>> getBranchesDeprecated(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
@@ -26,7 +26,6 @@ import java.lang.Double;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.SuppressWarnings;
 import java.lang.Void;
 import java.util.Map;
 import java.util.Optional;
@@ -437,7 +436,6 @@ public interface TestServiceAsync {
             }
 
             @Override
-            @SuppressWarnings("deprecation")
             public ListenableFuture<Set<String>> getBranchesDeprecated(
                     AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
@@ -30,7 +30,6 @@ import java.lang.Double;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.SuppressWarnings;
 import java.lang.Void;
 import java.util.Map;
 import java.util.Optional;
@@ -433,7 +432,6 @@ public interface TestServiceBlocking {
             }
 
             @Override
-            @SuppressWarnings("deprecation")
             public Set<String> getBranchesDeprecated(AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
@@ -26,7 +26,6 @@ import java.lang.Double;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.SuppressWarnings;
 import java.lang.Void;
 import java.util.Map;
 import java.util.Optional;
@@ -433,7 +432,6 @@ public interface TestServiceBlocking {
             }
 
             @Override
-            @SuppressWarnings("deprecation")
             public Set<String> getBranchesDeprecated(AuthHeader authHeader, ResourceIdentifier datasetRid) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());


### PR DESCRIPTION
Remove `@SuppressWarnings("deprecation")` on deprecated methods. The annotation is for suppressing calls of deprecated methods, not implementation of deprecated methods.

partial fix for #1635

Splitting out from https://github.com/palantir/conjure-java/pull/1916

## Before this PR
Generated code produces warnings in eclipse

## After this PR
==COMMIT_MSG==
Generated code does not produce deprecation warnings in eclipse by default
==COMMIT_MSG==

## Possible downsides?
Not tested in intellij. Only tested on one internal repo.
