### PR TITLE
RequestContext.peerCertificates returns List

### DIFF
--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.undertow.runtime;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
 import com.palantir.conjure.java.undertow.lib.Contexts;
 import com.palantir.conjure.java.undertow.lib.Endpoint;
 import com.palantir.conjure.java.undertow.lib.RequestContext;
@@ -86,7 +87,7 @@ final class ConjureContexts implements Contexts {
         }
 
         @Override
-        public ImmutableListMultimap<String, String> queryParameters() {
+        public ListMultimap<String, String> queryParameters() {
             ImmutableListMultimap<String, String> cachedQueryParamsSnapshot = cachedQueryParams;
             if (cachedQueryParamsSnapshot == null) {
                 cachedQueryParamsSnapshot = buildQueryParameters();
@@ -101,7 +102,7 @@ final class ConjureContexts implements Contexts {
         }
 
         @Override
-        public ImmutableList<Certificate> peerCertificates() {
+        public List<Certificate> peerCertificates() {
             SSLSession sslSession = exchange.getConnection().getSslSession();
             if (sslSession != null) {
                 try {

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
@@ -75,5 +75,5 @@ public interface RequestContext {
      *
      * @see javax.net.ssl.SSLSession#getPeerCertificates()
      */
-    ImmutableList<Certificate> peerCertificates();
+    List<Certificate> peerCertificates();
 }


### PR DESCRIPTION
There's no need to dictate a particular implementation in the `RequestContext` interface. We don't do this for the other methods here.

This is an ABI break, but I think it's unlikely to affect users because:
- There are very few users of this method
- These uses are almost certainly not in libraries

Searching our internal repos I don't see any uses of this method.