### PR TITLE
Parse form parameters as UTF-8 by default

### DIFF
--- a/changelog/@unreleased/pr-2037.v2.yml
+++ b/changelog/@unreleased/pr-2037.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: '`application/x-www-form-urlencoded` request parameters are decode
+    as `UTF-8` the request does not specify a charset.'
+  links:
+  - https://github.com/palantir/conjure-java/pull/2037

--- a/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/FormParamDeserializer.java
+++ b/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/FormParamDeserializer.java
@@ -26,6 +26,7 @@ import io.undertow.server.handlers.form.FormDataParser;
 import io.undertow.server.handlers.form.FormParserFactory;
 import io.undertow.util.Headers;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -33,8 +34,9 @@ import java.util.Deque;
 
 public final class FormParamDeserializer<T> implements Deserializer<T> {
 
-    private static final FormParserFactory FORM_PARSER_FACTORY =
-            FormParserFactory.builder().build();
+    private static final FormParserFactory FORM_PARSER_FACTORY = FormParserFactory.builder()
+            .withDefaultCharset(StandardCharsets.UTF_8.name())
+            .build();
 
     private final String parameter;
     private final CollectionParamDecoder<? extends T> decoder;


### PR DESCRIPTION
## Before this PR

If a `application/x-www-form-urlencoded` request does not specify a charset, form parameters are decoded as `ISO-8859-1`.

We recently migrated one of our services from Jersey to Undertow and believe this behavior change is resulting in errors. Jersey defaults to `UTF-8`:
- https://github.com/eclipse-ee4j/jersey/blob/2.36/core-common/src/main/java/org/glassfish/jersey/message/internal/AbstractFormProvider.java#L48
- https://github.com/eclipse-ee4j/jersey/blob/2.36/core-common/src/main/java/org/glassfish/jersey/message/internal/ReaderWriter.java#L121-L124

## After this PR

If a `application/x-www-form-urlencoded` request does not specify a charset, form parameters are decoded as `UTF-8`.

The [specification](https://url.spec.whatwg.org/#urlencoded-parsing) seems to recommend `UTF-8` as the default charset for `application/x-www-form-urlencoded`.

> A legacy server-oriented implementation might have to support [encodings](https://encoding.spec.whatwg.org/#encoding) other than [UTF-8](https://encoding.spec.whatwg.org/#utf-8) as well as have special logic for tuples of which the name is `_charset`. Such logic is not described here as only [UTF-8](https://encoding.spec.whatwg.org/#utf-8) is conforming.

> Let nameString and valueString be the result of running [UTF-8 decode without BOM](https://encoding.spec.whatwg.org/#utf-8-decode-without-bom) on the [percent-decoding](https://url.spec.whatwg.org/#percent-decode) of name and value, respectively.
