### PR TITLE
Distinguish error logging between thrown Errors and ServiceExceptions

### DIFF
--- a/changelog/@unreleased/pr-1955.v2.yml
+++ b/changelog/@unreleased/pr-1955.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Distinguish error logging between thrown Errors and ServiceExceptions
+  links:
+  - https://github.com/palantir/conjure-java/pull/1955

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
@@ -176,7 +176,7 @@ public enum ConjureExceptions implements ExceptionHandler {
     private static void error(HttpServerExchange exchange, Error error) {
         // log errors in order to associate the log line with the correct traceId but
         // avoid doing work beyond setting a 500 response code, no response body is sent.
-        log.error("Error handling request", error);
+        log.error("Error thrown while handling request", error);
         // The writeResponse method terminates responses if data has already been sent to clients
         // do not interpret partial data as a full response.
         writeResponse(exchange, Optional.empty(), ErrorType.INTERNAL.httpErrorCode());
@@ -220,13 +220,13 @@ public enum ConjureExceptions implements ExceptionHandler {
     private static void log(ServiceException serviceException, Throwable exceptionForLogging) {
         if (serviceException.getErrorType().httpErrorCode() / 100 == 4 /* client error */) {
             log.info(
-                    "Error handling request",
+                    "ServiceException thrown while handling request",
                     SafeArg.of("errorInstanceId", serviceException.getErrorInstanceId()),
                     SafeArg.of("errorName", serviceException.getErrorType().name()),
                     exceptionForLogging);
         } else {
             log.error(
-                    "Error handling request",
+                    "ServiceException thrown while handling request",
                     SafeArg.of("errorInstanceId", serviceException.getErrorInstanceId()),
                     SafeArg.of("errorName", serviceException.getErrorType().name()),
                     exceptionForLogging);


### PR DESCRIPTION
## Before this PR
When seeing "Error handling request" in logs, it is difficult to distinguish if the problem is a thrown Error or a thrown ServiceException.

## After this PR
==COMMIT_MSG==
Distinguish error logging between thrown Errors and ServiceExceptions
==COMMIT_MSG==

In general, log messages from a class should be unique, so that someone seeing the message and comparing with source code can uniquely identify the location of the log.