### PR TITLE
Methods in staged builder interfaces are ordered deterministically

### DIFF
--- a/changelog/@unreleased/pr-1979.v2.yml
+++ b/changelog/@unreleased/pr-1979.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Collect methods to be added to a staged builder interface in a list
+  links:
+  - https://github.com/palantir/conjure-java/pull/1979

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleOrderedStages.java
@@ -199,10 +199,22 @@ public final class MultipleOrderedStages {
 
     public interface Builder extends TokenStageBuilder, ItemStageBuilder, Completed_StageBuilder {
         @Override
+        Builder token(@Nonnull OneField token);
+
+        @Override
+        Builder from(MultipleOrderedStages other);
+
+        @Override
+        Builder item(@Nonnull String item);
+
+        @Override
         MultipleOrderedStages build();
 
         @Override
         Builder items(@Nonnull Iterable<SafeLong> items);
+
+        @Override
+        Builder addAllItems(@Nonnull Iterable<SafeLong> items);
 
         @Override
         Builder items(SafeLong items);
@@ -211,13 +223,10 @@ public final class MultipleOrderedStages {
         Builder mappedRids(@Nonnull Map<ResourceIdentifier, String> mappedRids);
 
         @Override
-        Builder from(MultipleOrderedStages other);
-
-        @Override
-        Builder addAllItems(@Nonnull Iterable<SafeLong> items);
-
-        @Override
         Builder putAllMappedRids(@Nonnull Map<ResourceIdentifier, String> mappedRids);
+
+        @Override
+        Builder mappedRids(ResourceIdentifier key, String value);
 
         /**
          * @deprecated this optional is deprecated
@@ -225,15 +234,6 @@ public final class MultipleOrderedStages {
         @Deprecated
         @Override
         Builder optionalItem(@Nonnull Optional<OneField> optionalItem);
-
-        @Override
-        Builder token(@Nonnull OneField token);
-
-        @Override
-        Builder mappedRids(ResourceIdentifier key, String value);
-
-        @Override
-        Builder item(@Nonnull String item);
 
         /**
          * @deprecated this optional is deprecated

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -207,7 +207,7 @@ public final class BeanGenerator {
                                                                 objectClass.simpleName(),
                                                                 "Builder"))
                                         .build())
-                                .collect(Collectors.toSet()))
+                                .collect(Collectors.toList()))
                         .addSuperinterfaces(interfacesAsClasses.stream()
                                 .map(Primitives::box)
                                 .collect(Collectors.toList()))


### PR DESCRIPTION
## Before this PR
Methods to be added to a staged builder interface were collected in a set. JavaPoet emits method definitions in the order in which they are added in `addMethod(s)` calls. Sets are not ordered collections, and don't have guarantees of deterministic ordering when iterated over. This could lead to different code being generated for the same definitions.

## After this PR
==COMMIT_MSG==
Collect methods to be added to a staged builder interface in a list
==COMMIT_MSG==
