### PR TITLE
Reauthor Timing Sensitive Test to Use Handlers

### DIFF
--- a/conjure-java-core/build.gradle
+++ b/conjure-java-core/build.gradle
@@ -68,7 +68,6 @@ dependencies {
     testImplementation project(':conjure-java-undertow-runtime')
     testImplementation 'com.fasterxml.jackson.core:jackson-core'
     testImplementation 'com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider'
-    testImplementation 'com.github.stefanbirkner:system-lambda'
     testImplementation 'com.palantir.conjure.java.api:service-config'
     testImplementation 'com.palantir.conjure.java.api:ssl-config'
     testImplementation 'com.palantir.conjure.java.runtime:client-config'

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.stefanbirkner.systemlambda.SystemLambda;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -30,7 +29,6 @@ import com.google.common.net.HttpHeaders;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import com.google.common.util.concurrent.Uninterruptibles;
 import com.palantir.conjure.defs.Conjure;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.SerializableError;
@@ -72,7 +70,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -473,22 +470,6 @@ public final class UndertowServiceEteTest extends TestBase {
                         }))
                 .isInstanceOfSatisfying(
                         RemoteException.class, re -> assertThat(re.getStatus()).isEqualTo(400));
-    }
-
-    @Test
-    @Timeout(20)
-    @SuppressWarnings("MustBeClosedChecker")
-    public void testBinaryResponseClientDisconnect() throws Exception {
-        String output = SystemLambda.tapSystemErrAndOut(() -> {
-            binaryClient
-                    .getBinaryFailure(AuthHeader.valueOf("authHeader"), Integer.MAX_VALUE)
-                    // Closing the stream triggers the conditions for this test to pass
-                    .close();
-            // Unfortunately there's no great way to tell when the server has finished processing
-            // our request.
-            Uninterruptibles.sleepUninterruptibly(Duration.ofMillis(500));
-        });
-        assertThat(output).contains("INFO", "aborted by the client");
     }
 
     @Test

--- a/conjure-java-undertow-runtime/build.gradle
+++ b/conjure-java-undertow-runtime/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api'
 
     testImplementation 'com.fasterxml.jackson.core:jackson-annotations'
+    testImplementation 'com.github.stefanbirkner:system-lambda'
     testImplementation 'com.palantir.conjure.java.api:test-utils'
     testImplementation 'com.palantir.safe-logging:preconditions-assertj'
     testImplementation 'org.assertj:assertj-core'

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ClientDisconnectTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/ClientDisconnectTest.java
@@ -1,0 +1,67 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.stefanbirkner.systemlambda.SystemLambda;
+import com.google.common.util.concurrent.Uninterruptibles;
+import io.undertow.Undertow;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ClientDisconnectTest {
+
+    private Undertow server;
+    private CountDownLatch latch = new CountDownLatch(1);
+
+    @BeforeEach
+    public void before() {
+        server = Undertow.builder()
+                .addHttpListener(12345, "localhost")
+                .setHandler(new ConjureExceptionHandler(
+                        _exchange -> Uninterruptibles.sleepUninterruptibly(Duration.ofMillis(50)),
+                        (_e, _t) -> latch.countDown()))
+                .build();
+        server.start();
+    }
+
+    @AfterEach
+    public void after() {
+        server.stop();
+    }
+
+    @Test
+    public void testClientDisconnect() throws Exception {
+        String output = SystemLambda.tapSystemErrAndOut(() -> {
+            URL url = new URL("http://localhost:12345");
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+            // necessary to execute the request
+            connection.getResponseCode();
+            connection.disconnect();
+        });
+        assertThat(latch.await(1000, TimeUnit.MILLISECONDS)).isTrue();
+        assertThat(output).contains("INFO", "aborted by the client");
+    }
+}


### PR DESCRIPTION
## Before this PR
`testBinaryResponseClientDisconnect` flakes ever so often, likely because of a timing issue

## After this PR
Now it is implemented using callbacks so that it is no longer timing sensitive


