### PR TITLE
nullable PlainSerDe#deserializeRid input

### DIFF
--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/PlainSerDe.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/PlainSerDe.java
@@ -99,7 +99,7 @@ public interface PlainSerDe {
 
     Set<Integer> deserializeIntegerSet(@Nullable Iterable<String> in);
 
-    ResourceIdentifier deserializeRid(String in);
+    ResourceIdentifier deserializeRid(@Nullable String in);
 
     ResourceIdentifier deserializeRid(@Nullable Iterable<String> in);
 


### PR DESCRIPTION
already true of the implementation https://github.com/palantir/conjure-java/blob/develop/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjurePlainSerDe.java#L324
```
    @Override
    public ResourceIdentifier deserializeRid(@Nullable String in) {
        checkArgumentNotNull(in);
        try {
            return ResourceIdentifier.valueOf(in);
        } catch (RuntimeException ex) {
            throw new SafeIllegalArgumentException("failed to deserialize rid", ex);
        }
    }
```

==COMMIT_MSG==
nullable PlainSerDe#deserializeRid input
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

