### PR TITLE
Support providing runtime to param decoders

### DIFF
--- a/changelog/@unreleased/pr-2267.v2.yml
+++ b/changelog/@unreleased/pr-2267.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: '`ParamDecoder` and `CollectionParamDecoder` types can not be instantiated
+    with constructors that take `UndertowRuntime` and/or `Endpoint`.'
+  links:
+  - https://github.com/palantir/conjure-java/pull/2267

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/Instantiables.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/Instantiables.java
@@ -18,8 +18,6 @@ package com.palantir.conjure.java.undertow.processor.data;
 
 import com.google.auto.common.MoreTypes;
 import com.google.common.collect.MoreCollectors;
-import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.TypeName;
 import javax.lang.model.element.Element;
@@ -32,18 +30,14 @@ final class Instantiables {
 
     private Instantiables() {}
 
+    static CodeBlock instantiate(TypeMirror mirror) {
+        return instantiate(MoreTypes.asDeclared(mirror));
+    }
+
     /**
      * Produces a {@link CodeBlock} of instantiation code for the provided type.
      * This supports both no-arg class constructors and single-value enum singletons.
      */
-    static CodeBlock instantiate(TypeMirror mirror) {
-        DeclaredType declaredType = MoreTypes.asDeclared(mirror);
-        if (declaredType == null) {
-            throw new SafeIllegalStateException("TypeMirror is not a DeclaredType", SafeArg.of("type", mirror));
-        }
-        return instantiate(declaredType);
-    }
-
     static CodeBlock instantiate(DeclaredType declaredType) {
         TypeElement typeElement = (TypeElement) declaredType.asElement();
         if (typeElement.getKind() == ElementKind.ENUM) {

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderService.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderService.java
@@ -22,6 +22,8 @@ import com.palantir.conjure.java.undertow.annotations.CollectionParamDecoder;
 import com.palantir.conjure.java.undertow.annotations.Handle;
 import com.palantir.conjure.java.undertow.annotations.HttpMethod;
 import com.palantir.conjure.java.undertow.annotations.ParamDecoder;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
 import com.palantir.ri.ResourceIdentifier;
 import java.time.OffsetDateTime;
 import java.util.Collection;
@@ -49,6 +51,8 @@ public interface DefaultDecoderService {
             @Handle.QueryParam("optionalSafeLongParam") Optional<SafeLong> optionalSafeLongParam,
             @Handle.QueryParam("uuidParam") UUID uuidParam,
             @Handle.QueryParam(value = "decoderParam", decoder = StringCollectionDecoder.class) String decoderParam,
+            @Handle.QueryParam(value = "constructorDecoderParam", decoder = ConstructorStringCollectionDecoder.class)
+                    String constructorDecoderParam,
             @Handle.QueryParam("constructor") Constructor constructor,
             @Handle.QueryParam("ofFactory") OfFactory ofFactory,
             @Handle.QueryParam("valueOfFactory") ValueOfFactory valueOfFactory,
@@ -70,6 +74,8 @@ public interface DefaultDecoderService {
             @Handle.FormParam("optionalSafeLongParam") Optional<SafeLong> optionalSafeLongParam,
             @Handle.FormParam("uuidParam") UUID uuidParam,
             @Handle.FormParam(value = "decoderParam", decoder = StringCollectionDecoder.class) String decoderParam,
+            @Handle.FormParam(value = "constructorDecoderParam", decoder = ConstructorStringCollectionDecoder.class)
+                    String constructorDecoderParam,
             @Handle.FormParam("constructor") Constructor constructor,
             @Handle.FormParam("ofFactory") OfFactory ofFactory,
             @Handle.FormParam("valueOfFactory") ValueOfFactory valueOfFactory,
@@ -86,6 +92,8 @@ public interface DefaultDecoderService {
             @Handle.Header("floatBoxed") Float floatBoxed,
             @Handle.Header("floatUnboxed") float floatUnboxed,
             @Handle.Header(value = "decoderParam", decoder = StringCollectionDecoder.class) String decoderParam,
+            @Handle.Header(value = "constructorDecoderParam", decoder = ConstructorStringCollectionDecoder.class)
+                    String constructorDecoderParam,
             @Handle.Header("constructor") Constructor constructor,
             @Handle.Header("ofFactory") OfFactory ofFactory,
             @Handle.Header("valueOfFactory") ValueOfFactory valueOfFactory,
@@ -94,12 +102,13 @@ public interface DefaultDecoderService {
 
     @Handle(
             method = HttpMethod.GET,
-            path = "/pathParam/{stringParam}/{booleanParam}/{decoderParam}/{floatBoxed}/{floatUnboxed}/{constructor}"
-                    + "/{ofFactory}/{valueOfFactory}/{fromStringFactory}/{createFactory}")
+            path = "/pathParam/{stringParam}/{booleanParam}/{decoderParam}/{constructorDecoderParam}/{floatBoxed}"
+                    + "/{floatUnboxed}/{constructor}/{ofFactory}/{valueOfFactory}/{fromStringFactory}/{createFactory}")
     String pathParam(
             @Handle.PathParam String stringParam,
             @Handle.PathParam Boolean booleanParam,
             @Handle.PathParam(decoder = StringDecoder.class) String decoderParam,
+            @Handle.PathParam(decoder = ConstructorStringDecoder.class) String constructorDecoderParam,
             @Handle.PathParam Float floatBoxed,
             @Handle.PathParam float floatUnboxed,
             @Handle.PathParam Constructor constructor,
@@ -117,8 +126,28 @@ public interface DefaultDecoderService {
         }
     }
 
+    final class ConstructorStringCollectionDecoder implements CollectionParamDecoder<String> {
+
+        ConstructorStringCollectionDecoder(UndertowRuntime _runtime, Endpoint _endpoint) {}
+
+        @Override
+        public String decode(Collection<String> value) {
+            return Iterables.getOnlyElement(value);
+        }
+    }
+
     enum StringDecoder implements ParamDecoder<String> {
         INSTANCE;
+
+        @Override
+        public String decode(String value) {
+            return value;
+        }
+    }
+
+    final class ConstructorStringDecoder implements ParamDecoder<String> {
+
+        ConstructorStringDecoder(UndertowRuntime _runtime, Endpoint _endpoint) {}
 
         @Override
         public String decode(String value) {

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderServiceEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderServiceEndpoints.java.generated
@@ -86,6 +86,8 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
 
         private final Deserializer<String> decoderParamDeserializer;
 
+        private final Deserializer<String> constructorDecoderParamDeserializer;
+
         private final Deserializer<DefaultDecoderService.Constructor> constructorDeserializer;
 
         private final Deserializer<DefaultDecoderService.OfFactory> ofFactoryDeserializer;
@@ -129,6 +131,9 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                     "uuidParam", ParamDecoders.uuidCollectionParamDecoder(runtime.plainSerDe()));
             this.decoderParamDeserializer = new QueryParamDeserializer<>(
                     "decoderParam", DefaultDecoderService.StringCollectionDecoder.INSTANCE);
+            this.constructorDecoderParamDeserializer = new QueryParamDeserializer<>(
+                    "constructorDecoderParam",
+                    new DefaultDecoderService.ConstructorStringCollectionDecoder(runtime, this));
             this.constructorDeserializer = new QueryParamDeserializer<>(
                     "constructor",
                     ParamDecoders.complexCollectionParamDecoder(
@@ -167,6 +172,7 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
             Optional<SafeLong> optionalSafeLongParam = this.optionalSafeLongParamDeserializer.deserialize(exchange);
             UUID uuidParam = this.uuidParamDeserializer.deserialize(exchange);
             String decoderParam = this.decoderParamDeserializer.deserialize(exchange);
+            String constructorDecoderParam = this.constructorDecoderParamDeserializer.deserialize(exchange);
             DefaultDecoderService.Constructor constructor = this.constructorDeserializer.deserialize(exchange);
             DefaultDecoderService.OfFactory ofFactory = this.ofFactoryDeserializer.deserialize(exchange);
             DefaultDecoderService.ValueOfFactory valueOfFactory = this.valueOfFactoryDeserializer.deserialize(exchange);
@@ -188,6 +194,7 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                             optionalSafeLongParam,
                             uuidParam,
                             decoderParam,
+                            constructorDecoderParam,
                             constructor,
                             ofFactory,
                             valueOfFactory,
@@ -258,6 +265,8 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
 
         private final Deserializer<String> decoderParamDeserializer;
 
+        private final Deserializer<String> constructorDecoderParamDeserializer;
+
         private final Deserializer<DefaultDecoderService.Constructor> constructorDeserializer;
 
         private final Deserializer<DefaultDecoderService.OfFactory> ofFactoryDeserializer;
@@ -301,6 +310,9 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                     "uuidParam", ParamDecoders.uuidCollectionParamDecoder(runtime.plainSerDe()));
             this.decoderParamDeserializer =
                     new FormParamDeserializer<>("decoderParam", DefaultDecoderService.StringCollectionDecoder.INSTANCE);
+            this.constructorDecoderParamDeserializer = new FormParamDeserializer<>(
+                    "constructorDecoderParam",
+                    new DefaultDecoderService.ConstructorStringCollectionDecoder(runtime, this));
             this.constructorDeserializer = new FormParamDeserializer<>(
                     "constructor",
                     ParamDecoders.complexCollectionParamDecoder(
@@ -339,6 +351,7 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
             Optional<SafeLong> optionalSafeLongParam = this.optionalSafeLongParamDeserializer.deserialize(exchange);
             UUID uuidParam = this.uuidParamDeserializer.deserialize(exchange);
             String decoderParam = this.decoderParamDeserializer.deserialize(exchange);
+            String constructorDecoderParam = this.constructorDecoderParamDeserializer.deserialize(exchange);
             DefaultDecoderService.Constructor constructor = this.constructorDeserializer.deserialize(exchange);
             DefaultDecoderService.OfFactory ofFactory = this.ofFactoryDeserializer.deserialize(exchange);
             DefaultDecoderService.ValueOfFactory valueOfFactory = this.valueOfFactoryDeserializer.deserialize(exchange);
@@ -360,6 +373,7 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                             optionalSafeLongParam,
                             uuidParam,
                             decoderParam,
+                            constructorDecoderParam,
                             constructor,
                             ofFactory,
                             valueOfFactory,
@@ -420,6 +434,8 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
 
         private final Deserializer<String> decoderParamDeserializer;
 
+        private final Deserializer<String> constructorDecoderParamDeserializer;
+
         private final Deserializer<DefaultDecoderService.Constructor> constructorDeserializer;
 
         private final Deserializer<DefaultDecoderService.OfFactory> ofFactoryDeserializer;
@@ -452,6 +468,9 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                     ParamDecoders.complexCollectionParamDecoder(runtime.plainSerDe(), Float::parseFloat));
             this.decoderParamDeserializer = new HeaderParamDeserializer<>(
                     "decoderParam", DefaultDecoderService.StringCollectionDecoder.INSTANCE);
+            this.constructorDecoderParamDeserializer = new HeaderParamDeserializer<>(
+                    "constructorDecoderParam",
+                    new DefaultDecoderService.ConstructorStringCollectionDecoder(runtime, this));
             this.constructorDeserializer = new HeaderParamDeserializer<>(
                     "constructor",
                     ParamDecoders.complexCollectionParamDecoder(
@@ -485,6 +504,7 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
             Float floatBoxed = this.floatBoxedDeserializer.deserialize(exchange);
             float floatUnboxed = this.floatUnboxedDeserializer.deserialize(exchange);
             String decoderParam = this.decoderParamDeserializer.deserialize(exchange);
+            String constructorDecoderParam = this.constructorDecoderParamDeserializer.deserialize(exchange);
             DefaultDecoderService.Constructor constructor = this.constructorDeserializer.deserialize(exchange);
             DefaultDecoderService.OfFactory ofFactory = this.ofFactoryDeserializer.deserialize(exchange);
             DefaultDecoderService.ValueOfFactory valueOfFactory = this.valueOfFactoryDeserializer.deserialize(exchange);
@@ -501,6 +521,7 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                             floatBoxed,
                             floatUnboxed,
                             decoderParam,
+                            constructorDecoderParam,
                             constructor,
                             ofFactory,
                             valueOfFactory,
@@ -551,6 +572,8 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
 
         private final Deserializer<String> decoderParamDeserializer;
 
+        private final Deserializer<String> constructorDecoderParamDeserializer;
+
         private final Deserializer<Float> floatBoxedDeserializer;
 
         private final Deserializer<Float> floatUnboxedDeserializer;
@@ -576,6 +599,8 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                     "booleanParam", ParamDecoders.booleanParamDecoder(runtime.plainSerDe()));
             this.decoderParamDeserializer =
                     new PathParamDeserializer<>("decoderParam", DefaultDecoderService.StringDecoder.INSTANCE);
+            this.constructorDecoderParamDeserializer = new PathParamDeserializer<>(
+                    "constructorDecoderParam", new DefaultDecoderService.ConstructorStringDecoder(runtime, this));
             this.floatBoxedDeserializer = new PathParamDeserializer<>(
                     "floatBoxed", ParamDecoders.complexParamDecoder(runtime.plainSerDe(), Float::valueOf));
             this.floatUnboxedDeserializer = new PathParamDeserializer<>(
@@ -606,6 +631,7 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
             String stringParam = this.stringParamDeserializer.deserialize(exchange);
             Boolean booleanParam = this.booleanParamDeserializer.deserialize(exchange);
             String decoderParam = this.decoderParamDeserializer.deserialize(exchange);
+            String constructorDecoderParam = this.constructorDecoderParamDeserializer.deserialize(exchange);
             Float floatBoxed = this.floatBoxedDeserializer.deserialize(exchange);
             float floatUnboxed = this.floatUnboxedDeserializer.deserialize(exchange);
             DefaultDecoderService.Constructor constructor = this.constructorDeserializer.deserialize(exchange);
@@ -619,6 +645,7 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                             stringParam,
                             booleanParam,
                             decoderParam,
+                            constructorDecoderParam,
                             floatBoxed,
                             floatUnboxed,
                             constructor,
@@ -641,7 +668,7 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
 
         @Override
         public String template() {
-            return "/pathParam/{stringParam}/{booleanParam}/{decoderParam}/{floatBoxed}/{floatUnboxed}/{constructor}/{ofFactory}/{valueOfFactory}/{fromStringFactory}/{createFactory}";
+            return "/pathParam/{stringParam}/{booleanParam}/{decoderParam}/{constructorDecoderParam}/{floatBoxed}/{floatUnboxed}/{constructor}/{ofFactory}/{valueOfFactory}/{fromStringFactory}/{createFactory}";
         }
 
         @Override


### PR DESCRIPTION
Param decoders often want to leverage the methods provided by `PlainSerDe` in order to get consistent handling of invalid inputs but are forced to instantiate their own local copy of `UndertowRuntime`. While this works today, it could be a bit dangerous in the future if the `PlainSerDe` becomes configurable and the behavior of the server's `UndertowRuntime` does not match the behavior of this local `UndertowRuntime`.

```java
class FooParamDecoder implements CollectionParamDecoder<Foo> {

    private static final PlainSerDe PLAIN_SER_DE =
            ConjureUndertowRuntime.builder().build().plainSerDe();

    @Override
    public Foo decode(Collection<String> values) {
        return PLAIN_SER_DE.deserializeComplex(values, FooParamDecoder::decode);
    }

    private decode(String value) { ... }
}
```