### PR TITLE
Add RequestContext method to get cookie value

### DIFF
--- a/changelog/@unreleased/pr-2033.v2.yml
+++ b/changelog/@unreleased/pr-2033.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add `RequestContext` method to get cookie values.
+  links:
+  - https://github.com/palantir/conjure-java/pull/2033

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
@@ -25,6 +25,7 @@ import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import io.undertow.server.HttpServerExchange;
+import io.undertow.server.handlers.Cookie;
 import io.undertow.util.HeaderValues;
 import java.security.cert.Certificate;
 import java.util.Collections;
@@ -69,6 +70,11 @@ final class ConjureContexts implements Contexts {
         @Override
         public Optional<String> firstHeader(String headerName) {
             return Optional.ofNullable(exchange.getRequestHeaders().getFirst(headerName));
+        }
+
+        @Override
+        public Optional<String> cookie(String cookieName) {
+            return Optional.ofNullable(exchange.getRequestCookie(cookieName)).map(Cookie::getValue);
         }
 
         @Override

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
@@ -42,6 +42,12 @@ public interface RequestContext {
     Optional<String> firstHeader(String headerName);
 
     /**
+     * Returns the value of the cookie named {@code cookieName}.
+     * An {@link Optional#empty()} is returned if no such cookie exists.
+     */
+    Optional<String> cookie(String cookieName);
+
+    /**
      * Returns all query parameters associated with the current request.
      */
     ListMultimap<String, String> queryParameters();


### PR DESCRIPTION
This is useful for:
- Reading cookie values in a Conjure generated endpoint
- Reading cookie values in a `conjure-undertow-annotations` endpoint when the cookie names are dynamic and not known at compile time (so the `@Cookie` annotation cannot be used).

