### PR TITLE
support deprecated-for-removal on dialogue code generation

### DIFF
--- a/changelog/@unreleased/pr-2159.v2.yml
+++ b/changelog/@unreleased/pr-2159.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: support deprecated-for-removal on dialogue code generation
+  links:
+  - https://github.com/palantir/conjure-java/pull/2159

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
@@ -166,7 +166,15 @@ public final class DialogueInterfaceGenerator {
                 .forEach(referenceType -> methodBuilder.addAnnotation(
                         ClassName.get(referenceType.getPackage(), referenceType.getName())));
 
-        endpointDef.getDeprecated().ifPresent(deprecatedDocsValue -> methodBuilder.addAnnotation(Deprecated.class));
+        endpointDef.getDeprecated().ifPresent(_deprecatedValue -> {
+            if (endpointDef.getTags().contains("deprecated-for-removal")) {
+                methodBuilder.addAnnotation(AnnotationSpec.builder(Deprecated.class)
+                        .addMember("forRemoval", "true")
+                        .build());
+            } else {
+                methodBuilder.addAnnotation(Deprecated.class);
+            }
+        });
         methodBuilder.addJavadoc("$L", ServiceGenerators.getJavaDocWithRequestLine(endpointDef));
 
         TypeName returnType = returnTypeMapper.apply(endpointDef.getReturns());

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceEteTest.java
@@ -39,6 +39,7 @@ import com.palantir.product.StringAliasExample;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
 import io.dropwizard.Configuration;
+import io.dropwizard.logging.ExternalLoggingFactory;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import java.io.DataOutputStream;

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyServiceEteTest.java
@@ -39,7 +39,6 @@ import com.palantir.product.StringAliasExample;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
 import io.dropwizard.Configuration;
-import io.dropwizard.logging.ExternalLoggingFactory;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import java.io.DataOutputStream;

--- a/conjure-java-core/src/test/resources/example-service.yml
+++ b/conjure-java-core/src/test/resources/example-service.yml
@@ -158,6 +158,21 @@ services:
         docs: |
           Gets all branches of this dataset.
         deprecated: use getBranches instead
+      getBranchesDeprecatedForRemoval:
+        http: GET /datasets/{datasetRid}/branchesDeprecatedForRemoval
+        args:
+          datasetRid:
+            type: rid
+            docs: |
+              A valid dataset resource identifier.
+            markers:
+              - Safe
+        returns: set<string>
+        docs: |
+          Gets all branches of this dataset.
+        deprecated: use getBranches instead
+        tags:
+          - deprecated-for-removal
 
       resolveBranch:
         http: GET /datasets/{datasetRid}/branches/{branch:.+}/resolve

--- a/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue
@@ -387,6 +387,48 @@ enum DialogueTestEndpoints implements Endpoint {
         }
     },
 
+    /** Gets all branches of this dataset. */
+    getBranchesDeprecatedForRemoval {
+        private final PathTemplate pathTemplate = PathTemplate.builder()
+                .fixed("catalog")
+                .fixed("datasets")
+                .variable("datasetRid")
+                .fixed("branchesDeprecatedForRemoval")
+                .build();
+
+        private final ImmutableSet<String> tags = ImmutableSet.of("deprecated-for-removal");
+
+        @Override
+        public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+            pathTemplate.fill(params, url);
+        }
+
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.GET;
+        }
+
+        @Override
+        public String serviceName() {
+            return "TestService";
+        }
+
+        @Override
+        public String endpointName() {
+            return "getBranchesDeprecatedForRemoval";
+        }
+
+        @Override
+        public String version() {
+            return VERSION;
+        }
+
+        @Override
+        public Set<String> tags() {
+            return tags;
+        }
+    },
+
     resolveBranch {
         private final PathTemplate pathTemplate = PathTemplate.builder()
                 .fixed("catalog")

--- a/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/DialogueTestEndpoints.java.dialogue.prefix
@@ -387,6 +387,48 @@ enum DialogueTestEndpoints implements Endpoint {
         }
     },
 
+    /** Gets all branches of this dataset. */
+    getBranchesDeprecatedForRemoval {
+        private final PathTemplate pathTemplate = PathTemplate.builder()
+                .fixed("catalog")
+                .fixed("datasets")
+                .variable("datasetRid")
+                .fixed("branchesDeprecatedForRemoval")
+                .build();
+
+        private final ImmutableSet<String> tags = ImmutableSet.of("deprecated-for-removal");
+
+        @Override
+        public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+            pathTemplate.fill(params, url);
+        }
+
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.GET;
+        }
+
+        @Override
+        public String serviceName() {
+            return "TestService";
+        }
+
+        @Override
+        public String endpointName() {
+            return "getBranchesDeprecatedForRemoval";
+        }
+
+        @Override
+        public String version() {
+            return VERSION;
+        }
+
+        @Override
+        public Set<String> tags() {
+            return tags;
+        }
+    },
+
     resolveBranch {
         private final PathTemplate pathTemplate = PathTemplate.builder()
                 .fixed("catalog")

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey
@@ -124,6 +124,20 @@ public interface TestService {
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
+    /**
+     * Gets all branches of this dataset.
+     *
+     * @param datasetRid A valid dataset resource identifier.
+     * @deprecated use getBranches instead
+     */
+    @GET
+    @Path("catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval")
+    @Deprecated
+    @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval")
+    Set<String> getBranchesDeprecatedForRemoval(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
+
     @GET
     @Path("catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.jakarta
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.jakarta
@@ -123,6 +123,20 @@ public interface TestService {
             @HeaderParam("Authorization") AuthHeader authHeader,
             @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
+    /**
+     * Gets all branches of this dataset.
+     *
+     * @param datasetRid A valid dataset resource identifier.
+     * @deprecated use getBranches instead
+     */
+    @GET
+    @Path("catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval")
+    @Deprecated
+    @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval")
+    Set<String> getBranchesDeprecatedForRemoval(
+            @HeaderParam("Authorization") AuthHeader authHeader,
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
+
     @GET
     @Path("catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey.prefix
@@ -123,6 +123,20 @@ public interface TestService {
             @HeaderParam("Authorization") AuthHeader authHeader,
             @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
+    /**
+     * Gets all branches of this dataset.
+     *
+     * @param datasetRid A valid dataset resource identifier.
+     * @deprecated use getBranches instead
+     */
+    @GET
+    @Path("catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval")
+    @Deprecated
+    @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval")
+    Set<String> getBranchesDeprecatedForRemoval(
+            @HeaderParam("Authorization") AuthHeader authHeader,
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
+
     @GET
     @Path("catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.jersey_require_not_null
@@ -124,6 +124,20 @@ public interface TestService {
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
 
+    /**
+     * Gets all branches of this dataset.
+     *
+     * @param datasetRid A valid dataset resource identifier.
+     * @deprecated use getBranches instead
+     */
+    @GET
+    @Path("catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval")
+    @Deprecated
+    @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval")
+    Set<String> getBranchesDeprecatedForRemoval(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @Safe @PathParam("datasetRid") ResourceIdentifier datasetRid);
+
     @GET
     @Path("catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow
@@ -72,6 +72,16 @@ public interface TestService {
     @Deprecated
     Set<String> getBranchesDeprecated(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
+    /**
+     * Gets all branches of this dataset.
+     *
+     * @apiNote {@code GET /catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval}
+     * @param datasetRid A valid dataset resource identifier.
+     * @deprecated use getBranches instead
+     */
+    @Deprecated
+    Set<String> getBranchesDeprecatedForRemoval(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
+
     /** @apiNote {@code GET /catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve} */
     Optional<String> resolveBranch(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid, String branch);
 

--- a/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestService.java.undertow.prefix
@@ -72,6 +72,16 @@ public interface TestService {
     @Deprecated
     Set<String> getBranchesDeprecated(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
+    /**
+     * Gets all branches of this dataset.
+     *
+     * @apiNote {@code GET /catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval}
+     * @param datasetRid A valid dataset resource identifier.
+     * @deprecated use getBranches instead
+     */
+    @Deprecated
+    Set<String> getBranchesDeprecatedForRemoval(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
+
     /** @apiNote {@code GET /catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve} */
     Optional<String> resolveBranch(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid, String branch);
 

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue
@@ -109,6 +109,18 @@ public interface TestServiceAsync {
     @Deprecated
     ListenableFuture<Set<String>> getBranchesDeprecated(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
+    /**
+     * Gets all branches of this dataset.
+     *
+     * @apiNote {@code GET /catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval}
+     * @param datasetRid A valid dataset resource identifier.
+     * @deprecated use getBranches instead
+     */
+    @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval")
+    @Deprecated(forRemoval = true)
+    ListenableFuture<Set<String>> getBranchesDeprecatedForRemoval(
+            AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
+
     /** @apiNote {@code GET /catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve} */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
     ListenableFuture<Optional<String>> resolveBranch(
@@ -232,6 +244,12 @@ public interface TestServiceAsync {
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.getBranchesDeprecated);
 
             private final Deserializer<Set<String>> getBranchesDeprecatedDeserializer =
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Set<String>>() {});
+
+            private final EndpointChannel getBranchesDeprecatedForRemovalChannel =
+                    _endpointChannelFactory.endpoint(DialogueTestEndpoints.getBranchesDeprecatedForRemoval);
+
+            private final Deserializer<Set<String>> getBranchesDeprecatedForRemovalDeserializer =
                     _runtime.bodySerDe().deserializer(new TypeMarker<Set<String>>() {});
 
             private final EndpointChannel resolveBranchChannel =
@@ -410,6 +428,20 @@ public interface TestServiceAsync {
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 return _runtime.clients()
                         .call(getBranchesDeprecatedChannel, _request.build(), getBranchesDeprecatedDeserializer);
+            }
+
+            @Override
+            @SuppressWarnings("deprecation")
+            public ListenableFuture<Set<String>> getBranchesDeprecatedForRemoval(
+                    AuthHeader authHeader, ResourceIdentifier datasetRid) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
+                        .call(
+                                getBranchesDeprecatedForRemovalChannel,
+                                _request.build(),
+                                getBranchesDeprecatedForRemovalDeserializer);
             }
 
             @Override

--- a/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceAsync.java.dialogue.prefix
@@ -109,6 +109,18 @@ public interface TestServiceAsync {
     @Deprecated
     ListenableFuture<Set<String>> getBranchesDeprecated(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
+    /**
+     * Gets all branches of this dataset.
+     *
+     * @apiNote {@code GET /catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval}
+     * @param datasetRid A valid dataset resource identifier.
+     * @deprecated use getBranches instead
+     */
+    @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval")
+    @Deprecated(forRemoval = true)
+    ListenableFuture<Set<String>> getBranchesDeprecatedForRemoval(
+            AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
+
     /** @apiNote {@code GET /catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve} */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
     ListenableFuture<Optional<String>> resolveBranch(
@@ -232,6 +244,12 @@ public interface TestServiceAsync {
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.getBranchesDeprecated);
 
             private final Deserializer<Set<String>> getBranchesDeprecatedDeserializer =
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Set<String>>() {});
+
+            private final EndpointChannel getBranchesDeprecatedForRemovalChannel =
+                    _endpointChannelFactory.endpoint(DialogueTestEndpoints.getBranchesDeprecatedForRemoval);
+
+            private final Deserializer<Set<String>> getBranchesDeprecatedForRemovalDeserializer =
                     _runtime.bodySerDe().deserializer(new TypeMarker<Set<String>>() {});
 
             private final EndpointChannel resolveBranchChannel =
@@ -410,6 +428,20 @@ public interface TestServiceAsync {
                 _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
                 return _runtime.clients()
                         .call(getBranchesDeprecatedChannel, _request.build(), getBranchesDeprecatedDeserializer);
+            }
+
+            @Override
+            @SuppressWarnings("deprecation")
+            public ListenableFuture<Set<String>> getBranchesDeprecatedForRemoval(
+                    AuthHeader authHeader, ResourceIdentifier datasetRid) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
+                        .call(
+                                getBranchesDeprecatedForRemovalChannel,
+                                _request.build(),
+                                getBranchesDeprecatedForRemovalDeserializer);
             }
 
             @Override

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue
@@ -110,6 +110,17 @@ public interface TestServiceBlocking {
     @Deprecated
     Set<String> getBranchesDeprecated(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
+    /**
+     * Gets all branches of this dataset.
+     *
+     * @apiNote {@code GET /catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval}
+     * @param datasetRid A valid dataset resource identifier.
+     * @deprecated use getBranches instead
+     */
+    @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval")
+    @Deprecated(forRemoval = true)
+    Set<String> getBranchesDeprecatedForRemoval(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
+
     /** @apiNote {@code GET /catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve} */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
     Optional<String> resolveBranch(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid, String branch);
@@ -230,6 +241,12 @@ public interface TestServiceBlocking {
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.getBranchesDeprecated);
 
             private final Deserializer<Set<String>> getBranchesDeprecatedDeserializer =
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Set<String>>() {});
+
+            private final EndpointChannel getBranchesDeprecatedForRemovalChannel =
+                    _endpointChannelFactory.endpoint(DialogueTestEndpoints.getBranchesDeprecatedForRemoval);
+
+            private final Deserializer<Set<String>> getBranchesDeprecatedForRemovalDeserializer =
                     _runtime.bodySerDe().deserializer(new TypeMarker<Set<String>>() {});
 
             private final EndpointChannel resolveBranchChannel =
@@ -406,6 +423,19 @@ public interface TestServiceBlocking {
                 return _runtime.clients()
                         .callBlocking(
                                 getBranchesDeprecatedChannel, _request.build(), getBranchesDeprecatedDeserializer);
+            }
+
+            @Override
+            @SuppressWarnings("deprecation")
+            public Set<String> getBranchesDeprecatedForRemoval(AuthHeader authHeader, ResourceIdentifier datasetRid) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
+                        .callBlocking(
+                                getBranchesDeprecatedForRemovalChannel,
+                                _request.build(),
+                                getBranchesDeprecatedForRemovalDeserializer);
             }
 
             @Override

--- a/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceBlocking.java.dialogue.prefix
@@ -110,6 +110,17 @@ public interface TestServiceBlocking {
     @Deprecated
     Set<String> getBranchesDeprecated(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
 
+    /**
+     * Gets all branches of this dataset.
+     *
+     * @apiNote {@code GET /catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval}
+     * @param datasetRid A valid dataset resource identifier.
+     * @deprecated use getBranches instead
+     */
+    @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval")
+    @Deprecated(forRemoval = true)
+    Set<String> getBranchesDeprecatedForRemoval(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid);
+
     /** @apiNote {@code GET /catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve} */
     @ClientEndpoint(method = "GET", path = "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve")
     Optional<String> resolveBranch(AuthHeader authHeader, @Safe ResourceIdentifier datasetRid, String branch);
@@ -230,6 +241,12 @@ public interface TestServiceBlocking {
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.getBranchesDeprecated);
 
             private final Deserializer<Set<String>> getBranchesDeprecatedDeserializer =
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Set<String>>() {});
+
+            private final EndpointChannel getBranchesDeprecatedForRemovalChannel =
+                    _endpointChannelFactory.endpoint(DialogueTestEndpoints.getBranchesDeprecatedForRemoval);
+
+            private final Deserializer<Set<String>> getBranchesDeprecatedForRemovalDeserializer =
                     _runtime.bodySerDe().deserializer(new TypeMarker<Set<String>>() {});
 
             private final EndpointChannel resolveBranchChannel =
@@ -406,6 +423,19 @@ public interface TestServiceBlocking {
                 return _runtime.clients()
                         .callBlocking(
                                 getBranchesDeprecatedChannel, _request.build(), getBranchesDeprecatedDeserializer);
+            }
+
+            @Override
+            @SuppressWarnings("deprecation")
+            public Set<String> getBranchesDeprecatedForRemoval(AuthHeader authHeader, ResourceIdentifier datasetRid) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.putPathParams("datasetRid", _plainSerDe.serializeRid(datasetRid));
+                return _runtime.clients()
+                        .callBlocking(
+                                getBranchesDeprecatedForRemovalChannel,
+                                _request.build(),
+                                getBranchesDeprecatedForRemovalDeserializer);
             }
 
             @Override

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow
@@ -61,6 +61,7 @@ public final class TestServiceEndpoints implements UndertowService {
                 new UploadAliasedRawDataEndpoint(runtime, delegate),
                 new GetBranchesEndpoint(runtime, delegate),
                 new GetBranchesDeprecatedEndpoint(runtime, delegate),
+                new GetBranchesDeprecatedForRemovalEndpoint(runtime, delegate),
                 new ResolveBranchEndpoint(runtime, delegate),
                 new TestParamEndpoint(runtime, delegate),
                 new TestQueryParamsEndpoint(runtime, delegate),
@@ -618,6 +619,70 @@ public final class TestServiceEndpoints implements UndertowService {
         @Override
         public String name() {
             return "getBranchesDeprecated";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+
+        @Override
+        public Optional<String> deprecated() {
+            return Optional.of("use getBranches instead");
+        }
+    }
+
+    private static final class GetBranchesDeprecatedForRemovalEndpoint implements HttpHandler, Endpoint {
+        private static final ImmutableSet<String> TAGS = ImmutableSet.of("deprecated-for-removal");
+
+        private final UndertowRuntime runtime;
+
+        private final TestService delegate;
+
+        private final Serializer<Set<String>> serializer;
+
+        GetBranchesDeprecatedForRemovalEndpoint(UndertowRuntime runtime, TestService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Set<String>>() {}, this);
+        }
+
+        @Override
+        public Set<String> tags() {
+            return TAGS;
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            RequestContext requestContext = runtime.contexts().createContext(exchange, this);
+            Map<String, String> pathParams =
+                    exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
+            ResourceIdentifier datasetRid = runtime.plainSerDe().deserializeRid(pathParams.get("datasetRid"));
+            requestContext.requestArg(SafeArg.of("datasetRid", datasetRid));
+            Set<String> result = delegate.getBranchesDeprecatedForRemoval(authHeader, datasetRid);
+            serializer.serialize(result, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval";
+        }
+
+        @Override
+        public String serviceName() {
+            return "TestService";
+        }
+
+        @Override
+        public String name() {
+            return "getBranchesDeprecatedForRemoval";
         }
 
         @Override

--- a/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestServiceEndpoints.java.undertow.prefix
@@ -61,6 +61,7 @@ public final class TestServiceEndpoints implements UndertowService {
                 new UploadAliasedRawDataEndpoint(runtime, delegate),
                 new GetBranchesEndpoint(runtime, delegate),
                 new GetBranchesDeprecatedEndpoint(runtime, delegate),
+                new GetBranchesDeprecatedForRemovalEndpoint(runtime, delegate),
                 new ResolveBranchEndpoint(runtime, delegate),
                 new TestParamEndpoint(runtime, delegate),
                 new TestQueryParamsEndpoint(runtime, delegate),
@@ -618,6 +619,70 @@ public final class TestServiceEndpoints implements UndertowService {
         @Override
         public String name() {
             return "getBranchesDeprecated";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+
+        @Override
+        public Optional<String> deprecated() {
+            return Optional.of("use getBranches instead");
+        }
+    }
+
+    private static final class GetBranchesDeprecatedForRemovalEndpoint implements HttpHandler, Endpoint {
+        private static final ImmutableSet<String> TAGS = ImmutableSet.of("deprecated-for-removal");
+
+        private final UndertowRuntime runtime;
+
+        private final TestService delegate;
+
+        private final Serializer<Set<String>> serializer;
+
+        GetBranchesDeprecatedForRemovalEndpoint(UndertowRuntime runtime, TestService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Set<String>>() {}, this);
+        }
+
+        @Override
+        public Set<String> tags() {
+            return TAGS;
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            RequestContext requestContext = runtime.contexts().createContext(exchange, this);
+            Map<String, String> pathParams =
+                    exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
+            ResourceIdentifier datasetRid = runtime.plainSerDe().deserializeRid(pathParams.get("datasetRid"));
+            requestContext.requestArg(SafeArg.of("datasetRid", datasetRid));
+            Set<String> result = delegate.getBranchesDeprecatedForRemoval(authHeader, datasetRid);
+            serializer.serialize(result, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/catalog/datasets/{datasetRid}/branchesDeprecatedForRemoval";
+        }
+
+        @Override
+        public String serviceName() {
+            return "TestService";
+        }
+
+        @Override
+        public String name() {
+            return "getBranchesDeprecatedForRemoval";
         }
 
         @Override

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ The recommended way to use conjure-java is via a build tool like [gradle-conjure
 * `incubating`: Describes an endpoint as incubating and likely to change. These endpoints are generated with an `@Incubating` annotation.
 * `server-request-context`: Opt into an additional [RequestContext](conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java) parameter in conjure-undertow interfaces, which allows request metadata to be read, and additional arguments to be associated with the request log.
 * `server-async`: Opt into [asynchronous request processing](#asynchronous-request-processing) in conjure-undertow. The generated interface returns a `ListenableFuture` of the defined return type, allowing processing to occur in the background without blocking the request thread.
-* `deprecated-for-removal`: (applies to Dialogue services only) For endpoint definitions that [are marked deprecated](https://github.com/palantir/conjure/blob/master/docs/spec/conjure_definitions.md#endpointdefinition), indicates that the endpoint will be removed in a future release. This has the effect of Java client being generated with an `@Deprecated(forRemoval = true)` annotation on the endpoint method in the Dialogue service interface.
+* `deprecated-for-removal`: (applies to Dialogue services only) For endpoint definitions that [are marked deprecated](https://github.com/palantir/conjure/blob/master/docs/spec/conjure_definitions.md#endpointdefinition), indicates that the endpoint will be removed in a future release. This has the effect of Java code being generated with an `@Deprecated(forRemoval = true)` annotation on the endpoint method in the Dialogue service interface.
 
 #### Endpoint Argument Tags
 

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,7 @@ The recommended way to use conjure-java is via a build tool like [gradle-conjure
 * `incubating`: Describes an endpoint as incubating and likely to change. These endpoints are generated with an `@Incubating` annotation.
 * `server-request-context`: Opt into an additional [RequestContext](conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java) parameter in conjure-undertow interfaces, which allows request metadata to be read, and additional arguments to be associated with the request log.
 * `server-async`: Opt into [asynchronous request processing](#asynchronous-request-processing) in conjure-undertow. The generated interface returns a `ListenableFuture` of the defined return type, allowing processing to occur in the background without blocking the request thread.
+* `deprecated-for-removal`: (applies to Dialogue services only) For endpoint definitions that [are marked deprecated](https://github.com/palantir/conjure/blob/master/docs/spec/conjure_definitions.md#endpointdefinition), indicates that the endpoint will be removed in a future release. This has the effect of Java client being generated with an `@Deprecated(forRemoval = true)` annotation on the endpoint method in the Dialogue service interface.
 
 #### Endpoint Argument Tags
 

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ The recommended way to use conjure-java is via a build tool like [gradle-conjure
 * `incubating`: Describes an endpoint as incubating and likely to change. These endpoints are generated with an `@Incubating` annotation.
 * `server-request-context`: Opt into an additional [RequestContext](conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java) parameter in conjure-undertow interfaces, which allows request metadata to be read, and additional arguments to be associated with the request log.
 * `server-async`: Opt into [asynchronous request processing](#asynchronous-request-processing) in conjure-undertow. The generated interface returns a `ListenableFuture` of the defined return type, allowing processing to occur in the background without blocking the request thread.
-* `deprecated-for-removal`: (applies to Dialogue services only) For endpoint definitions that [are marked deprecated](https://github.com/palantir/conjure/blob/master/docs/spec/conjure_definitions.md#endpointdefinition), indicates that the endpoint will be removed in a future release. This has the effect of Java code being generated with an `@Deprecated(forRemoval = true)` annotation on the endpoint method in the Dialogue service interface.
+* `deprecated-for-removal`: For endpoint definitions that [are marked deprecated](https://github.com/palantir/conjure/blob/master/docs/spec/conjure_definitions.md#endpointdefinition), indicates that the endpoint will be removed in a future release. This has the effect of Java code being generated with an `@Deprecated(forRemoval = true)` annotation on the endpoint method in the Dialogue service interface.
 
 #### Endpoint Argument Tags
 


### PR DESCRIPTION
For endpoints containing the "deprecated" field, we generate a `@java.lang.Deprecated` annotation on the method. With this change, if the endpoint additionally contains a tag named "deprecated-for-removal", the generated annotation changes to `@Deprecated(forRemoval = true)`.

Note that this change only affects dialogue service code generation, and does not alter the behavior for Undertow or Jersey code generation.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
support deprecated-for-removal on dialogue code generation
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

