### PR TITLE
Nullable annotation for cause in ConjureErrors

### DIFF
--- a/changelog/@unreleased/pr-2001.v2.yml
+++ b/changelog/@unreleased/pr-2001.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Conjure errors have the "Throwable cause" parameter marked as Nullable
+  links:
+  - https://github.com/palantir/conjure-java/pull/2001

--- a/conjure-java-core/src/integrationInput/java/com/palantir/another/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/another/ConjureErrors.java
@@ -4,6 +4,7 @@ import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.logsafe.Preconditions;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 import org.jetbrains.annotations.Contract;
 
@@ -21,7 +22,7 @@ public final class ConjureErrors {
         return new ServiceException(DIFFERENT_PACKAGE);
     }
 
-    public static ServiceException differentPackage(Throwable cause) {
+    public static ServiceException differentPackage(@Nullable Throwable cause) {
         return new ServiceException(DIFFERENT_PACKAGE, cause);
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/another/ConjureJavaOtherErrors.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/another/ConjureJavaOtherErrors.java
@@ -4,6 +4,7 @@ import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.logsafe.Preconditions;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 import org.jetbrains.annotations.Contract;
 
@@ -21,7 +22,7 @@ public final class ConjureJavaOtherErrors {
         return new ServiceException(JAVA_COMPILATION_FAILED);
     }
 
-    public static ServiceException javaCompilationFailed(Throwable cause) {
+    public static ServiceException javaCompilationFailed(@Nullable Throwable cause) {
         return new ServiceException(JAVA_COMPILATION_FAILED, cause);
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ConjureErrors.java
@@ -8,6 +8,7 @@ import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.Unsafe;
 import com.palantir.logsafe.UnsafeArg;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 import org.jetbrains.annotations.Contract;
 
@@ -43,7 +44,7 @@ public final class ConjureErrors {
      * @param serviceDef Details of the invalid service definition.
      */
     public static ServiceException invalidServiceDefinition(
-            Throwable cause, @Safe String serviceName, @Unsafe Object serviceDef) {
+            @Nullable Throwable cause, @Safe String serviceName, @Unsafe Object serviceDef) {
         return new ServiceException(
                 INVALID_SERVICE_DEFINITION,
                 cause,
@@ -57,7 +58,7 @@ public final class ConjureErrors {
     }
 
     public static ServiceException invalidTypeDefinition(
-            Throwable cause, @Safe String typeName, @Unsafe Object typeDef) {
+            @Nullable Throwable cause, @Safe String typeName, @Unsafe Object typeDef) {
         return new ServiceException(
                 INVALID_TYPE_DEFINITION, cause, SafeArg.of("typeName", typeName), UnsafeArg.of("typeDef", typeDef));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ConjureJavaErrors.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ConjureJavaErrors.java
@@ -4,6 +4,7 @@ import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.logsafe.Preconditions;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 import org.jetbrains.annotations.Contract;
 
@@ -21,7 +22,7 @@ public final class ConjureJavaErrors {
         return new ServiceException(JAVA_COMPILATION_FAILED);
     }
 
-    public static ServiceException javaCompilationFailed(Throwable cause) {
+    public static ServiceException javaCompilationFailed(@Nullable Throwable cause) {
         return new ServiceException(JAVA_COMPILATION_FAILED, cause);
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ErrorGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ErrorGenerator.java
@@ -52,6 +52,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
 
@@ -276,7 +277,10 @@ public final class ErrorGenerator implements Generator {
         methodBuilder.addCode("return new $T($L", ServiceException.class, typeName);
 
         if (withCause) {
-            methodBuilder.addParameter(Throwable.class, "cause");
+            ParameterSpec causeParameter = ParameterSpec.builder(Throwable.class, "cause")
+                    .addAnnotation(Nullable.class)
+                    .build();
+            methodBuilder.addParameter(causeParameter);
             methodBuilder.addCode(", cause");
         }
 


### PR DESCRIPTION
## Before this PR
the cause parameter in generated code was not annotated with a nullable annotation even though ServiceException accepts a nullable Throwable parameter.

## After this PR
Compile time code checks wont complain when exceptions.getCause() is passed in as a parameter.
==COMMIT_MSG==
Conjure errors have the "Throwable cause" parameter marked as Nullable
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

