### PR TITLE
idea - do not merge: Refactoring `BeanGenerator` and `BeanBuilderGenerator`

### DIFF
--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -115,6 +115,19 @@ public final class BeanBuilderGenerator {
         this.options = options;
     }
 
+    public static void addBuilder(
+            TypeSpec.Builder spec,
+            TypeMapper typeMapper,
+            SafetyEvaluator safetyEvaluator,
+            ClassName objectClass,
+            ClassName builderClass,
+            ObjectDefinition typeDef,
+            Map<com.palantir.conjure.spec.TypeName, TypeDefinition> typesMap,
+            Options options,
+            Optional<ClassName> builderInterfaceClass) {
+        return;
+    }
+
     public static TypeSpec generate(
             TypeMapper typeMapper,
             SafetyEvaluator safetyEvaluator,


### PR DESCRIPTION
## High level ideas
- `BeanGenerator::generateBeanType` is a long, and complex method
  - I think we can have a simpler method by delegating some of the logic to helper methods, and other modules 
- There exists `BeanBuilderGenerator` containing some methods used to generate builders, but still much of the staged builder generation logic is in `BeanGenerator`.
  - Staged builders are a specific type of builder, and I think we should move the stage builder generation logic into `BeanBuilderGenerator` or create a new file `BeanStagedBuilderGenerator`


