### PR TITLE
Add RequestContext method to get request target

### DIFF
--- a/changelog/@unreleased/pr-2030.v2.yml
+++ b/changelog/@unreleased/pr-2030.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add `RequestContext` method to get the request target.
+  links:
+  - https://github.com/palantir/conjure-java/pull/2030

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
@@ -61,6 +61,13 @@ final class ConjureContexts implements Contexts {
         }
 
         @Override
+        public String requestTarget() {
+            String requestUri = exchange.getRequestURI();
+            String queryString = exchange.getQueryString();
+            return queryString.isEmpty() ? requestUri : requestUri + "?" + queryString;
+        }
+
+        @Override
         public List<String> header(String headerName) {
             HeaderValues header = exchange.getRequestHeaders().get(headerName);
             return header == null ? ImmutableList.of() : Collections.unmodifiableList(header);

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.undertow.runtime;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.palantir.conjure.java.undertow.lib.Contexts;
@@ -64,7 +65,7 @@ final class ConjureContexts implements Contexts {
         public String requestTarget() {
             String requestUri = exchange.getRequestURI();
             String queryString = exchange.getQueryString();
-            return queryString.isEmpty() ? requestUri : requestUri + "?" + queryString;
+            return Strings.isNullOrEmpty(queryString) ? requestUri : requestUri + "?" + queryString;
         }
 
         @Override

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
@@ -30,6 +30,13 @@ import java.util.Optional;
 public interface RequestContext {
 
     /**
+     * Returns the <a href="https://www.rfc-editor.org/rfc/rfc7230#section-5.3">request target</a>.
+     *
+     * This includes the query string and is not decoded in any way.
+     */
+    String requestTarget();
+
+    /**
      * Returns all values of the header named {@code headerName}. The name is case insensitive. An empty list is
      * returned if no such header exists.
      */

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.undertow.lib;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Unsafe;
 import java.security.cert.Certificate;
 import java.util.List;
 import java.util.Optional;
@@ -34,6 +35,7 @@ public interface RequestContext {
      *
      * This includes the query string and is not decoded in any way.
      */
+    @Unsafe
     String requestTarget();
 
     /**


### PR DESCRIPTION
We use this logic in a couple different places in our internal authentication service. For example, when we receive an unauthenticated request we want to grab the current request target so we can redirect the user back to their original destination after they have authenticated.

It's easy to get this logic wrong. `HttpServerExchange` has a couple of methods that appear similar but have subtle differences. It's particularly important to know whether the returned value has been decoded or not.
- `getRequestURI` returns the raw request target, excluding the query string.
- `getRequestURL` returns the raw request URL, excluding the query string.
    - If the request target is not in absolute form, then it will construct the URL using the schema, host, and port of the request. This can result in URLs with things like IP addresses and is almost never what you want.
- `getRequestPath` return the decoded path component of the request target, excluding the query string
    - If you are storing this for a later redirect, using the decoded value is incorrect.

This PR adds a `requestTarget` method to `RequestContext` to centralize the correct implementation with the goal of making is easier for devs to use the correct value.