### PR TITLE
SafeLoggable exception for invalid UUID values

### DIFF
--- a/changelog/@unreleased/pr-2212.v2.yml
+++ b/changelog/@unreleased/pr-2212.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: SafeLoggable exception for invalid UUID values
+  links:
+  - https://github.com/palantir/conjure-java/pull/2212

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidAliasExample.java
@@ -3,6 +3,8 @@ package com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -38,7 +40,11 @@ public final class UuidAliasExample {
     }
 
     public static UuidAliasExample valueOf(String value) {
-        return of(UUID.fromString(value));
+        try {
+            return of(UUID.fromString(value));
+        } catch (IllegalArgumentException e) {
+            throw new SafeIllegalArgumentException("Unable to parse as UUID", e, UnsafeArg.of("input", value));
+        }
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UuidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UuidAliasExample.java
@@ -3,6 +3,8 @@ package test.prefix.com.palantir.product;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -38,7 +40,11 @@ public final class UuidAliasExample {
     }
 
     public static UuidAliasExample valueOf(String value) {
-        return of(UUID.fromString(value));
+        try {
+            return of(UUID.fromString(value));
+        } catch (IllegalArgumentException e) {
+            throw new SafeIllegalArgumentException("Unable to parse as UUID", e, UnsafeArg.of("input", value));
+        }
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -39,6 +39,8 @@ import com.palantir.conjure.visitor.TypeDefinitionVisitor;
 import com.palantir.conjure.visitor.TypeVisitor;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
@@ -385,7 +387,14 @@ public final class AliasGenerator {
                         .build();
             case UUID:
                 return CodeBlock.builder()
+                        .beginControlFlow("try")
                         .addStatement("return of($T.fromString(value))", aliasTypeName.withoutAnnotations())
+                        .nextControlFlow("catch (IllegalArgumentException e)")
+                        .addStatement(
+                                "throw new $T(\"Unable to parse as UUID\", e, $T.of(\"input\", value))",
+                                SafeIllegalArgumentException.class,
+                                UnsafeArg.class)
+                        .endControlFlow()
                         .build();
             case DATETIME:
                 return CodeBlock.builder()

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/AliasTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/AliasTests.java
@@ -16,17 +16,21 @@
 
 package com.palantir.conjure.java.types;
 
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.conjure.java.serialization.ObjectMappers;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.exceptions.SafeNullPointerException;
 import com.palantir.product.DoubleAliasExample;
 import com.palantir.product.ExternalLongAliasOne;
 import com.palantir.product.ExternalLongAliasTwo;
 import com.palantir.product.UuidAliasExample;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 public class AliasTests {
@@ -37,6 +41,20 @@ public class AliasTests {
         assertThatThrownBy(() -> UuidAliasExample.of(null))
                 .isInstanceOf(SafeNullPointerException.class)
                 .hasMessage("value cannot be null");
+    }
+
+    @Test
+    void testValueOf_validUuid_succeeds() {
+        UUID uuid = UUID.randomUUID();
+        assertThat(UuidAliasExample.valueOf(uuid.toString())).isEqualTo(UuidAliasExample.of(uuid));
+    }
+
+    @Test
+    void testValueOf_invalidUuid_throwsSafeException() {
+        assertThatLoggableExceptionThrownBy(() -> UuidAliasExample.valueOf("not-a-uuid"))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("Unable to parse as UUID")
+                .hasExactlyArgs(UnsafeArg.of("input", "not-a-uuid"));
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
Parsing a too-long UUID string fails with an IllegalArgumentException which does not include the invalid value:

```
java.lang.IllegalArgumentException: UUID string too large
        at java.base/java.util.UUID.fromString1(UUID.java:264)
        at java.base/java.util.UUID.fromString(UUID.java:258)
        at com.palantir.example.BlockInternalId.valueOf(BlockInternalId.java:45)
```

[openjdk/jdk source](https://github.com/openjdk/jdk/blob/998d0baab0fd051c38d9fd6021628eb863b80554/src/java.base/share/classes/java/util/UUID.java#L270)

See https://pl.ntr/2l6 for an internal example stacktrace.

This makes it difficult to debug, as there is no log of the value, even at unsafe level, to assist with debugging.

## After this PR
==COMMIT_MSG==
SafeLoggable exception for invalid UUID values
==COMMIT_MSG==

## Possible downsides?
Potentially there is some performance impact from this change for parsing invalid UUID aliases, or even valid UUIDs.  I think it's likely slight -- just wrapped in a try block for the valid case, and creating a wrapping exception for the invalid case.