### PR TITLE
Update wildfly to 1.6.0.Final

### DIFF
--- a/conjure-undertow-lib/build.gradle
+++ b/conjure-undertow-lib/build.gradle
@@ -23,4 +23,6 @@ dependencies {
     // Ideally we would declare a dependency on 'com.google.guava:listenablefuture:1.0' without all of guava,
     // however gcv forces consistent versions across the project.
     api 'com.google.guava:guava'
+    // Recommend a higher version of wildfly (1.6.0.Final+) then the one shipped with undertow to avoid CVEs.
+    runtimeOnly 'org.wildfly.common:wildfly-common'
 }

--- a/versions.lock
+++ b/versions.lock
@@ -83,7 +83,7 @@ org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir:1.1.3 (1 constraint
 org.slf4j:slf4j-api:1.7.36 (27 constraints: 608897a9)
 org.slf4j:slf4j-simple:1.7.36 (1 constraints: 43054b3b)
 org.wildfly.client:wildfly-client-config:1.0.1.Final (1 constraints: 940c6308)
-org.wildfly.common:wildfly-common:1.5.4.Final (2 constraints: 741cfbf1)
+org.wildfly.common:wildfly-common:1.6.0.Final (3 constraints: 94236ea3)
 org.yaml:snakeyaml:1.33 (1 constraints: 6f17f827)
 
 [Test dependencies]

--- a/versions.props
+++ b/versions.props
@@ -42,6 +42,7 @@ com.palantir.human-readable-types:* = 1.6.0
 org.derive4j:* = 1.1.1
 com.google.auto:auto-common = 1.2.1
 com.google.testing.compile:compile-testing = 0.19
+org.wildfly.common:wildfly-common = 1.6.0.Final
 
 # dependency-upgrader:OFF
 # Avoid forcing consumers to upgrade jackson


### PR DESCRIPTION
## Before this PR

`org.wildfly.common:wildfly-common ≤ 1.5.4.Final` gets flagged for "an XXE (Xml eXternal Entity) injection flaw in javax.xml.parsers.DocumentBuilderFactory and javax.xml.stream.XMLInputFactory". Can't find a CVE for the finding and saw previous discussions on this possibly being a false positive.

## After this PR

Let's update to avoid the finding. All of our internal servers already get a `1.6.0.Final` constraint from our server framework but I saw two dependency bundles that consume conjure-java and get flagged for this.

==COMMIT_MSG==
Update wildfly to 1.6.0.Final
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

