### PR TITLE
Make generated enums comparable

### DIFF
--- a/changelog/@unreleased/pr-2095.v2.yml
+++ b/changelog/@unreleased/pr-2095.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Enums are comparable
+  links:
+  - https://github.com/palantir/conjure-java/pull/2095

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -28,7 +28,7 @@ import javax.annotation.processing.Generated;
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
 @Safe
 @Immutable
-public final class EnumExample {
+public final class EnumExample implements Comparable<EnumExample> {
     public static final EnumExample ONE = new EnumExample(Value.ONE, "ONE");
 
     /**
@@ -112,6 +112,11 @@ public final class EnumExample {
 
     public static List<EnumExample> values() {
         return values;
+    }
+
+    @Override
+    public int compareTo(EnumExample other) {
+        return this.string.compareTo(other.string);
     }
 
     @Generated("com.palantir.conjure.java.types.EnumGenerator")

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
@@ -26,7 +26,7 @@ import javax.annotation.processing.Generated;
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
 @Safe
 @Immutable
-public final class SimpleEnum {
+public final class SimpleEnum implements Comparable<SimpleEnum> {
     public static final SimpleEnum VALUE = new SimpleEnum(Value.VALUE, "VALUE");
 
     private static final List<SimpleEnum> values = Collections.unmodifiableList(Arrays.asList(VALUE));
@@ -86,6 +86,11 @@ public final class SimpleEnum {
 
     public static List<SimpleEnum> values() {
         return values;
+    }
+
+    @Override
+    public int compareTo(SimpleEnum other) {
+        return this.string.compareTo(other.string);
     }
 
     @Generated("com.palantir.conjure.java.types.EnumGenerator")

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
@@ -28,7 +28,7 @@ import javax.annotation.processing.Generated;
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
 @Safe
 @Immutable
-public final class EnumExample {
+public final class EnumExample implements Comparable<EnumExample> {
     public static final EnumExample ONE = new EnumExample(Value.ONE, "ONE");
 
     /**
@@ -112,6 +112,11 @@ public final class EnumExample {
 
     public static List<EnumExample> values() {
         return values;
+    }
+
+    @Override
+    public int compareTo(EnumExample other) {
+        return this.string.compareTo(other.string);
     }
 
     @Generated("com.palantir.conjure.java.types.EnumGenerator")

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
@@ -26,7 +26,7 @@ import javax.annotation.processing.Generated;
 @Generated("com.palantir.conjure.java.types.EnumGenerator")
 @Safe
 @Immutable
-public final class SimpleEnum {
+public final class SimpleEnum implements Comparable<SimpleEnum> {
     public static final SimpleEnum VALUE = new SimpleEnum(Value.VALUE, "VALUE");
 
     private static final List<SimpleEnum> values = Collections.unmodifiableList(Arrays.asList(VALUE));
@@ -86,6 +86,11 @@ public final class SimpleEnum {
 
     public static List<SimpleEnum> values() {
         return values;
+    }
+
+    @Override
+    public int compareTo(SimpleEnum other) {
+        return this.string.compareTo(other.string);
     }
 
     @Generated("com.palantir.conjure.java.types.EnumGenerator")

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -102,7 +102,10 @@ public final class EnumGenerator {
                 .addMethod(createHashCode())
                 .addMethod(createValueOf(thisClass, typeDef.getValues()))
                 .addMethod(generateAcceptVisitMethod(visitorClass, typeDef.getValues()))
-                .addMethod(createValues(thisClass));
+                .addMethod(createValues(thisClass))
+                .addSuperinterface(
+                        ParameterizedTypeName.get(ClassName.get(Comparable.class), thisClass))
+                .addMethod(createCompareTo(thisClass));
 
         typeDef.getDocs().ifPresent(docs -> wrapper.addJavadoc("$L<p>\n", Javadoc.render(docs)));
 
@@ -330,6 +333,16 @@ public final class EnumGenerator {
                 .addAnnotation(Override.class)
                 .returns(TypeName.INT)
                 .addStatement("return this.string.hashCode()")
+                .build();
+    }
+
+    private static MethodSpec createCompareTo(TypeName thisClass) {
+        return MethodSpec.methodBuilder("compareTo")
+                .addModifiers(Modifier.PUBLIC)
+                .addAnnotation(Override.class)
+                .returns(TypeName.INT)
+                .addParameter(ParameterSpec.builder(thisClass, "other").build())
+                .addStatement("return this.string.compareTo(other.string)")
                 .build();
     }
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -103,8 +103,7 @@ public final class EnumGenerator {
                 .addMethod(createValueOf(thisClass, typeDef.getValues()))
                 .addMethod(generateAcceptVisitMethod(visitorClass, typeDef.getValues()))
                 .addMethod(createValues(thisClass))
-                .addSuperinterface(
-                        ParameterizedTypeName.get(ClassName.get(Comparable.class), thisClass))
+                .addSuperinterface(ParameterizedTypeName.get(ClassName.get(Comparable.class), thisClass))
                 .addMethod(createCompareTo(thisClass));
 
         typeDef.getDocs().ifPresent(docs -> wrapper.addJavadoc("$L<p>\n", Javadoc.render(docs)));

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
@@ -71,13 +71,11 @@ public class EnumTests {
 
     @Test
     public void testSorted() {
-        List<EnumExample> valuesUnsorted = List.of(
-                EnumExample.ONE,
-                EnumExample.valueOf("A"),
-                EnumExample.valueOf("Z"));
+        List<EnumExample> valuesUnsorted = List.of(EnumExample.ONE, EnumExample.valueOf("A"), EnumExample.valueOf("Z"));
         assertThat(ImmutableList.sortedCopyOf(valuesUnsorted))
                 .describedAs("enum sorting order should equal string value sorting order")
-                .containsExactlyElementsOf(ImmutableList.sortedCopyOf(Comparator.comparing(EnumExample::toString), valuesUnsorted));
+                .containsExactlyElementsOf(
+                        ImmutableList.sortedCopyOf(Comparator.comparing(EnumExample::toString), valuesUnsorted));
     }
 
     private enum Visitor implements EnumExample.Visitor<String> {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
@@ -19,8 +19,11 @@ package com.palantir.conjure.java.types;
 import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import com.palantir.product.EnumExample;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
@@ -64,6 +67,17 @@ public class EnumTests {
                 .filter(v -> !v.equals(EnumExample.Value.UNKNOWN))
                 .collect(Collectors.toSet());
         assertThat(valuesFromClass).containsExactlyInAnyOrderElementsOf(valuesFromEnum);
+    }
+
+    @Test
+    public void testSorted() {
+        List<EnumExample> valuesUnsorted = List.of(
+                EnumExample.ONE,
+                EnumExample.valueOf("A"),
+                EnumExample.valueOf("Z"));
+        assertThat(ImmutableList.sortedCopyOf(valuesUnsorted))
+                .describedAs("enum sorting order should equal string value sorting order")
+                .containsExactlyElementsOf(ImmutableList.sortedCopyOf(Comparator.comparing(EnumExample::toString), valuesUnsorted));
     }
 
     private enum Visitor implements EnumExample.Visitor<String> {


### PR DESCRIPTION
## Before this PR
Aliases of comparable primitives were made comparable so they could be used as sorted map keys, but enums were not made comparable during this change (https://github.com/palantir/conjure-java/pull/1780)

## After this PR
==COMMIT_MSG==
Make generated enums comparable
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

