### PR TITLE
Require non-null elements in collection body params

### DIFF
--- a/changelog/@unreleased/pr-1970.v2.yml
+++ b/changelog/@unreleased/pr-1970.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Services generated using `conjure-undertow-annotations` no longer allow
+    null elements in top-level collection body parameters.
+  links:
+  - https://github.com/palantir/conjure-java/pull/1970

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/DefaultClassNameVisitor.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/DefaultClassNameVisitor.java
@@ -35,6 +35,8 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import java.nio.ByteBuffer;
 import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
@@ -58,13 +60,19 @@ public final class DefaultClassNameVisitor implements ClassNameVisitor {
     @Override
     public TypeName visitList(ListType type) {
         TypeName itemType = Primitives.box(type.getItemType().accept(this));
-        return ParameterizedTypeName.get(ClassName.get(java.util.List.class), itemType);
+        return ParameterizedTypeName.get(ClassName.get(List.class), itemType);
+    }
+
+    @Override
+    public TypeName visitSet(SetType type) {
+        TypeName itemType = Primitives.box(type.getItemType().accept(this));
+        return ParameterizedTypeName.get(ClassName.get(Set.class), itemType);
     }
 
     @Override
     public TypeName visitMap(MapType type) {
         return ParameterizedTypeName.get(
-                ClassName.get(java.util.Map.class),
+                ClassName.get(Map.class),
                 Primitives.box(type.getKeyType().accept(this)),
                 Primitives.box(type.getValueType().accept(this)));
     }
@@ -153,12 +161,6 @@ public final class DefaultClassNameVisitor implements ClassNameVisitor {
         ClassName typeName = ClassName.get(
                 conjurePackage, externalType.getExternalReference().getName());
         return Primitives.isBoxedPrimitive(typeName) ? Primitives.unbox(typeName) : typeName;
-    }
-
-    @Override
-    public TypeName visitSet(SetType type) {
-        TypeName itemType = Primitives.box(type.getItemType().accept(this));
-        return ParameterizedTypeName.get(ClassName.get(Set.class), itemType);
     }
 
     @Override

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
@@ -64,6 +64,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.processing.Generated;
 import javax.lang.model.element.Modifier;
 import org.immutables.value.Value;
@@ -179,8 +180,9 @@ public final class ConjureUndertowEndpointsGenerator {
                     CodeBlock deserializerFactory,
                     String deserializerFieldName,
                     SafeLoggingAnnotation safeLoggable) {
-                TypeName requestBodyType =
-                        def.argType().match(ArgTypeTypeName.INSTANCE).box();
+                TypeName requestBodyType = immutableCollection(
+                        def.argType().match(ArgTypeTypeName.INSTANCE).box());
+
                 additionalFields.add(ImmutableAdditionalField.builder()
                         .field(FieldSpec.builder(
                                         ParameterizedTypeName.get(ClassName.get(Deserializer.class), requestBodyType),
@@ -753,6 +755,26 @@ public final class ConjureUndertowEndpointsGenerator {
             default:
                 throw new SafeIllegalStateException("Illegal value", SafeArg.of("value", safeLoggable));
         }
+    }
+
+    private static final ClassName LIST_NAME = ClassName.get(List.class);
+    private static final ClassName IMMUTABLE_LIST_NAME = ClassName.get(ImmutableList.class);
+    private static final ClassName SET_NAME = ClassName.get(Set.class);
+    private static final ClassName IMMUTABLE_SET_NAME = ClassName.get(ImmutableSet.class);
+
+    private static TypeName immutableCollection(TypeName input) {
+        if (input instanceof ParameterizedTypeName) {
+            ParameterizedTypeName parameterized = (ParameterizedTypeName) input;
+            if (LIST_NAME.equals(parameterized.rawType)) {
+                return ParameterizedTypeName.get(
+                        IMMUTABLE_LIST_NAME, parameterized.typeArguments.toArray(new TypeName[0]));
+            } else if (SET_NAME.equals(parameterized.rawType)) {
+                return ParameterizedTypeName.get(
+                        IMMUTABLE_SET_NAME, parameterized.typeArguments.toArray(new TypeName[0]));
+            }
+        }
+
+        return input;
     }
 
     @Value.Immutable

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
@@ -17,7 +17,15 @@
 package com.palantir.conjure.java.undertow.processor.generate;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.SetMultimap;
 import com.palantir.conjure.java.undertow.annotations.BearerTokenCookieDeserializer;
 import com.palantir.conjure.java.undertow.annotations.CookieDeserializer;
 import com.palantir.conjure.java.undertow.annotations.FormParamDeserializer;
@@ -61,7 +69,9 @@ import io.undertow.util.Methods;
 import io.undertow.util.StatusCodes;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -757,20 +767,25 @@ public final class ConjureUndertowEndpointsGenerator {
         }
     }
 
-    private static final ClassName LIST_NAME = ClassName.get(List.class);
-    private static final ClassName IMMUTABLE_LIST_NAME = ClassName.get(ImmutableList.class);
-    private static final ClassName SET_NAME = ClassName.get(Set.class);
-    private static final ClassName IMMUTABLE_SET_NAME = ClassName.get(ImmutableSet.class);
+    private static final Map<ClassName, Class<?>> COLLECTION_CLASSES = ImmutableMap.<ClassName, Class<?>>builder()
+            .put(ClassName.get(Collection.class), ImmutableList.class)
+            .put(ClassName.get(List.class), ImmutableList.class)
+            .put(ClassName.get(Set.class), ImmutableSet.class)
+            .put(ClassName.get(Map.class), ImmutableMap.class)
+            .put(ClassName.get(Multiset.class), ImmutableMultiset.class)
+            .put(ClassName.get(Multimap.class), ImmutableListMultimap.class)
+            .put(ClassName.get(ListMultimap.class), ImmutableListMultimap.class)
+            .put(ClassName.get(SetMultimap.class), ImmutableSetMultimap.class)
+            .buildOrThrow();
 
     private static TypeName immutableCollection(TypeName input) {
         if (input instanceof ParameterizedTypeName) {
             ParameterizedTypeName parameterized = (ParameterizedTypeName) input;
-            if (LIST_NAME.equals(parameterized.rawType)) {
+
+            Class<?> collectionClass = COLLECTION_CLASSES.get(parameterized.rawType);
+            if (collectionClass != null) {
                 return ParameterizedTypeName.get(
-                        IMMUTABLE_LIST_NAME, parameterized.typeArguments.toArray(new TypeName[0]));
-            } else if (SET_NAME.equals(parameterized.rawType)) {
-                return ParameterizedTypeName.get(
-                        IMMUTABLE_SET_NAME, parameterized.typeArguments.toArray(new TypeName[0]));
+                        ClassName.get(collectionClass), parameterized.typeArguments.toArray(new TypeName[0]));
             }
         }
 

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
@@ -25,6 +25,7 @@ import com.google.common.io.ByteStreams;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.Compiler;
 import com.google.testing.compile.JavaFileObjects;
+import com.palantir.conjure.java.undertow.processor.sample.CollectionBodyParam;
 import com.palantir.conjure.java.undertow.processor.sample.CookieParams;
 import com.palantir.conjure.java.undertow.processor.sample.DefaultDecoderService;
 import com.palantir.conjure.java.undertow.processor.sample.DeprecatedEndpointResource;
@@ -82,6 +83,11 @@ public class ConjureUndertowAnnotationProcessorTest {
     @Test
     public void testPrimitiveBodyParam() {
         assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, PrimitiveBodyParam.class);
+    }
+
+    @Test
+    public void testCollectionBodyParam() {
+        assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, CollectionBodyParam.class);
     }
 
     @Test

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/CollectionBodyParam.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/CollectionBodyParam.java
@@ -16,16 +16,40 @@
 
 package com.palantir.conjure.java.undertow.processor.sample;
 
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.SetMultimap;
 import com.palantir.conjure.java.undertow.annotations.Handle;
 import com.palantir.conjure.java.undertow.annotations.HttpMethod;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public interface CollectionBodyParam {
+
+    @Handle(method = HttpMethod.POST, path = "/collection")
+    void collection(@Handle.Body Collection<String> values);
 
     @Handle(method = HttpMethod.POST, path = "/list")
     void list(@Handle.Body List<String> values);
 
     @Handle(method = HttpMethod.POST, path = "/set")
     void set(@Handle.Body Set<String> values);
+
+    @Handle(method = HttpMethod.POST, path = "/map")
+    void map(@Handle.Body Map<String, String> values);
+
+    @Handle(method = HttpMethod.POST, path = "/multiset")
+    void multiset(@Handle.Body Multiset<String> values);
+
+    @Handle(method = HttpMethod.POST, path = "/multimap")
+    void multimap(@Handle.Body Multimap<String, String> values);
+
+    @Handle(method = HttpMethod.POST, path = "/listMultimap")
+    void listMultimap(@Handle.Body ListMultimap<String, String> values);
+
+    @Handle(method = HttpMethod.POST, path = "/setMultimap")
+    void setMultimap(@Handle.Body SetMultimap<String, String> values);
 }

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/CollectionBodyParam.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/CollectionBodyParam.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,18 @@
  * limitations under the License.
  */
 
-apply plugin: 'com.palantir.external-publish-jar'
+package com.palantir.conjure.java.undertow.processor.sample;
 
-dependencies {
-    api project(':conjure-lib')
-    // Generated code depends on Undertow APIs
-    api 'io.undertow:undertow-core'
-    // Generated code depends on ListenableFuture and immutable collections
-    api 'com.google.guava:guava'
-    // Recommend a higher version of wildfly (1.6.0.Final+) then the one shipped with undertow to avoid CVEs.
-    runtimeOnly 'org.wildfly.common:wildfly-common'
+import com.palantir.conjure.java.undertow.annotations.Handle;
+import com.palantir.conjure.java.undertow.annotations.HttpMethod;
+import java.util.List;
+import java.util.Set;
+
+public interface CollectionBodyParam {
+
+    @Handle(method = HttpMethod.POST, path = "/list")
+    void list(@Handle.Body List<String> values);
+
+    @Handle(method = HttpMethod.POST, path = "/set")
+    void set(@Handle.Body Set<String> values);
 }

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/CollectionBodyParamEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/CollectionBodyParamEndpoints.java.generated
@@ -1,0 +1,132 @@
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.conjure.java.undertow.annotations.DefaultSerDe;
+import com.palantir.conjure.java.undertow.lib.Deserializer;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import io.undertow.util.StatusCodes;
+import java.lang.Exception;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.undertow.processor.generate.ConjureUndertowEndpointsGenerator")
+public final class CollectionBodyParamEndpoints implements UndertowService {
+    private final CollectionBodyParam delegate;
+
+    private CollectionBodyParamEndpoints(CollectionBodyParam delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(CollectionBodyParam delegate) {
+        return new CollectionBodyParamEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return ImmutableList.of(new ListEndpoint(runtime, delegate), new SetEndpoint(runtime, delegate));
+    }
+
+    private static final class ListEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final CollectionBodyParam delegate;
+
+        private final Deserializer<ImmutableList<String>> valuesDeserializer;
+
+        ListEndpoint(UndertowRuntime runtime, CollectionBodyParam delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.valuesDeserializer =
+                    DefaultSerDe.INSTANCE.deserializer(new TypeMarker<ImmutableList<String>>() {}, runtime, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            ImmutableList<String> values = valuesDeserializer.deserialize(exchange);
+            this.delegate.list(values);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/list";
+        }
+
+        @Override
+        public String serviceName() {
+            return "CollectionBodyParam";
+        }
+
+        @Override
+        public String name() {
+            return "list";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class SetEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final CollectionBodyParam delegate;
+
+        private final Deserializer<ImmutableSet<String>> valuesDeserializer;
+
+        SetEndpoint(UndertowRuntime runtime, CollectionBodyParam delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.valuesDeserializer =
+                    DefaultSerDe.INSTANCE.deserializer(new TypeMarker<ImmutableSet<String>>() {}, runtime, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            ImmutableSet<String> values = valuesDeserializer.deserialize(exchange);
+            this.delegate.set(values);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/set";
+        }
+
+        @Override
+        public String serviceName() {
+            return "CollectionBodyParam";
+        }
+
+        @Override
+        public String name() {
+            return "set";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/CollectionBodyParamEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/CollectionBodyParamEndpoints.java.generated
@@ -1,7 +1,11 @@
 package com.palantir.conjure.java.undertow.processor.sample;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
 import com.palantir.conjure.java.undertow.annotations.DefaultSerDe;
 import com.palantir.conjure.java.undertow.lib.Deserializer;
 import com.palantir.conjure.java.undertow.lib.Endpoint;
@@ -33,7 +37,62 @@ public final class CollectionBodyParamEndpoints implements UndertowService {
 
     @Override
     public List<Endpoint> endpoints(UndertowRuntime runtime) {
-        return ImmutableList.of(new ListEndpoint(runtime, delegate), new SetEndpoint(runtime, delegate));
+        return ImmutableList.of(
+                new CollectionEndpoint(runtime, delegate),
+                new ListEndpoint(runtime, delegate),
+                new SetEndpoint(runtime, delegate),
+                new MapEndpoint(runtime, delegate),
+                new MultisetEndpoint(runtime, delegate),
+                new MultimapEndpoint(runtime, delegate),
+                new ListMultimapEndpoint(runtime, delegate),
+                new SetMultimapEndpoint(runtime, delegate));
+    }
+
+    private static final class CollectionEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final CollectionBodyParam delegate;
+
+        private final Deserializer<ImmutableList<String>> valuesDeserializer;
+
+        CollectionEndpoint(UndertowRuntime runtime, CollectionBodyParam delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.valuesDeserializer =
+                    DefaultSerDe.INSTANCE.deserializer(new TypeMarker<ImmutableList<String>>() {}, runtime, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            ImmutableList<String> values = valuesDeserializer.deserialize(exchange);
+            this.delegate.collection(values);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/collection";
+        }
+
+        @Override
+        public String serviceName() {
+            return "CollectionBodyParam";
+        }
+
+        @Override
+        public String name() {
+            return "collection";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
     }
 
     private static final class ListEndpoint implements HttpHandler, Endpoint {
@@ -122,6 +181,241 @@ public final class CollectionBodyParamEndpoints implements UndertowService {
         @Override
         public String name() {
             return "set";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class MapEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final CollectionBodyParam delegate;
+
+        private final Deserializer<ImmutableMap<String, String>> valuesDeserializer;
+
+        MapEndpoint(UndertowRuntime runtime, CollectionBodyParam delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.valuesDeserializer = DefaultSerDe.INSTANCE.deserializer(
+                    new TypeMarker<ImmutableMap<String, String>>() {}, runtime, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            ImmutableMap<String, String> values = valuesDeserializer.deserialize(exchange);
+            this.delegate.map(values);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/map";
+        }
+
+        @Override
+        public String serviceName() {
+            return "CollectionBodyParam";
+        }
+
+        @Override
+        public String name() {
+            return "map";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class MultisetEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final CollectionBodyParam delegate;
+
+        private final Deserializer<ImmutableMultiset<String>> valuesDeserializer;
+
+        MultisetEndpoint(UndertowRuntime runtime, CollectionBodyParam delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.valuesDeserializer =
+                    DefaultSerDe.INSTANCE.deserializer(new TypeMarker<ImmutableMultiset<String>>() {}, runtime, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            ImmutableMultiset<String> values = valuesDeserializer.deserialize(exchange);
+            this.delegate.multiset(values);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/multiset";
+        }
+
+        @Override
+        public String serviceName() {
+            return "CollectionBodyParam";
+        }
+
+        @Override
+        public String name() {
+            return "multiset";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class MultimapEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final CollectionBodyParam delegate;
+
+        private final Deserializer<ImmutableListMultimap<String, String>> valuesDeserializer;
+
+        MultimapEndpoint(UndertowRuntime runtime, CollectionBodyParam delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.valuesDeserializer = DefaultSerDe.INSTANCE.deserializer(
+                    new TypeMarker<ImmutableListMultimap<String, String>>() {}, runtime, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            ImmutableListMultimap<String, String> values = valuesDeserializer.deserialize(exchange);
+            this.delegate.multimap(values);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/multimap";
+        }
+
+        @Override
+        public String serviceName() {
+            return "CollectionBodyParam";
+        }
+
+        @Override
+        public String name() {
+            return "multimap";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class ListMultimapEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final CollectionBodyParam delegate;
+
+        private final Deserializer<ImmutableListMultimap<String, String>> valuesDeserializer;
+
+        ListMultimapEndpoint(UndertowRuntime runtime, CollectionBodyParam delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.valuesDeserializer = DefaultSerDe.INSTANCE.deserializer(
+                    new TypeMarker<ImmutableListMultimap<String, String>>() {}, runtime, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            ImmutableListMultimap<String, String> values = valuesDeserializer.deserialize(exchange);
+            this.delegate.listMultimap(values);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/listMultimap";
+        }
+
+        @Override
+        public String serviceName() {
+            return "CollectionBodyParam";
+        }
+
+        @Override
+        public String name() {
+            return "listMultimap";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class SetMultimapEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final CollectionBodyParam delegate;
+
+        private final Deserializer<ImmutableSetMultimap<String, String>> valuesDeserializer;
+
+        SetMultimapEndpoint(UndertowRuntime runtime, CollectionBodyParam delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.valuesDeserializer = DefaultSerDe.INSTANCE.deserializer(
+                    new TypeMarker<ImmutableSetMultimap<String, String>>() {}, runtime, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            ImmutableSetMultimap<String, String> values = valuesDeserializer.deserialize(exchange);
+            this.delegate.setMultimap(values);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/setMultimap";
+        }
+
+        @Override
+        public String serviceName() {
+            return "CollectionBodyParam";
+        }
+
+        @Override
+        public String name() {
+            return "setMultimap";
         }
 
         @Override


### PR DESCRIPTION
## Before this PR

Services generated using `conjure-undertow-annotations` allow null elements in top-level collection body parameters.

## After this PR

Services generated using `conjure-undertow-annotations` do not allow null elements in top-level collection body parameters.

This is similar to https://github.com/palantir/conjure-java/pull/1051, but for `conjure-undertow-annotations`.

Unlike the `nonNullCollections` flag, this behavior is not configurable. This matches the behavior of the built-in collection deserializers for query/header params, which do not allow null elements. If users want nullable elements, they should use `Optional`.

Unlike https://github.com/palantir/conjure-java/pull/1051, this should be safe to apply by default because it does not affect clients of the API, only servers.

## Possible downsides?

We may break services that were allowing requests with null elements. However it is very likely that the authors did not intended to allow null elements. Allowing null elements can results in data correctness issues in the future if the services do not perform their own validation. It is better to fail loudly in these cases than to silently allow bad input.