### PR TITLE
Performance: faster enum equals method

### DIFF
--- a/changelog/@unreleased/pr-1919.v2.yml
+++ b/changelog/@unreleased/pr-1919.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: 'Performance: faster enum equals method.'
+  links:
+  - https://github.com/palantir/conjure-java/pull/1919

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -68,8 +68,8 @@ public final class EnumExample {
     @Override
     public boolean equals(Object other) {
         return (this == other)
-                || (other instanceof EnumExample
-                        && this.value == Value.UNKNOWN
+                || (this.value == Value.UNKNOWN
+                        && other instanceof EnumExample
                         && this.string.equals(((EnumExample) other).string));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -69,8 +69,8 @@ public final class EnumExample {
     public boolean equals(Object other) {
         return (this == other)
                 || (other instanceof EnumExample
-                        && ((this.value == ((EnumExample) other).value)
-                                || (this.value == Value.UNKNOWN && this.string.equals(((EnumExample) other).string))));
+                        && this.value == Value.UNKNOWN
+                        && this.string.equals(((EnumExample) other).string));
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -67,7 +67,10 @@ public final class EnumExample {
 
     @Override
     public boolean equals(Object other) {
-        return (this == other) || (other instanceof EnumExample && this.string.equals(((EnumExample) other).string));
+        return (this == other)
+                || (other instanceof EnumExample
+                        && ((this.value == ((EnumExample) other).value)
+                                || (this.value == Value.UNKNOWN && this.string.equals(((EnumExample) other).string))));
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
@@ -53,8 +53,8 @@ public final class SimpleEnum {
     public boolean equals(Object other) {
         return (this == other)
                 || (other instanceof SimpleEnum
-                        && ((this.value == ((SimpleEnum) other).value)
-                                || (this.value == Value.UNKNOWN && this.string.equals(((SimpleEnum) other).string))));
+                        && this.value == Value.UNKNOWN
+                        && this.string.equals(((SimpleEnum) other).string));
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
@@ -51,7 +51,10 @@ public final class SimpleEnum {
 
     @Override
     public boolean equals(Object other) {
-        return (this == other) || (other instanceof SimpleEnum && this.string.equals(((SimpleEnum) other).string));
+        return (this == other)
+                || (other instanceof SimpleEnum
+                        && ((this.value == ((SimpleEnum) other).value)
+                                || (this.value == Value.UNKNOWN && this.string.equals(((SimpleEnum) other).string))));
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
@@ -52,8 +52,8 @@ public final class SimpleEnum {
     @Override
     public boolean equals(Object other) {
         return (this == other)
-                || (other instanceof SimpleEnum
-                        && this.value == Value.UNKNOWN
+                || (this.value == Value.UNKNOWN
+                        && other instanceof SimpleEnum
                         && this.string.equals(((SimpleEnum) other).string));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
@@ -68,8 +68,8 @@ public final class EnumExample {
     @Override
     public boolean equals(Object other) {
         return (this == other)
-                || (other instanceof EnumExample
-                        && this.value == Value.UNKNOWN
+                || (this.value == Value.UNKNOWN
+                        && other instanceof EnumExample
                         && this.string.equals(((EnumExample) other).string));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
@@ -69,8 +69,8 @@ public final class EnumExample {
     public boolean equals(Object other) {
         return (this == other)
                 || (other instanceof EnumExample
-                        && ((this.value == ((EnumExample) other).value)
-                                || (this.value == Value.UNKNOWN && this.string.equals(((EnumExample) other).string))));
+                        && this.value == Value.UNKNOWN
+                        && this.string.equals(((EnumExample) other).string));
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
@@ -67,7 +67,10 @@ public final class EnumExample {
 
     @Override
     public boolean equals(Object other) {
-        return (this == other) || (other instanceof EnumExample && this.string.equals(((EnumExample) other).string));
+        return (this == other)
+                || (other instanceof EnumExample
+                        && ((this.value == ((EnumExample) other).value)
+                                || (this.value == Value.UNKNOWN && this.string.equals(((EnumExample) other).string))));
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
@@ -53,8 +53,8 @@ public final class SimpleEnum {
     public boolean equals(Object other) {
         return (this == other)
                 || (other instanceof SimpleEnum
-                        && ((this.value == ((SimpleEnum) other).value)
-                                || (this.value == Value.UNKNOWN && this.string.equals(((SimpleEnum) other).string))));
+                        && this.value == Value.UNKNOWN
+                        && this.string.equals(((SimpleEnum) other).string));
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
@@ -51,7 +51,10 @@ public final class SimpleEnum {
 
     @Override
     public boolean equals(Object other) {
-        return (this == other) || (other instanceof SimpleEnum && this.string.equals(((SimpleEnum) other).string));
+        return (this == other)
+                || (other instanceof SimpleEnum
+                        && ((this.value == ((SimpleEnum) other).value)
+                                || (this.value == Value.UNKNOWN && this.string.equals(((SimpleEnum) other).string))));
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
@@ -52,8 +52,8 @@ public final class SimpleEnum {
     @Override
     public boolean equals(Object other) {
         return (this == other)
-                || (other instanceof SimpleEnum
-                        && this.value == Value.UNKNOWN
+                || (this.value == Value.UNKNOWN
+                        && other instanceof SimpleEnum
                         && this.string.equals(((SimpleEnum) other).string));
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -39,7 +39,6 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -55,8 +54,7 @@ public final class EnumGenerator {
     private static final String VISIT_UNKNOWN_METHOD_NAME = "visitUnknown";
     private static final TypeVariableName TYPE_VARIABLE = TypeVariableName.get("T");
 
-    private EnumGenerator() {
-    }
+    private EnumGenerator() {}
 
     public static JavaFile generateEnumType(EnumDefinition typeDef, Options options) {
         com.palantir.conjure.spec.TypeName prefixedTypeName =
@@ -215,8 +213,8 @@ public final class EnumGenerator {
                 .addAnnotations(
                         anyDeprecatedValues
                                 ? ImmutableList.of(AnnotationSpec.builder(SuppressWarnings.class)
-                                .addMember("value", "$S", "deprecation")
-                                .build())
+                                        .addMember("value", "$S", "deprecation")
+                                        .build())
                                 : ImmutableList.of())
                 .build();
     }
@@ -266,8 +264,8 @@ public final class EnumGenerator {
                 .addAnnotations(
                         anyDeprecatedValues
                                 ? ImmutableList.of(AnnotationSpec.builder(SuppressWarnings.class)
-                                .addMember("value", "$S", "deprecation")
-                                .build())
+                                        .addMember("value", "$S", "deprecation")
+                                        .build())
                                 : ImmutableList.of())
                 .addParameter(param)
                 .addStatement("$L", Expressions.requireNonNull(param.name, param.name + " cannot be null"))
@@ -294,8 +292,8 @@ public final class EnumGenerator {
                 .addAnnotations(
                         anyDeprecatedValues
                                 ? ImmutableList.of(AnnotationSpec.builder(SuppressWarnings.class)
-                                .addMember("value", "$S", "deprecation")
-                                .build())
+                                        .addMember("value", "$S", "deprecation")
+                                        .build())
                                 : ImmutableList.of())
                 .build();
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -314,8 +314,8 @@ public final class EnumGenerator {
                 .addParameter(other)
                 .returns(TypeName.BOOLEAN)
                 .addStatement(
-                        "return (this == $1N) || ($1N instanceof $2T && ((this.value == (($2T) $1N).value) "
-                                + "|| (this.value == Value.UNKNOWN && this.string.equals((($2T) $1N).string))))",
+                        "return (this == $1N) || ($1N instanceof $2T "
+                                + "&& this.value == Value.UNKNOWN && this.string.equals((($2T) $1N).string))",
                         other,
                         thisClass)
                 .build();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -39,6 +39,7 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -54,7 +55,8 @@ public final class EnumGenerator {
     private static final String VISIT_UNKNOWN_METHOD_NAME = "visitUnknown";
     private static final TypeVariableName TYPE_VARIABLE = TypeVariableName.get("T");
 
-    private EnumGenerator() {}
+    private EnumGenerator() {
+    }
 
     public static JavaFile generateEnumType(EnumDefinition typeDef, Options options) {
         com.palantir.conjure.spec.TypeName prefixedTypeName =
@@ -213,8 +215,8 @@ public final class EnumGenerator {
                 .addAnnotations(
                         anyDeprecatedValues
                                 ? ImmutableList.of(AnnotationSpec.builder(SuppressWarnings.class)
-                                        .addMember("value", "$S", "deprecation")
-                                        .build())
+                                .addMember("value", "$S", "deprecation")
+                                .build())
                                 : ImmutableList.of())
                 .build();
     }
@@ -264,8 +266,8 @@ public final class EnumGenerator {
                 .addAnnotations(
                         anyDeprecatedValues
                                 ? ImmutableList.of(AnnotationSpec.builder(SuppressWarnings.class)
-                                        .addMember("value", "$S", "deprecation")
-                                        .build())
+                                .addMember("value", "$S", "deprecation")
+                                .build())
                                 : ImmutableList.of())
                 .addParameter(param)
                 .addStatement("$L", Expressions.requireNonNull(param.name, param.name + " cannot be null"))
@@ -292,8 +294,8 @@ public final class EnumGenerator {
                 .addAnnotations(
                         anyDeprecatedValues
                                 ? ImmutableList.of(AnnotationSpec.builder(SuppressWarnings.class)
-                                        .addMember("value", "$S", "deprecation")
-                                        .build())
+                                .addMember("value", "$S", "deprecation")
+                                .build())
                                 : ImmutableList.of())
                 .build();
     }
@@ -314,7 +316,8 @@ public final class EnumGenerator {
                 .addParameter(other)
                 .returns(TypeName.BOOLEAN)
                 .addStatement(
-                        "return (this == $1N) || ($1N instanceof $2T && this.string.equals((($2T) $1N).string))",
+                        "return (this == $1N) || ($1N instanceof $2T && ((this.value == (($2T) $1N).value) "
+                                + "|| (this.value == Value.UNKNOWN && this.string.equals((($2T) $1N).string))))",
                         other,
                         thisClass)
                 .build();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -314,8 +314,8 @@ public final class EnumGenerator {
                 .addParameter(other)
                 .returns(TypeName.BOOLEAN)
                 .addStatement(
-                        "return (this == $1N) || ($1N instanceof $2T "
-                                + "&& this.value == Value.UNKNOWN && this.string.equals((($2T) $1N).string))",
+                        "return (this == $1N) || (this.value == Value.UNKNOWN && $1N instanceof $2T "
+                                + "&& this.string.equals((($2T) $1N).string))",
                         other,
                         thisClass)
                 .build();


### PR DESCRIPTION
Conjure enums are usually not unknown. Here, equals devolves to string equality when the two enum cases are _not_ equal, which is slower than you'd think. This PR short circuits in most cases with an object equality check, at the cost of doing an extra reference equality checks when comparing unknown types (aka extremely unlikely).

In my case this is approximately 3% of all JMH samples. Slightly contrived example but this should be a small win everywhere.
