### PR TITLE
Fix externalFallbackTypes to also apply to endpoint return types

### DIFF
--- a/changelog/@unreleased/pr-2225.v2.yml
+++ b/changelog/@unreleased/pr-2225.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix externalFallbackTypes to also apply to endpoint return types
+  links:
+  - https://github.com/palantir/conjure-java/pull/2225

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/external/ServiceUsingExternalTypes.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/external/ServiceUsingExternalTypes.java
@@ -1,0 +1,12 @@
+package com.palantir.product.external;
+
+import com.palantir.logsafe.Safe;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
+public interface ServiceUsingExternalTypes {
+    /** @apiNote {@code PUT /external/{path}} */
+    Map<String, String> external(@Safe String path, @Safe List<String> body);
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/external/ServiceUsingExternalTypesAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/external/ServiceUsingExternalTypesAsync.java
@@ -15,7 +15,6 @@ import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Serializer;
 import com.palantir.dialogue.TypeMarker;
 import com.palantir.logsafe.Safe;
-import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
@@ -27,7 +26,7 @@ import javax.annotation.processing.Generated;
 public interface ServiceUsingExternalTypesAsync {
     /** @apiNote {@code PUT /external/{path}} */
     @ClientEndpoint(method = "PUT", path = "/external/{path}")
-    ListenableFuture<Map<Long, Long>> external(@Safe String path, @Safe List<String> body);
+    ListenableFuture<Map<String, String>> external(@Safe String path, @Safe List<String> body);
 
     /** Creates an asynchronous/non-blocking client for a ServiceUsingExternalTypes service. */
     static ServiceUsingExternalTypesAsync of(EndpointChannelFactory _endpointChannelFactory, ConjureRuntime _runtime) {
@@ -40,11 +39,11 @@ public interface ServiceUsingExternalTypesAsync {
             private final EndpointChannel externalChannel =
                     _endpointChannelFactory.endpoint(DialogueServiceUsingExternalTypesEndpoints.external);
 
-            private final Deserializer<Map<Long, Long>> externalDeserializer =
-                    _runtime.bodySerDe().deserializer(new TypeMarker<Map<Long, Long>>() {});
+            private final Deserializer<Map<String, String>> externalDeserializer =
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Map<String, String>>() {});
 
             @Override
-            public ListenableFuture<Map<Long, Long>> external(String path, List<String> body) {
+            public ListenableFuture<Map<String, String>> external(String path, List<String> body) {
                 Request.Builder _request = Request.builder();
                 _request.putPathParams("path", _plainSerDe.serializeString(path));
                 _request.body(externalSerializer.serialize(body));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/external/ServiceUsingExternalTypesBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/external/ServiceUsingExternalTypesBlocking.java
@@ -14,7 +14,6 @@ import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Serializer;
 import com.palantir.dialogue.TypeMarker;
 import com.palantir.logsafe.Safe;
-import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
@@ -26,7 +25,7 @@ import javax.annotation.processing.Generated;
 public interface ServiceUsingExternalTypesBlocking {
     /** @apiNote {@code PUT /external/{path}} */
     @ClientEndpoint(method = "PUT", path = "/external/{path}")
-    Map<Long, Long> external(@Safe String path, @Safe List<String> body);
+    Map<String, String> external(@Safe String path, @Safe List<String> body);
 
     /** Creates a synchronous/blocking client for a ServiceUsingExternalTypes service. */
     static ServiceUsingExternalTypesBlocking of(
@@ -40,11 +39,11 @@ public interface ServiceUsingExternalTypesBlocking {
             private final EndpointChannel externalChannel =
                     _endpointChannelFactory.endpoint(DialogueServiceUsingExternalTypesEndpoints.external);
 
-            private final Deserializer<Map<Long, Long>> externalDeserializer =
-                    _runtime.bodySerDe().deserializer(new TypeMarker<Map<Long, Long>>() {});
+            private final Deserializer<Map<String, String>> externalDeserializer =
+                    _runtime.bodySerDe().deserializer(new TypeMarker<Map<String, String>>() {});
 
             @Override
-            public Map<Long, Long> external(String path, List<String> body) {
+            public Map<String, String> external(String path, List<String> body) {
                 Request.Builder _request = Request.builder();
                 _request.putPathParams("path", _plainSerDe.serializeString(path));
                 _request.body(externalSerializer.serialize(body));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/external/ServiceUsingExternalTypesEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/external/ServiceUsingExternalTypesEndpoints.java
@@ -1,0 +1,92 @@
+package com.palantir.product.external;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.java.undertow.lib.Deserializer;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.RequestContext;
+import com.palantir.conjure.java.undertow.lib.Serializer;
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import com.palantir.logsafe.SafeArg;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import io.undertow.util.PathTemplateMatch;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.services.UndertowServiceHandlerGenerator")
+public final class ServiceUsingExternalTypesEndpoints implements UndertowService {
+    private final ServiceUsingExternalTypes delegate;
+
+    private ServiceUsingExternalTypesEndpoints(ServiceUsingExternalTypes delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(ServiceUsingExternalTypes delegate) {
+        return new ServiceUsingExternalTypesEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return ImmutableList.of(new ExternalEndpoint(runtime, delegate));
+    }
+
+    private static final class ExternalEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final ServiceUsingExternalTypes delegate;
+
+        private final Deserializer<ImmutableList<String>> deserializer;
+
+        private final Serializer<Map<String, String>> serializer;
+
+        ExternalEndpoint(UndertowRuntime runtime, ServiceUsingExternalTypes delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<ImmutableList<String>>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Map<String, String>>() {}, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            RequestContext requestContext = runtime.contexts().createContext(exchange, this);
+            List<String> body = deserializer.deserialize(exchange);
+            Map<String, String> pathParams =
+                    exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
+            String path = runtime.plainSerDe().deserializeString(pathParams.get("path"));
+            requestContext.requestArg(SafeArg.of("path", path));
+            Map<String, String> result = delegate.external(path, body);
+            serializer.serialize(result, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.PUT;
+        }
+
+        @Override
+        public String template() {
+            return "/external/{path}";
+        }
+
+        @Override
+        public String serviceName() {
+            return "ServiceUsingExternalTypes";
+        }
+
+        @Override
+        public String name() {
+            return "external";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/ExternalImportFilter.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/ExternalImportFilter.java
@@ -127,6 +127,7 @@ final class ExternalImportFilter {
                 // Remove markers, which are required to be external type imports
                 .markers(ImmutableList.of())
                 .args(Lists.transform(definition.getArgs(), this::filter))
+                .returns(definition.getReturns().map(this::filter).map(TypeWithSafety::type))
                 .build();
     }
 

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ExternalTypeFallbackTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ExternalTypeFallbackTests.java
@@ -24,6 +24,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.conjure.defs.Conjure;
 import com.palantir.conjure.java.GenerationCoordinator;
 import com.palantir.conjure.java.Options;
+import com.palantir.conjure.java.services.UndertowServiceGenerator;
 import com.palantir.conjure.java.services.dialogue.DialogueServiceGenerator;
 import com.palantir.conjure.spec.ConjureDefinition;
 import java.io.File;
@@ -56,7 +57,10 @@ public final class ExternalTypeFallbackTests {
         ConjureDefinition def = Conjure.parse(ImmutableList.of(new File("src/test/resources/external-types.yml")));
         List<Path> files = new GenerationCoordinator(
                         MoreExecutors.directExecutor(),
-                        ImmutableSet.of(new ObjectGenerator(options), new DialogueServiceGenerator(options)),
+                        ImmutableSet.of(
+                                new ObjectGenerator(options),
+                                new DialogueServiceGenerator(options),
+                                new UndertowServiceGenerator(options)),
                         options)
                 .emit(def, tempDir);
 

--- a/conjure-java-core/src/test/resources/external-types.yml
+++ b/conjure-java-core/src/test/resources/external-types.yml
@@ -4,7 +4,8 @@ types:
       base-type: string
       safety: safe
       external:
-        java: java.lang.Long
+        # an intentionally unavailable class
+        java: com.my.custom.Long
   definitions:
     default-package: com.palantir.product.external
     errors:


### PR DESCRIPTION
FLUP to https://github.com/palantir/conjure-java/pull/2213

## Before this PR
Enabling `externalFallbackTypes` would erase external import types to their base type in most places, but not in the return type of endpoints.

## After this PR
==COMMIT_MSG==
Fix externalFallbackTypes to also apply to endpoint return types
==COMMIT_MSG==

Changes in this PR:
1. Change ExternalImportFilter to also erase types for EndpointDefinition returns
2. Enable UndertowServiceGenerator for the test.  For fakes, I am using conjure-java-local not just to generate clients, but also to generate the server-side interface.
3. Change `ExternalLong` in the test conjure file to point to an unknown reference. The classes in src/integrationInput are compiled as part of `check`, so this will help ensure these continue to compile in the future in the face of missing local classes.

## Possible downsides?
None known