### PR TITLE
verifier.gradle uses the javax ws.rs-api dep rather than jakarta

### DIFF
--- a/gradle/verifier.gradle
+++ b/gradle/verifier.gradle
@@ -33,7 +33,7 @@ conjure {
 subprojects {
     dependencies {
         api project(':conjure-lib')
-        api 'jakarta.ws.rs:jakarta.ws.rs-api'
+        api 'javax.ws.rs:javax.ws.rs-api'
     }
 }
 


### PR DESCRIPTION
==COMMIT_MSG==
verifier.gradle uses the javax ws.rs-api dep rather than jakarta
==COMMIT_MSG==

