### PR TITLE
Fix alias-of-optional codegen with safety info

### DIFF
--- a/changelog/@unreleased/pr-1974.v2.yml
+++ b/changelog/@unreleased/pr-1974.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix alias-of-optional codegen with safety info
+  links:
+  - https://github.com/palantir/conjure-java/pull/1974

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalDoubleAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalDoubleAlias.java
@@ -1,0 +1,57 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Unsafe;
+import java.util.OptionalDouble;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@Unsafe
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class OptionalDoubleAlias {
+    private static final OptionalDoubleAlias EMPTY = new OptionalDoubleAlias();
+
+    private final @Unsafe OptionalDouble value;
+
+    private OptionalDoubleAlias(@Nonnull @Unsafe OptionalDouble value) {
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
+    }
+
+    private OptionalDoubleAlias() {
+        this(OptionalDouble.empty());
+    }
+
+    @JsonValue
+    public @Unsafe OptionalDouble get() {
+        return value;
+    }
+
+    @Override
+    @Unsafe
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other
+                || (other instanceof OptionalDoubleAlias && this.value.equals(((OptionalDoubleAlias) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static OptionalDoubleAlias of(@Nonnull @Unsafe OptionalDouble value) {
+        return new OptionalDoubleAlias(value);
+    }
+
+    public static OptionalDoubleAlias empty() {
+        return EMPTY;
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalDoubleAlias.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalDoubleAlias.java
@@ -1,0 +1,57 @@
+package test.prefix.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Unsafe;
+import java.util.OptionalDouble;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@Unsafe
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class OptionalDoubleAlias {
+    private static final OptionalDoubleAlias EMPTY = new OptionalDoubleAlias();
+
+    private final @Unsafe OptionalDouble value;
+
+    private OptionalDoubleAlias(@Nonnull @Unsafe OptionalDouble value) {
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
+    }
+
+    private OptionalDoubleAlias() {
+        this(OptionalDouble.empty());
+    }
+
+    @JsonValue
+    public @Unsafe OptionalDouble get() {
+        return value;
+    }
+
+    @Override
+    @Unsafe
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other
+                || (other instanceof OptionalDoubleAlias && this.value.equals(((OptionalDoubleAlias) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static OptionalDoubleAlias of(@Nonnull @Unsafe OptionalDouble value) {
+        return new OptionalDoubleAlias(value);
+    }
+
+    public static OptionalDoubleAlias empty() {
+        return EMPTY;
+    }
+}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -266,7 +266,9 @@ public final class AliasGenerator {
                     .addModifiers(Modifier.PRIVATE)
                     .addStatement(
                             "this($T.empty())",
-                            aliasTypeName instanceof ParameterizedTypeName ? Optional.class : aliasTypeName)
+                            aliasTypeName instanceof ParameterizedTypeName
+                                    ? Optional.class
+                                    : aliasTypeName.withoutAnnotations())
                     .build());
         }
 

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -63,6 +63,9 @@ types:
       OptionalAliasExample:
         fields:
           optionalAlias: OptionalAlias
+      OptionalDoubleAlias:
+        alias: optional<double>
+        safety: unsafe
       ListExample:
         fields:
           items: 


### PR DESCRIPTION
## Before this PR
Previously aliases such as the newly added test:
```yaml
alias: optional<double>
safety:unsafe
```

Failed to compile with:
```
<identifier> expected
        this(java.util. @Unsafe OptionalDouble.empty());
```

## After this PR
==COMMIT_MSG==
Fix alias-of-optional codegen with safety info
==COMMIT_MSG==

## Possible downsides?
none

