### PR TITLE
Add enum visitor builder

### DIFF
--- a/changelog/@unreleased/pr-2096.v2.yml
+++ b/changelog/@unreleased/pr-2096.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Enum types now have a visitor builder
+  links:
+  - https://github.com/palantir/conjure-java/pull/2096

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
@@ -5,10 +5,14 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.errorprone.annotations.Immutable;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
@@ -100,5 +104,70 @@ public final class SimpleEnum {
         T visitValue();
 
         T visitUnknown(String unknownValue);
+
+        static <T> ValueStageVisitorBuilder<T> builder() {
+            return new VisitorBuilder<T>();
+        }
+    }
+
+    private static final class VisitorBuilder<T>
+            implements ValueStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, CompletedStageVisitorBuilder<T> {
+        private Supplier<T> valueVisitor;
+
+        private Function<@Safe String, T> unknownVisitor;
+
+        @Override
+        public UnknownStageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor) {
+            Preconditions.checkNotNull(valueVisitor, "valueVisitor cannot be null");
+            this.valueVisitor = valueVisitor;
+            return this;
+        }
+
+        @Override
+        public CompletedStageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor) {
+            Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
+            this.unknownVisitor = unknownType -> unknownVisitor.apply(unknownType);
+            return this;
+        }
+
+        @Override
+        public CompletedStageVisitorBuilder<T> throwOnUnknown() {
+            this.unknownVisitor = unknownType -> {
+                throw new SafeIllegalArgumentException(
+                        "Unknown variant of the 'SimpleEnum' union", SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
+        public Visitor<T> build() {
+            final Supplier<T> valueVisitor = this.valueVisitor;
+            final Function<@Safe String, T> unknownVisitor = this.unknownVisitor;
+            return new Visitor<T>() {
+                @Override
+                public T visitValue() {
+                    return valueVisitor.get();
+                }
+
+                @Override
+                public T visitUnknown(String unknownType) {
+                    return unknownVisitor.apply(unknownType);
+                }
+            };
+        }
+    }
+
+    public interface ValueStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor);
+    }
+
+    public interface UnknownStageVisitorBuilder<T> {
+        CompletedStageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
+
+        CompletedStageVisitorBuilder<T> throwOnUnknown();
+    }
+
+    public interface CompletedStageVisitorBuilder<T> {
+        Visitor<T> build();
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
@@ -5,10 +5,14 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.errorprone.annotations.Immutable;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
@@ -100,5 +104,70 @@ public final class SimpleEnum {
         T visitValue();
 
         T visitUnknown(String unknownValue);
+
+        static <T> ValueStageVisitorBuilder<T> builder() {
+            return new VisitorBuilder<T>();
+        }
+    }
+
+    private static final class VisitorBuilder<T>
+            implements ValueStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, CompletedStageVisitorBuilder<T> {
+        private Supplier<T> valueVisitor;
+
+        private Function<@Safe String, T> unknownVisitor;
+
+        @Override
+        public UnknownStageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor) {
+            Preconditions.checkNotNull(valueVisitor, "valueVisitor cannot be null");
+            this.valueVisitor = valueVisitor;
+            return this;
+        }
+
+        @Override
+        public CompletedStageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor) {
+            Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
+            this.unknownVisitor = unknownType -> unknownVisitor.apply(unknownType);
+            return this;
+        }
+
+        @Override
+        public CompletedStageVisitorBuilder<T> throwOnUnknown() {
+            this.unknownVisitor = unknownType -> {
+                throw new SafeIllegalArgumentException(
+                        "Unknown variant of the 'SimpleEnum' union", SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
+        public Visitor<T> build() {
+            final Supplier<T> valueVisitor = this.valueVisitor;
+            final Function<@Safe String, T> unknownVisitor = this.unknownVisitor;
+            return new Visitor<T>() {
+                @Override
+                public T visitValue() {
+                    return valueVisitor.get();
+                }
+
+                @Override
+                public T visitUnknown(String unknownType) {
+                    return unknownVisitor.apply(unknownType);
+                }
+            };
+        }
+    }
+
+    public interface ValueStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor);
+    }
+
+    public interface UnknownStageVisitorBuilder<T> {
+        CompletedStageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
+
+        CompletedStageVisitorBuilder<T> throwOnUnknown();
+    }
+
+    public interface CompletedStageVisitorBuilder<T> {
+        Visitor<T> build();
     }
 }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
@@ -18,7 +18,9 @@ package com.palantir.conjure.java.types;
 
 import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.product.EnumExample;
 import java.util.Arrays;
 import java.util.Set;
@@ -32,6 +34,7 @@ public class EnumTests {
         EnumExample enumExample = EnumExample.ONE;
         assertThat(enumExample.accept(Visitor.INSTANCE)).isEqualTo("one");
         assertThat(enumExample.accept(VISITOR_FROM_BUILDER)).isEqualTo("one");
+        assertThat(enumExample.accept(VISITOR_FROM_BUILDER_THROW_ON_UNKNOWN)).isEqualTo("one");
     }
 
     @Test
@@ -45,6 +48,9 @@ public class EnumTests {
         assertThat(enumExample.get()).isEqualTo(EnumExample.Value.UNKNOWN);
         assertThat(enumExample.toString()).isEqualTo("SOME_VALUE");
         assertThat(enumExample.accept(VISITOR_FROM_BUILDER)).isEqualTo("SOME_VALUE");
+        assertThatThrownBy(() -> enumExample.accept(VISITOR_FROM_BUILDER_THROW_ON_UNKNOWN))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageStartingWith("Unknown variant of the 'EnumExample' union");
     }
 
     @Test
@@ -98,4 +104,12 @@ public class EnumTests {
             .visitOneHundred(() -> "one hundred")
             .visitUnknown(unknownType -> unknownType)
             .build();
+
+    private static final EnumExample.Visitor<String> VISITOR_FROM_BUILDER_THROW_ON_UNKNOWN =
+            EnumExample.Visitor.<String>builder()
+                    .visitOne(() -> "one")
+                    .visitTwo(() -> "two")
+                    .visitOneHundred(() -> "one hundred")
+                    .throwOnUnknown()
+                    .build();
 }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumTests.java
@@ -31,6 +31,7 @@ public class EnumTests {
     public void testVisitOne() {
         EnumExample enumExample = EnumExample.ONE;
         assertThat(enumExample.accept(Visitor.INSTANCE)).isEqualTo("one");
+        assertThat(enumExample.accept(VISITOR_FROM_BUILDER)).isEqualTo("one");
     }
 
     @Test
@@ -43,6 +44,7 @@ public class EnumTests {
         EnumExample enumExample = EnumExample.valueOf("SOME_VALUE");
         assertThat(enumExample.get()).isEqualTo(EnumExample.Value.UNKNOWN);
         assertThat(enumExample.toString()).isEqualTo("SOME_VALUE");
+        assertThat(enumExample.accept(VISITOR_FROM_BUILDER)).isEqualTo("SOME_VALUE");
     }
 
     @Test
@@ -89,4 +91,11 @@ public class EnumTests {
             return unknownValue;
         }
     }
+
+    private static final EnumExample.Visitor<String> VISITOR_FROM_BUILDER = EnumExample.Visitor.<String>builder()
+            .visitOne(() -> "one")
+            .visitTwo(() -> "two")
+            .visitOneHundred(() -> "one hundred")
+            .visitUnknown(unknownType -> unknownType)
+            .build();
 }


### PR DESCRIPTION
## Before this PR
Union types' visitor classes have a nice builder to generate them more concisely, but enum types do not

## After this PR
Addresses https://github.com/palantir/conjure-java/issues/1058
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Enum types now have a visitor builder
==COMMIT_MSG==

## Possible downsides?
Implemented this just by copying the relevant methods over from UnionGenerator and adapting them so they fit the enum semantics and types. There's potential for code reuse in future, but seemed like more effort than needed right now since this functionality has been desired for over 3 years (see when the linked issue was created).

