### PR TITLE
Add StdSerializer and StdDeserializer

### DIFF
--- a/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/StdDeserializer.java
+++ b/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/StdDeserializer.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.annotations;
+
+import com.palantir.conjure.java.undertow.lib.Deserializer;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+
+@SuppressWarnings({"RawTypes", "unchecked"})
+public interface StdDeserializer<T> extends DeserializerFactory<T>, Deserializer<T> {
+
+    @Override
+    default <T1 extends T> Deserializer<T1> deserializer(
+            TypeMarker<T1> _type, UndertowRuntime _runtime, Endpoint _endpoint) {
+        return (Deserializer<T1>) this;
+    }
+}

--- a/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/StdSerializer.java
+++ b/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/StdSerializer.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.annotations;
+
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.Serializer;
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+
+@SuppressWarnings({"RawTypes", "unchecked"})
+public interface StdSerializer<T> extends SerializerFactory<T>, Serializer<T> {
+
+    @Override
+    default <T1 extends T> Serializer<T1> serializer(
+            TypeMarker<T1> _type, UndertowRuntime _runtime, Endpoint _endpoint) {
+        return (Serializer<T1>) this;
+    }
+}

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/PrimitiveBodyParam.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/PrimitiveBodyParam.java
@@ -16,27 +16,23 @@
 
 package com.palantir.conjure.java.undertow.processor.sample;
 
-import com.palantir.conjure.java.undertow.annotations.DeserializerFactory;
 import com.palantir.conjure.java.undertow.annotations.Handle;
 import com.palantir.conjure.java.undertow.annotations.HttpMethod;
-import com.palantir.conjure.java.undertow.lib.Deserializer;
-import com.palantir.conjure.java.undertow.lib.Endpoint;
-import com.palantir.conjure.java.undertow.lib.TypeMarker;
-import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.annotations.StdDeserializer;
+import io.undertow.server.HttpServerExchange;
+import java.io.IOException;
 
 public interface PrimitiveBodyParam {
 
     @Handle(method = HttpMethod.POST, path = "/post")
     void handlePrimitiveBody(@Handle.Body(IntParamDeserializerFactory.class) int count);
 
-    enum IntParamDeserializerFactory implements DeserializerFactory<Integer> {
+    enum IntParamDeserializerFactory implements StdDeserializer<Integer> {
         INSTANCE;
 
-        @SuppressWarnings("unchecked")
         @Override
-        public <T extends Integer> Deserializer<T> deserializer(
-                TypeMarker<T> _type, UndertowRuntime _runtime, Endpoint _endpoint) {
-            return _exchange -> (T) (Integer) 1;
+        public Integer deserialize(HttpServerExchange _exchange) throws IOException {
+            return 1;
         }
     }
 }


### PR DESCRIPTION
These are analogous to the identically named Dialogue classes:
- [`StdSerializer`](https://github.com/palantir/dialogue/blob/bbf619283f1a4bc7a3e838f2c20a95b81a7cfb08/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/StdSerializer.java)
- [`StdDeserializer`](https://github.com/palantir/dialogue/blob/bbf619283f1a4bc7a3e838f2c20a95b81a7cfb08/dialogue-annotations/src/main/java/com/palantir/dialogue/annotations/StdDeserializer.java)

## Possible downsides?
These classes can be a footgun if the selected type parameter has multiple subclasses (the use of `ImmutableList` after https://github.com/palantir/conjure-java/pull/1970 is the most common occurrence we've seen). But this problem exists with the Dialogue classes as well, so I'm not sure that's a sufficient reason to not provide these utilities.

