### PR TITLE
Refactor BeanGenerator#generateBeanType to move logic for creating empty beans to separate method

### DIFF
--- a/changelog/@unreleased/pr-2088.v2.yml
+++ b/changelog/@unreleased/pr-2088.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Refactor BeanGenerator#generateBeanType to move logic for creating
+    empty beans to separate method
+  links:
+  - https://github.com/palantir/conjure-java/pull/2088

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -191,10 +191,8 @@ public final class BeanGenerator {
             ImmutableList<AnnotationSpec> safety,
             ClassName objectClass,
             Options options) {
-        // Add ctor
         typeBuilder.addMethod(createConstructor(ImmutableList.of(), ImmutableList.of()));
 
-        // Add toString
         typeBuilder.addMethod(MethodSpecs.createToString(prefixedName.getName(), Collections.emptyList()).toBuilder()
                 .addAnnotations(safety)
                 .build());

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -102,12 +102,16 @@ public final class BeanGenerator {
 
         TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(prefixedName.getName())
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                .addAnnotations(safety)
-                .addFields(poetFields)
-                .addMethod(createConstructor(fields, poetFields))
-                .addMethods(createGetters(fields, typesMap, options, safetyEvaluator));
+                .addAnnotations(safety);
 
-        if (!poetFields.isEmpty()) {
+        if (poetFields.isEmpty()) {
+            addEmptyBean(typeBuilder, prefixedName, safety, objectClass, options);
+        } else {
+            typeBuilder
+                    .addFields(poetFields)
+                    .addMethod(createConstructor(fields, poetFields))
+                    .addMethods(createGetters(fields, typesMap, options, safetyEvaluator));
+
             boolean useCachedHashCode = useCachedHashCode(fields);
             typeBuilder
                     .addMethod(MethodSpecs.createEquals(objectClass))
@@ -117,48 +121,59 @@ public final class BeanGenerator {
             } else {
                 typeBuilder.addMethod(MethodSpecs.createHashCode(poetFields));
             }
-        }
 
-        typeBuilder.addMethod(MethodSpecs.createToString(
-                        prefixedName.getName(),
-                        fields.stream().map(EnrichedField::fieldName).collect(Collectors.toList()))
-                .toBuilder()
-                .addAnnotations(safety)
-                .build());
+            typeBuilder.addMethod(MethodSpecs.createToString(
+                            prefixedName.getName(),
+                            fields.stream().map(EnrichedField::fieldName).collect(Collectors.toList()))
+                    .toBuilder()
+                    .addAnnotations(safety)
+                    .build());
 
-        if (poetFields.size() <= MAX_NUM_PARAMS_FOR_FACTORY) {
-            typeBuilder.addMethod(createStaticFactoryMethod(
-                    fields,
-                    objectClass,
-                    safetyEvaluator,
-                    options.useStagedBuilders() && !options.useStrictStagedBuilders()));
-        }
-
-        if (!nonPrimitiveEnrichedFields.isEmpty()) {
-            typeBuilder
-                    .addMethod(createValidateFields(nonPrimitiveEnrichedFields))
-                    .addMethod(createAddFieldIfMissing(nonPrimitiveEnrichedFields.size()));
-        }
-
-        if (poetFields.isEmpty()) {
-            // Need to add JsonSerialize annotation which indicates that the empty bean serializer should be used to
-            // serialize this class. Without this annotation no serializer will be set for this class, thus preventing
-            // serialization.
-            typeBuilder.addAnnotation(JsonSerialize.class).addField(createSingletonField(objectClass));
-            if (!options.strictObjects()) {
-                typeBuilder.addAnnotation(AnnotationSpec.builder(JsonIgnoreProperties.class)
-                        .addMember("ignoreUnknown", "$L", true)
-                        .build());
+            if (poetFields.size() <= MAX_NUM_PARAMS_FOR_FACTORY) {
+                typeBuilder.addMethod(createStaticFactoryMethod(
+                        fields,
+                        objectClass,
+                        safetyEvaluator,
+                        options.useStagedBuilders() && !options.useStrictStagedBuilders()));
             }
-        } else if (options.useStrictStagedBuilders()) {
-            BeanBuilderGenerator.addStrictStagedBuilder(
-                    typeBuilder, typeMapper, safetyEvaluator, objectClass, builderClass, typeDef, typesMap, options);
-        } else if (options.useStagedBuilders()) {
-            BeanBuilderGenerator.addStagedBuilder(
-                    typeBuilder, typeMapper, safetyEvaluator, objectClass, builderClass, typeDef, typesMap, options);
-        } else {
-            BeanBuilderGenerator.addBuilder(
-                    typeBuilder, typeMapper, safetyEvaluator, objectClass, builderClass, typeDef, typesMap, options);
+
+            if (!nonPrimitiveEnrichedFields.isEmpty()) {
+                typeBuilder
+                        .addMethod(createValidateFields(nonPrimitiveEnrichedFields))
+                        .addMethod(createAddFieldIfMissing(nonPrimitiveEnrichedFields.size()));
+            }
+
+            if (options.useStrictStagedBuilders()) {
+                BeanBuilderGenerator.addStrictStagedBuilder(
+                        typeBuilder,
+                        typeMapper,
+                        safetyEvaluator,
+                        objectClass,
+                        builderClass,
+                        typeDef,
+                        typesMap,
+                        options);
+            } else if (options.useStagedBuilders()) {
+                BeanBuilderGenerator.addStagedBuilder(
+                        typeBuilder,
+                        typeMapper,
+                        safetyEvaluator,
+                        objectClass,
+                        builderClass,
+                        typeDef,
+                        typesMap,
+                        options);
+            } else {
+                BeanBuilderGenerator.addBuilder(
+                        typeBuilder,
+                        typeMapper,
+                        safetyEvaluator,
+                        objectClass,
+                        builderClass,
+                        typeDef,
+                        typesMap,
+                        options);
+            }
         }
         typeBuilder.addAnnotation(ConjureAnnotations.getConjureGeneratedAnnotation(BeanGenerator.class));
 
@@ -168,6 +183,33 @@ public final class BeanGenerator {
                 .skipJavaLangImports(true)
                 .indent("    ")
                 .build();
+    }
+
+    private static void addEmptyBean(
+            TypeSpec.Builder typeBuilder,
+            com.palantir.conjure.spec.TypeName prefixedName,
+            ImmutableList<AnnotationSpec> safety,
+            ClassName objectClass,
+            Options options) {
+        // Add ctor
+        typeBuilder.addMethod(createConstructor(ImmutableList.of(), ImmutableList.of()));
+
+        // Add toString
+        typeBuilder.addMethod(MethodSpecs.createToString(prefixedName.getName(), Collections.emptyList()).toBuilder()
+                .addAnnotations(safety)
+                .build());
+
+        typeBuilder.addMethod(createStaticFactoryMethodForEmptyBean(objectClass));
+
+        // Need to add JsonSerialize annotation which indicates that the empty bean serializer should be used to
+        // serialize this class. Without this annotation no serializer will be set for this class, thus preventing
+        // serialization.
+        typeBuilder.addAnnotation(JsonSerialize.class).addField(createSingletonField(objectClass));
+        if (!options.strictObjects()) {
+            typeBuilder.addAnnotation(AnnotationSpec.builder(JsonIgnoreProperties.class)
+                    .addMember("ignoreUnknown", "$L", true)
+                    .build());
+        }
     }
 
     private static boolean useCachedHashCode(Collection<EnrichedField> fields) {
@@ -331,35 +373,43 @@ public final class BeanGenerator {
             ClassName objectClass,
             SafetyEvaluator safetyEvaluator,
             boolean useNonStrictStagedBuilders) {
+        if (fields.isEmpty()) {
+            createStaticFactoryMethodForEmptyBean(objectClass);
+        }
+
         MethodSpec.Builder builder = MethodSpec.methodBuilder("of")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .returns(objectClass);
 
-        if (fields.isEmpty()) {
-            builder.addAnnotation(ConjureAnnotations.delegatingJsonCreator())
-                    .addCode("return $L;", SINGLETON_INSTANCE_NAME);
-        } else {
-            builder.addCode("return builder()");
-            fields.forEach(field -> builder.addParameter(ParameterSpec.builder(
-                            getTypeNameWithoutOptional(field.poetSpec()), field.poetSpec().name)
-                    .addAnnotations(ConjureAnnotations.safety(safetyEvaluator.getUsageTimeSafety(field.conjureDef())))
-                    .build()));
+        builder.addCode("return builder()");
+        fields.forEach(field -> builder.addParameter(ParameterSpec.builder(
+                        getTypeNameWithoutOptional(field.poetSpec()), field.poetSpec().name)
+                .addAnnotations(ConjureAnnotations.safety(safetyEvaluator.getUsageTimeSafety(field.conjureDef())))
+                .build()));
 
-            Stream<EnrichedField> methodArgs = useNonStrictStagedBuilders
-                    ? fields.stream()
-                            .sorted(Comparator.comparing(BeanBuilderGenerator::stagedBuilderFieldShouldBeInFinalStage))
-                    : fields.stream();
-            methodArgs.map(EnrichedField::poetSpec).forEach(spec -> {
-                if (isOptional(spec)) {
-                    builder.addCode("\n    .$L(Optional.of($L))", spec.name, spec.name);
-                } else {
-                    builder.addCode("\n    .$L($L)", spec.name, spec.name);
-                }
-            });
-            builder.addCode("\n    .build();\n");
-        }
+        Stream<EnrichedField> methodArgs = useNonStrictStagedBuilders
+                ? fields.stream()
+                        .sorted(Comparator.comparing(BeanBuilderGenerator::stagedBuilderFieldShouldBeInFinalStage))
+                : fields.stream();
+        methodArgs.map(EnrichedField::poetSpec).forEach(spec -> {
+            if (isOptional(spec)) {
+                builder.addCode("\n    .$L(Optional.of($L))", spec.name, spec.name);
+            } else {
+                builder.addCode("\n    .$L($L)", spec.name, spec.name);
+            }
+        });
+        builder.addCode("\n    .build();\n");
 
         return builder.build();
+    }
+
+    private static MethodSpec createStaticFactoryMethodForEmptyBean(ClassName objectClass) {
+        return MethodSpec.methodBuilder("of")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .returns(objectClass)
+                .addAnnotation(ConjureAnnotations.delegatingJsonCreator())
+                .addCode("return $L;", SINGLETON_INSTANCE_NAME)
+                .build();
     }
 
     private static MethodSpec createAddFieldIfMissing(int fieldCount) {


### PR DESCRIPTION
## Before this PR
In preparation of merging #2087, I'd like to refactor the `BeanGenerator#generateBeanType` to reduce the branching logic. There are several places where there is special handling for generating an empty bean. This PR moves this logic into a separate method.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Refactor BeanGenerator#generateBeanType to move logic for creating empty beans to separate method
==COMMIT_MSG==

## Possible downsides?
