### PR TITLE
Don't add incubating annotation to server interfaces

### DIFF
--- a/changelog/@unreleased/pr-2108.v2.yml
+++ b/changelog/@unreleased/pr-2108.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: The `@Incubating` annotation is no longer applied to server interfaces.
+  links:
+  - https://github.com/palantir/conjure-java/pull/2108

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/ConjureAnnotations.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/ConjureAnnotations.java
@@ -79,13 +79,6 @@ public final class ConjureAnnotations {
                 .build();
     }
 
-    public static ImmutableList<AnnotationSpec> incubating(EndpointDefinition definition) {
-        if (definition.getTags().contains("incubating")) {
-            return INCUBATING;
-        }
-        return ImmutableList.of();
-    }
-
     public static ImmutableList<AnnotationSpec> safety(Optional<LogSafety> value) {
         return value.map(safety -> {
                     switch (safety.get()) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceInterfaceGenerator.java
@@ -91,8 +91,7 @@ final class UndertowServiceInterfaceGenerator {
                 JavaNameSanitizer.sanitize(endpointDef.getEndpointName().get());
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(methodName)
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-                .addParameters(createServiceMethodParameters(endpointDef, safetyEvaluator, typeMapper))
-                .addAnnotations(ConjureAnnotations.incubating(endpointDef));
+                .addParameters(createServiceMethodParameters(endpointDef, safetyEvaluator, typeMapper));
 
         endpointDef.getDeprecated().ifPresent(deprecatedDocsValue -> methodBuilder.addAnnotation(Deprecated.class));
 

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
@@ -1,6 +1,5 @@
 package com.palantir.another;
 
-import com.palantir.conjure.java.lib.internal.Incubating;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.logsafe.Safe;
 import com.palantir.product.AliasedString;
@@ -26,7 +25,6 @@ public interface TestService {
      * Returns a mapping from file system id to backing file system configuration.
      * @apiNote {@code GET /catalog/fileSystems}
      */
-    @Incubating
     Map<String, BackingFileSystem> getFileSystems(AuthHeader authHeader);
 
     /**

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.prefix
@@ -1,6 +1,5 @@
 package test.prefix.com.palantir.another;
 
-import com.palantir.conjure.java.lib.internal.Incubating;
 import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.logsafe.Safe;
 import com.palantir.ri.ResourceIdentifier;
@@ -26,7 +25,6 @@ public interface TestService {
      * Returns a mapping from file system id to backing file system configuration.
      * @apiNote {@code GET /catalog/fileSystems}
      */
-    @Incubating
     Map<String, BackingFileSystem> getFileSystems(AuthHeader authHeader);
 
     /**


### PR DESCRIPTION
This is only necessary for client interfaces.

Adding it to server interfaces forces service to add a bunch of `@SuppressWarnings("IncubatingMethod")` annotations.