### PR TITLE
Expose a TypeMarker factory to wrap an arbitrary Type

### DIFF
--- a/changelog/@unreleased/pr-2264.v2.yml
+++ b/changelog/@unreleased/pr-2264.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Expose a TypeMarker factory to wrap an arbitrary Type
+  links:
+  - https://github.com/palantir/conjure-java/pull/2264

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/TypeMarker.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/TypeMarker.java
@@ -21,6 +21,7 @@ import com.palantir.logsafe.SafeArg;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.util.Objects;
 
 /**
  * Captures generic type information.
@@ -49,6 +50,10 @@ public abstract class TypeMarker<T> {
                 SafeArg.of("typeVariable", type));
     }
 
+    private TypeMarker(Type type) {
+        this.type = Preconditions.checkNotNull(type, "Type is required");
+    }
+
     public final Type getType() {
         return type;
     }
@@ -56,5 +61,30 @@ public abstract class TypeMarker<T> {
     @Override
     public final String toString() {
         return "TypeMarker{type=" + type + '}';
+    }
+
+    /** Create a new {@link TypeMarker} instance wrapping the provided {@link Type}. */
+    public static TypeMarker<?> of(Type type) {
+        return new WrappingTypeMarker(type);
+    }
+
+    private static final class WrappingTypeMarker extends TypeMarker<Object> {
+        private WrappingTypeMarker(Type type) {
+            super(type);
+        }
+
+        @Override
+        public int hashCode() {
+            return getType().hashCode();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other instanceof WrappingTypeMarker) {
+                WrappingTypeMarker otherMarker = (WrappingTypeMarker) other;
+                return Objects.equals(getType(), otherMarker.getType());
+            }
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## Before this PR
It was impossible to make a reusable serializer/deserializer factory for a generic wrapper type, a new de/serializer would need to be implemented for each component, passing the concrete `TypeMarker`. While likely safer, it's not ideal to repeat unnecessary cruft like this.

## After this PR
==COMMIT_MSG==
Expose a TypeMarker factory to wrap an arbitrary Type
==COMMIT_MSG==

Downsides: This method doesn't provide compile-time safety, as the returned `TypeMarker` cannot have generic type info (result is `TypeMarker<?>` because `Type` itself doesn't provide type info). However, this is reasonable because it can simplify code used by the annotation processor, and doesn't represent anything more dangerous than cast suppressions folks already use.