### PR TITLE
completed has underscore in enum visitor builders

### DIFF
--- a/changelog/@unreleased/pr-2100.v2.yml
+++ b/changelog/@unreleased/pr-2100.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Enum visitor builders now work when an enum value is named COMPLETED
+  links:
+  - https://github.com/palantir/conjure-java/pull/2100

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumExample.java
@@ -167,7 +167,7 @@ public final class EnumExample {
                     TwoStageVisitorBuilder<T>,
                     OneHundredStageVisitorBuilder<T>,
                     UnknownStageVisitorBuilder<T>,
-                    CompletedStageVisitorBuilder<T> {
+                    Completed_StageVisitorBuilder<T> {
         private Supplier<T> oneVisitor;
 
         private Supplier<T> twoVisitor;
@@ -198,14 +198,14 @@ public final class EnumExample {
         }
 
         @Override
-        public CompletedStageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownType -> unknownVisitor.apply(unknownType);
             return this;
         }
 
         @Override
-        public CompletedStageVisitorBuilder<T> throwOnUnknown() {
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
                 throw new SafeIllegalArgumentException(
                         "Unknown variant of the 'EnumExample' union", SafeArg.of("unknownType", unknownType));
@@ -256,12 +256,12 @@ public final class EnumExample {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 
-        CompletedStageVisitorBuilder<T> throwOnUnknown();
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
     }
 
-    public interface CompletedStageVisitorBuilder<T> {
+    public interface Completed_StageVisitorBuilder<T> {
         Visitor<T> build();
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumNameTestExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EnumNameTestExample.java
@@ -1,0 +1,206 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.errorprone.annotations.Immutable;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+/**
+ * This class is used instead of a native enum to support unknown values.
+ * Rather than throw an exception, the {@link EnumNameTestExample#valueOf} method defaults to a new instantiation of
+ * {@link EnumNameTestExample} where {@link EnumNameTestExample#get} will return {@link EnumNameTestExample.Value#UNKNOWN}.
+ * <p>
+ * For example, {@code EnumNameTestExample.valueOf("corrupted value").get()} will return {@link EnumNameTestExample.Value#UNKNOWN},
+ * but {@link EnumNameTestExample#toString} will return "corrupted value".
+ * <p>
+ * There is no method to access all instantiations of this class, since they cannot be known at compile time.
+ */
+@Generated("com.palantir.conjure.java.types.EnumGenerator")
+@Safe
+@Immutable
+public final class EnumNameTestExample {
+    public static final EnumNameTestExample INCOMPLETE = new EnumNameTestExample(Value.INCOMPLETE, "INCOMPLETE");
+
+    public static final EnumNameTestExample COMPLETED = new EnumNameTestExample(Value.COMPLETED, "COMPLETED");
+
+    private static final List<EnumNameTestExample> values =
+            Collections.unmodifiableList(Arrays.asList(INCOMPLETE, COMPLETED));
+
+    private final Value value;
+
+    private final String string;
+
+    private EnumNameTestExample(Value value, String string) {
+        this.value = value;
+        this.string = string;
+    }
+
+    public Value get() {
+        return this.value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return this.string;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return (this == other)
+                || (this.value == Value.UNKNOWN
+                        && other instanceof EnumNameTestExample
+                        && this.string.equals(((EnumNameTestExample) other).string));
+    }
+
+    @Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static EnumNameTestExample valueOf(@Nonnull @Safe String value) {
+        Preconditions.checkNotNull(value, "value cannot be null");
+        String upperCasedValue = value.toUpperCase(Locale.ROOT);
+        switch (upperCasedValue) {
+            case "INCOMPLETE":
+                return INCOMPLETE;
+            case "COMPLETED":
+                return COMPLETED;
+            default:
+                return new EnumNameTestExample(Value.UNKNOWN, upperCasedValue);
+        }
+    }
+
+    public <T> T accept(Visitor<T> visitor) {
+        switch (value) {
+            case INCOMPLETE:
+                return visitor.visitIncomplete();
+            case COMPLETED:
+                return visitor.visitCompleted();
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    public static List<EnumNameTestExample> values() {
+        return values;
+    }
+
+    @Generated("com.palantir.conjure.java.types.EnumGenerator")
+    public enum Value {
+        INCOMPLETE,
+
+        COMPLETED,
+
+        UNKNOWN
+    }
+
+    @Generated("com.palantir.conjure.java.types.EnumGenerator")
+    public interface Visitor<T> {
+        T visitIncomplete();
+
+        T visitCompleted();
+
+        T visitUnknown(String unknownValue);
+
+        static <T> IncompleteStageVisitorBuilder<T> builder() {
+            return new VisitorBuilder<T>();
+        }
+    }
+
+    private static final class VisitorBuilder<T>
+            implements IncompleteStageVisitorBuilder<T>,
+                    CompletedStageVisitorBuilder<T>,
+                    UnknownStageVisitorBuilder<T>,
+                    Completed_StageVisitorBuilder<T> {
+        private Supplier<T> incompleteVisitor;
+
+        private Supplier<T> completedVisitor;
+
+        private Function<@Safe String, T> unknownVisitor;
+
+        @Override
+        public CompletedStageVisitorBuilder<T> visitIncomplete(@Nonnull Supplier<T> incompleteVisitor) {
+            Preconditions.checkNotNull(incompleteVisitor, "incompleteVisitor cannot be null");
+            this.incompleteVisitor = incompleteVisitor;
+            return this;
+        }
+
+        @Override
+        public UnknownStageVisitorBuilder<T> visitCompleted(@Nonnull Supplier<T> completedVisitor) {
+            Preconditions.checkNotNull(completedVisitor, "completedVisitor cannot be null");
+            this.completedVisitor = completedVisitor;
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor) {
+            Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
+            this.unknownVisitor = unknownType -> unknownVisitor.apply(unknownType);
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
+            this.unknownVisitor = unknownType -> {
+                throw new SafeIllegalArgumentException(
+                        "Unknown variant of the 'EnumNameTestExample' union", SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
+        public Visitor<T> build() {
+            final Supplier<T> incompleteVisitor = this.incompleteVisitor;
+            final Supplier<T> completedVisitor = this.completedVisitor;
+            final Function<@Safe String, T> unknownVisitor = this.unknownVisitor;
+            return new Visitor<T>() {
+                @Override
+                public T visitIncomplete() {
+                    return incompleteVisitor.get();
+                }
+
+                @Override
+                public T visitCompleted() {
+                    return completedVisitor.get();
+                }
+
+                @Override
+                public T visitUnknown(String unknownType) {
+                    return unknownVisitor.apply(unknownType);
+                }
+            };
+        }
+    }
+
+    public interface IncompleteStageVisitorBuilder<T> {
+        CompletedStageVisitorBuilder<T> visitIncomplete(@Nonnull Supplier<T> incompleteVisitor);
+    }
+
+    public interface CompletedStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> visitCompleted(@Nonnull Supplier<T> completedVisitor);
+    }
+
+    public interface UnknownStageVisitorBuilder<T> {
+        Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
+    }
+
+    public interface Completed_StageVisitorBuilder<T> {
+        Visitor<T> build();
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SimpleEnum.java
@@ -111,7 +111,7 @@ public final class SimpleEnum {
     }
 
     private static final class VisitorBuilder<T>
-            implements ValueStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, CompletedStageVisitorBuilder<T> {
+            implements ValueStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
         private Supplier<T> valueVisitor;
 
         private Function<@Safe String, T> unknownVisitor;
@@ -124,14 +124,14 @@ public final class SimpleEnum {
         }
 
         @Override
-        public CompletedStageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownType -> unknownVisitor.apply(unknownType);
             return this;
         }
 
         @Override
-        public CompletedStageVisitorBuilder<T> throwOnUnknown() {
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
                 throw new SafeIllegalArgumentException(
                         "Unknown variant of the 'SimpleEnum' union", SafeArg.of("unknownType", unknownType));
@@ -162,12 +162,12 @@ public final class SimpleEnum {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 
-        CompletedStageVisitorBuilder<T> throwOnUnknown();
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
     }
 
-    public interface CompletedStageVisitorBuilder<T> {
+    public interface Completed_StageVisitorBuilder<T> {
         Visitor<T> build();
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumExample.java
@@ -167,7 +167,7 @@ public final class EnumExample {
                     TwoStageVisitorBuilder<T>,
                     OneHundredStageVisitorBuilder<T>,
                     UnknownStageVisitorBuilder<T>,
-                    CompletedStageVisitorBuilder<T> {
+                    Completed_StageVisitorBuilder<T> {
         private Supplier<T> oneVisitor;
 
         private Supplier<T> twoVisitor;
@@ -198,14 +198,14 @@ public final class EnumExample {
         }
 
         @Override
-        public CompletedStageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownType -> unknownVisitor.apply(unknownType);
             return this;
         }
 
         @Override
-        public CompletedStageVisitorBuilder<T> throwOnUnknown() {
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
                 throw new SafeIllegalArgumentException(
                         "Unknown variant of the 'EnumExample' union", SafeArg.of("unknownType", unknownType));
@@ -256,12 +256,12 @@ public final class EnumExample {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 
-        CompletedStageVisitorBuilder<T> throwOnUnknown();
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
     }
 
-    public interface CompletedStageVisitorBuilder<T> {
+    public interface Completed_StageVisitorBuilder<T> {
         Visitor<T> build();
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumNameTestExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EnumNameTestExample.java
@@ -1,0 +1,206 @@
+package test.prefix.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.errorprone.annotations.Immutable;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+/**
+ * This class is used instead of a native enum to support unknown values.
+ * Rather than throw an exception, the {@link EnumNameTestExample#valueOf} method defaults to a new instantiation of
+ * {@link EnumNameTestExample} where {@link EnumNameTestExample#get} will return {@link EnumNameTestExample.Value#UNKNOWN}.
+ * <p>
+ * For example, {@code EnumNameTestExample.valueOf("corrupted value").get()} will return {@link EnumNameTestExample.Value#UNKNOWN},
+ * but {@link EnumNameTestExample#toString} will return "corrupted value".
+ * <p>
+ * There is no method to access all instantiations of this class, since they cannot be known at compile time.
+ */
+@Generated("com.palantir.conjure.java.types.EnumGenerator")
+@Safe
+@Immutable
+public final class EnumNameTestExample {
+    public static final EnumNameTestExample INCOMPLETE = new EnumNameTestExample(Value.INCOMPLETE, "INCOMPLETE");
+
+    public static final EnumNameTestExample COMPLETED = new EnumNameTestExample(Value.COMPLETED, "COMPLETED");
+
+    private static final List<EnumNameTestExample> values =
+            Collections.unmodifiableList(Arrays.asList(INCOMPLETE, COMPLETED));
+
+    private final Value value;
+
+    private final String string;
+
+    private EnumNameTestExample(Value value, String string) {
+        this.value = value;
+        this.string = string;
+    }
+
+    public Value get() {
+        return this.value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return this.string;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return (this == other)
+                || (this.value == Value.UNKNOWN
+                        && other instanceof EnumNameTestExample
+                        && this.string.equals(((EnumNameTestExample) other).string));
+    }
+
+    @Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static EnumNameTestExample valueOf(@Nonnull @Safe String value) {
+        Preconditions.checkNotNull(value, "value cannot be null");
+        String upperCasedValue = value.toUpperCase(Locale.ROOT);
+        switch (upperCasedValue) {
+            case "INCOMPLETE":
+                return INCOMPLETE;
+            case "COMPLETED":
+                return COMPLETED;
+            default:
+                return new EnumNameTestExample(Value.UNKNOWN, upperCasedValue);
+        }
+    }
+
+    public <T> T accept(Visitor<T> visitor) {
+        switch (value) {
+            case INCOMPLETE:
+                return visitor.visitIncomplete();
+            case COMPLETED:
+                return visitor.visitCompleted();
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    public static List<EnumNameTestExample> values() {
+        return values;
+    }
+
+    @Generated("com.palantir.conjure.java.types.EnumGenerator")
+    public enum Value {
+        INCOMPLETE,
+
+        COMPLETED,
+
+        UNKNOWN
+    }
+
+    @Generated("com.palantir.conjure.java.types.EnumGenerator")
+    public interface Visitor<T> {
+        T visitIncomplete();
+
+        T visitCompleted();
+
+        T visitUnknown(String unknownValue);
+
+        static <T> IncompleteStageVisitorBuilder<T> builder() {
+            return new VisitorBuilder<T>();
+        }
+    }
+
+    private static final class VisitorBuilder<T>
+            implements IncompleteStageVisitorBuilder<T>,
+                    CompletedStageVisitorBuilder<T>,
+                    UnknownStageVisitorBuilder<T>,
+                    Completed_StageVisitorBuilder<T> {
+        private Supplier<T> incompleteVisitor;
+
+        private Supplier<T> completedVisitor;
+
+        private Function<@Safe String, T> unknownVisitor;
+
+        @Override
+        public CompletedStageVisitorBuilder<T> visitIncomplete(@Nonnull Supplier<T> incompleteVisitor) {
+            Preconditions.checkNotNull(incompleteVisitor, "incompleteVisitor cannot be null");
+            this.incompleteVisitor = incompleteVisitor;
+            return this;
+        }
+
+        @Override
+        public UnknownStageVisitorBuilder<T> visitCompleted(@Nonnull Supplier<T> completedVisitor) {
+            Preconditions.checkNotNull(completedVisitor, "completedVisitor cannot be null");
+            this.completedVisitor = completedVisitor;
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor) {
+            Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
+            this.unknownVisitor = unknownType -> unknownVisitor.apply(unknownType);
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
+            this.unknownVisitor = unknownType -> {
+                throw new SafeIllegalArgumentException(
+                        "Unknown variant of the 'EnumNameTestExample' union", SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
+        public Visitor<T> build() {
+            final Supplier<T> incompleteVisitor = this.incompleteVisitor;
+            final Supplier<T> completedVisitor = this.completedVisitor;
+            final Function<@Safe String, T> unknownVisitor = this.unknownVisitor;
+            return new Visitor<T>() {
+                @Override
+                public T visitIncomplete() {
+                    return incompleteVisitor.get();
+                }
+
+                @Override
+                public T visitCompleted() {
+                    return completedVisitor.get();
+                }
+
+                @Override
+                public T visitUnknown(String unknownType) {
+                    return unknownVisitor.apply(unknownType);
+                }
+            };
+        }
+    }
+
+    public interface IncompleteStageVisitorBuilder<T> {
+        CompletedStageVisitorBuilder<T> visitIncomplete(@Nonnull Supplier<T> incompleteVisitor);
+    }
+
+    public interface CompletedStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> visitCompleted(@Nonnull Supplier<T> completedVisitor);
+    }
+
+    public interface UnknownStageVisitorBuilder<T> {
+        Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
+    }
+
+    public interface Completed_StageVisitorBuilder<T> {
+        Visitor<T> build();
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java
@@ -111,7 +111,7 @@ public final class SimpleEnum {
     }
 
     private static final class VisitorBuilder<T>
-            implements ValueStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, CompletedStageVisitorBuilder<T> {
+            implements ValueStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
         private Supplier<T> valueVisitor;
 
         private Function<@Safe String, T> unknownVisitor;
@@ -124,14 +124,14 @@ public final class SimpleEnum {
         }
 
         @Override
-        public CompletedStageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor) {
+        public Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor) {
             Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
             this.unknownVisitor = unknownType -> unknownVisitor.apply(unknownType);
             return this;
         }
 
         @Override
-        public CompletedStageVisitorBuilder<T> throwOnUnknown() {
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
             this.unknownVisitor = unknownType -> {
                 throw new SafeIllegalArgumentException(
                         "Unknown variant of the 'SimpleEnum' union", SafeArg.of("unknownType", unknownType));
@@ -162,12 +162,12 @@ public final class SimpleEnum {
     }
 
     public interface UnknownStageVisitorBuilder<T> {
-        CompletedStageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
+        Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 
-        CompletedStageVisitorBuilder<T> throwOnUnknown();
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
     }
 
-    public interface CompletedStageVisitorBuilder<T> {
+    public interface Completed_StageVisitorBuilder<T> {
         Visitor<T> build();
     }
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -63,9 +63,11 @@ public final class EnumGenerator {
     private static final String VISIT_METHOD_NAME = "visit";
     private static final String VISIT_UNKNOWN_METHOD_NAME = "visitUnknown";
     private static final TypeVariableName TYPE_VARIABLE = TypeVariableName.get("T");
-    public static final String UNKNOWN_TYPE_PARAM_NAME = "unknownType";
-    static final String UNKNOWN_TYPE_NAME = "unknown";
+    private static final String UNKNOWN_TYPE_PARAM_NAME = "unknownType";
+    private static final String UNKNOWN_TYPE_NAME = "unknown";
     private static final String COMPLETED = "completed_";
+    private static final String STAGE_VISITOR_BUILDER = "StageVisitorBuilder";
+    private static final String VISITOR_FIELD_NAME_SUFFIX = "Visitor";
     private static final TypeName UNKNOWN_MEMBER_TYPE = ClassName.get(String.class);
 
     private EnumGenerator() {}
@@ -577,17 +579,24 @@ public final class EnumGenerator {
     }
 
     private static String getVisitorMethodName(String value) {
-        return VISIT_METHOD_NAME + CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, value);
+        return VISIT_METHOD_NAME + formatName(value, CaseFormat.UPPER_CAMEL);
     }
 
     /** Generates the name of the interface of a visitor builder stage. */
     private static ClassName visitorStageInterfaceName(ClassName enclosingClass, String stageName) {
-        return enclosingClass.nestedClass(
-                CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, stageName) + "StageVisitorBuilder");
+        return enclosingClass.nestedClass(formatName(stageName, CaseFormat.UPPER_CAMEL) + STAGE_VISITOR_BUILDER);
     }
 
     private static String visitorFieldName(String value) {
-        return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, value) + "Visitor";
+        return formatName(value, CaseFormat.LOWER_CAMEL) + VISITOR_FIELD_NAME_SUFFIX;
+    }
+
+    private static String formatName(String value, CaseFormat camelCase) {
+        String formatted = CaseFormat.UPPER_UNDERSCORE.to(camelCase, value);
+        if (value.endsWith("_")) {
+            formatted += "_";
+        }
+        return formatted;
     }
 
     private static MethodSpec createConstructor(ClassName enumClass) {

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -89,6 +89,10 @@ types:
           items: map<string, string>
           optionalItems: map<string, optional<string>>
           aliasOptionalItems: map<string, OptionalAlias>
+      EnumNameTestExample:
+        values:
+          - INCOMPLETE
+          - COMPLETED
       EnumExample:
         docs: |
           This enumerates the numbers 1:2 also 100.


### PR DESCRIPTION
## Before this PR
Because enums are UPPER_UNDERSCORE, we use different formatting logic than for unions, so we can remove their underscores. But that meant that we named the completed type CompletedStageVisitorBuilder instead of Completed_StageVisitorBuilder, so there could be errors if an enum actually had a value called COMPLETED.

## After this PR
==COMMIT_MSG==
Enum visitor builders now work when an enum value is named COMPLETED
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

