### PR TITLE
`Double` Alias types with log safety equality fix

### DIFF
--- a/changelog/@unreleased/pr-2295.v2.yml
+++ b/changelog/@unreleased/pr-2295.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Ensure that Aliased `Double` types with specified log safety have a
+    correct `equalTo`.
+  links:
+  - https://github.com/palantir/conjure-java/pull/2295

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeDoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeDoubleAliasExample.java
@@ -1,0 +1,88 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.conjure.java.lib.SafeLong;
+import com.palantir.logsafe.Safe;
+import java.math.BigDecimal;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@Safe
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class SafeDoubleAliasExample implements Comparable<SafeDoubleAliasExample> {
+    private final @Safe double value;
+
+    private SafeDoubleAliasExample(@Safe double value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public @Safe double get() {
+        return value;
+    }
+
+    @Override
+    @Safe
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof SafeDoubleAliasExample && equalTo((SafeDoubleAliasExample) other));
+    }
+
+    private boolean equalTo(SafeDoubleAliasExample other) {
+        return this.value == other.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Double.hashCode(this.value);
+    }
+
+    @Override
+    public int compareTo(SafeDoubleAliasExample other) {
+        return Double.compare(value, other.get());
+    }
+
+    public static SafeDoubleAliasExample valueOf(@Safe String value) {
+        return of(Double.parseDouble(value));
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static SafeDoubleAliasExample of(@Safe double value) {
+        return new SafeDoubleAliasExample(value);
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static SafeDoubleAliasExample of(@Safe long value) {
+        long safeValue = SafeLong.of(value).longValue();
+        return new SafeDoubleAliasExample((double) safeValue);
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static SafeDoubleAliasExample of(@Safe int value) {
+        return new SafeDoubleAliasExample((double) value);
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    private static SafeDoubleAliasExample of(@Safe BigDecimal value) {
+        return new SafeDoubleAliasExample(value.doubleValue());
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static SafeDoubleAliasExample of(@Safe String value) {
+        switch (value) {
+            case "NaN":
+                return SafeDoubleAliasExample.of(Double.NaN);
+            case "Infinity":
+                return SafeDoubleAliasExample.of(Double.POSITIVE_INFINITY);
+            case "-Infinity":
+                return SafeDoubleAliasExample.of(Double.NEGATIVE_INFINITY);
+            default:
+                throw new IllegalArgumentException("Cannot deserialize string into double: " + value);
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeDoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeDoubleAliasExample.java
@@ -34,7 +34,7 @@ public final class SafeDoubleAliasExample implements Comparable<SafeDoubleAliasE
     }
 
     private boolean equalTo(SafeDoubleAliasExample other) {
-        return this.value == other.value;
+        return Double.doubleToLongBits(this.value) == Double.doubleToLongBits(other.value);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeDoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeDoubleAliasExample.java
@@ -34,7 +34,7 @@ public final class SafeDoubleAliasExample implements Comparable<SafeDoubleAliasE
     }
 
     private boolean equalTo(SafeDoubleAliasExample other) {
-        return this.value == other.value;
+        return Double.doubleToLongBits(this.value) == Double.doubleToLongBits(other.value);
     }
 
     @Override

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeDoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeDoubleAliasExample.java
@@ -1,0 +1,88 @@
+package test.prefix.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.conjure.java.lib.SafeLong;
+import com.palantir.logsafe.Safe;
+import java.math.BigDecimal;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@Safe
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class SafeDoubleAliasExample implements Comparable<SafeDoubleAliasExample> {
+    private final @Safe double value;
+
+    private SafeDoubleAliasExample(@Safe double value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public @Safe double get() {
+        return value;
+    }
+
+    @Override
+    @Safe
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof SafeDoubleAliasExample && equalTo((SafeDoubleAliasExample) other));
+    }
+
+    private boolean equalTo(SafeDoubleAliasExample other) {
+        return this.value == other.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Double.hashCode(this.value);
+    }
+
+    @Override
+    public int compareTo(SafeDoubleAliasExample other) {
+        return Double.compare(value, other.get());
+    }
+
+    public static SafeDoubleAliasExample valueOf(@Safe String value) {
+        return of(Double.parseDouble(value));
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static SafeDoubleAliasExample of(@Safe double value) {
+        return new SafeDoubleAliasExample(value);
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static SafeDoubleAliasExample of(@Safe long value) {
+        long safeValue = SafeLong.of(value).longValue();
+        return new SafeDoubleAliasExample((double) safeValue);
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static SafeDoubleAliasExample of(@Safe int value) {
+        return new SafeDoubleAliasExample((double) value);
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    private static SafeDoubleAliasExample of(@Safe BigDecimal value) {
+        return new SafeDoubleAliasExample(value.doubleValue());
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static SafeDoubleAliasExample of(@Safe String value) {
+        switch (value) {
+            case "NaN":
+                return SafeDoubleAliasExample.of(Double.NaN);
+            case "Infinity":
+                return SafeDoubleAliasExample.of(Double.POSITIVE_INFINITY);
+            case "-Infinity":
+                return SafeDoubleAliasExample.of(Double.NEGATIVE_INFINITY);
+            default:
+                throw new IllegalArgumentException("Cannot deserialize string into double: " + value);
+        }
+    }
+}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/MethodSpecs.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/MethodSpecs.java
@@ -90,7 +90,7 @@ public final class MethodSpecs {
         String thisField = "this." + field.name;
         String otherField = "other." + field.name;
 
-        if (field.type.equals(TypeName.DOUBLE)) {
+        if (Primitives.isDouble(field.type)) {
             return CodeBlock.of(
                     "$1T.doubleToLongBits($2L) == $1T.doubleToLongBits($3L)", Double.class, thisField, otherField);
         } else if (Primitives.isPrimitive(field.type)) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/Primitives.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/Primitives.java
@@ -46,6 +46,10 @@ public final class Primitives {
         }
     }
 
+    public static boolean isDouble(TypeName type) {
+        return type.withoutAnnotations().equals(TypeName.DOUBLE);
+    }
+
     public static boolean isPrimitive(TypeName type) {
         return getPrimitiveType(type).isPresent();
     }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/AliasTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/AliasTests.java
@@ -20,17 +20,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.logsafe.exceptions.SafeNullPointerException;
 import com.palantir.product.DoubleAliasExample;
 import com.palantir.product.ExternalLongAliasOne;
 import com.palantir.product.ExternalLongAliasTwo;
+import com.palantir.product.SafeDoubleAliasExample;
 import com.palantir.product.UuidAliasExample;
 import org.junit.jupiter.api.Test;
 
 public class AliasTests {
-    private static final ObjectMapper TEST_MAPPER = ObjectMappers.newServerObjectMapper();
+    private static final ObjectMapper TEST_MAPPER = ObjectMappers.newServerObjectMapper()
+            .configure(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS.mappedFeature(), true);
 
     @Test
     public void testNullValueSafeLoggable() {
@@ -68,5 +71,11 @@ public class AliasTests {
         // Doesn't fit in an int, but does fit comfortably in a double; looks like a long
         assertThat(TEST_MAPPER.readValue("9667500000", DoubleAliasExample.class))
                 .isEqualTo(DoubleAliasExample.of(9667500000.0));
+    }
+
+    @Test
+    public void testNaNEqualityOnSafeDoubleAlias() throws JsonProcessingException {
+        assertThat(TEST_MAPPER.readValue("NaN", SafeDoubleAliasExample.class))
+                .isEqualTo(SafeDoubleAliasExample.of(Double.NaN));
     }
 }

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -125,6 +125,9 @@ types:
         alias: StringAliasExample
       DoubleAliasExample:
         alias: double
+      SafeDoubleAliasExample:
+        alias: double
+        safety: safe
       IntegerAliasExample:
         alias: integer
       BooleanAliasExample:


### PR DESCRIPTION
## Before this PR
After #2291 merged, some tests started failing in a specific case of an aliased `Double` that had safety annotations on.

The `equalTo` method was now generating something like this:
```diff
-Double.doubleToLongBits(this.value) == Double.doubleToLongBits(((Float) other).value))
+this.value == other.value
```

https://github.com/palantir/conjure-java/blob/7891d80363baa9843cc75b39b8a04d1430be1a2e/conjure-java-core/src/main/java/com/palantir/conjure/java/types/MethodSpecs.java#L93-L97

The type we pass in is `ConjureAnnotations.withSafety(<underlying type>)` and if you have any safety annotations, you end up with a `TypeName.Double` *with* annotations on top which are not equal to `TypeName.Double`, hence why we're hitting the second block.

This was the confusing part as `AliasDoubleExample` was actually generating the correct output.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Ensure that Aliased `Double` types with specified log safety have a correct `equalTo`.
==COMMIT_MSG==

* added a new [example type](https://github.com/palantir/conjure-java/commit/5a266de4c717707f653935b8811657bca46672f3) and you can see the incorrect generated code.

* added a convenience method, `Primitives#isDouble` so don't have to remember to remove annotations etc.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

