### PR TITLE
add sizes to traced encoding spans

### DIFF
--- a/changelog/@unreleased/pr-2018.v2.yml
+++ b/changelog/@unreleased/pr-2018.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Include sizes of deserialized requests or serialized responses in the
+    traced encoding spans.
+  links:
+  - https://github.com/palantir/conjure-java/pull/2018

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/TracedEncoding.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/TracedEncoding.java
@@ -111,7 +111,7 @@ final class TracedEncoding implements Encoding {
                 ImmutableMap<String, String> metadata = ImmutableMap.<String, String>builder()
                         .putAll(tags)
                         .put("outputSize", Long.toString(countingOutput.getCount()))
-                        .build();
+                        .buildOrThrow();
                 Tracer.fastCompleteSpan(metadata);
             }
         }
@@ -139,7 +139,7 @@ final class TracedEncoding implements Encoding {
                 ImmutableMap<String, String> metadata = ImmutableMap.<String, String>builder()
                         .putAll(tags)
                         .put("inputSize", Long.toString(countingInput.getCount()))
-                        .build();
+                        .buildOrThrow();
                 Tracer.fastCompleteSpan(metadata);
             }
         }


### PR DESCRIPTION
## Before this PR
When debugging slow request deserialization/response serialization, you have to manually cross-reference request logs.

## After this PR
==COMMIT_MSG==
Include sizes of deserialized requests or serialized responses in the traced encoding spans.
==COMMIT_MSG==

## Possible downsides?
The adding the extra key/value to the immutable tags is a bit ugly

