### PR TITLE
Handle path param validation regexes for undertow handlers

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DialogueEteEndpoints.java
@@ -431,6 +431,41 @@ enum DialogueEteEndpoints implements Endpoint {
         }
     },
 
+    pathParamRegex {
+        private final PathTemplate pathTemplate = PathTemplate.builder()
+                .fixed("base")
+                .fixed("path")
+                .variable("paramOne")
+                .variable("paramTwo")
+                .variable("paramThree")
+                .build();
+
+        @Override
+        public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+            pathTemplate.fill(params, url);
+        }
+
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.GET;
+        }
+
+        @Override
+        public String serviceName() {
+            return "EteService";
+        }
+
+        @Override
+        public String endpointName() {
+            return "pathParamRegex";
+        }
+
+        @Override
+        public String version() {
+            return "1.2.3";
+        }
+    },
+
     optionalExternalLongQuery {
         private final PathTemplate pathTemplate = PathTemplate.builder()
                 .fixed("base")

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteService.java
@@ -112,6 +112,15 @@ public interface EteService {
     long externalLongPath(@HeaderParam("Authorization") @NotNull AuthHeader authHeader, @PathParam("param") long param);
 
     @GET
+    @Path("base/path/{paramOne}/{paramTwo:.+}/{paramThree:.*}")
+    @ClientEndpoint(method = "GET", path = "/base/path/{paramOne}/{paramTwo:.+}/{paramThree:.*}")
+    String pathParamRegex(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @PathParam("paramOne") String paramOne,
+            @PathParam("paramTwo") String paramTwo,
+            @PathParam("paramThree") String paramThree);
+
+    @GET
     @Path("base/optionalExternalLong")
     @ClientEndpoint(method = "GET", path = "/base/optionalExternalLong")
     Optional<Long> optionalExternalLongQuery(

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceAsync.java
@@ -125,6 +125,12 @@ public interface EteServiceAsync {
     ListenableFuture<Long> externalLongPath(AuthHeader authHeader, long param);
 
     /**
+     * @apiNote {@code GET /base/path/{paramOne}/{paramTwo:.+}/{paramThree:.*}}
+     */
+    @ClientEndpoint(method = "GET", path = "/base/path/{paramOne}/{paramTwo:.+}/{paramThree:.*}")
+    ListenableFuture<String> pathParamRegex(AuthHeader authHeader, String paramOne, String paramTwo, String paramThree);
+
+    /**
      * @apiNote {@code GET /base/optionalExternalLong}
      */
     @ClientEndpoint(method = "GET", path = "/base/optionalExternalLong")
@@ -319,6 +325,12 @@ public interface EteServiceAsync {
 
             private final Deserializer<Long> externalLongPathDeserializer =
                     _runtime.bodySerDe().deserializer(new TypeMarker<Long>() {});
+
+            private final EndpointChannel pathParamRegexChannel =
+                    _endpointChannelFactory.endpoint(DialogueEteEndpoints.pathParamRegex);
+
+            private final Deserializer<String> pathParamRegexDeserializer =
+                    _runtime.bodySerDe().deserializer(new TypeMarker<String>() {});
 
             private final EndpointChannel optionalExternalLongQueryChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.optionalExternalLongQuery);
@@ -541,6 +553,17 @@ public interface EteServiceAsync {
                 _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putPathParams("param", Objects.toString(param));
                 return _runtime.clients().call(externalLongPathChannel, _request.build(), externalLongPathDeserializer);
+            }
+
+            @Override
+            public ListenableFuture<String> pathParamRegex(
+                    AuthHeader authHeader, String paramOne, String paramTwo, String paramThree) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.putPathParams("paramOne", _plainSerDe.serializeString(paramOne));
+                _request.putPathParams("paramTwo", _plainSerDe.serializeString(paramTwo));
+                _request.putPathParams("paramThree", _plainSerDe.serializeString(paramThree));
+                return _runtime.clients().call(pathParamRegexChannel, _request.build(), pathParamRegexDeserializer);
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceBlocking.java
@@ -126,6 +126,12 @@ public interface EteServiceBlocking {
     long externalLongPath(AuthHeader authHeader, long param);
 
     /**
+     * @apiNote {@code GET /base/path/{paramOne}/{paramTwo:.+}/{paramThree:.*}}
+     */
+    @ClientEndpoint(method = "GET", path = "/base/path/{paramOne}/{paramTwo:.+}/{paramThree:.*}")
+    String pathParamRegex(AuthHeader authHeader, String paramOne, String paramTwo, String paramThree);
+
+    /**
      * @apiNote {@code GET /base/optionalExternalLong}
      */
     @ClientEndpoint(method = "GET", path = "/base/optionalExternalLong")
@@ -315,6 +321,12 @@ public interface EteServiceBlocking {
 
             private final Deserializer<Long> externalLongPathDeserializer =
                     _runtime.bodySerDe().deserializer(new TypeMarker<Long>() {});
+
+            private final EndpointChannel pathParamRegexChannel =
+                    _endpointChannelFactory.endpoint(DialogueEteEndpoints.pathParamRegex);
+
+            private final Deserializer<String> pathParamRegexDeserializer =
+                    _runtime.bodySerDe().deserializer(new TypeMarker<String>() {});
 
             private final EndpointChannel optionalExternalLongQueryChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.optionalExternalLongQuery);
@@ -540,6 +552,17 @@ public interface EteServiceBlocking {
                 _request.putPathParams("param", Objects.toString(param));
                 return _runtime.clients()
                         .callBlocking(externalLongPathChannel, _request.build(), externalLongPathDeserializer);
+            }
+
+            @Override
+            public String pathParamRegex(AuthHeader authHeader, String paramOne, String paramTwo, String paramThree) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.putPathParams("paramOne", _plainSerDe.serializeString(paramOne));
+                _request.putPathParams("paramTwo", _plainSerDe.serializeString(paramTwo));
+                _request.putPathParams("paramThree", _plainSerDe.serializeString(paramThree));
+                return _runtime.clients()
+                        .callBlocking(pathParamRegexChannel, _request.build(), pathParamRegexDeserializer);
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
@@ -59,6 +59,7 @@ public final class EteServiceEndpoints implements UndertowService {
                 new BinaryEndpoint(runtime, delegate),
                 new PathEndpoint(runtime, delegate),
                 new ExternalLongPathEndpoint(runtime, delegate),
+                new PathParamRegexEndpoint(runtime, delegate),
                 new OptionalExternalLongQueryEndpoint(runtime, delegate),
                 new NotNullBodyEndpoint(runtime, delegate),
                 new AliasOneEndpoint(runtime, delegate),
@@ -687,6 +688,57 @@ public final class EteServiceEndpoints implements UndertowService {
         @Override
         public String name() {
             return "externalLongPath";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class PathParamRegexEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final UndertowEteService delegate;
+
+        private final Serializer<String> serializer;
+
+        PathParamRegexEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            Map<String, String> pathParams =
+                    exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
+            String paramOne = runtime.plainSerDe().deserializeString(pathParams.get("paramOne"));
+            String paramTwo = runtime.plainSerDe().deserializeString(pathParams.get("paramTwo"));
+            String paramThree = runtime.plainSerDe().deserializeString(pathParams.get("paramThree"));
+            String result = delegate.pathParamRegex(authHeader, paramOne, paramTwo, paramThree);
+            serializer.serialize(result, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/base/path/{paramOne}/{paramTwo:.+}/{paramThree:.*}";
+        }
+
+        @Override
+        public String serviceName() {
+            return "EteService";
+        }
+
+        @Override
+        public String name() {
+            return "pathParamRegex";
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceEndpoints.java
@@ -728,7 +728,7 @@ public final class EteServiceEndpoints implements UndertowService {
 
         @Override
         public String template() {
-            return "/base/path/{paramOne}/{paramTwo:.+}/{paramThree:.*}";
+            return "/base/path/{paramOne}/{paramTwo}/{paramThree}";
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteServiceRetrofit.java
@@ -107,6 +107,15 @@ public interface EteServiceRetrofit {
     @ClientEndpoint(method = "GET", path = "/base/externalLong/{param}")
     ListenableFuture<Long> externalLongPath(@Header("Authorization") AuthHeader authHeader, @Path("param") long param);
 
+    @GET("./base/path/{paramOne}/{paramTwo}/{paramThree}")
+    @Headers({"hr-path-template: /base/path/{paramOne}/{paramTwo}/{paramThree}", "Accept: application/json"})
+    @ClientEndpoint(method = "GET", path = "/base/path/{paramOne}/{paramTwo:.+}/{paramThree:.*}")
+    ListenableFuture<String> pathParamRegex(
+            @Header("Authorization") AuthHeader authHeader,
+            @Path("paramOne") String paramOne,
+            @Path(value = "paramTwo", encoded = true) String paramTwo,
+            @Path(value = "paramThree", encoded = true) String paramThree);
+
     @GET("./base/optionalExternalLong")
     @Headers({"hr-path-template: /base/optionalExternalLong", "Accept: application/json"})
     @ClientEndpoint(method = "GET", path = "/base/optionalExternalLong")

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteService.java
@@ -89,6 +89,11 @@ public interface UndertowEteService {
     long externalLongPath(AuthHeader authHeader, long param);
 
     /**
+     * @apiNote {@code GET /base/path/{paramOne}/{paramTwo:.+}/{paramThree:.*}}
+     */
+    String pathParamRegex(AuthHeader authHeader, String paramOne, String paramTwo, String paramThree);
+
+    /**
      * @apiNote {@code GET /base/optionalExternalLong}
      */
     Optional<Long> optionalExternalLongQuery(AuthHeader authHeader, Optional<Long> param);

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/EteResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/EteResource.java
@@ -105,6 +105,11 @@ public class EteResource implements EteService {
     }
 
     @Override
+    public String pathParamRegex(AuthHeader authHeader, String paramOne, String paramTwo, String paramThree) {
+        return paramOne + "," + paramTwo + "," + paramThree;
+    }
+
+    @Override
     public Optional<Long> optionalExternalLongQuery(AuthHeader _authHeader, Optional<Long> param) {
         return param;
     }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -429,6 +429,12 @@ public final class UndertowServiceEteTest extends TestBase {
     }
 
     @Test
+    public void testRegexPath() {
+        assertThat(client.pathParamRegex(AuthHeader.valueOf("bearer"), "foo", "bar", "baz"))
+                .isEqualTo("foo,bar,baz");
+    }
+
+    @Test
     public void testBinaryOptionalEmptyResponse() {
         Optional<ResponseBody> response =
                 Futures.getUnchecked(binaryClient.getOptionalBinaryEmpty(AuthHeader.valueOf("authHeader")));

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/services/UndertowServiceHandlerGeneratorTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/services/UndertowServiceHandlerGeneratorTest.java
@@ -1,0 +1,46 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.conjure.spec.HttpPath;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+final class UndertowServiceHandlerGeneratorTest {
+
+    @ParameterizedTest
+    @MethodSource("normalizes_http_path_templates")
+    void normalizes_http_path_templates(String given, String expected) {
+        HttpPath normalized = UndertowServiceHandlerGenerator.normalizeHttpPathTemplates(HttpPath.of(given));
+
+        assertThat(normalized).isEqualTo(HttpPath.of(expected));
+    }
+
+    private static Stream<Arguments> normalizes_http_path_templates() {
+        return Stream.of(
+                Arguments.of("{param:.+}", "{param}"),
+                Arguments.of("{param:.*}", "{param}"),
+                Arguments.of("{param}", "{param}"),
+                // We ignore any other regex, because those are not allowed by the Conjure spec.
+                Arguments.of("{param:[a-zA-Z0-9]+}", "{param:[a-zA-Z0-9]+}"),
+                Arguments.of("/foo/{paramA:.*}/{paramB:.+}/{paramC}", "/foo/{paramA}/{paramB}/{paramC}"));
+    }
+}

--- a/conjure-java-core/src/test/resources/ete-service.yml
+++ b/conjure-java-core/src/test/resources/ete-service.yml
@@ -111,6 +111,18 @@ services:
           param: Long
         returns: Long
 
+      # The Conjure spec technically supports path params regexes even though they are unused
+      pathParamRegex:
+        http: GET /path/{paramOne}/{paramTwo:.+}/{paramThree:.*}
+        args:
+          paramOne:
+            type: string
+          paramTwo:
+            type: string
+          paramThree:
+            type: string
+        returns: string
+
       optionalExternalLongQuery:
         http: GET /optionalExternalLong
         args:

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
@@ -668,7 +668,7 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public String template() {
-            return "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve";
+            return "/catalog/datasets/{datasetRid}/branches/{branch}/resolve";
         }
 
         @Override

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.prefix
@@ -668,7 +668,7 @@ public final class TestServiceEndpoints implements UndertowService {
 
         @Override
         public String template() {
-            return "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve";
+            return "/catalog/datasets/{datasetRid}/branches/{branch}/resolve";
         }
 
         @Override


### PR DESCRIPTION
## Before this PR

The Conjure spec technically allows simple regex validations in http path parameters such as `/foo/{bar:.+}` (see https://github.com/palantir/conjure/issues/297, [code](https://github.com/palantir/conjure/blob/a849637dadaa2bf86dd6525cc7ab3ca8fbefd736/conjure-core/src/main/java/com/palantir/conjure/defs/validator/HttpPathValidator.java#L41C1-L42)). However, when used to generate an Undertow endpoint handler, those would result in runtime errors when trying to access the path param.

Currently, an Undertow handler would look something like this:

```java
private static final class MyEndpoint implements HttpHandler, Endpoint {

    @Override
    public void handleRequest(HttpServerExchange exchange) throws IOException {
        Map<String, String> pathParams =
                exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
        String param = runtime.plainSerDe().deserializeString(pathParams.get("param"));
        // ...
    }

    @Override
    public String template() {
        return "/{param:.+}";
    }
}
```

Notice how it uses `pathParams.get("param")` while the path template still contains the regex validation. The template gets passed to undertow's [`PathTemplate`](https://github.com/undertow-io/undertow/blob/88553c2ca5727f8c09d653c8bb451afd6efb26f0/core/src/main/java/io/undertow/util/PathTemplate.java#L61), which doesn't support regex validations and instead handles the entire `param:.+` as the parameter name.

At runtime, this will result in an invalid argument exception, due to the requested parameter `param` being null (see test: https://github.com/palantir/conjure-java/commit/4610af8b4f3c7a5fe18decf629f63234a0e07bbf).


## After this PR

This PR adds a naive fix of ignoring path param validation regexes when generating Undertow handlers but I'm not sure if that's the best path forward.

If we don't want to support those validations, we could still allow them in the spec but drop them much earlier when parsing into endpoint definitions? There are a few usages in conjure definitions in the wild, so we can't drop them from the spec without a break.

==COMMIT_MSG==
Handle path param validation regexes for undertow handlers
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

