### PR TITLE
Documenting ordering on conjure-undertow-annotations inferred deserialization

### DIFF
--- a/conjure-undertow-annotations/readme.md
+++ b/conjure-undertow-annotations/readme.md
@@ -167,8 +167,13 @@ Note that file form parameters are currently not supported by this annotation bu
 ### Using Custom Serializer or Deserializers
 
 Per default, conjure-undertow-processor supports decoding parameters for all [plain Conjure types](https://palantir.github.io/conjure/#/docs/spec/wire?id=_7-plain-format)
-as well as primitives and types that have either a constructor that accepts a single String argument or a static
-method named `valueOf` that accepts a single String argument.
+as well as primitives and types that have one of the following:
+1. A public static method named `valueOf` that accepts a single String argument.
+2. A public constructor that accepts a single String argument.
+3. A public static method named `of` that accepts a single String argument.
+4. A public static method named `create` that accepts a single String argument.
+
+In the presence of more than one eligible method or constructor, the first matching element following the ordering above is used.
 
 For other parameter types, you can provide a custom decoder by providing an implementation of
 either [`ParamDecoder`](src/main/java/com/palantir/conjure/java/undertow/annotations/ParamDecoder.java) or


### PR DESCRIPTION
Documenting behavior from https://github.com/palantir/conjure-java/blob/3a425c144ae6293fb6bd8f67d9dea21c8edaadac/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParamTypesResolver.java#L406-L410

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

