### PR TITLE
Methods in staged builder interfaces are ordered deterministically

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
@@ -160,9 +160,9 @@ public final class MultipleOrderedStages {
     }
 
     public interface TokenStageBuilder {
-        Builder from(MultipleOrderedStages other);
-
         ItemStageBuilder token(@Nonnull OneField token);
+
+        Builder from(MultipleOrderedStages other);
     }
 
     public interface ItemStageBuilder {
@@ -199,10 +199,10 @@ public final class MultipleOrderedStages {
 
     public interface Builder extends TokenStageBuilder, ItemStageBuilder, Completed_StageBuilder {
         @Override
-        Builder from(MultipleOrderedStages other);
+        Builder token(@Nonnull OneField token);
 
         @Override
-        Builder token(@Nonnull OneField token);
+        Builder from(MultipleOrderedStages other);
 
         @Override
         Builder item(@Nonnull String item);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
@@ -160,9 +160,9 @@ public final class MultipleOrderedStages {
     }
 
     public interface TokenStageBuilder {
-        ItemStageBuilder token(@Nonnull OneField token);
-
         Builder from(MultipleOrderedStages other);
+
+        ItemStageBuilder token(@Nonnull OneField token);
     }
 
     public interface ItemStageBuilder {
@@ -199,10 +199,22 @@ public final class MultipleOrderedStages {
 
     public interface Builder extends TokenStageBuilder, ItemStageBuilder, Completed_StageBuilder {
         @Override
+        Builder from(MultipleOrderedStages other);
+
+        @Override
+        Builder token(@Nonnull OneField token);
+
+        @Override
+        Builder item(@Nonnull String item);
+
+        @Override
         MultipleOrderedStages build();
 
         @Override
         Builder items(@Nonnull Iterable<SafeLong> items);
+
+        @Override
+        Builder addAllItems(@Nonnull Iterable<SafeLong> items);
 
         @Override
         Builder items(SafeLong items);
@@ -211,13 +223,10 @@ public final class MultipleOrderedStages {
         Builder mappedRids(@Nonnull Map<ResourceIdentifier, String> mappedRids);
 
         @Override
-        Builder from(MultipleOrderedStages other);
-
-        @Override
-        Builder addAllItems(@Nonnull Iterable<SafeLong> items);
-
-        @Override
         Builder putAllMappedRids(@Nonnull Map<ResourceIdentifier, String> mappedRids);
+
+        @Override
+        Builder mappedRids(ResourceIdentifier key, String value);
 
         /**
          * @deprecated this optional is deprecated
@@ -225,15 +234,6 @@ public final class MultipleOrderedStages {
         @Deprecated
         @Override
         Builder optionalItem(@Nonnull Optional<OneField> optionalItem);
-
-        @Override
-        Builder token(@Nonnull OneField token);
-
-        @Override
-        Builder mappedRids(ResourceIdentifier key, String value);
-
-        @Override
-        Builder item(@Nonnull String item);
 
         /**
          * @deprecated this optional is deprecated

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OneField.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OneField.java
@@ -80,9 +80,9 @@ public final class OneField {
     }
 
     public interface BearerTokenValueStageBuilder {
-        Builder from(OneField other);
-
         Completed_StageBuilder bearerTokenValue(@Nonnull BearerToken bearerTokenValue);
+
+        Builder from(OneField other);
     }
 
     public interface Completed_StageBuilder {
@@ -91,10 +91,10 @@ public final class OneField {
 
     public interface Builder extends BearerTokenValueStageBuilder, Completed_StageBuilder {
         @Override
-        Builder from(OneField other);
+        Builder bearerTokenValue(@Nonnull BearerToken bearerTokenValue);
 
         @Override
-        Builder bearerTokenValue(@Nonnull BearerToken bearerTokenValue);
+        Builder from(OneField other);
 
         @Override
         OneField build();

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OneField.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OneField.java
@@ -80,9 +80,9 @@ public final class OneField {
     }
 
     public interface BearerTokenValueStageBuilder {
-        Completed_StageBuilder bearerTokenValue(@Nonnull BearerToken bearerTokenValue);
-
         Builder from(OneField other);
+
+        Completed_StageBuilder bearerTokenValue(@Nonnull BearerToken bearerTokenValue);
     }
 
     public interface Completed_StageBuilder {
@@ -91,10 +91,10 @@ public final class OneField {
 
     public interface Builder extends BearerTokenValueStageBuilder, Completed_StageBuilder {
         @Override
-        Builder bearerTokenValue(@Nonnull BearerToken bearerTokenValue);
+        Builder from(OneField other);
 
         @Override
-        Builder from(OneField other);
+        Builder bearerTokenValue(@Nonnull BearerToken bearerTokenValue);
 
         @Override
         OneField build();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.PeekingIterator;
 import com.palantir.conjure.CaseConverter;
 import com.palantir.conjure.java.ConjureAnnotations;
 import com.palantir.conjure.java.Options;
@@ -272,28 +274,21 @@ public final class BeanGenerator {
             SafetyEvaluator safetyEvaluator) {
         List<TypeSpec.Builder> interfaces = new ArrayList<>();
 
-        List<EnrichedField> fields =
-                sortedEnrichedFields(fieldsNeedingBuilderStage).collect(Collectors.toList());
-        for (int i = 0; i < fields.size(); i++) {
-            EnrichedField field = fields.get(i);
-            String nextBuilderStageName = i < fields.size() - 1
-                    ? JavaNameSanitizer.sanitize(fields.get(i + 1).fieldName())
+        PeekingIterator<EnrichedField> fieldPeekingIterator = Iterators.peekingIterator(
+                sortedEnrichedFields(fieldsNeedingBuilderStage).iterator());
+
+        while (fieldPeekingIterator.hasNext()) {
+            EnrichedField field = fieldPeekingIterator.next();
+            String nextBuilderStageName = fieldPeekingIterator.hasNext()
+                    ? JavaNameSanitizer.sanitize(fieldPeekingIterator.peek().fieldName())
                     : "completed_";
 
             ClassName nextStageClassName = stageBuilderInterfaceName(objectClass, nextBuilderStageName);
 
-            TypeSpec.Builder interfaceBuilder = TypeSpec.interfaceBuilder(
+            interfaces.add(TypeSpec.interfaceBuilder(
                             stageBuilderInterfaceName(objectClass, JavaNameSanitizer.sanitize(field.fieldName())))
-                    .addModifiers(Modifier.PUBLIC);
-            if (i == 0) {
-                interfaceBuilder.addMethod(MethodSpec.methodBuilder("from")
-                        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-                        .returns(builderClass)
-                        .addParameter(objectClass, "other")
-                        .build());
-            }
-            interfaces.add(
-                    interfaceBuilder.addMethod(MethodSpec.methodBuilder(JavaNameSanitizer.sanitize(field.fieldName()))
+                    .addModifiers(Modifier.PUBLIC)
+                    .addMethod(MethodSpec.methodBuilder(JavaNameSanitizer.sanitize(field.fieldName()))
                             .addParameter(ParameterSpec.builder(
                                             field.poetSpec().type, JavaNameSanitizer.sanitize(field.fieldName()))
                                     .addAnnotation(Nonnull.class)
@@ -319,6 +314,15 @@ public final class BeanGenerator {
                 .collect(Collectors.toList()));
 
         interfaces.add(completedStage);
+
+        interfaces
+                .get(0)
+                .addMethod(MethodSpec.methodBuilder("from")
+                        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                        .returns(builderClass)
+                        .addParameter(objectClass, "other")
+                        .build());
+
         return interfaces.stream().map(TypeSpec.Builder::build).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## Before this PR
Methods to be added to a staged builder interface were collected in a set. There are no guarantees on order when iterating a set. This could lead to different code being generated for the same definitions.

## After this PR
==COMMIT_MSG==
Collect methods to be added to a staged builder interface in a list
==COMMIT_MSG==
