### PR TITLE
Alias types use memoized hashCode for collections

### DIFF
--- a/changelog/@unreleased/pr-2291.v2.yml
+++ b/changelog/@unreleased/pr-2291.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Alias types use memoized hashCode for collections
+  links:
+  - https://github.com/palantir/conjure-java/pull/2291

--- a/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/binary/BinaryAliasExample.java
@@ -28,13 +28,16 @@ public final class BinaryAliasExample {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof BinaryAliasExample && this.value.equals(((BinaryAliasExample) other).value));
+        return this == other || (other instanceof BinaryAliasExample && equalTo((BinaryAliasExample) other));
+    }
+
+    private boolean equalTo(BinaryAliasExample other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasOptionalDoubleAliasedBinaryResult.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasOptionalDoubleAliasedBinaryResult.java
@@ -36,12 +36,16 @@ public final class AliasOptionalDoubleAliasedBinaryResult {
     public boolean equals(@Nullable Object other) {
         return this == other
                 || (other instanceof AliasOptionalDoubleAliasedBinaryResult
-                        && this.value.equals(((AliasOptionalDoubleAliasedBinaryResult) other).value));
+                        && equalTo((AliasOptionalDoubleAliasedBinaryResult) other));
+    }
+
+    private boolean equalTo(AliasOptionalDoubleAliasedBinaryResult other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedBinaryResult.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedBinaryResult.java
@@ -28,13 +28,16 @@ public final class AliasedBinaryResult {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof AliasedBinaryResult && this.value.equals(((AliasedBinaryResult) other).value));
+        return this == other || (other instanceof AliasedBinaryResult && equalTo((AliasedBinaryResult) other));
+    }
+
+    private boolean equalTo(AliasedBinaryResult other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedBoolean.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedBoolean.java
@@ -25,12 +25,16 @@ public final class AliasedBoolean {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other || (other instanceof AliasedBoolean && this.value == ((AliasedBoolean) other).value);
+        return this == other || (other instanceof AliasedBoolean && equalTo((AliasedBoolean) other));
+    }
+
+    private boolean equalTo(AliasedBoolean other) {
+        return this.value == other.value;
     }
 
     @Override
     public int hashCode() {
-        return Boolean.hashCode(value);
+        return Boolean.hashCode(this.value);
     }
 
     public static AliasedBoolean valueOf(String value) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedDouble.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedDouble.java
@@ -27,15 +27,16 @@ public final class AliasedDouble implements Comparable<AliasedDouble> {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof AliasedDouble
-                        && Double.doubleToLongBits(this.value)
-                                == Double.doubleToLongBits(((AliasedDouble) other).value));
+        return this == other || (other instanceof AliasedDouble && equalTo((AliasedDouble) other));
+    }
+
+    private boolean equalTo(AliasedDouble other) {
+        return Double.doubleToLongBits(this.value) == Double.doubleToLongBits(other.value);
     }
 
     @Override
     public int hashCode() {
-        return Double.hashCode(value);
+        return Double.hashCode(this.value);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedInteger.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedInteger.java
@@ -25,12 +25,16 @@ public final class AliasedInteger implements Comparable<AliasedInteger> {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other || (other instanceof AliasedInteger && this.value == ((AliasedInteger) other).value);
+        return this == other || (other instanceof AliasedInteger && equalTo((AliasedInteger) other));
+    }
+
+    private boolean equalTo(AliasedInteger other) {
+        return this.value == other.value;
     }
 
     @Override
     public int hashCode() {
-        return Integer.hashCode(value);
+        return this.value;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedSafeLong.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedSafeLong.java
@@ -28,13 +28,16 @@ public final class AliasedSafeLong implements Comparable<AliasedSafeLong> {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof AliasedSafeLong && this.value.equals(((AliasedSafeLong) other).value));
+        return this == other || (other instanceof AliasedSafeLong && equalTo((AliasedSafeLong) other));
+    }
+
+    private boolean equalTo(AliasedSafeLong other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BearerTokenAliasExample.java
@@ -30,14 +30,16 @@ public final class BearerTokenAliasExample {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof BearerTokenAliasExample
-                        && this.value.equals(((BearerTokenAliasExample) other).value));
+        return this == other || (other instanceof BearerTokenAliasExample && equalTo((BearerTokenAliasExample) other));
+    }
+
+    private boolean equalTo(BearerTokenAliasExample other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     public static BearerTokenAliasExample valueOf(@DoNotLog String value) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasExample.java
@@ -28,13 +28,16 @@ public final class BinaryAliasExample {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof BinaryAliasExample && this.value.equals(((BinaryAliasExample) other).value));
+        return this == other || (other instanceof BinaryAliasExample && equalTo((BinaryAliasExample) other));
+    }
+
+    private boolean equalTo(BinaryAliasExample other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasOne.java
@@ -28,12 +28,16 @@ public final class BinaryAliasOne {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other || (other instanceof BinaryAliasOne && this.value.equals(((BinaryAliasOne) other).value));
+        return this == other || (other instanceof BinaryAliasOne && equalTo((BinaryAliasOne) other));
+    }
+
+    private boolean equalTo(BinaryAliasOne other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BinaryAliasTwo.java
@@ -27,12 +27,16 @@ public final class BinaryAliasTwo {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other || (other instanceof BinaryAliasTwo && this.value.equals(((BinaryAliasTwo) other).value));
+        return this == other || (other instanceof BinaryAliasTwo && equalTo((BinaryAliasTwo) other));
+    }
+
+    private boolean equalTo(BinaryAliasTwo other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/BooleanAliasExample.java
@@ -25,13 +25,16 @@ public final class BooleanAliasExample {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof BooleanAliasExample && this.value == ((BooleanAliasExample) other).value);
+        return this == other || (other instanceof BooleanAliasExample && equalTo((BooleanAliasExample) other));
+    }
+
+    private boolean equalTo(BooleanAliasExample other) {
+        return this.value == other.value;
     }
 
     @Override
     public int hashCode() {
-        return Boolean.hashCode(value);
+        return Boolean.hashCode(this.value);
     }
 
     public static BooleanAliasExample valueOf(String value) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestAliasList.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestAliasList.java
@@ -15,6 +15,8 @@ public final class CollectionsTestAliasList {
 
     private final List<Integer> value;
 
+    private int memoizedHashCode;
+
     private CollectionsTestAliasList(@Nonnull List<Integer> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
@@ -36,13 +38,26 @@ public final class CollectionsTestAliasList {
     @Override
     public boolean equals(@Nullable Object other) {
         return this == other
-                || (other instanceof CollectionsTestAliasList
-                        && this.value.equals(((CollectionsTestAliasList) other).value));
+                || (other instanceof CollectionsTestAliasList && equalTo((CollectionsTestAliasList) other));
+    }
+
+    private boolean equalTo(CollectionsTestAliasList other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = this.value.hashCode();
+            memoizedHashCode = result;
+        }
+        return result;
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestAliasMap.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestAliasMap.java
@@ -15,6 +15,8 @@ public final class CollectionsTestAliasMap {
 
     private final Map<String, Integer> value;
 
+    private int memoizedHashCode;
+
     private CollectionsTestAliasMap(@Nonnull Map<String, Integer> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
@@ -35,14 +37,26 @@ public final class CollectionsTestAliasMap {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof CollectionsTestAliasMap
-                        && this.value.equals(((CollectionsTestAliasMap) other).value));
+        return this == other || (other instanceof CollectionsTestAliasMap && equalTo((CollectionsTestAliasMap) other));
+    }
+
+    private boolean equalTo(CollectionsTestAliasMap other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = this.value.hashCode();
+            memoizedHashCode = result;
+        }
+        return result;
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestAliasSet.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestAliasSet.java
@@ -15,6 +15,8 @@ public final class CollectionsTestAliasSet {
 
     private final Set<Integer> value;
 
+    private int memoizedHashCode;
+
     private CollectionsTestAliasSet(@Nonnull Set<Integer> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
@@ -35,14 +37,26 @@ public final class CollectionsTestAliasSet {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof CollectionsTestAliasSet
-                        && this.value.equals(((CollectionsTestAliasSet) other).value));
+        return this == other || (other instanceof CollectionsTestAliasSet && equalTo((CollectionsTestAliasSet) other));
+    }
+
+    private boolean equalTo(CollectionsTestAliasSet other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = this.value.hashCode();
+            memoizedHashCode = result;
+        }
+        return result;
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DangerousLongAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DangerousLongAlias.java
@@ -28,13 +28,16 @@ public final class DangerousLongAlias {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof DangerousLongAlias && this.value == ((DangerousLongAlias) other).value);
+        return this == other || (other instanceof DangerousLongAlias && equalTo((DangerousLongAlias) other));
+    }
+
+    private boolean equalTo(DangerousLongAlias other) {
+        return this.value == other.value;
     }
 
     @Override
     public int hashCode() {
-        return Long.hashCode(value);
+        return Long.hashCode(this.value);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DateTimeAliasExample.java
@@ -12,6 +12,8 @@ import javax.annotation.processing.Generated;
 public final class DateTimeAliasExample implements Comparable<DateTimeAliasExample> {
     private final OffsetDateTime value;
 
+    private int memoizedHashCode;
+
     private DateTimeAliasExample(@Nonnull OffsetDateTime value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
@@ -28,13 +30,26 @@ public final class DateTimeAliasExample implements Comparable<DateTimeAliasExamp
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof DateTimeAliasExample && this.value.equals(((DateTimeAliasExample) other).value));
+        return this == other || (other instanceof DateTimeAliasExample && equalTo((DateTimeAliasExample) other));
+    }
+
+    private boolean equalTo(DateTimeAliasExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.value.isEqual(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = this.value.toInstant().hashCode();
+            memoizedHashCode = result;
+        }
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
@@ -27,15 +27,16 @@ public final class DoubleAliasExample implements Comparable<DoubleAliasExample> 
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof DoubleAliasExample
-                        && Double.doubleToLongBits(this.value)
-                                == Double.doubleToLongBits(((DoubleAliasExample) other).value));
+        return this == other || (other instanceof DoubleAliasExample && equalTo((DoubleAliasExample) other));
+    }
+
+    private boolean equalTo(DoubleAliasExample other) {
+        return Double.doubleToLongBits(this.value) == Double.doubleToLongBits(other.value);
     }
 
     @Override
     public int hashCode() {
-        return Double.hashCode(value);
+        return Double.hashCode(this.value);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasedBinaryResult.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasedBinaryResult.java
@@ -28,13 +28,16 @@ public final class DoubleAliasedBinaryResult {
     @Override
     public boolean equals(@Nullable Object other) {
         return this == other
-                || (other instanceof DoubleAliasedBinaryResult
-                        && this.value.equals(((DoubleAliasedBinaryResult) other).value));
+                || (other instanceof DoubleAliasedBinaryResult && equalTo((DoubleAliasedBinaryResult) other));
+    }
+
+    private boolean equalTo(DoubleAliasedBinaryResult other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAlias.java
@@ -25,12 +25,16 @@ public final class ExternalLongAlias {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other || (other instanceof ExternalLongAlias && this.value == ((ExternalLongAlias) other).value);
+        return this == other || (other instanceof ExternalLongAlias && equalTo((ExternalLongAlias) other));
+    }
+
+    private boolean equalTo(ExternalLongAlias other) {
+        return this.value == other.value;
     }
 
     @Override
     public int hashCode() {
-        return Long.hashCode(value);
+        return Long.hashCode(this.value);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasExample.java
@@ -26,13 +26,16 @@ public final class ExternalLongAliasExample {
     @Override
     public boolean equals(@Nullable Object other) {
         return this == other
-                || (other instanceof ExternalLongAliasExample
-                        && this.value == ((ExternalLongAliasExample) other).value);
+                || (other instanceof ExternalLongAliasExample && equalTo((ExternalLongAliasExample) other));
+    }
+
+    private boolean equalTo(ExternalLongAliasExample other) {
+        return this.value == other.value;
     }
 
     @Override
     public int hashCode() {
-        return Long.hashCode(value);
+        return Long.hashCode(this.value);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasOne.java
@@ -25,13 +25,16 @@ public final class ExternalLongAliasOne {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof ExternalLongAliasOne && this.value == ((ExternalLongAliasOne) other).value);
+        return this == other || (other instanceof ExternalLongAliasOne && equalTo((ExternalLongAliasOne) other));
+    }
+
+    private boolean equalTo(ExternalLongAliasOne other) {
+        return this.value == other.value;
     }
 
     @Override
     public int hashCode() {
-        return Long.hashCode(value);
+        return Long.hashCode(this.value);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongAliasTwo.java
@@ -27,13 +27,16 @@ public final class ExternalLongAliasTwo {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof ExternalLongAliasTwo && this.value.equals(((ExternalLongAliasTwo) other).value));
+        return this == other || (other instanceof ExternalLongAliasTwo && equalTo((ExternalLongAliasTwo) other));
+    }
+
+    private boolean equalTo(ExternalLongAliasTwo other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     public static ExternalLongAliasTwo valueOf(String value) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalStringAliasExample.java
@@ -28,13 +28,16 @@ public final class ExternalStringAliasExample {
     @Override
     public boolean equals(@Nullable Object other) {
         return this == other
-                || (other instanceof ExternalStringAliasExample
-                        && this.value.equals(((ExternalStringAliasExample) other).value));
+                || (other instanceof ExternalStringAliasExample && equalTo((ExternalStringAliasExample) other));
+    }
+
+    private boolean equalTo(ExternalStringAliasExample other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/IntegerAliasExample.java
@@ -25,13 +25,16 @@ public final class IntegerAliasExample implements Comparable<IntegerAliasExample
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof IntegerAliasExample && this.value == ((IntegerAliasExample) other).value);
+        return this == other || (other instanceof IntegerAliasExample && equalTo((IntegerAliasExample) other));
+    }
+
+    private boolean equalTo(IntegerAliasExample other) {
+        return this.value == other.value;
     }
 
     @Override
     public int hashCode() {
-        return Integer.hashCode(value);
+        return this.value;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListAlias.java
@@ -15,6 +15,8 @@ public final class ListAlias {
 
     private final List<String> value;
 
+    private int memoizedHashCode;
+
     private ListAlias(@Nonnull List<String> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
@@ -35,12 +37,26 @@ public final class ListAlias {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other || (other instanceof ListAlias && this.value.equals(((ListAlias) other).value));
+        return this == other || (other instanceof ListAlias && equalTo((ListAlias) other));
+    }
+
+    private boolean equalTo(ListAlias other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = this.value.hashCode();
+            memoizedHashCode = result;
+        }
+        return result;
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/LongAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/LongAlias.java
@@ -25,12 +25,16 @@ public final class LongAlias {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other || (other instanceof LongAlias && this.value == ((LongAlias) other).value);
+        return this == other || (other instanceof LongAlias && equalTo((LongAlias) other));
+    }
+
+    private boolean equalTo(LongAlias other) {
+        return this.value == other.value;
     }
 
     @Override
     public int hashCode() {
-        return Long.hashCode(value);
+        return Long.hashCode(this.value);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MapAliasExample.java
@@ -15,6 +15,8 @@ public final class MapAliasExample {
 
     private final Map<String, Object> value;
 
+    private int memoizedHashCode;
+
     private MapAliasExample(@Nonnull Map<String, Object> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
@@ -35,13 +37,26 @@ public final class MapAliasExample {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof MapAliasExample && this.value.equals(((MapAliasExample) other).value));
+        return this == other || (other instanceof MapAliasExample && equalTo((MapAliasExample) other));
+    }
+
+    private boolean equalTo(MapAliasExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = this.value.hashCode();
+            memoizedHashCode = result;
+        }
+        return result;
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/NestedStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/NestedStringAliasExample.java
@@ -30,13 +30,16 @@ public final class NestedStringAliasExample {
     @Override
     public boolean equals(@Nullable Object other) {
         return this == other
-                || (other instanceof NestedStringAliasExample
-                        && this.value.equals(((NestedStringAliasExample) other).value));
+                || (other instanceof NestedStringAliasExample && equalTo((NestedStringAliasExample) other));
+    }
+
+    private boolean equalTo(NestedStringAliasExample other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     public static NestedStringAliasExample valueOf(@Safe String value) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalAlias.java
@@ -37,12 +37,16 @@ public final class OptionalAlias {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other || (other instanceof OptionalAlias && this.value.equals(((OptionalAlias) other).value));
+        return this == other || (other instanceof OptionalAlias && equalTo((OptionalAlias) other));
+    }
+
+    private boolean equalTo(OptionalAlias other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalDoubleAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalDoubleAlias.java
@@ -37,13 +37,16 @@ public final class OptionalDoubleAlias {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof OptionalDoubleAlias && this.value.equals(((OptionalDoubleAlias) other).value));
+        return this == other || (other instanceof OptionalDoubleAlias && equalTo((OptionalDoubleAlias) other));
+    }
+
+    private boolean equalTo(OptionalDoubleAlias other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalListAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalListAliasExample.java
@@ -15,6 +15,8 @@ public final class OptionalListAliasExample {
 
     private final Optional<List<String>> value;
 
+    private int memoizedHashCode;
+
     private OptionalListAliasExample(@Nonnull Optional<List<String>> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
@@ -36,13 +38,26 @@ public final class OptionalListAliasExample {
     @Override
     public boolean equals(@Nullable Object other) {
         return this == other
-                || (other instanceof OptionalListAliasExample
-                        && this.value.equals(((OptionalListAliasExample) other).value));
+                || (other instanceof OptionalListAliasExample && equalTo((OptionalListAliasExample) other));
+    }
+
+    private boolean equalTo(OptionalListAliasExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = this.value.hashCode();
+            memoizedHashCode = result;
+        }
+        return result;
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalMapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalMapAliasExample.java
@@ -15,6 +15,8 @@ public final class OptionalMapAliasExample {
 
     private final Optional<Map<String, Object>> value;
 
+    private int memoizedHashCode;
+
     private OptionalMapAliasExample(@Nonnull Optional<Map<String, Object>> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
@@ -35,14 +37,26 @@ public final class OptionalMapAliasExample {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof OptionalMapAliasExample
-                        && this.value.equals(((OptionalMapAliasExample) other).value));
+        return this == other || (other instanceof OptionalMapAliasExample && equalTo((OptionalMapAliasExample) other));
+    }
+
+    private boolean equalTo(OptionalMapAliasExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = this.value.hashCode();
+            memoizedHashCode = result;
+        }
+        return result;
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalSetAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/OptionalSetAliasExample.java
@@ -15,6 +15,8 @@ public final class OptionalSetAliasExample {
 
     private final Optional<Set<String>> value;
 
+    private int memoizedHashCode;
+
     private OptionalSetAliasExample(@Nonnull Optional<Set<String>> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
@@ -35,14 +37,26 @@ public final class OptionalSetAliasExample {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof OptionalSetAliasExample
-                        && this.value.equals(((OptionalSetAliasExample) other).value));
+        return this == other || (other instanceof OptionalSetAliasExample && equalTo((OptionalSetAliasExample) other));
+    }
+
+    private boolean equalTo(OptionalSetAliasExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = this.value.hashCode();
+            memoizedHashCode = result;
+        }
+        return result;
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ReferenceAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ReferenceAliasExample.java
@@ -27,13 +27,16 @@ public final class ReferenceAliasExample {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof ReferenceAliasExample && this.value.equals(((ReferenceAliasExample) other).value));
+        return this == other || (other instanceof ReferenceAliasExample && equalTo((ReferenceAliasExample) other));
+    }
+
+    private boolean equalTo(ReferenceAliasExample other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/RidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/RidAliasExample.java
@@ -28,13 +28,16 @@ public final class RidAliasExample {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof RidAliasExample && this.value.equals(((RidAliasExample) other).value));
+        return this == other || (other instanceof RidAliasExample && equalTo((RidAliasExample) other));
+    }
+
+    private boolean equalTo(RidAliasExample other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     public static RidAliasExample valueOf(String value) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeExternalLongAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeExternalLongAlias.java
@@ -28,13 +28,16 @@ public final class SafeExternalLongAlias {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof SafeExternalLongAlias && this.value == ((SafeExternalLongAlias) other).value);
+        return this == other || (other instanceof SafeExternalLongAlias && equalTo((SafeExternalLongAlias) other));
+    }
+
+    private boolean equalTo(SafeExternalLongAlias other) {
+        return this.value == other.value;
     }
 
     @Override
     public int hashCode() {
-        return Long.hashCode(value);
+        return Long.hashCode(this.value);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongAlias.java
@@ -28,12 +28,16 @@ public final class SafeLongAlias {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other || (other instanceof SafeLongAlias && this.value == ((SafeLongAlias) other).value);
+        return this == other || (other instanceof SafeLongAlias && equalTo((SafeLongAlias) other));
+    }
+
+    private boolean equalTo(SafeLongAlias other) {
+        return this.value == other.value;
     }
 
     @Override
     public int hashCode() {
-        return Long.hashCode(value);
+        return Long.hashCode(this.value);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongAliasExample.java
@@ -31,13 +31,16 @@ public final class SafeLongAliasExample implements Comparable<SafeLongAliasExamp
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof SafeLongAliasExample && this.value.equals(((SafeLongAliasExample) other).value));
+        return this == other || (other instanceof SafeLongAliasExample && equalTo((SafeLongAliasExample) other));
+    }
+
+    private boolean equalTo(SafeLongAliasExample other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SetAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SetAlias.java
@@ -15,6 +15,8 @@ public final class SetAlias {
 
     private final Set<String> value;
 
+    private int memoizedHashCode;
+
     private SetAlias(@Nonnull Set<String> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
@@ -35,12 +37,26 @@ public final class SetAlias {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other || (other instanceof SetAlias && this.value.equals(((SetAlias) other).value));
+        return this == other || (other instanceof SetAlias && equalTo((SetAlias) other));
+    }
+
+    private boolean equalTo(SetAlias other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = this.value.hashCode();
+            memoizedHashCode = result;
+        }
+        return result;
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasExample.java
@@ -30,13 +30,16 @@ public final class StringAliasExample implements Comparable<StringAliasExample> 
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof StringAliasExample && this.value.equals(((StringAliasExample) other).value));
+        return this == other || (other instanceof StringAliasExample && equalTo((StringAliasExample) other));
+    }
+
+    private boolean equalTo(StringAliasExample other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasOne.java
@@ -27,12 +27,16 @@ public final class StringAliasOne implements Comparable<StringAliasOne> {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other || (other instanceof StringAliasOne && this.value.equals(((StringAliasOne) other).value));
+        return this == other || (other instanceof StringAliasOne && equalTo((StringAliasOne) other));
+    }
+
+    private boolean equalTo(StringAliasOne other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasThree.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasThree.java
@@ -27,13 +27,16 @@ public final class StringAliasThree {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof StringAliasThree && this.value.equals(((StringAliasThree) other).value));
+        return this == other || (other instanceof StringAliasThree && equalTo((StringAliasThree) other));
+    }
+
+    private boolean equalTo(StringAliasThree other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StringAliasTwo.java
@@ -34,12 +34,16 @@ public final class StringAliasTwo {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other || (other instanceof StringAliasTwo && this.value.equals(((StringAliasTwo) other).value));
+        return this == other || (other instanceof StringAliasTwo && equalTo((StringAliasTwo) other));
+    }
+
+    private boolean equalTo(StringAliasTwo other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UuidAliasExample.java
@@ -28,13 +28,16 @@ public final class UuidAliasExample {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof UuidAliasExample && this.value.equals(((UuidAliasExample) other).value));
+        return this == other || (other instanceof UuidAliasExample && equalTo((UuidAliasExample) other));
+    }
+
+    private boolean equalTo(UuidAliasExample other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     public static UuidAliasExample valueOf(String value) {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/external/AliasToExternal.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/external/AliasToExternal.java
@@ -30,13 +30,16 @@ public final class AliasToExternal implements Comparable<AliasToExternal> {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof AliasToExternal && this.value.equals(((AliasToExternal) other).value));
+        return this == other || (other instanceof AliasToExternal && equalTo((AliasToExternal) other));
+    }
+
+    private boolean equalTo(AliasToExternal other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BearerTokenAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BearerTokenAliasExample.java
@@ -30,14 +30,16 @@ public final class BearerTokenAliasExample {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof BearerTokenAliasExample
-                        && this.value.equals(((BearerTokenAliasExample) other).value));
+        return this == other || (other instanceof BearerTokenAliasExample && equalTo((BearerTokenAliasExample) other));
+    }
+
+    private boolean equalTo(BearerTokenAliasExample other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     public static BearerTokenAliasExample valueOf(@DoNotLog String value) {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasExample.java
@@ -28,13 +28,16 @@ public final class BinaryAliasExample {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof BinaryAliasExample && this.value.equals(((BinaryAliasExample) other).value));
+        return this == other || (other instanceof BinaryAliasExample && equalTo((BinaryAliasExample) other));
+    }
+
+    private boolean equalTo(BinaryAliasExample other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasOne.java
@@ -28,12 +28,16 @@ public final class BinaryAliasOne {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other || (other instanceof BinaryAliasOne && this.value.equals(((BinaryAliasOne) other).value));
+        return this == other || (other instanceof BinaryAliasOne && equalTo((BinaryAliasOne) other));
+    }
+
+    private boolean equalTo(BinaryAliasOne other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BinaryAliasTwo.java
@@ -27,12 +27,16 @@ public final class BinaryAliasTwo {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other || (other instanceof BinaryAliasTwo && this.value.equals(((BinaryAliasTwo) other).value));
+        return this == other || (other instanceof BinaryAliasTwo && equalTo((BinaryAliasTwo) other));
+    }
+
+    private boolean equalTo(BinaryAliasTwo other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BooleanAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/BooleanAliasExample.java
@@ -25,13 +25,16 @@ public final class BooleanAliasExample {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof BooleanAliasExample && this.value == ((BooleanAliasExample) other).value);
+        return this == other || (other instanceof BooleanAliasExample && equalTo((BooleanAliasExample) other));
+    }
+
+    private boolean equalTo(BooleanAliasExample other) {
+        return this.value == other.value;
     }
 
     @Override
     public int hashCode() {
-        return Boolean.hashCode(value);
+        return Boolean.hashCode(this.value);
     }
 
     public static BooleanAliasExample valueOf(String value) {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DateTimeAliasExample.java
@@ -12,6 +12,8 @@ import javax.annotation.processing.Generated;
 public final class DateTimeAliasExample implements Comparable<DateTimeAliasExample> {
     private final OffsetDateTime value;
 
+    private int memoizedHashCode;
+
     private DateTimeAliasExample(@Nonnull OffsetDateTime value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
@@ -28,13 +30,26 @@ public final class DateTimeAliasExample implements Comparable<DateTimeAliasExamp
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof DateTimeAliasExample && this.value.equals(((DateTimeAliasExample) other).value));
+        return this == other || (other instanceof DateTimeAliasExample && equalTo((DateTimeAliasExample) other));
+    }
+
+    private boolean equalTo(DateTimeAliasExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.value.isEqual(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = this.value.toInstant().hashCode();
+            memoizedHashCode = result;
+        }
+        return result;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleAliasExample.java
@@ -27,15 +27,16 @@ public final class DoubleAliasExample implements Comparable<DoubleAliasExample> 
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof DoubleAliasExample
-                        && Double.doubleToLongBits(this.value)
-                                == Double.doubleToLongBits(((DoubleAliasExample) other).value));
+        return this == other || (other instanceof DoubleAliasExample && equalTo((DoubleAliasExample) other));
+    }
+
+    private boolean equalTo(DoubleAliasExample other) {
+        return Double.doubleToLongBits(this.value) == Double.doubleToLongBits(other.value);
     }
 
     @Override
     public int hashCode() {
-        return Double.hashCode(value);
+        return Double.hashCode(this.value);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasExample.java
@@ -26,13 +26,16 @@ public final class ExternalLongAliasExample {
     @Override
     public boolean equals(@Nullable Object other) {
         return this == other
-                || (other instanceof ExternalLongAliasExample
-                        && this.value == ((ExternalLongAliasExample) other).value);
+                || (other instanceof ExternalLongAliasExample && equalTo((ExternalLongAliasExample) other));
+    }
+
+    private boolean equalTo(ExternalLongAliasExample other) {
+        return this.value == other.value;
     }
 
     @Override
     public int hashCode() {
-        return Long.hashCode(value);
+        return Long.hashCode(this.value);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasOne.java
@@ -25,13 +25,16 @@ public final class ExternalLongAliasOne {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof ExternalLongAliasOne && this.value == ((ExternalLongAliasOne) other).value);
+        return this == other || (other instanceof ExternalLongAliasOne && equalTo((ExternalLongAliasOne) other));
+    }
+
+    private boolean equalTo(ExternalLongAliasOne other) {
+        return this.value == other.value;
     }
 
     @Override
     public int hashCode() {
-        return Long.hashCode(value);
+        return Long.hashCode(this.value);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongAliasTwo.java
@@ -27,13 +27,16 @@ public final class ExternalLongAliasTwo {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof ExternalLongAliasTwo && this.value.equals(((ExternalLongAliasTwo) other).value));
+        return this == other || (other instanceof ExternalLongAliasTwo && equalTo((ExternalLongAliasTwo) other));
+    }
+
+    private boolean equalTo(ExternalLongAliasTwo other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     public static ExternalLongAliasTwo valueOf(String value) {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalStringAliasExample.java
@@ -28,13 +28,16 @@ public final class ExternalStringAliasExample {
     @Override
     public boolean equals(@Nullable Object other) {
         return this == other
-                || (other instanceof ExternalStringAliasExample
-                        && this.value.equals(((ExternalStringAliasExample) other).value));
+                || (other instanceof ExternalStringAliasExample && equalTo((ExternalStringAliasExample) other));
+    }
+
+    private boolean equalTo(ExternalStringAliasExample other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/IntegerAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/IntegerAliasExample.java
@@ -25,13 +25,16 @@ public final class IntegerAliasExample implements Comparable<IntegerAliasExample
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof IntegerAliasExample && this.value == ((IntegerAliasExample) other).value);
+        return this == other || (other instanceof IntegerAliasExample && equalTo((IntegerAliasExample) other));
+    }
+
+    private boolean equalTo(IntegerAliasExample other) {
+        return this.value == other.value;
     }
 
     @Override
     public int hashCode() {
-        return Integer.hashCode(value);
+        return this.value;
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListAlias.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListAlias.java
@@ -15,6 +15,8 @@ public final class ListAlias {
 
     private final List<String> value;
 
+    private int memoizedHashCode;
+
     private ListAlias(@Nonnull List<String> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
@@ -35,12 +37,26 @@ public final class ListAlias {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other || (other instanceof ListAlias && this.value.equals(((ListAlias) other).value));
+        return this == other || (other instanceof ListAlias && equalTo((ListAlias) other));
+    }
+
+    private boolean equalTo(ListAlias other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = this.value.hashCode();
+            memoizedHashCode = result;
+        }
+        return result;
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/MapAliasExample.java
@@ -15,6 +15,8 @@ public final class MapAliasExample {
 
     private final Map<String, Object> value;
 
+    private int memoizedHashCode;
+
     private MapAliasExample(@Nonnull Map<String, Object> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
@@ -35,13 +37,26 @@ public final class MapAliasExample {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof MapAliasExample && this.value.equals(((MapAliasExample) other).value));
+        return this == other || (other instanceof MapAliasExample && equalTo((MapAliasExample) other));
+    }
+
+    private boolean equalTo(MapAliasExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = this.value.hashCode();
+            memoizedHashCode = result;
+        }
+        return result;
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/NestedStringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/NestedStringAliasExample.java
@@ -30,13 +30,16 @@ public final class NestedStringAliasExample {
     @Override
     public boolean equals(@Nullable Object other) {
         return this == other
-                || (other instanceof NestedStringAliasExample
-                        && this.value.equals(((NestedStringAliasExample) other).value));
+                || (other instanceof NestedStringAliasExample && equalTo((NestedStringAliasExample) other));
+    }
+
+    private boolean equalTo(NestedStringAliasExample other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     public static NestedStringAliasExample valueOf(@Safe String value) {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAlias.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalAlias.java
@@ -37,12 +37,16 @@ public final class OptionalAlias {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other || (other instanceof OptionalAlias && this.value.equals(((OptionalAlias) other).value));
+        return this == other || (other instanceof OptionalAlias && equalTo((OptionalAlias) other));
+    }
+
+    private boolean equalTo(OptionalAlias other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalDoubleAlias.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalDoubleAlias.java
@@ -37,13 +37,16 @@ public final class OptionalDoubleAlias {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof OptionalDoubleAlias && this.value.equals(((OptionalDoubleAlias) other).value));
+        return this == other || (other instanceof OptionalDoubleAlias && equalTo((OptionalDoubleAlias) other));
+    }
+
+    private boolean equalTo(OptionalDoubleAlias other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalListAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalListAliasExample.java
@@ -15,6 +15,8 @@ public final class OptionalListAliasExample {
 
     private final Optional<List<String>> value;
 
+    private int memoizedHashCode;
+
     private OptionalListAliasExample(@Nonnull Optional<List<String>> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
@@ -36,13 +38,26 @@ public final class OptionalListAliasExample {
     @Override
     public boolean equals(@Nullable Object other) {
         return this == other
-                || (other instanceof OptionalListAliasExample
-                        && this.value.equals(((OptionalListAliasExample) other).value));
+                || (other instanceof OptionalListAliasExample && equalTo((OptionalListAliasExample) other));
+    }
+
+    private boolean equalTo(OptionalListAliasExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = this.value.hashCode();
+            memoizedHashCode = result;
+        }
+        return result;
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalMapAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalMapAliasExample.java
@@ -15,6 +15,8 @@ public final class OptionalMapAliasExample {
 
     private final Optional<Map<String, Object>> value;
 
+    private int memoizedHashCode;
+
     private OptionalMapAliasExample(@Nonnull Optional<Map<String, Object>> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
@@ -35,14 +37,26 @@ public final class OptionalMapAliasExample {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof OptionalMapAliasExample
-                        && this.value.equals(((OptionalMapAliasExample) other).value));
+        return this == other || (other instanceof OptionalMapAliasExample && equalTo((OptionalMapAliasExample) other));
+    }
+
+    private boolean equalTo(OptionalMapAliasExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = this.value.hashCode();
+            memoizedHashCode = result;
+        }
+        return result;
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalSetAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/OptionalSetAliasExample.java
@@ -15,6 +15,8 @@ public final class OptionalSetAliasExample {
 
     private final Optional<Set<String>> value;
 
+    private int memoizedHashCode;
+
     private OptionalSetAliasExample(@Nonnull Optional<Set<String>> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
@@ -35,14 +37,26 @@ public final class OptionalSetAliasExample {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof OptionalSetAliasExample
-                        && this.value.equals(((OptionalSetAliasExample) other).value));
+        return this == other || (other instanceof OptionalSetAliasExample && equalTo((OptionalSetAliasExample) other));
+    }
+
+    private boolean equalTo(OptionalSetAliasExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = this.value.hashCode();
+            memoizedHashCode = result;
+        }
+        return result;
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReferenceAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ReferenceAliasExample.java
@@ -27,13 +27,16 @@ public final class ReferenceAliasExample {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof ReferenceAliasExample && this.value.equals(((ReferenceAliasExample) other).value));
+        return this == other || (other instanceof ReferenceAliasExample && equalTo((ReferenceAliasExample) other));
+    }
+
+    private boolean equalTo(ReferenceAliasExample other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/RidAliasExample.java
@@ -28,13 +28,16 @@ public final class RidAliasExample {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof RidAliasExample && this.value.equals(((RidAliasExample) other).value));
+        return this == other || (other instanceof RidAliasExample && equalTo((RidAliasExample) other));
+    }
+
+    private boolean equalTo(RidAliasExample other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     public static RidAliasExample valueOf(String value) {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeExternalLongAlias.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeExternalLongAlias.java
@@ -28,13 +28,16 @@ public final class SafeExternalLongAlias {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof SafeExternalLongAlias && this.value == ((SafeExternalLongAlias) other).value);
+        return this == other || (other instanceof SafeExternalLongAlias && equalTo((SafeExternalLongAlias) other));
+    }
+
+    private boolean equalTo(SafeExternalLongAlias other) {
+        return this.value == other.value;
     }
 
     @Override
     public int hashCode() {
-        return Long.hashCode(value);
+        return Long.hashCode(this.value);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeLongAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeLongAliasExample.java
@@ -31,13 +31,16 @@ public final class SafeLongAliasExample implements Comparable<SafeLongAliasExamp
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof SafeLongAliasExample && this.value.equals(((SafeLongAliasExample) other).value));
+        return this == other || (other instanceof SafeLongAliasExample && equalTo((SafeLongAliasExample) other));
+    }
+
+    private boolean equalTo(SafeLongAliasExample other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetAlias.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SetAlias.java
@@ -15,6 +15,8 @@ public final class SetAlias {
 
     private final Set<String> value;
 
+    private int memoizedHashCode;
+
     private SetAlias(@Nonnull Set<String> value) {
         this.value = Preconditions.checkNotNull(value, "value cannot be null");
     }
@@ -35,12 +37,26 @@ public final class SetAlias {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other || (other instanceof SetAlias && this.value.equals(((SetAlias) other).value));
+        return this == other || (other instanceof SetAlias && equalTo((SetAlias) other));
+    }
+
+    private boolean equalTo(SetAlias other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = this.value.hashCode();
+            memoizedHashCode = result;
+        }
+        return result;
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasExample.java
@@ -30,13 +30,16 @@ public final class StringAliasExample implements Comparable<StringAliasExample> 
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof StringAliasExample && this.value.equals(((StringAliasExample) other).value));
+        return this == other || (other instanceof StringAliasExample && equalTo((StringAliasExample) other));
+    }
+
+    private boolean equalTo(StringAliasExample other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasOne.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasOne.java
@@ -27,12 +27,16 @@ public final class StringAliasOne implements Comparable<StringAliasOne> {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other || (other instanceof StringAliasOne && this.value.equals(((StringAliasOne) other).value));
+        return this == other || (other instanceof StringAliasOne && equalTo((StringAliasOne) other));
+    }
+
+    private boolean equalTo(StringAliasOne other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasThree.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasThree.java
@@ -27,13 +27,16 @@ public final class StringAliasThree {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof StringAliasThree && this.value.equals(((StringAliasThree) other).value));
+        return this == other || (other instanceof StringAliasThree && equalTo((StringAliasThree) other));
+    }
+
+    private boolean equalTo(StringAliasThree other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasTwo.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/StringAliasTwo.java
@@ -34,12 +34,16 @@ public final class StringAliasTwo {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other || (other instanceof StringAliasTwo && this.value.equals(((StringAliasTwo) other).value));
+        return this == other || (other instanceof StringAliasTwo && equalTo((StringAliasTwo) other));
+    }
+
+    private boolean equalTo(StringAliasTwo other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UuidAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/UuidAliasExample.java
@@ -28,13 +28,16 @@ public final class UuidAliasExample {
 
     @Override
     public boolean equals(@Nullable Object other) {
-        return this == other
-                || (other instanceof UuidAliasExample && this.value.equals(((UuidAliasExample) other).value));
+        return this == other || (other instanceof UuidAliasExample && equalTo((UuidAliasExample) other));
+    }
+
+    private boolean equalTo(UuidAliasExample other) {
+        return this.value.equals(other.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return this.value.hashCode();
     }
 
     public static UuidAliasExample valueOf(String value) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -492,8 +492,8 @@ public final class BeanGenerator {
      * Any types we generate directly will produce an efficient hashCode, but collections may be large, and we must
      * traverse through optionals.
      */
-    private static final class FieldRequiresMemoizedHashCode extends DefaultTypeVisitor<Boolean> {
-        private static final DefaultTypeVisitor<Boolean> INSTANCE = new FieldRequiresMemoizedHashCode();
+    static final class FieldRequiresMemoizedHashCode extends DefaultTypeVisitor<Boolean> {
+        static final DefaultTypeVisitor<Boolean> INSTANCE = new FieldRequiresMemoizedHashCode();
 
         @Override
         public Boolean visitOptional(OptionalType value) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/MethodSpecs.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/MethodSpecs.java
@@ -170,7 +170,10 @@ public final class MethodSpecs {
                 return createHashInput(fieldSpec);
             } else {
                 return CodeBlock.of(
-                        "$1T.$2N($3L)", Primitives.box(fieldSpec.type), "hashCode", createHashInput(fieldSpec));
+                        "$1T.$2N($3L)",
+                        Primitives.box(fieldSpec.type).withoutAnnotations(),
+                        "hashCode",
+                        createHashInput(fieldSpec));
             }
         }
         return CodeBlock.of("$L.hashCode()", createHashInput(fieldSpec));

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/Primitives.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/Primitives.java
@@ -40,7 +40,7 @@ public final class Primitives {
     public static TypeName box(TypeName type) {
         if (isPrimitive(type)) {
             List<AnnotationSpec> annotations = type.annotations;
-            return PRIMITIVES.get(getPrimitiveType(type).get()).annotated(annotations);
+            return PRIMITIVES.get(getPrimitiveType(type).orElseThrow()).annotated(annotations);
         } else {
             return type;
         }
@@ -61,8 +61,6 @@ public final class Primitives {
 
     private static Optional<TypeName> getPrimitiveType(TypeName type) {
         TypeName rawType = type.withoutAnnotations();
-        return PRIMITIVES.keySet().stream()
-                .filter(typeName -> typeName.equals(rawType))
-                .findAny();
+        return PRIMITIVES.containsKey(rawType) ? Optional.of(rawType) : Optional.empty();
     }
 }


### PR DESCRIPTION
## Before this PR

Generated alias types did not memoize `hashCode`, potentially leading to expensive hash code computations when the aliased type is an immutable collection or map.

A hypothetical example `CompositeKey` alias for `Map<Field, Value>` currently generates:

```
@Generated("com.palantir.conjure.java.types.AliasGenerator")
public final class CompositeKey {
    private static final CompositeKey EMPTY = new CompositeKey();

    private final Map<Field, Value> value;

    private CompositeKey(@Nonnull Map<Field, Value> value) {
        this.value = Preconditions.checkNotNull(value, "value cannot be null");
    }

    private CompositeKey() {
        this(Collections.emptyMap());
    }

    @JsonValue
    public Map<Field, Value> get() {
        return value;
    }

    @Override
    public String toString() {
        return value.toString();
    }

    @Override
    public boolean equals(@Nullable Object other) {
        return this == other
                || (other instanceof CompositeKey && this.value.equals(((CompositeKey) other).value));
    }

    @Override
    public int hashCode() {
        return value.hashCode();
    }

    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
    public static CompositeKey of(@Nonnull Map<Field, Value> value) {
        return new CompositeKey(value);
    }

    public static CompositeKey empty() {
        return EMPTY;
    }
}
```



## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Alias types use memoized hashCode for collections
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

