### PR TITLE
Add nullable annotation in equals for union and enums

### DIFF
--- a/changelog/@unreleased/pr-2004.v2.yml
+++ b/changelog/@unreleased/pr-2004.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Enums and Union types now have an `@Nullable` annotation for the `other`
+    parameter in the generated `equals` method
+  links:
+  - https://github.com/palantir/conjure-java/pull/2004

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyUnionTypeExample.java
@@ -46,7 +46,7 @@ public final class EmptyUnionTypeExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof EmptyUnionTypeExample && equalTo((EmptyUnionTypeExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 /**
@@ -66,7 +67,7 @@ public final class EnumExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return (this == other)
                 || (this.value == Value.UNKNOWN
                         && other instanceof EnumExample

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongUnionExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongUnionExample.java
@@ -59,7 +59,7 @@ public final class ExternalLongUnionExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof ExternalLongUnionExample && equalTo((ExternalLongUnionExample) other));
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 /**
@@ -50,7 +51,7 @@ public final class SimpleEnum {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return (this == other)
                 || (this.value == Value.UNKNOWN
                         && other instanceof SimpleEnum

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SingleUnion.java
@@ -56,7 +56,7 @@ public final class SingleUnion {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof SingleUnion && equalTo((SingleUnion) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/Union.java
@@ -80,7 +80,7 @@ public final class Union {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof Union && equalTo((Union) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionTypeExample.java
@@ -196,7 +196,7 @@ public final class UnionTypeExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof UnionTypeExample && equalTo((UnionTypeExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UnionWithUnknownString.java
@@ -56,7 +56,7 @@ public final class UnionWithUnknownString {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof UnionWithUnknownString && equalTo((UnionWithUnknownString) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyUnionTypeExample.java
@@ -45,7 +45,7 @@ public final class EmptyUnionTypeExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof EmptyUnionTypeExample && equalTo((EmptyUnionTypeExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 /**
@@ -66,7 +67,7 @@ public final class EnumExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return (this == other)
                 || (this.value == Value.UNKNOWN
                         && other instanceof EnumExample

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongUnionExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongUnionExample.java
@@ -58,7 +58,7 @@ public final class ExternalLongUnionExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof ExternalLongUnionExample && equalTo((ExternalLongUnionExample) other));
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 /**
@@ -50,7 +51,7 @@ public final class SimpleEnum {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return (this == other)
                 || (this.value == Value.UNKNOWN
                         && other instanceof SimpleEnum

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SingleUnion.java
@@ -55,7 +55,7 @@ public final class SingleUnion {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof SingleUnion && equalTo((SingleUnion) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/Union.java
@@ -79,7 +79,7 @@ public final class Union {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof Union && equalTo((Union) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionTypeExample.java
@@ -195,7 +195,7 @@ public final class UnionTypeExample {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof UnionTypeExample && equalTo((UnionTypeExample) other));
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UnionWithUnknownString.java
@@ -55,7 +55,7 @@ public final class UnionWithUnknownString {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof UnionWithUnknownString && equalTo((UnionWithUnknownString) other));
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.lang.model.element.Modifier;
 
 public final class EnumGenerator {
@@ -307,7 +308,9 @@ public final class EnumGenerator {
     }
 
     private static MethodSpec createEquals(TypeName thisClass) {
-        ParameterSpec other = ParameterSpec.builder(ClassName.OBJECT, "other").build();
+        ParameterSpec other = ParameterSpec.builder(ClassName.OBJECT, "other")
+                .addAnnotation(Nullable.class)
+                .build();
         return MethodSpec.methodBuilder("equals")
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(Override.class)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -127,7 +127,7 @@ public final class UnionGenerator {
                 .addTypes(generateWrapperClasses(
                         typeMapper, typesMap, baseClass, visitorClass, typeDef.getUnion(), options))
                 .addType(generateUnknownWrapper(baseClass, visitorClass, options))
-                .addMethod(generateEquals(unionClass))
+                .addMethod(MethodSpecs.createEquals(unionClass))
                 .addMethod(MethodSpecs.createEqualTo(unionClass, fields))
                 .addMethod(MethodSpecs.createHashCode(fields))
                 .addMethod(MethodSpecs.createToString(
@@ -245,20 +245,6 @@ public final class UnionGenerator {
                 .addTypeVariable(TYPE_VARIABLE)
                 .addStatement("return $L.accept($N)", VALUE_FIELD_NAME, visitor)
                 .returns(TYPE_VARIABLE)
-                .build();
-    }
-
-    private static MethodSpec generateEquals(ClassName unionClass) {
-        ParameterSpec other = ParameterSpec.builder(ClassName.OBJECT, "other").build();
-        CodeBlock.Builder codeBuilder = CodeBlock.builder()
-                .add("return this == $1N || ($1N instanceof $2T && equalTo(($2T) $1N))", other, unionClass);
-
-        return MethodSpec.methodBuilder("equals")
-                .addModifiers(Modifier.PUBLIC)
-                .addAnnotation(Override.class)
-                .addParameter(other)
-                .returns(TypeName.BOOLEAN)
-                .addStatement("$L", codeBuilder.build())
                 .build();
     }
 


### PR DESCRIPTION
## Before this PR
Passing a potentially null value to equals will cause NullAway to error, even when null is supported by equals.

<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Enums and Union types now have an `@Nullable` annotation for the `other` parameter in the generated `equals` method
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

