### PR TITLE
Jackson StreamConstraintExceptions parsing requests produce 422 status

### DIFF
--- a/changelog/@unreleased/pr-2120.v2.yml
+++ b/changelog/@unreleased/pr-2120.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Jackson StreamConstraintExceptions parsing requests produce 422 status
+  links:
+  - https://github.com/palantir/conjure-java/pull/2120

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encodings.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encodings.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.java.undertow.runtime;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -90,6 +91,12 @@ public final class Encodings {
                     // validation (setter null checks) fail in our objects.
                     throw FrameworkException.unprocessableEntity(
                             "Failed to deserialize request",
+                            e,
+                            SafeArg.of("contentType", getContentType()),
+                            SafeArg.of("type", type));
+                } catch (StreamConstraintsException e) {
+                    throw FrameworkException.unprocessableEntity(
+                            "Stream constraint violation deserializing request",
                             e,
                             SafeArg.of("contentType", getContentType()),
                             SafeArg.of("type", type));


### PR DESCRIPTION
## Before this PR

Previously these resulted in 500 response codes, which aren't the most accurate, and worse often result in retries which consume large buffers. I considered using 413 "request entity too large" here, but that's not entirely accurate as the entity itself may be a reasonable size. We're refusing to parse an entity because a value is much larger than we expect, which is a bit more more nuanced than http response status codes can (or should) convey.

## After this PR
==COMMIT_MSG==
Jackson StreamConstraintExceptions parsing requests produce 422 status
==COMMIT_MSG==

## Possible downsides?
This exception type is relatively new, using a 4xx status code may reduce their visibility. We already have mitigation for this by default through request body size limits internally, which make it unlikely that most projects are capable of triggering this exception, so it should be relatively safe.

