### PR TITLE
Only set the Content-Type response header if is isn't already set

### DIFF
--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureBodySerDe.java
@@ -88,7 +88,11 @@ final class ConjureBodySerDe implements BodySerDe {
     @Override
     public void serialize(BinaryResponseBody value, HttpServerExchange exchange) throws IOException {
         Preconditions.checkNotNull(value, "A BinaryResponseBody value is required");
-        exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, BINARY_CONTENT_TYPE);
+        // Only set the Content-Type header if it isn't present.
+        // This allows implementations to set custom binary content types for images/videos.
+        if (!exchange.getResponseHeaders().contains(Headers.CONTENT_TYPE)) {
+            exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, BINARY_CONTENT_TYPE);
+        }
         Tracer.fastStartSpan(TracedEncoding.SERIALIZE_OPERATION);
         try {
             value.write(exchange.getOutputStream());


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Servers which use a custom content-type response header had this header overwritten silently.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Only set the Content-Type response header if is isn't already set
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
It should have very little impact on standard code-paths.
