### PR TITLE
Always log QosException at info

### DIFF
--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
@@ -94,7 +94,9 @@ public enum ConjureExceptions implements ExceptionHandler {
     private static void qosException(HttpServerExchange exchange, QosException qosException) {
         qosException.accept(QOS_EXCEPTION_HEADERS).accept(exchange);
 
-        if (qosExceptionHasAdditionalMetadata(qosException) || qosLoggingRateLimiter.tryAcquire()) {
+        if (log.isDebugEnabled()) {
+            log.debug("Quality-of-Service error handling request", qosException);
+        } else if (qosExceptionHasAdditionalMetadata(qosException) || qosLoggingRateLimiter.tryAcquire()) {
             log.info("Quality-of-Service error handling request", qosException);
         }
 

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
@@ -89,27 +89,8 @@ public enum ConjureExceptions implements ExceptionHandler {
 
     private static void qosException(HttpServerExchange exchange, QosException qosException) {
         qosException.accept(QOS_EXCEPTION_HEADERS).accept(exchange);
-        if (qosExceptionHasAdditionalMetadata(qosException)) {
-            log.info("quality-of-service intervention", qosException);
-        } else {
-            log.debug("quality-of-service intervention", qosException);
-        }
+        log.info("quality-of-service intervention", qosException);
         writeResponse(exchange, Optional.empty(), qosException.accept(QOS_EXCEPTION_STATUS_CODE));
-    }
-
-    /** Returns  true if {@link QosException} provides additional metadata and should be logged at {@code info}. */
-    private static boolean qosExceptionHasAdditionalMetadata(QosException qosException) {
-        try {
-            if (qosException.getCause() != null) {
-                return true;
-            }
-            Throwable[] suppressed = qosException.getSuppressed();
-            return suppressed != null && suppressed.length > 1;
-        } catch (Throwable t) {
-            // Fallback in case of unexpected bytecode manipulation (getCause or getSuppressed throws due to
-            // poor instrumentation/mocks)
-            return true;
-        }
     }
 
     // RemoteExceptions are thrown by Conjure clients to indicate a remote/service-side problem.


### PR DESCRIPTION
Continuation of https://github.com/palantir/conjure-java/pull/1519

## Before this PR
It is common for services to throw `QosException` without a cause, particularly in cases where requests are being rate-limited.

When this happens, it is difficult to determine why requests are failing without a stacktrace, especially when `QosException` is thrown in multiple places.

## After this PR
Requests that fail with `QosException` always log at the `INFO` level so operators can determine why a request failed.

