### PR TITLE
Include request/response size metadata in tracing spans

### DIFF
--- a/changelog/@unreleased/pr-2019.v2.yml
+++ b/changelog/@unreleased/pr-2019.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Include request/response size metadata in tracing spans
+  links:
+  - https://github.com/palantir/conjure-java/pull/2019

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/CompletedRequestTagTranslator.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/CompletedRequestTagTranslator.java
@@ -45,6 +45,13 @@ enum CompletedRequestTagTranslator implements TagTranslator<HttpServerExchange> 
         adapter.tag(target, TraceTags.HTTP_METHOD, exchange.getRequestMethod().toString());
         adapter.tag(target, TraceTags.HTTP_URL_SCHEME, exchange.getRequestScheme());
         adapter.tag(target, TraceTags.HTTP_VERSION, exchange.getProtocol().toString());
+        adapter.tag(target, TraceTags.NETWORK_BYTES_WRITTEN, Long.toString(exchange.getResponseBytesSent()));
+        // The amount of content that has been read is nontrivial to glean without using a conduitwrapper,
+        // for now reporting the Content-Length header from requests which aren't chunked is a start.
+        long requestContentLength = exchange.getRequestContentLength();
+        if (requestContentLength >= 0) {
+            adapter.tag(target, TraceTags.NETWORK_BYTES_READ, Long.toString(requestContentLength));
+        }
     }
 
     static String statusString(int statusCode) {


### PR DESCRIPTION
==COMMIT_MSG==
Include request/response size metadata in tracing spans
==COMMIT_MSG==
