### PR TITLE
Fix regression causing union visitor primitive functions not to be used when safety is specified

### DIFF
--- a/changelog/@unreleased/pr-1989.v2.yml
+++ b/changelog/@unreleased/pr-1989.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix regression which resulted in `IntFunction` and `DoubleFunction`
+    not being used when log-safety information is provided
+  links:
+  - https://github.com/palantir/conjure-java/pull/1989

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.function.DoubleFunction;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import javax.annotation.Nonnull;
@@ -309,7 +310,7 @@ public final class UnionTypeExample {
 
         private Function<OptionalAlias, T> optionalAliasVisitor;
 
-        private Function<@Safe Integer, T> safeIntVisitor;
+        private IntFunction<T> safeIntVisitor;
 
         private Function<Set<String>, T> setVisitor;
 
@@ -321,7 +322,7 @@ public final class UnionTypeExample {
 
         private IntFunction<T> unknown_Visitor;
 
-        private Function<@Unsafe Double, T> unsafeDoubleVisitor;
+        private DoubleFunction<T> unsafeDoubleVisitor;
 
         private BiFunction<@Safe String, Object, T> unknownVisitor;
 
@@ -410,7 +411,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public SetStageVisitorBuilder<T> safeInt(@Nonnull Function<@Safe Integer, T> safeIntVisitor) {
+        public SetStageVisitorBuilder<T> safeInt(@Nonnull IntFunction<T> safeIntVisitor) {
             Preconditions.checkNotNull(safeIntVisitor, "safeIntVisitor cannot be null");
             this.safeIntVisitor = safeIntVisitor;
             return this;
@@ -454,7 +455,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public UnknownStageVisitorBuilder<T> unsafeDouble(@Nonnull Function<@Unsafe Double, T> unsafeDoubleVisitor) {
+        public UnknownStageVisitorBuilder<T> unsafeDouble(@Nonnull DoubleFunction<T> unsafeDoubleVisitor) {
             Preconditions.checkNotNull(unsafeDoubleVisitor, "unsafeDoubleVisitor cannot be null");
             this.unsafeDoubleVisitor = unsafeDoubleVisitor;
             return this;
@@ -497,13 +498,13 @@ public final class UnionTypeExample {
             final IntFunction<T> newVisitor = this.newVisitor;
             final Function<Optional<String>, T> optionalVisitor = this.optionalVisitor;
             final Function<OptionalAlias, T> optionalAliasVisitor = this.optionalAliasVisitor;
-            final Function<@Safe Integer, T> safeIntVisitor = this.safeIntVisitor;
+            final IntFunction<T> safeIntVisitor = this.safeIntVisitor;
             final Function<Set<String>, T> setVisitor = this.setVisitor;
             final Function<SetAlias, T> setAliasVisitor = this.setAliasVisitor;
             final Function<StringExample, T> stringExampleVisitor = this.stringExampleVisitor;
             final IntFunction<T> thisFieldIsAnIntegerVisitor = this.thisFieldIsAnIntegerVisitor;
             final IntFunction<T> unknown_Visitor = this.unknown_Visitor;
-            final Function<@Unsafe Double, T> unsafeDoubleVisitor = this.unsafeDoubleVisitor;
+            final DoubleFunction<T> unsafeDoubleVisitor = this.unsafeDoubleVisitor;
             final BiFunction<@Safe String, Object, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
@@ -658,7 +659,7 @@ public final class UnionTypeExample {
     }
 
     public interface SafeIntStageVisitorBuilder<T> {
-        SetStageVisitorBuilder<T> safeInt(@Nonnull Function<@Safe Integer, T> safeIntVisitor);
+        SetStageVisitorBuilder<T> safeInt(@Nonnull IntFunction<T> safeIntVisitor);
     }
 
     public interface SetStageVisitorBuilder<T> {
@@ -683,7 +684,7 @@ public final class UnionTypeExample {
     }
 
     public interface UnsafeDoubleStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> unsafeDouble(@Nonnull Function<@Unsafe Double, T> unsafeDoubleVisitor);
+        UnknownStageVisitorBuilder<T> unsafeDouble(@Nonnull DoubleFunction<T> unsafeDoubleVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.Nulls;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.Unsafe;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,6 +32,7 @@ import javax.annotation.processing.Generated;
 /**
  * A type which can either be a StringExample, a set of strings, or an integer.
  */
+@Unsafe
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class UnionTypeExample {
     private final Base value;
@@ -116,6 +118,14 @@ public final class UnionTypeExample {
         return new UnionTypeExample(new BooleanFieldWrapper(value));
     }
 
+    public static UnionTypeExample safeInt(@Safe int value) {
+        return new UnionTypeExample(new SafeIntWrapper(value));
+    }
+
+    public static UnionTypeExample unsafeDouble(@Unsafe double value) {
+        return new UnionTypeExample(new UnsafeDoubleWrapper(value));
+    }
+
     public static UnionTypeExample unknown(@Safe String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
             case "stringExample":
@@ -169,6 +179,12 @@ public final class UnionTypeExample {
             case "booleanField":
                 throw new SafeIllegalArgumentException(
                         "Unknown type cannot be created as the provided type is known: booleanField");
+            case "safeInt":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: safeInt");
+            case "unsafeDouble":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: unsafeDouble");
             default:
                 return new UnionTypeExample(new UnknownWrapper(type, Collections.singletonMap(type, value)));
         }
@@ -193,6 +209,7 @@ public final class UnionTypeExample {
     }
 
     @Override
+    @Unsafe
     public String toString() {
         return "UnionTypeExample{value: " + value + '}';
     }
@@ -235,6 +252,10 @@ public final class UnionTypeExample {
 
         T visitBooleanField(@Safe boolean value);
 
+        T visitSafeInt(@Safe int value);
+
+        T visitUnsafeDouble(@Unsafe double value);
+
         T visitUnknown(@Safe String unknownType, Object unknownValue);
 
         static <T> AlsoAnIntegerStageVisitorBuilder<T> builder() {
@@ -255,11 +276,13 @@ public final class UnionTypeExample {
                     NewStageVisitorBuilder<T>,
                     OptionalStageVisitorBuilder<T>,
                     OptionalAliasStageVisitorBuilder<T>,
+                    SafeIntStageVisitorBuilder<T>,
                     SetStageVisitorBuilder<T>,
                     SetAliasStageVisitorBuilder<T>,
                     StringExampleStageVisitorBuilder<T>,
                     ThisFieldIsAnIntegerStageVisitorBuilder<T>,
                     Unknown_StageVisitorBuilder<T>,
+                    UnsafeDoubleStageVisitorBuilder<T>,
                     UnknownStageVisitorBuilder<T>,
                     Completed_StageVisitorBuilder<T> {
         private IntFunction<T> alsoAnIntegerVisitor;
@@ -286,6 +309,8 @@ public final class UnionTypeExample {
 
         private Function<OptionalAlias, T> optionalAliasVisitor;
 
+        private Function<@Safe Integer, T> safeIntVisitor;
+
         private Function<Set<String>, T> setVisitor;
 
         private Function<SetAlias, T> setAliasVisitor;
@@ -295,6 +320,8 @@ public final class UnionTypeExample {
         private IntFunction<T> thisFieldIsAnIntegerVisitor;
 
         private IntFunction<T> unknown_Visitor;
+
+        private Function<@Unsafe Double, T> unsafeDoubleVisitor;
 
         private BiFunction<@Safe String, Object, T> unknownVisitor;
 
@@ -376,9 +403,16 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public SetStageVisitorBuilder<T> optionalAlias(@Nonnull Function<OptionalAlias, T> optionalAliasVisitor) {
+        public SafeIntStageVisitorBuilder<T> optionalAlias(@Nonnull Function<OptionalAlias, T> optionalAliasVisitor) {
             Preconditions.checkNotNull(optionalAliasVisitor, "optionalAliasVisitor cannot be null");
             this.optionalAliasVisitor = optionalAliasVisitor;
+            return this;
+        }
+
+        @Override
+        public SetStageVisitorBuilder<T> safeInt(@Nonnull Function<@Safe Integer, T> safeIntVisitor) {
+            Preconditions.checkNotNull(safeIntVisitor, "safeIntVisitor cannot be null");
+            this.safeIntVisitor = safeIntVisitor;
             return this;
         }
 
@@ -413,9 +447,16 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public UnknownStageVisitorBuilder<T> unknown_(@Nonnull IntFunction<T> unknown_Visitor) {
+        public UnsafeDoubleStageVisitorBuilder<T> unknown_(@Nonnull IntFunction<T> unknown_Visitor) {
             Preconditions.checkNotNull(unknown_Visitor, "unknown_Visitor cannot be null");
             this.unknown_Visitor = unknown_Visitor;
+            return this;
+        }
+
+        @Override
+        public UnknownStageVisitorBuilder<T> unsafeDouble(@Nonnull Function<@Unsafe Double, T> unsafeDoubleVisitor) {
+            Preconditions.checkNotNull(unsafeDoubleVisitor, "unsafeDoubleVisitor cannot be null");
+            this.unsafeDoubleVisitor = unsafeDoubleVisitor;
             return this;
         }
 
@@ -456,11 +497,13 @@ public final class UnionTypeExample {
             final IntFunction<T> newVisitor = this.newVisitor;
             final Function<Optional<String>, T> optionalVisitor = this.optionalVisitor;
             final Function<OptionalAlias, T> optionalAliasVisitor = this.optionalAliasVisitor;
+            final Function<@Safe Integer, T> safeIntVisitor = this.safeIntVisitor;
             final Function<Set<String>, T> setVisitor = this.setVisitor;
             final Function<SetAlias, T> setAliasVisitor = this.setAliasVisitor;
             final Function<StringExample, T> stringExampleVisitor = this.stringExampleVisitor;
             final IntFunction<T> thisFieldIsAnIntegerVisitor = this.thisFieldIsAnIntegerVisitor;
             final IntFunction<T> unknown_Visitor = this.unknown_Visitor;
+            final Function<@Unsafe Double, T> unsafeDoubleVisitor = this.unsafeDoubleVisitor;
             final BiFunction<@Safe String, Object, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
@@ -524,6 +567,11 @@ public final class UnionTypeExample {
                 }
 
                 @Override
+                public T visitSafeInt(@Safe int value) {
+                    return safeIntVisitor.apply(value);
+                }
+
+                @Override
                 public T visitSet(Set<String> value) {
                     return setVisitor.apply(value);
                 }
@@ -546,6 +594,11 @@ public final class UnionTypeExample {
                 @Override
                 public T visitUnknown_(int value) {
                     return unknown_Visitor.apply(value);
+                }
+
+                @Override
+                public T visitUnsafeDouble(@Unsafe double value) {
+                    return unsafeDoubleVisitor.apply(value);
                 }
 
                 @Override
@@ -601,7 +654,11 @@ public final class UnionTypeExample {
     }
 
     public interface OptionalAliasStageVisitorBuilder<T> {
-        SetStageVisitorBuilder<T> optionalAlias(@Nonnull Function<OptionalAlias, T> optionalAliasVisitor);
+        SafeIntStageVisitorBuilder<T> optionalAlias(@Nonnull Function<OptionalAlias, T> optionalAliasVisitor);
+    }
+
+    public interface SafeIntStageVisitorBuilder<T> {
+        SetStageVisitorBuilder<T> safeInt(@Nonnull Function<@Safe Integer, T> safeIntVisitor);
     }
 
     public interface SetStageVisitorBuilder<T> {
@@ -622,7 +679,11 @@ public final class UnionTypeExample {
     }
 
     public interface Unknown_StageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> unknown_(@Nonnull IntFunction<T> unknown_Visitor);
+        UnsafeDoubleStageVisitorBuilder<T> unknown_(@Nonnull IntFunction<T> unknown_Visitor);
+    }
+
+    public interface UnsafeDoubleStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> unsafeDouble(@Nonnull Function<@Unsafe Double, T> unsafeDoubleVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {
@@ -660,7 +721,9 @@ public final class UnionTypeExample {
         @JsonSubTypes.Type(ListAliasWrapper.class),
         @JsonSubTypes.Type(SetAliasWrapper.class),
         @JsonSubTypes.Type(MapAliasWrapper.class),
-        @JsonSubTypes.Type(BooleanFieldWrapper.class)
+        @JsonSubTypes.Type(BooleanFieldWrapper.class),
+        @JsonSubTypes.Type(SafeIntWrapper.class),
+        @JsonSubTypes.Type(UnsafeDoubleWrapper.class)
     })
     @JsonIgnoreProperties(ignoreUnknown = true)
     private interface Base {
@@ -1433,6 +1496,96 @@ public final class UnionTypeExample {
         @Override
         public String toString() {
             return "BooleanFieldWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("safeInt")
+    private static final class SafeIntWrapper implements Base {
+        private final int value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private SafeIntWrapper(@JsonSetter("safeInt") @Nonnull int value) {
+            Preconditions.checkNotNull(value, "safeInt cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(value = "type", index = 0)
+        private String getType() {
+            return "safeInt";
+        }
+
+        @JsonProperty("safeInt")
+        private int getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitSafeInt(value);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof SafeIntWrapper && equalTo((SafeIntWrapper) other));
+        }
+
+        private boolean equalTo(SafeIntWrapper other) {
+            return this.value == other.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return this.value;
+        }
+
+        @Override
+        public String toString() {
+            return "SafeIntWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("unsafeDouble")
+    private static final class UnsafeDoubleWrapper implements Base {
+        private final double value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private UnsafeDoubleWrapper(@JsonSetter("unsafeDouble") @Nonnull double value) {
+            Preconditions.checkNotNull(value, "unsafeDouble cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(value = "type", index = 0)
+        private String getType() {
+            return "unsafeDouble";
+        }
+
+        @JsonProperty("unsafeDouble")
+        private double getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitUnsafeDouble(value);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof UnsafeDoubleWrapper && equalTo((UnsafeDoubleWrapper) other));
+        }
+
+        private boolean equalTo(UnsafeDoubleWrapper other) {
+            return Double.doubleToLongBits(this.value) == Double.doubleToLongBits(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Double.hashCode(this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "UnsafeDoubleWrapper{value: " + value + '}';
         }
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.DoubleFunction;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import javax.annotation.Nonnull;
@@ -308,7 +309,7 @@ public final class UnionTypeExample {
 
         private Function<OptionalAlias, T> optionalAliasVisitor;
 
-        private Function<@Safe Integer, T> safeIntVisitor;
+        private IntFunction<T> safeIntVisitor;
 
         private Function<Set<String>, T> setVisitor;
 
@@ -320,7 +321,7 @@ public final class UnionTypeExample {
 
         private IntFunction<T> unknown_Visitor;
 
-        private Function<@Unsafe Double, T> unsafeDoubleVisitor;
+        private DoubleFunction<T> unsafeDoubleVisitor;
 
         private Function<String, T> unknownVisitor;
 
@@ -409,7 +410,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public SetStageVisitorBuilder<T> safeInt(@Nonnull Function<@Safe Integer, T> safeIntVisitor) {
+        public SetStageVisitorBuilder<T> safeInt(@Nonnull IntFunction<T> safeIntVisitor) {
             Preconditions.checkNotNull(safeIntVisitor, "safeIntVisitor cannot be null");
             this.safeIntVisitor = safeIntVisitor;
             return this;
@@ -453,7 +454,7 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public UnknownStageVisitorBuilder<T> unsafeDouble(@Nonnull Function<@Unsafe Double, T> unsafeDoubleVisitor) {
+        public UnknownStageVisitorBuilder<T> unsafeDouble(@Nonnull DoubleFunction<T> unsafeDoubleVisitor) {
             Preconditions.checkNotNull(unsafeDoubleVisitor, "unsafeDoubleVisitor cannot be null");
             this.unsafeDoubleVisitor = unsafeDoubleVisitor;
             return this;
@@ -489,13 +490,13 @@ public final class UnionTypeExample {
             final IntFunction<T> newVisitor = this.newVisitor;
             final Function<Optional<String>, T> optionalVisitor = this.optionalVisitor;
             final Function<OptionalAlias, T> optionalAliasVisitor = this.optionalAliasVisitor;
-            final Function<@Safe Integer, T> safeIntVisitor = this.safeIntVisitor;
+            final IntFunction<T> safeIntVisitor = this.safeIntVisitor;
             final Function<Set<String>, T> setVisitor = this.setVisitor;
             final Function<SetAlias, T> setAliasVisitor = this.setAliasVisitor;
             final Function<StringExample, T> stringExampleVisitor = this.stringExampleVisitor;
             final IntFunction<T> thisFieldIsAnIntegerVisitor = this.thisFieldIsAnIntegerVisitor;
             final IntFunction<T> unknown_Visitor = this.unknown_Visitor;
-            final Function<@Unsafe Double, T> unsafeDoubleVisitor = this.unsafeDoubleVisitor;
+            final DoubleFunction<T> unsafeDoubleVisitor = this.unsafeDoubleVisitor;
             final Function<String, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
@@ -650,7 +651,7 @@ public final class UnionTypeExample {
     }
 
     public interface SafeIntStageVisitorBuilder<T> {
-        SetStageVisitorBuilder<T> safeInt(@Nonnull Function<@Safe Integer, T> safeIntVisitor);
+        SetStageVisitorBuilder<T> safeInt(@Nonnull IntFunction<T> safeIntVisitor);
     }
 
     public interface SetStageVisitorBuilder<T> {
@@ -675,7 +676,7 @@ public final class UnionTypeExample {
     }
 
     public interface UnsafeDoubleStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> unsafeDouble(@Nonnull Function<@Unsafe Double, T> unsafeDoubleVisitor);
+        UnknownStageVisitorBuilder<T> unsafeDouble(@Nonnull DoubleFunction<T> unsafeDoubleVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.Nulls;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.Unsafe;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,6 +31,7 @@ import javax.annotation.processing.Generated;
 /**
  * A type which can either be a StringExample, a set of strings, or an integer.
  */
+@Unsafe
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 public final class UnionTypeExample {
     private final Base value;
@@ -115,6 +117,14 @@ public final class UnionTypeExample {
         return new UnionTypeExample(new BooleanFieldWrapper(value));
     }
 
+    public static UnionTypeExample safeInt(@Safe int value) {
+        return new UnionTypeExample(new SafeIntWrapper(value));
+    }
+
+    public static UnionTypeExample unsafeDouble(@Unsafe double value) {
+        return new UnionTypeExample(new UnsafeDoubleWrapper(value));
+    }
+
     public static UnionTypeExample unknown(@Safe String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
             case "stringExample":
@@ -168,6 +178,12 @@ public final class UnionTypeExample {
             case "booleanField":
                 throw new SafeIllegalArgumentException(
                         "Unknown type cannot be created as the provided type is known: booleanField");
+            case "safeInt":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: safeInt");
+            case "unsafeDouble":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: unsafeDouble");
             default:
                 return new UnionTypeExample(new UnknownWrapper(type, Collections.singletonMap(type, value)));
         }
@@ -192,6 +208,7 @@ public final class UnionTypeExample {
     }
 
     @Override
+    @Unsafe
     public String toString() {
         return "UnionTypeExample{value: " + value + '}';
     }
@@ -234,6 +251,10 @@ public final class UnionTypeExample {
 
         T visitBooleanField(@Safe boolean value);
 
+        T visitSafeInt(@Safe int value);
+
+        T visitUnsafeDouble(@Unsafe double value);
+
         T visitUnknown(@Safe String unknownType);
 
         static <T> AlsoAnIntegerStageVisitorBuilder<T> builder() {
@@ -254,11 +275,13 @@ public final class UnionTypeExample {
                     NewStageVisitorBuilder<T>,
                     OptionalStageVisitorBuilder<T>,
                     OptionalAliasStageVisitorBuilder<T>,
+                    SafeIntStageVisitorBuilder<T>,
                     SetStageVisitorBuilder<T>,
                     SetAliasStageVisitorBuilder<T>,
                     StringExampleStageVisitorBuilder<T>,
                     ThisFieldIsAnIntegerStageVisitorBuilder<T>,
                     Unknown_StageVisitorBuilder<T>,
+                    UnsafeDoubleStageVisitorBuilder<T>,
                     UnknownStageVisitorBuilder<T>,
                     Completed_StageVisitorBuilder<T> {
         private IntFunction<T> alsoAnIntegerVisitor;
@@ -285,6 +308,8 @@ public final class UnionTypeExample {
 
         private Function<OptionalAlias, T> optionalAliasVisitor;
 
+        private Function<@Safe Integer, T> safeIntVisitor;
+
         private Function<Set<String>, T> setVisitor;
 
         private Function<SetAlias, T> setAliasVisitor;
@@ -294,6 +319,8 @@ public final class UnionTypeExample {
         private IntFunction<T> thisFieldIsAnIntegerVisitor;
 
         private IntFunction<T> unknown_Visitor;
+
+        private Function<@Unsafe Double, T> unsafeDoubleVisitor;
 
         private Function<String, T> unknownVisitor;
 
@@ -375,9 +402,16 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public SetStageVisitorBuilder<T> optionalAlias(@Nonnull Function<OptionalAlias, T> optionalAliasVisitor) {
+        public SafeIntStageVisitorBuilder<T> optionalAlias(@Nonnull Function<OptionalAlias, T> optionalAliasVisitor) {
             Preconditions.checkNotNull(optionalAliasVisitor, "optionalAliasVisitor cannot be null");
             this.optionalAliasVisitor = optionalAliasVisitor;
+            return this;
+        }
+
+        @Override
+        public SetStageVisitorBuilder<T> safeInt(@Nonnull Function<@Safe Integer, T> safeIntVisitor) {
+            Preconditions.checkNotNull(safeIntVisitor, "safeIntVisitor cannot be null");
+            this.safeIntVisitor = safeIntVisitor;
             return this;
         }
 
@@ -412,9 +446,16 @@ public final class UnionTypeExample {
         }
 
         @Override
-        public UnknownStageVisitorBuilder<T> unknown_(@Nonnull IntFunction<T> unknown_Visitor) {
+        public UnsafeDoubleStageVisitorBuilder<T> unknown_(@Nonnull IntFunction<T> unknown_Visitor) {
             Preconditions.checkNotNull(unknown_Visitor, "unknown_Visitor cannot be null");
             this.unknown_Visitor = unknown_Visitor;
+            return this;
+        }
+
+        @Override
+        public UnknownStageVisitorBuilder<T> unsafeDouble(@Nonnull Function<@Unsafe Double, T> unsafeDoubleVisitor) {
+            Preconditions.checkNotNull(unsafeDoubleVisitor, "unsafeDoubleVisitor cannot be null");
+            this.unsafeDoubleVisitor = unsafeDoubleVisitor;
             return this;
         }
 
@@ -448,11 +489,13 @@ public final class UnionTypeExample {
             final IntFunction<T> newVisitor = this.newVisitor;
             final Function<Optional<String>, T> optionalVisitor = this.optionalVisitor;
             final Function<OptionalAlias, T> optionalAliasVisitor = this.optionalAliasVisitor;
+            final Function<@Safe Integer, T> safeIntVisitor = this.safeIntVisitor;
             final Function<Set<String>, T> setVisitor = this.setVisitor;
             final Function<SetAlias, T> setAliasVisitor = this.setAliasVisitor;
             final Function<StringExample, T> stringExampleVisitor = this.stringExampleVisitor;
             final IntFunction<T> thisFieldIsAnIntegerVisitor = this.thisFieldIsAnIntegerVisitor;
             final IntFunction<T> unknown_Visitor = this.unknown_Visitor;
+            final Function<@Unsafe Double, T> unsafeDoubleVisitor = this.unsafeDoubleVisitor;
             final Function<String, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
@@ -516,6 +559,11 @@ public final class UnionTypeExample {
                 }
 
                 @Override
+                public T visitSafeInt(@Safe int value) {
+                    return safeIntVisitor.apply(value);
+                }
+
+                @Override
                 public T visitSet(Set<String> value) {
                     return setVisitor.apply(value);
                 }
@@ -538,6 +586,11 @@ public final class UnionTypeExample {
                 @Override
                 public T visitUnknown_(int value) {
                     return unknown_Visitor.apply(value);
+                }
+
+                @Override
+                public T visitUnsafeDouble(@Unsafe double value) {
+                    return unsafeDoubleVisitor.apply(value);
                 }
 
                 @Override
@@ -593,7 +646,11 @@ public final class UnionTypeExample {
     }
 
     public interface OptionalAliasStageVisitorBuilder<T> {
-        SetStageVisitorBuilder<T> optionalAlias(@Nonnull Function<OptionalAlias, T> optionalAliasVisitor);
+        SafeIntStageVisitorBuilder<T> optionalAlias(@Nonnull Function<OptionalAlias, T> optionalAliasVisitor);
+    }
+
+    public interface SafeIntStageVisitorBuilder<T> {
+        SetStageVisitorBuilder<T> safeInt(@Nonnull Function<@Safe Integer, T> safeIntVisitor);
     }
 
     public interface SetStageVisitorBuilder<T> {
@@ -614,7 +671,11 @@ public final class UnionTypeExample {
     }
 
     public interface Unknown_StageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> unknown_(@Nonnull IntFunction<T> unknown_Visitor);
+        UnsafeDoubleStageVisitorBuilder<T> unknown_(@Nonnull IntFunction<T> unknown_Visitor);
+    }
+
+    public interface UnsafeDoubleStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> unsafeDouble(@Nonnull Function<@Unsafe Double, T> unsafeDoubleVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {
@@ -650,7 +711,9 @@ public final class UnionTypeExample {
         @JsonSubTypes.Type(ListAliasWrapper.class),
         @JsonSubTypes.Type(SetAliasWrapper.class),
         @JsonSubTypes.Type(MapAliasWrapper.class),
-        @JsonSubTypes.Type(BooleanFieldWrapper.class)
+        @JsonSubTypes.Type(BooleanFieldWrapper.class),
+        @JsonSubTypes.Type(SafeIntWrapper.class),
+        @JsonSubTypes.Type(UnsafeDoubleWrapper.class)
     })
     @JsonIgnoreProperties(ignoreUnknown = true)
     private interface Base {
@@ -1423,6 +1486,96 @@ public final class UnionTypeExample {
         @Override
         public String toString() {
             return "BooleanFieldWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("safeInt")
+    private static final class SafeIntWrapper implements Base {
+        private final int value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private SafeIntWrapper(@JsonSetter("safeInt") @Nonnull int value) {
+            Preconditions.checkNotNull(value, "safeInt cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(value = "type", index = 0)
+        private String getType() {
+            return "safeInt";
+        }
+
+        @JsonProperty("safeInt")
+        private int getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitSafeInt(value);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof SafeIntWrapper && equalTo((SafeIntWrapper) other));
+        }
+
+        private boolean equalTo(SafeIntWrapper other) {
+            return this.value == other.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return this.value;
+        }
+
+        @Override
+        public String toString() {
+            return "SafeIntWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("unsafeDouble")
+    private static final class UnsafeDoubleWrapper implements Base {
+        private final double value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private UnsafeDoubleWrapper(@JsonSetter("unsafeDouble") @Nonnull double value) {
+            Preconditions.checkNotNull(value, "unsafeDouble cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(value = "type", index = 0)
+        private String getType() {
+            return "unsafeDouble";
+        }
+
+        @JsonProperty("unsafeDouble")
+        private double getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitUnsafeDouble(value);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof UnsafeDoubleWrapper && equalTo((UnsafeDoubleWrapper) other));
+        }
+
+        private boolean equalTo(UnsafeDoubleWrapper other) {
+            return Double.doubleToLongBits(this.value) == Double.doubleToLongBits(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Double.hashCode(this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "UnsafeDoubleWrapper{value: " + value + '}';
         }
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -549,9 +549,9 @@ public final class UnionGenerator {
      * of the new unknownVisitor.
      */
     private static TypeName visitorObjectTypeName(NameTypeMetadata member, TypeName visitResultType, Options options) {
-        if (member.type.equals(TypeName.INT)) {
+        if (member.type.withoutAnnotations().equals(TypeName.INT)) {
             return ParameterizedTypeName.get(ClassName.get(IntFunction.class), visitResultType);
-        } else if (member.type.equals(TypeName.DOUBLE)) {
+        } else if (member.type.withoutAnnotations().equals(TypeName.DOUBLE)) {
             return ParameterizedTypeName.get(ClassName.get(DoubleFunction.class), visitResultType);
         } else if (NameTypeMetadata.UNKNOWN.equals(member) && options.unionsWithUnknownValues()) {
             return ParameterizedTypeName.get(

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -712,6 +712,16 @@ public final class WireFormatTests {
         }
 
         @Override
+        public Integer visitSafeInt(int value) {
+            return null;
+        }
+
+        @Override
+        public Integer visitUnsafeDouble(double value) {
+            return (int) value;
+        }
+
+        @Override
         public Integer visitIf(int value) {
             return value;
         }

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -229,6 +229,12 @@ types:
           booleanField:
             type: boolean
             safety: safe
+          safeInt:
+            type: integer
+            safety: safe
+          unsafeDouble:
+            type: double
+            safety: unsafe
       UnionWithUnknownString:
         union:
           unknown: string


### PR DESCRIPTION
First commit reproduces the issue, second commit fixes it.

==COMMIT_MSG==
Fix regression which resulted in `IntFunction` and `DoubleFunction` not being used when log-safety information is provided
==COMMIT_MSG==

