### PR TITLE
Bytes has signed and unsigned comparators

### DIFF
--- a/changelog/@unreleased/pr-2102.v2.yml
+++ b/changelog/@unreleased/pr-2102.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bytes has signed and unsigned comparators
+  links:
+  - https://github.com/palantir/conjure-java/pull/2102

--- a/conjure-lib/build.gradle
+++ b/conjure-lib/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'com.fasterxml.jackson.core:jackson-core'
+    implementation 'com.google.guava:guava'
     implementation 'com.palantir.safe-logging:safe-logging'
 
     testImplementation 'com.palantir.safe-logging:preconditions-assertj'

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/Bytes.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/Bytes.java
@@ -24,11 +24,14 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.primitives.SignedBytes;
+import com.google.common.primitives.UnsignedBytes;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Comparator;
 
 /** An immutable {@code byte[]} wrapper. */
 @JsonSerialize(using = Bytes.Serializer.class)
@@ -112,6 +115,14 @@ public final class Bytes {
         local.get(safe);
 
         return new Bytes(safe);
+    }
+
+    public static Comparator<Bytes> signed() {
+        return (x, y) -> SignedBytes.lexicographicalComparator().compare(x.safe, y.safe);
+    }
+
+    public static Comparator<Bytes> unsigned() {
+        return (x, y) -> UnsignedBytes.lexicographicalComparator().compare(x.safe, y.safe);
     }
 
     static final class Serializer extends JsonSerializer<Bytes> {


### PR DESCRIPTION
## Before this PR
Sorting collections of `Bytes` requires either expensive allocation of `byte[]` copies or allocations of read only `ByteBuffer`.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Bytes has signed and unsigned comparators
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

