### PR TITLE
Deconflict Jersey Undertow Tests

### DIFF
--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/EteTestServer.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/EteTestServer.java
@@ -56,10 +56,12 @@ public final class EteTestServer extends Application<Configuration> {
     private static final X509TrustManager TRUST_MANAGER =
             SslSocketFactories.createX509TrustManager(TRUST_STORE_CONFIGURATION);
 
-    public static ClientConfiguration clientConfiguration() {
+    public static ClientConfiguration clientConfiguration(int port) {
         return ClientConfiguration.builder()
                 .from(ClientConfigurations.of(
-                        ImmutableList.of("http://localhost:8080/test-example/api"), SSL_SOCKET_FACTORY, TRUST_MANAGER))
+                        ImmutableList.of("http://localhost:" + port + "/test-example/api"),
+                        SSL_SOCKET_FACTORY,
+                        TRUST_MANAGER))
                 // Disable retries to avoid spinning unnecessarily on negative tests
                 .maxNumRetries(0)
                 .userAgent(clientUserAgent())

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/EteTestServer.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/EteTestServer.java
@@ -57,9 +57,15 @@ public final class EteTestServer extends Application<Configuration> {
             SslSocketFactories.createX509TrustManager(TRUST_STORE_CONFIGURATION);
 
     public static ClientConfiguration clientConfiguration() {
+        return clientConfiguration(8080);
+    }
+
+    public static ClientConfiguration clientConfiguration(int port) {
         return ClientConfiguration.builder()
                 .from(ClientConfigurations.of(
-                        ImmutableList.of("http://localhost:8080/test-example/api"), SSL_SOCKET_FACTORY, TRUST_MANAGER))
+                        ImmutableList.of("http://localhost:" + port + "/test-example/api"),
+                        SSL_SOCKET_FACTORY,
+                        TRUST_MANAGER))
                 // Disable retries to avoid spinning unnecessarily on negative tests
                 .maxNumRetries(0)
                 .userAgent(clientUserAgent())

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceEteTest.java
@@ -63,12 +63,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.junit.jupiter.api.parallel.ResourceLock;
 
 @Execution(ExecutionMode.CONCURRENT)
 @ExtendWith(DropwizardExtensionsSupport.class)
-@ResourceLock("port:8080")
 public final class JerseyServiceEteTest extends TestBase {
+    private static final int PORT = 8080;
     private static final ObjectMapper CLIENT_OBJECT_MAPPER = ObjectMappers.newClientObjectMapper();
 
     @TempDir
@@ -81,14 +80,14 @@ public final class JerseyServiceEteTest extends TestBase {
     private final EteBinaryServiceBlocking binaryClient;
 
     public JerseyServiceEteTest() {
-        this.client = DialogueClients.create(EteServiceBlocking.class, clientConfiguration());
-        this.binaryClient = DialogueClients.create(EteBinaryServiceBlocking.class, clientConfiguration());
+        this.client = DialogueClients.create(EteServiceBlocking.class, clientConfiguration(PORT));
+        this.binaryClient = DialogueClients.create(EteBinaryServiceBlocking.class, clientConfiguration(PORT));
     }
 
     @Test
     public void jaxrs_client_can_make_a_call_to_an_empty_path() throws Exception {
         EmptyPathService emptyPathClient = JaxRsClient.create(
-                EmptyPathService.class, clientUserAgent(), new HostMetricsRegistry(), clientConfiguration());
+                EmptyPathService.class, clientUserAgent(), new HostMetricsRegistry(), clientConfiguration(PORT));
         assertThat(emptyPathClient.emptyPath()).isTrue();
     }
 

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceEteTest.java
@@ -63,9 +63,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 @Execution(ExecutionMode.CONCURRENT)
 @ExtendWith(DropwizardExtensionsSupport.class)
+@ResourceLock("port:8080")
 public final class JerseyServiceEteTest extends TestBase {
     private static final int PORT = 8080;
     private static final ObjectMapper CLIENT_OBJECT_MAPPER = ObjectMappers.newClientObjectMapper();


### PR DESCRIPTION
## Before this PR
We observed in #2128 that a specific Undertow test was an order of magnitude slower when run in a suite with the Jersey variants of the test. We suspect their is some conflict between the two. It cannot be the port, but its possible that its some odd lock contention underneath?

## After this PR
Runs them concurrently, but runs them on different ports so they are mutually exclusive.

## Possible downsides?
All I might have done is make them not run serially and made this a heisenbug in that depending on which tests run first it could fail. This also might be fixed but we are on a super ancient version of dropwizard and the comment says dont upgrade it soooo.

