### PR TITLE
Remove unused jaxrs dependency from conjure-lib

### DIFF
--- a/changelog/@unreleased/pr-1949.v2.yml
+++ b/changelog/@unreleased/pr-1949.v2.yml
@@ -1,0 +1,5 @@
+type: break
+break:
+  description: Remove unused jaxrs dependency from conjure-lib
+  links:
+  - https://github.com/palantir/conjure-java/pull/1949

--- a/conjure-lib/build.gradle
+++ b/conjure-lib/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     api 'com.palantir.tokens:auth-tokens'
     api 'com.palantir.conjure.java.api:errors'
     api 'javax.annotation:javax.annotation-api'
-    api 'javax.ws.rs:javax.ws.rs-api'
     api 'com.google.errorprone:error_prone_annotations'
 
     testImplementation 'org.assertj:assertj-core'

--- a/gradle/verifier.gradle
+++ b/gradle/verifier.gradle
@@ -33,6 +33,7 @@ conjure {
 subprojects {
     dependencies {
         api project(':conjure-lib')
+        api 'jakarta.ws.rs:jakarta.ws.rs-api'
     }
 }
 


### PR DESCRIPTION
==COMMIT_MSG==
Remove unused jaxrs dependency from conjure-lib
==COMMIT_MSG==

## Possible downsides?
This has the potential to break consumers who depend on javax.ws.rs-api without declaring their own dependency, however jersey and feign support have been deprecated for several years at this point, so upgrades should be safe.


