### PR TITLE
Fix inferred deserialization docs

### DIFF
--- a/conjure-undertow-annotations/readme.md
+++ b/conjure-undertow-annotations/readme.md
@@ -16,7 +16,7 @@ while still profiting from code generation.
 
 ## Getting Started
 
-In your API project, add the following dependencies to your `build.gradle` file (make sure you are using 
+In your API project, add the following dependencies to your `build.gradle` file (make sure you are using
 [gradle-processors](https://github.com/palantir/gradle-processors)):
 
 ```gradle
@@ -77,7 +77,7 @@ public interface MyService {
 }
 ```
 
-When using an HTTP authentication header in the form of `Bearer [token]`, the token can be automatically injected when 
+When using an HTTP authentication header in the form of `Bearer [token]`, the token can be automatically injected when
 using an [`AuthHeader`](https://github.com/palantir/auth-tokens/blob/develop/auth-tokens/src/main/java/com/palantir/tokens/auth/AuthHeader.java) parameter:
 
 ```java
@@ -143,7 +143,7 @@ The conjure-undertow-processor supports async handlers by wrapping the response 
 public interface MyService {
     @Handle(method = HttpMethod.GET, path = "/path/async")
     ListenableFuture<MyResponse> asyncEndpoint();
-    
+
     @Handle(method = HttpMethod.GET, path = "/path/async-void")
     ListenableFuture<Void> asyncVoidEndpoint();
 }
@@ -169,9 +169,10 @@ Note that file form parameters are currently not supported by this annotation bu
 Per default, conjure-undertow-processor supports decoding parameters for all [plain Conjure types](https://palantir.github.io/conjure/#/docs/spec/wire?id=_7-plain-format)
 as well as primitives and types that have one of the following:
 1. A public static method named `valueOf` that accepts a single String argument.
-2. A public constructor that accepts a single String argument.
-3. A public static method named `of` that accepts a single String argument.
-4. A public static method named `create` that accepts a single String argument.
+1. A public constructor that accepts a single String argument.
+1. A public static method named `of` that accepts a single String argument.
+1. A public static method named `fromString` that accepts a single String argument.
+1. A public static method named `create` that accepts a single String argument.
 
 In the presence of more than one eligible method or constructor, the first matching element following the ordering above is used.
 


### PR DESCRIPTION
Looks like we missed the `fromString` case in https://github.com/palantir/conjure-java/pull/2193.