### PR TITLE
do not attempt to generate a dialog service if no endpoints

### DIFF
--- a/changelog/@unreleased/pr-2237.v2.yml
+++ b/changelog/@unreleased/pr-2237.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: do not attempt to generate a dialog service if no endpoints
+  links:
+  - https://github.com/palantir/conjure-java/pull/2237

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueServiceGenerator.java
@@ -82,9 +82,13 @@ public final class DialogueServiceGenerator implements Generator {
                 StaticFactoryMethodType.BLOCKING);
 
         return conjureDefinition.getServices().stream()
-                .flatMap(serviceDef -> Stream.of(
-                        endpoints.endpointsClass(serviceDef),
-                        interfaceGenerator.generateBlocking(serviceDef, blockingGenerator),
-                        interfaceGenerator.generateAsync(serviceDef, asyncGenerator)));
+                .flatMap(serviceDef -> !serviceDef.getEndpoints().isEmpty()
+                        ? Stream.of(
+                                endpoints.endpointsClass(serviceDef),
+                                interfaceGenerator.generateBlocking(serviceDef, blockingGenerator),
+                                interfaceGenerator.generateAsync(serviceDef, asyncGenerator))
+                        : Stream.of(
+                                interfaceGenerator.generateBlocking(serviceDef, blockingGenerator),
+                                interfaceGenerator.generateAsync(serviceDef, asyncGenerator)));
     }
 }

--- a/conjure-java-core/src/test/resources/example-service.yml
+++ b/conjure-java-core/src/test/resources/example-service.yml
@@ -278,3 +278,12 @@ services:
           strings:
             type: set<AliasedString>
             param-type: query
+  TestEmptyService:
+    name: Empty Test Service
+    package: com.palantir.another
+    default-auth: header
+    base-path: /testEmptyService
+    docs: |
+      This service has no endpoints.
+
+    endpoints: {}

--- a/conjure-java-core/src/test/resources/test/api/TestEmptyService.java.jersey
+++ b/conjure-java-core/src/test/resources/test/api/TestEmptyService.java.jersey
@@ -1,0 +1,14 @@
+package com.palantir.another;
+
+import javax.annotation.processing.Generated;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/** This service has no endpoints. */
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/")
+@Generated("com.palantir.conjure.java.services.JerseyServiceGenerator")
+public interface TestEmptyService {}

--- a/conjure-java-core/src/test/resources/test/api/TestEmptyService.java.jersey.jakarta
+++ b/conjure-java-core/src/test/resources/test/api/TestEmptyService.java.jersey.jakarta
@@ -1,0 +1,14 @@
+package com.palantir.another;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import javax.annotation.processing.Generated;
+
+/** This service has no endpoints. */
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/")
+@Generated("com.palantir.conjure.java.services.JerseyServiceGenerator")
+public interface TestEmptyService {}

--- a/conjure-java-core/src/test/resources/test/api/TestEmptyService.java.jersey.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestEmptyService.java.jersey.prefix
@@ -1,0 +1,14 @@
+package test.prefix.com.palantir.another;
+
+import javax.annotation.processing.Generated;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/** This service has no endpoints. */
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/")
+@Generated("com.palantir.conjure.java.services.JerseyServiceGenerator")
+public interface TestEmptyService {}

--- a/conjure-java-core/src/test/resources/test/api/TestEmptyService.java.jersey_require_not_null
+++ b/conjure-java-core/src/test/resources/test/api/TestEmptyService.java.jersey_require_not_null
@@ -1,0 +1,14 @@
+package com.palantir.another;
+
+import javax.annotation.processing.Generated;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/** This service has no endpoints. */
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/")
+@Generated("com.palantir.conjure.java.services.JerseyServiceGenerator")
+public interface TestEmptyService {}

--- a/conjure-java-core/src/test/resources/test/api/TestEmptyService.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestEmptyService.java.undertow
@@ -1,0 +1,7 @@
+package com.palantir.another;
+
+import javax.annotation.processing.Generated;
+
+/** This service has no endpoints. */
+@Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
+public interface TestEmptyService {}

--- a/conjure-java-core/src/test/resources/test/api/TestEmptyService.java.undertow.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestEmptyService.java.undertow.prefix
@@ -1,0 +1,7 @@
+package test.prefix.com.palantir.another;
+
+import javax.annotation.processing.Generated;
+
+/** This service has no endpoints. */
+@Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
+public interface TestEmptyService {}

--- a/conjure-java-core/src/test/resources/test/api/TestEmptyServiceAsync.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestEmptyServiceAsync.java.dialogue
@@ -1,0 +1,53 @@
+package com.palantir.another;
+
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.ConjureRuntime;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.EndpointChannelFactory;
+import com.palantir.dialogue.PlainSerDe;
+import java.lang.Override;
+import java.lang.String;
+import javax.annotation.processing.Generated;
+
+/** This service has no endpoints. */
+@Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(TestEmptyServiceAsync.Factory.class)
+public interface TestEmptyServiceAsync {
+    /** Creates an asynchronous/non-blocking client for a TestEmptyService service. */
+    static TestEmptyServiceAsync of(EndpointChannelFactory _endpointChannelFactory, ConjureRuntime _runtime) {
+        return new TestEmptyServiceAsync() {
+            private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
+
+            @Override
+            public String toString() {
+                return "TestEmptyServiceAsync{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime="
+                        + _runtime + '}';
+            }
+        };
+    }
+
+    /** Creates an asynchronous/non-blocking client for a TestEmptyService service. */
+    static TestEmptyServiceAsync of(Channel _channel, ConjureRuntime _runtime) {
+        if (_channel instanceof EndpointChannelFactory) {
+            return of((EndpointChannelFactory) _channel, _runtime);
+        }
+        return of(
+                new EndpointChannelFactory() {
+                    @Override
+                    public EndpointChannel endpoint(Endpoint endpoint) {
+                        return _runtime.clients().bind(_channel, endpoint);
+                    }
+                },
+                _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<TestEmptyServiceAsync> {
+        @Override
+        public TestEmptyServiceAsync create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return TestEmptyServiceAsync.of(endpointChannelFactory, runtime);
+        }
+    }
+}

--- a/conjure-java-core/src/test/resources/test/api/TestEmptyServiceAsync.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestEmptyServiceAsync.java.dialogue.prefix
@@ -1,0 +1,53 @@
+package test.prefix.com.palantir.another;
+
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.ConjureRuntime;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.EndpointChannelFactory;
+import com.palantir.dialogue.PlainSerDe;
+import java.lang.Override;
+import java.lang.String;
+import javax.annotation.processing.Generated;
+
+/** This service has no endpoints. */
+@Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(TestEmptyServiceAsync.Factory.class)
+public interface TestEmptyServiceAsync {
+    /** Creates an asynchronous/non-blocking client for a TestEmptyService service. */
+    static TestEmptyServiceAsync of(EndpointChannelFactory _endpointChannelFactory, ConjureRuntime _runtime) {
+        return new TestEmptyServiceAsync() {
+            private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
+
+            @Override
+            public String toString() {
+                return "TestEmptyServiceAsync{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime="
+                        + _runtime + '}';
+            }
+        };
+    }
+
+    /** Creates an asynchronous/non-blocking client for a TestEmptyService service. */
+    static TestEmptyServiceAsync of(Channel _channel, ConjureRuntime _runtime) {
+        if (_channel instanceof EndpointChannelFactory) {
+            return of((EndpointChannelFactory) _channel, _runtime);
+        }
+        return of(
+                new EndpointChannelFactory() {
+                    @Override
+                    public EndpointChannel endpoint(Endpoint endpoint) {
+                        return _runtime.clients().bind(_channel, endpoint);
+                    }
+                },
+                _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<TestEmptyServiceAsync> {
+        @Override
+        public TestEmptyServiceAsync create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return TestEmptyServiceAsync.of(endpointChannelFactory, runtime);
+        }
+    }
+}

--- a/conjure-java-core/src/test/resources/test/api/TestEmptyServiceBlocking.java.dialogue
+++ b/conjure-java-core/src/test/resources/test/api/TestEmptyServiceBlocking.java.dialogue
@@ -1,0 +1,53 @@
+package com.palantir.another;
+
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.ConjureRuntime;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.EndpointChannelFactory;
+import com.palantir.dialogue.PlainSerDe;
+import java.lang.Override;
+import java.lang.String;
+import javax.annotation.processing.Generated;
+
+/** This service has no endpoints. */
+@Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(TestEmptyServiceBlocking.Factory.class)
+public interface TestEmptyServiceBlocking {
+    /** Creates a synchronous/blocking client for a TestEmptyService service. */
+    static TestEmptyServiceBlocking of(EndpointChannelFactory _endpointChannelFactory, ConjureRuntime _runtime) {
+        return new TestEmptyServiceBlocking() {
+            private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
+
+            @Override
+            public String toString() {
+                return "TestEmptyServiceBlocking{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime="
+                        + _runtime + '}';
+            }
+        };
+    }
+
+    /** Creates an asynchronous/non-blocking client for a TestEmptyService service. */
+    static TestEmptyServiceBlocking of(Channel _channel, ConjureRuntime _runtime) {
+        if (_channel instanceof EndpointChannelFactory) {
+            return of((EndpointChannelFactory) _channel, _runtime);
+        }
+        return of(
+                new EndpointChannelFactory() {
+                    @Override
+                    public EndpointChannel endpoint(Endpoint endpoint) {
+                        return _runtime.clients().bind(_channel, endpoint);
+                    }
+                },
+                _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<TestEmptyServiceBlocking> {
+        @Override
+        public TestEmptyServiceBlocking create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return TestEmptyServiceBlocking.of(endpointChannelFactory, runtime);
+        }
+    }
+}

--- a/conjure-java-core/src/test/resources/test/api/TestEmptyServiceBlocking.java.dialogue.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestEmptyServiceBlocking.java.dialogue.prefix
@@ -1,0 +1,53 @@
+package test.prefix.com.palantir.another;
+
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.ConjureRuntime;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.EndpointChannelFactory;
+import com.palantir.dialogue.PlainSerDe;
+import java.lang.Override;
+import java.lang.String;
+import javax.annotation.processing.Generated;
+
+/** This service has no endpoints. */
+@Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(TestEmptyServiceBlocking.Factory.class)
+public interface TestEmptyServiceBlocking {
+    /** Creates a synchronous/blocking client for a TestEmptyService service. */
+    static TestEmptyServiceBlocking of(EndpointChannelFactory _endpointChannelFactory, ConjureRuntime _runtime) {
+        return new TestEmptyServiceBlocking() {
+            private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
+
+            @Override
+            public String toString() {
+                return "TestEmptyServiceBlocking{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime="
+                        + _runtime + '}';
+            }
+        };
+    }
+
+    /** Creates an asynchronous/non-blocking client for a TestEmptyService service. */
+    static TestEmptyServiceBlocking of(Channel _channel, ConjureRuntime _runtime) {
+        if (_channel instanceof EndpointChannelFactory) {
+            return of((EndpointChannelFactory) _channel, _runtime);
+        }
+        return of(
+                new EndpointChannelFactory() {
+                    @Override
+                    public EndpointChannel endpoint(Endpoint endpoint) {
+                        return _runtime.clients().bind(_channel, endpoint);
+                    }
+                },
+                _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<TestEmptyServiceBlocking> {
+        @Override
+        public TestEmptyServiceBlocking create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return TestEmptyServiceBlocking.of(endpointChannelFactory, runtime);
+        }
+    }
+}

--- a/conjure-java-core/src/test/resources/test/api/TestEmptyServiceEndpoints.java.undertow
+++ b/conjure-java-core/src/test/resources/test/api/TestEmptyServiceEndpoints.java.undertow
@@ -1,0 +1,26 @@
+package com.palantir.another;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.services.UndertowServiceHandlerGenerator")
+public final class TestEmptyServiceEndpoints implements UndertowService {
+    private final TestEmptyService delegate;
+
+    private TestEmptyServiceEndpoints(TestEmptyService delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(TestEmptyService delegate) {
+        return new TestEmptyServiceEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return ImmutableList.of();
+    }
+}

--- a/conjure-java-core/src/test/resources/test/api/TestEmptyServiceEndpoints.java.undertow.prefix
+++ b/conjure-java-core/src/test/resources/test/api/TestEmptyServiceEndpoints.java.undertow.prefix
@@ -1,0 +1,26 @@
+package test.prefix.com.palantir.another;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.services.UndertowServiceHandlerGenerator")
+public final class TestEmptyServiceEndpoints implements UndertowService {
+    private final TestEmptyService delegate;
+
+    private TestEmptyServiceEndpoints(TestEmptyService delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(TestEmptyService delegate) {
+        return new TestEmptyServiceEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return ImmutableList.of();
+    }
+}


### PR DESCRIPTION
## Before this PR
If a service had no declared endpoints the dialogue service generator fails trying to create the Endpoints enum.  The poet library will not allow an empty enum class.  All other generators handle things correctly.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Skips generating the Endpoints enum if no endpoints.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

