### PR TITLE
Refactor `BeanBuilderGenerator` to handle all builder generation logic

### DIFF
--- a/changelog/@unreleased/pr-1980.v2.yml
+++ b/changelog/@unreleased/pr-1980.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Refactor BeanBuilderGenerator to handle all builder generation logic
+  links:
+  - https://github.com/palantir/conjure-java/pull/1980

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -102,7 +102,9 @@ public final class BeanBuilderGenerator {
     private static final String BUILT_FIELD = "_buildInvoked";
     private static final String CHECK_NOT_BUILT_METHOD = "checkNotBuilt";
     private static final String BUILDER_IMPLEMENTATION_NAME = "Builder";
+    /* The name of the interface extending all stage interfaces. */
     private static final String STAGED_BUILDER_INTERFACE_NAME = "Builder";
+    /* The name of the class implementing the interface extending all stage interfaces. */
     private static final String STAGED_BUILDER_IMPLEMENTATION_NAME = "DefaultBuilder";
 
     private final TypeMapper typeMapper;
@@ -224,7 +226,7 @@ public final class BeanBuilderGenerator {
                 .map(Primitives::box)
                 .collect(Collectors.toList());
 
-        TypeSpec builderInterface = TypeSpec.interfaceBuilder("Builder")
+        TypeSpec builderInterface = TypeSpec.interfaceBuilder(STAGED_BUILDER_INTERFACE_NAME)
                 .addModifiers(Modifier.PUBLIC)
                 .addMethods(interfaces.stream()
                         .map(stageInterface -> stageInterface.methodSpecs)
@@ -235,7 +237,9 @@ public final class BeanBuilderGenerator {
                                         method.name.equals("build")
                                                 ? method.returnType
                                                 : ClassName.get(
-                                                        objectClass.packageName(), objectClass.simpleName(), "Builder"))
+                                                        objectClass.packageName(),
+                                                        objectClass.simpleName(),
+                                                        STAGED_BUILDER_INTERFACE_NAME))
                                 .build())
                         .collect(Collectors.toList()))
                 .addSuperinterfaces(interfaceClassNames)
@@ -247,7 +251,7 @@ public final class BeanBuilderGenerator {
                 .addMethod(MethodSpec.methodBuilder("builder")
                         .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                         .returns(interfaceClassNames.get(0))
-                        .addStatement("return new DefaultBuilder()")
+                        .addStatement(String.format("return new %s()", STAGED_BUILDER_IMPLEMENTATION_NAME))
                         .build());
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -251,7 +251,7 @@ public final class BeanBuilderGenerator {
                 .addMethod(MethodSpec.methodBuilder("builder")
                         .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                         .returns(interfaceClassNames.get(0))
-                        .addStatement(String.format("return new %s()", STAGED_BUILDER_IMPLEMENTATION_NAME))
+                        .addStatement("return new $N()", STAGED_BUILDER_IMPLEMENTATION_NAME)
                         .build());
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -206,7 +206,8 @@ public final class BeanBuilderGenerator {
             TypeSpec.Builder specBuilder,
             List<EnrichedField> allFields,
             List<EnrichedField> fieldsNeedingBuilderStage) {
-        Preconditions.checkState(!fieldsNeedingBuilderStage.isEmpty(), "TODO(pritham)");
+        Preconditions.checkState(
+                !fieldsNeedingBuilderStage.isEmpty(), "Expected at least one field needing a builder stage.");
         List<TypeSpec> interfaces = generateStageInterfaces(
                 objectClass,
                 builderClass,

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -174,7 +174,7 @@ public final class BeanBuilderGenerator {
     }
 
     private void addStagedBuilderImpl(
-            TypeSpec.Builder builder,
+            TypeSpec.Builder specBuilder,
             ObjectDefinition typeDef,
             Map<com.palantir.conjure.spec.TypeName, TypeDefinition> typesMap) {
         List<EnrichedField> allFields = enrichFields(typeDef.getFields());
@@ -182,13 +182,13 @@ public final class BeanBuilderGenerator {
                 allFields.stream().filter(f -> !fieldShouldBeInFinalStage(f)).collect(Collectors.toList());
 
         if (fieldsNeedingBuilderStage.isEmpty()) {
-            addBuilderImpl(builder, typeDef, typesMap);
+            addBuilderImpl(specBuilder, typeDef, typesMap);
             return;
         }
 
-        addJsonDeserializeUsingBuilderAnnotation(builder, STAGED_BUILDER_IMPLEMENTATION_NAME);
-        addStageInterfacesAndBuilderMethod(builder, allFields, fieldsNeedingBuilderStage);
-        builder.addType(generateBuilderImplementation(
+        addJsonDeserializeUsingBuilderAnnotation(specBuilder, STAGED_BUILDER_IMPLEMENTATION_NAME);
+        addStageInterfacesAndBuilderMethod(specBuilder, allFields, fieldsNeedingBuilderStage);
+        specBuilder.addType(generateBuilderImplementation(
                 typeDef, typesMap, STAGED_BUILDER_IMPLEMENTATION_NAME, Optional.of(STAGED_BUILDER_INTERFACE_NAME)));
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -150,6 +150,14 @@ public final class BeanBuilderGenerator {
                 .addStagedBuilderImpl(specBuilder, typeDef, typesMap);
     }
 
+    public static boolean fieldShouldBeInFinalStage(EnrichedField field) {
+        Type type = field.conjureDef().getType();
+        return type.accept(TypeVisitor.IS_LIST)
+                || type.accept(TypeVisitor.IS_SET)
+                || type.accept(TypeVisitor.IS_MAP)
+                || type.accept(TypeVisitor.IS_OPTIONAL);
+    }
+
     private void addBuilderImpl(
             TypeSpec.Builder specBuilder,
             ObjectDefinition typeDef,
@@ -192,14 +200,6 @@ public final class BeanBuilderGenerator {
                         "$T.class",
                         ClassName.get(objectClass.packageName(), objectClass.simpleName(), implementationClassName))
                 .build());
-    }
-
-    private static boolean fieldShouldBeInFinalStage(EnrichedField field) {
-        Type type = field.conjureDef().getType();
-        return type.accept(TypeVisitor.IS_LIST)
-                || type.accept(TypeVisitor.IS_SET)
-                || type.accept(TypeVisitor.IS_MAP)
-                || type.accept(TypeVisitor.IS_OPTIONAL);
     }
 
     private void addStageInterfacesAndBuilderMethod(

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -24,8 +24,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
-import com.google.common.collect.PeekingIterator;
 import com.palantir.conjure.CaseConverter;
 import com.palantir.conjure.java.ConjureAnnotations;
 import com.palantir.conjure.java.Options;
@@ -39,7 +37,6 @@ import com.palantir.conjure.java.visitor.MoreVisitors;
 import com.palantir.conjure.spec.FieldDefinition;
 import com.palantir.conjure.spec.FieldName;
 import com.palantir.conjure.spec.ListType;
-import com.palantir.conjure.spec.LogSafety;
 import com.palantir.conjure.spec.MapType;
 import com.palantir.conjure.spec.ObjectDefinition;
 import com.palantir.conjure.spec.OptionalType;
@@ -63,13 +60,10 @@ import com.squareup.javapoet.TypeSpec;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import javax.annotation.Nonnull;
 import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
 import org.immutables.value.Value;
@@ -100,10 +94,6 @@ public final class BeanGenerator {
                 Packages.getPrefixedName(typeDef.getTypeName(), options.packagePrefix());
         ClassName objectClass = ClassName.get(prefixedName.getPackage(), prefixedName.getName());
         ClassName builderClass = ClassName.get(objectClass.packageName(), objectClass.simpleName(), "Builder");
-        ClassName builderImplementation =
-                options.useStagedBuilders() && fields.stream().anyMatch(field -> !fieldShouldBeInFinalStage(field))
-                        ? ClassName.get(objectClass.packageName(), objectClass.simpleName(), "DefaultBuilder")
-                        : builderClass;
 
         // Use the fully-resolved/computed safety value for the top-level class, however
         // fields (setters/getters) are annotated with declared values because complex objects
@@ -158,13 +148,17 @@ public final class BeanGenerator {
                         .build());
             }
         } else {
+            ClassName builderImplementation = options.useStagedBuilders()
+                            && fields.stream().anyMatch(field -> !BeanBuilderGenerator.fieldShouldBeInFinalStage(field))
+                    ? ClassName.get(objectClass.packageName(), objectClass.simpleName(), "DefaultBuilder")
+                    : builderClass;
             ImmutableList<EnrichedField> fieldsNeedingBuilderStage = fields.stream()
-                    .filter(field -> !fieldShouldBeInFinalStage(field))
+                    .filter(field -> !BeanBuilderGenerator.fieldShouldBeInFinalStage(field))
                     .collect(ImmutableList.toImmutableList());
-            typeBuilder.addAnnotation(AnnotationSpec.builder(JsonDeserialize.class)
-                    .addMember("builder", "$T.class", builderImplementation)
-                    .build());
             if (!options.useStagedBuilders() || fieldsNeedingBuilderStage.isEmpty()) {
+                typeBuilder.addAnnotation(AnnotationSpec.builder(JsonDeserialize.class)
+                        .addMember("builder", "$T.class", builderImplementation)
+                        .build());
                 typeBuilder
                         .addMethod(createBuilder(builderClass))
                         .addType(BeanBuilderGenerator.generate(
@@ -177,60 +171,15 @@ public final class BeanGenerator {
                                 options,
                                 Optional.empty()));
             } else {
-                List<TypeSpec> interfaces = generateStageInterfaces(
+                BeanBuilderGenerator.generateStagedBuilder(
+                        typeBuilder,
+                        typeMapper,
+                        safetyEvaluator,
                         objectClass,
                         builderClass,
-                        typeMapper,
-                        fieldsNeedingBuilderStage,
-                        fields.stream()
-                                .filter(BeanGenerator::fieldShouldBeInFinalStage)
-                                .collect(ImmutableList.toImmutableList()),
-                        safetyEvaluator);
-
-                List<ClassName> interfacesAsClasses = interfaces.stream()
-                        .map(stageInterface ->
-                                ClassName.get(objectClass.packageName(), objectClass.simpleName(), stageInterface.name))
-                        .collect(Collectors.toList());
-
-                TypeSpec builderInterface = TypeSpec.interfaceBuilder("Builder")
-                        .addModifiers(Modifier.PUBLIC)
-                        .addMethods(interfaces.stream()
-                                .map(stageInterface -> stageInterface.methodSpecs)
-                                .flatMap(List::stream)
-                                .map(method -> method.toBuilder()
-                                        .addAnnotation(Override.class)
-                                        .returns(
-                                                method.name.equals("build")
-                                                        ? method.returnType
-                                                        : ClassName.get(
-                                                                objectClass.packageName(),
-                                                                objectClass.simpleName(),
-                                                                "Builder"))
-                                        .build())
-                                .collect(Collectors.toList()))
-                        .addSuperinterfaces(interfacesAsClasses.stream()
-                                .map(Primitives::box)
-                                .collect(Collectors.toList()))
-                        .build();
-
-                typeBuilder
-                        .addTypes(interfaces)
-                        .addType(builderInterface)
-                        .addMethod(MethodSpec.methodBuilder("builder")
-                                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                                .returns(interfacesAsClasses.get(0))
-                                .addStatement("return new DefaultBuilder()")
-                                .build())
-                        .addType(BeanBuilderGenerator.generate(
-                                typeMapper,
-                                safetyEvaluator,
-                                objectClass,
-                                builderClass,
-                                typeDef,
-                                typesMap,
-                                options,
-                                Optional.of(ClassName.get(
-                                        objectClass.packageName(), objectClass.simpleName(), builderInterface.name))));
+                        typeDef,
+                        typesMap,
+                        options);
             }
         }
         typeBuilder.addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(BeanGenerator.class));
@@ -241,153 +190,6 @@ public final class BeanGenerator {
                 .skipJavaLangImports(true)
                 .indent("    ")
                 .build();
-    }
-
-    private static boolean fieldShouldBeInFinalStage(EnrichedField field) {
-        Type type = field.conjureDef().getType();
-        return type.accept(TypeVisitor.IS_LIST)
-                || type.accept(TypeVisitor.IS_SET)
-                || type.accept(TypeVisitor.IS_MAP)
-                || type.accept(TypeVisitor.IS_OPTIONAL);
-    }
-
-    /**
-     * Sorts input fields in the order they should be applied to the builder: Original order with required
-     * fields prior to optional/collection values.
-     */
-    private static Stream<EnrichedField> sortedEnrichedFields(ImmutableList<EnrichedField> enrichedFields) {
-        return enrichedFields.stream()
-                .sorted(Comparator.comparing(BeanGenerator::fieldShouldBeInFinalStage)
-                        .thenComparing(enrichedFields::indexOf));
-    }
-
-    private static ClassName stageBuilderInterfaceName(ClassName enclosingClass, String stageName) {
-        return enclosingClass.nestedClass(StringUtils.capitalize(stageName) + "StageBuilder");
-    }
-
-    private static List<TypeSpec> generateStageInterfaces(
-            ClassName objectClass,
-            ClassName builderClass,
-            TypeMapper typeMapper,
-            ImmutableList<EnrichedField> fieldsNeedingBuilderStage,
-            ImmutableList<EnrichedField> otherFields,
-            SafetyEvaluator safetyEvaluator) {
-        List<TypeSpec.Builder> interfaces = new ArrayList<>();
-
-        PeekingIterator<EnrichedField> fieldPeekingIterator = Iterators.peekingIterator(
-                sortedEnrichedFields(fieldsNeedingBuilderStage).iterator());
-
-        while (fieldPeekingIterator.hasNext()) {
-            EnrichedField field = fieldPeekingIterator.next();
-            String nextBuilderStageName = fieldPeekingIterator.hasNext()
-                    ? JavaNameSanitizer.sanitize(fieldPeekingIterator.peek().fieldName())
-                    : "completed_";
-
-            ClassName nextStageClassName = stageBuilderInterfaceName(objectClass, nextBuilderStageName);
-
-            interfaces.add(TypeSpec.interfaceBuilder(
-                            stageBuilderInterfaceName(objectClass, JavaNameSanitizer.sanitize(field.fieldName())))
-                    .addModifiers(Modifier.PUBLIC)
-                    .addMethod(MethodSpec.methodBuilder(JavaNameSanitizer.sanitize(field.fieldName()))
-                            .addParameter(ParameterSpec.builder(
-                                            field.poetSpec().type, JavaNameSanitizer.sanitize(field.fieldName()))
-                                    .addAnnotation(Nonnull.class)
-                                    .build())
-                            .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-                            .returns(Primitives.box(nextStageClassName))
-                            .build()));
-        }
-
-        ClassName completedStageClass = stageBuilderInterfaceName(objectClass, "completed_");
-
-        TypeSpec.Builder completedStage = TypeSpec.interfaceBuilder(completedStageClass)
-                .addModifiers(Modifier.PUBLIC)
-                .addMethod(MethodSpec.methodBuilder("build")
-                        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-                        .returns(Primitives.box(objectClass))
-                        .build());
-
-        completedStage.addMethods(otherFields.stream()
-                .map(field ->
-                        generateMethodsForFinalStageField(field, typeMapper, completedStageClass, safetyEvaluator))
-                .flatMap(List::stream)
-                .collect(Collectors.toList()));
-
-        interfaces.add(completedStage);
-
-        interfaces
-                .get(0)
-                .addMethod(MethodSpec.methodBuilder("from")
-                        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-                        .returns(builderClass)
-                        .addParameter(objectClass, "other")
-                        .build());
-
-        return interfaces.stream().map(TypeSpec.Builder::build).collect(Collectors.toList());
-    }
-
-    private static List<MethodSpec> generateMethodsForFinalStageField(
-            EnrichedField enriched, TypeMapper typeMapper, ClassName returnClass, SafetyEvaluator safetyEvaluator) {
-        List<MethodSpec> methodSpecs = new ArrayList<>();
-        Type type = enriched.conjureDef().getType();
-        FieldDefinition definition = enriched.conjureDef();
-        Optional<LogSafety> safety = safetyEvaluator.getUsageTimeSafety(definition);
-
-        methodSpecs.add(MethodSpec.methodBuilder(JavaNameSanitizer.sanitize(enriched.fieldName()))
-                .addParameter(ParameterSpec.builder(
-                                BeanBuilderAuxiliarySettersUtils.widenParameterIfPossible(
-                                        enriched.poetSpec().type, type, typeMapper, safety),
-                                JavaNameSanitizer.sanitize(enriched.fieldName()))
-                        .addAnnotation(Nonnull.class)
-                        .build())
-                .addJavadoc(Javadoc.render(definition.getDocs(), definition.getDeprecated())
-                        .map(rendered -> CodeBlock.of("$L", rendered))
-                        .orElseGet(() -> CodeBlock.builder().build()))
-                .addAnnotations(ConjureAnnotations.deprecation(definition.getDeprecated()))
-                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-                .returns(Primitives.box(returnClass))
-                .build());
-
-        if (type.accept(TypeVisitor.IS_LIST)) {
-            methodSpecs.add(BeanBuilderAuxiliarySettersUtils.createCollectionSetterBuilder(
-                            "addAll", enriched, typeMapper, returnClass, safetyEvaluator)
-                    .addModifiers(Modifier.ABSTRACT)
-                    .build());
-            methodSpecs.add(BeanBuilderAuxiliarySettersUtils.createItemSetterBuilder(
-                            enriched, type.accept(TypeVisitor.LIST).getItemType(), typeMapper, returnClass, safety)
-                    .addModifiers(Modifier.ABSTRACT)
-                    .build());
-        }
-
-        if (type.accept(TypeVisitor.IS_SET)) {
-            methodSpecs.add(BeanBuilderAuxiliarySettersUtils.createCollectionSetterBuilder(
-                            "addAll", enriched, typeMapper, returnClass, safetyEvaluator)
-                    .addModifiers(Modifier.ABSTRACT)
-                    .build());
-            methodSpecs.add(BeanBuilderAuxiliarySettersUtils.createItemSetterBuilder(
-                            enriched, type.accept(TypeVisitor.SET).getItemType(), typeMapper, returnClass, safety)
-                    .addModifiers(Modifier.ABSTRACT)
-                    .build());
-        }
-
-        if (type.accept(TypeVisitor.IS_MAP)) {
-            methodSpecs.add(BeanBuilderAuxiliarySettersUtils.createCollectionSetterBuilder(
-                            "putAll", enriched, typeMapper, returnClass, safetyEvaluator)
-                    .addModifiers(Modifier.ABSTRACT)
-                    .build());
-            methodSpecs.add(BeanBuilderAuxiliarySettersUtils.createMapSetterBuilder(enriched, typeMapper, returnClass)
-                    .addModifiers(Modifier.ABSTRACT)
-                    .build());
-        }
-
-        if (type.accept(TypeVisitor.IS_OPTIONAL)) {
-            methodSpecs.add(BeanBuilderAuxiliarySettersUtils.createOptionalSetterBuilder(
-                            enriched, typeMapper, returnClass, safetyEvaluator)
-                    .addModifiers(Modifier.ABSTRACT)
-                    .build());
-        }
-
-        return methodSpecs;
     }
 
     private static boolean useCachedHashCode(Collection<EnrichedField> fields) {
@@ -557,13 +359,15 @@ public final class BeanGenerator {
                     .addAnnotations(ConjureAnnotations.safety(safetyEvaluator.getUsageTimeSafety(field.conjureDef())))
                     .build()));
             // Follow order on adding methods on builder to comply with staged builders option if set
-            sortedEnrichedFields(fields).map(EnrichedField::poetSpec).forEach(spec -> {
-                if (isOptional(spec)) {
-                    builder.addCode("\n    .$L(Optional.of($L))", spec.name, spec.name);
-                } else {
-                    builder.addCode("\n    .$L($L)", spec.name, spec.name);
-                }
-            });
+            BeanBuilderGenerator.sortedEnrichedFields(fields)
+                    .map(EnrichedField::poetSpec)
+                    .forEach(spec -> {
+                        if (isOptional(spec)) {
+                            builder.addCode("\n    .$L(Optional.of($L))", spec.name, spec.name);
+                        } else {
+                            builder.addCode("\n    .$L($L)", spec.name, spec.name);
+                        }
+                    });
             builder.addCode("\n    .build();\n");
         }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -320,7 +320,7 @@ public final class BeanGenerator {
             ImmutableList<EnrichedField> fields,
             ClassName objectClass,
             SafetyEvaluator safetyEvaluator,
-            boolean orderFieldsInFinalBuilderStagesLast) {
+            boolean useStagedBuilders) {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("of")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .returns(objectClass);
@@ -335,7 +335,7 @@ public final class BeanGenerator {
                     .addAnnotations(ConjureAnnotations.safety(safetyEvaluator.getUsageTimeSafety(field.conjureDef())))
                     .build()));
 
-            Stream<EnrichedField> methodArgs = orderFieldsInFinalBuilderStagesLast
+            Stream<EnrichedField> methodArgs = useStagedBuilders
                     ? fields.stream().sorted(Comparator.comparing(BeanBuilderGenerator::fieldShouldBeInFinalStage))
                     : fields.stream();
 


### PR DESCRIPTION
**Note**: Would like to merge #1981 before this PR.

## Before this PR
`BeanGenerator::generateBeanType` is a long, and complex method. While there exists `BeanBuilderGenerator` containing some methods used to generate builders, much of the staged builder generation code is in `BeanGenerator`.


## After this PR
Staged builders are a specific type of builder, and I think we should move all builder generation logic into `BeanBuilderGenerator`.

This PR:
- Moves all builder and staged builder generation logic in `BeanGenerator` into `BeanBuilderGenerator`
- Expose methods `BeanBuilderGenerator::addBuilder` and `BeanBuilderGenerator::addStagedBuilder`, which are called in `BeanGenerator`

==COMMIT_MSG==
Refactor BeanBuilderGenerator to handle all builder generation logic
==COMMIT_MSG==

## Possible downsides?
`BeanBuilderGenerator::addBuilder` and `BeanBuilderGenerator::addStagedBuilder` both have side effects (they modify the `TypeSpec.Builder` object passed in). It's possible that future developers introduce subtle errors because of this. However, given that `BeanGenerator` and `BeanBuilderGenerator` are tightly coupled (e.g. they share the `EnrichedField` structure), I think this it's reasonable to expect contributors to have enough context on the effects of these `add...` methods in `BeanGenerator`.