### PR TITLE
Add TypeMarker static factory method

### DIFF
--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/TypeMarker.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/TypeMarker.java
@@ -42,11 +42,24 @@ public abstract class TypeMarker<T> {
                 genericSuperclass instanceof ParameterizedType,
                 "Class is not parameterized",
                 SafeArg.of("class", genericSuperclass));
-        type = ((ParameterizedType) genericSuperclass).getActualTypeArguments()[0];
+        Type typeArgument = ((ParameterizedType) genericSuperclass).getActualTypeArguments()[0];
+        Preconditions.checkArgument(
+                !(typeArgument instanceof TypeVariable),
+                "TypeMarker does not support variable types",
+                SafeArg.of("typeVariable", typeArgument));
+        this.type = typeArgument;
+    }
+
+    private TypeMarker(Type type) {
         Preconditions.checkArgument(
                 !(type instanceof TypeVariable),
                 "TypeMarker does not support variable types",
                 SafeArg.of("typeVariable", type));
+        this.type = type;
+    }
+
+    public static <T> TypeMarker<T> of(Type type) {
+        return new TypeMarker<>(type) {};
     }
 
     public final Type getType() {


### PR DESCRIPTION
There are a variety of use cases where consumers may want to derive one `TypeMarker` into another.

For example, if you want to delegate to the default JSON serializer but add some additional serialization logic:

```java
interface WithHeaders<T> {
    // Some JSON value
    T body();

    Map<HttpString, String> headers();
}

class MyResponseSerializerFactory<T> implements SerializerFactory<MyResponse<T>> {
    public <R extends WithHeaders<T>> Serializer<R> serializer(TypeMarker<R> type, UndertowRuntime runtime, Endpoint endpoint) {
        // I can't create a anonymous TypeMarker here,
        // but I can obtain a Type from the provided TypeMarker
        Serializer<T> bodySerializer = runtime.bodySerDe().serializer(/* TypeMarker */);

        return (value, exchange) -> {
            response.headers().forEach(exchange.headers()::put);
            bodySerializer.serialize(value.body(), exchange);
        };
    }
}
```

This PR adds a `TypeMarker.of(Type)` method to support these use cases.

This method is completely unchecked. Callers are responsible for choosing the correct type parameter.
