### PR TITLE
Add primitive array setter optimization [Primitive Arrays Pt.4]

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
@@ -218,6 +218,13 @@ public final class ListExample {
             return this;
         }
 
+        public Builder primitiveItems(@Nonnull int[] primitiveItems) {
+            checkNotBuilt();
+            this.primitiveItems = ConjureCollections.newNonNullIntegerList(
+                    Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
+            return this;
+        }
+
         public Builder addAllPrimitiveItems(@Nonnull Iterable<Integer> primitiveItems) {
             checkNotBuilt();
             ConjureCollections.addAllAndCheckNonNull(
@@ -234,6 +241,13 @@ public final class ListExample {
 
         @JsonSetter(value = "doubleItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder doubleItems(@Nonnull Iterable<Double> doubleItems) {
+            checkNotBuilt();
+            this.doubleItems = ConjureCollections.newNonNullDoubleList(
+                    Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
+            return this;
+        }
+
+        public Builder doubleItems(@Nonnull double[] doubleItems) {
             checkNotBuilt();
             this.doubleItems = ConjureCollections.newNonNullDoubleList(
                     Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
@@ -135,6 +135,13 @@ public final class SafeLongExample {
             return this;
         }
 
+        public Builder safeLongList(@Nonnull long[] safeLongList) {
+            checkNotBuilt();
+            this.safeLongList = ConjureCollections.newNonNullSafeLongList(
+                    Preconditions.checkNotNull(safeLongList, "safeLongList cannot be null"));
+            return this;
+        }
+
         public Builder addAllSafeLongList(@Nonnull Iterable<SafeLong> safeLongList) {
             checkNotBuilt();
             ConjureCollections.addAllAndCheckNonNull(

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
@@ -178,6 +178,15 @@ public interface Options {
         return false;
     }
 
+    /**
+     * When set, enables codegen for array setters for primitive optimized collections.
+     * This feature is experimental and subject to change.
+     */
+    @Value.Default
+    default boolean primitiveCollectionArraySetters() {
+        return false;
+    }
+
     Optional<String> packagePrefix();
 
     Optional<String> apiVersion();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -800,7 +800,8 @@ public final class BeanBuilderGenerator {
         if (type.accept(TypeVisitor.IS_LIST)) {
             CollectionType collectionType = getCollectionType(type);
             if (collectionType.getConjureCollectionType().isPrimitiveCollection()
-                    && collectionType.useNonNullFactory()) {
+                    && collectionType.useNonNullFactory()
+                    && options.primitiveCollectionArraySetters()) {
                 return ImmutableList.of(
                         createPrimitiveCollectionSetter(enriched),
                         createCollectionSetter("addAll", enriched, override),

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
@@ -67,6 +67,7 @@ public final class ObjectGeneratorTests {
                                 .unionsWithUnknownValues(true)
                                 .jetbrainsContractAnnotations(true)
                                 .primitiveOptimizedCollections(true)
+                                .primitiveCollectionArraySetters(true)
                                 .build())))
                 .emit(def, tempDir);
 

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -235,6 +235,12 @@ public final class ConjureJavaCli implements Runnable {
                 description = "Enables codegen for primitive optimized collections.")
         private boolean primitiveOptimizedCollections;
 
+        @CommandLine.Option(
+                names = "--primitiveCollectionArraySetters",
+                defaultValue = "false",
+                description = "Ecodegen for array setters for primitive optimized collections.")
+        private boolean primitiveCollectionArraySetters;
+
         @SuppressWarnings("unused")
         @CommandLine.Unmatched
         private List<String> unmatchedOptions;
@@ -304,6 +310,7 @@ public final class ConjureJavaCli implements Runnable {
                             .unionsWithUnknownValues(unionsWithUnknownValues)
                             .externalFallbackTypes(externalFallbackTypes)
                             .primitiveOptimizedCollections(primitiveOptimizedCollections)
+                            .primitiveCollectionArraySetters(primitiveCollectionArraySetters)
                             .build())
                     .build();
         }

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
@@ -154,9 +154,7 @@ public final class ConjureCollections {
 
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
     public static List<Double> newNonNullDoubleList(double[] doubles) {
-        double[] conjureCopy = new double[doubles.length];
-        System.arraycopy(doubles, 0, conjureCopy, 0, doubles.length);
-        return new ConjureDoubleList(DoubleArrayList.newListWith(conjureCopy));
+        return new ConjureDoubleList(DoubleArrayList.newListWith(doubles.clone()));
     }
 
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
@@ -179,9 +177,7 @@ public final class ConjureCollections {
 
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
     public static List<Integer> newNonNullIntegerList(int[] integers) {
-        int[] conjureCopy = new int[integers.length];
-        System.arraycopy(integers, 0, conjureCopy, 0, integers.length);
-        return new ConjureIntegerList(IntArrayList.newListWith(conjureCopy));
+        return new ConjureIntegerList(IntArrayList.newListWith(integers.clone()));
     }
 
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
@@ -204,9 +200,7 @@ public final class ConjureCollections {
 
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
     public static List<Boolean> newNonNullBooleanList(boolean[] booleans) {
-        boolean[] conjureCopy = new boolean[booleans.length];
-        System.arraycopy(booleans, 0, conjureCopy, 0, booleans.length);
-        return new ConjureBooleanList(BooleanArrayList.newListWith(conjureCopy));
+        return new ConjureBooleanList(BooleanArrayList.newListWith(booleans.clone()));
     }
 
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
@@ -229,8 +223,7 @@ public final class ConjureCollections {
 
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
     public static List<SafeLong> newNonNullSafeLongList(long[] longs) {
-        long[] conjureCopy = new long[longs.length];
-        System.arraycopy(longs, 0, conjureCopy, 0, longs.length);
+        long[] conjureCopy = longs.clone();
         for (long value : conjureCopy) {
             if (!safeLongCheck(value)) {
                 throw new SafeIllegalArgumentException(

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
@@ -154,7 +154,9 @@ public final class ConjureCollections {
 
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
     public static List<Double> newNonNullDoubleList(double[] doubles) {
-        return new ConjureDoubleList(DoubleArrayList.newListWith(doubles));
+        double[] conjureCopy = new double[doubles.length];
+        System.arraycopy(doubles, 0, conjureCopy, 0, doubles.length);
+        return new ConjureDoubleList(DoubleArrayList.newListWith(conjureCopy));
     }
 
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
@@ -177,7 +179,9 @@ public final class ConjureCollections {
 
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
     public static List<Integer> newNonNullIntegerList(int[] integers) {
-        return new ConjureIntegerList(IntArrayList.newListWith(integers));
+        int[] conjureCopy = new int[integers.length];
+        System.arraycopy(integers, 0, conjureCopy, 0, integers.length);
+        return new ConjureIntegerList(IntArrayList.newListWith(conjureCopy));
     }
 
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
@@ -200,7 +204,9 @@ public final class ConjureCollections {
 
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
     public static List<Boolean> newNonNullBooleanList(boolean[] booleans) {
-        return new ConjureBooleanList(BooleanArrayList.newListWith(booleans));
+        boolean[] conjureCopy = new boolean[booleans.length];
+        System.arraycopy(booleans, 0, conjureCopy, 0, booleans.length);
+        return new ConjureBooleanList(BooleanArrayList.newListWith(conjureCopy));
     }
 
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
@@ -223,14 +229,16 @@ public final class ConjureCollections {
 
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
     public static List<SafeLong> newNonNullSafeLongList(long[] longs) {
-        for (long value : longs) {
+        long[] conjureCopy = new long[longs.length];
+        System.arraycopy(longs, 0, conjureCopy, 0, longs.length);
+        for (long value : conjureCopy) {
             if (!safeLongCheck(value)) {
                 throw new SafeIllegalArgumentException(
                         "number must be safely representable in javascript i.e. lie between -9007199254740991 and "
                                 + "9007199254740991");
             }
         }
-        return new ConjureSafeLongList(LongArrayList.newListWith(longs));
+        return new ConjureSafeLongList(LongArrayList.newListWith(conjureCopy));
     }
 
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.java.lib.internal;
 
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -140,9 +141,20 @@ public final class ConjureCollections {
         return set;
     }
 
+    /**
+     * The following Conjure boxed list wrappers for the eclipse-collections [type]ArrayList are temporary (except
+     * ConjureSafeLongList). In eclipse-collections 12, a BoxedMutable[type]List will be released. Once available,
+     * Conjure[type]List should be replaced with that.
+     */
+
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
     public static List<Double> newNonNullDoubleList() {
         return new ConjureDoubleList(new DoubleArrayList());
+    }
+
+    // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
+    public static List<Double> newNonNullDoubleList(double[] doubles) {
+        return new ConjureDoubleList(DoubleArrayList.newListWith(doubles));
     }
 
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
@@ -158,15 +170,14 @@ public final class ConjureCollections {
         return doubleList;
     }
 
-    /**
-     * The following Conjure boxed list wrappers for the eclipse-collections [type]ArrayList are temporary (except
-     * ConjureSafeLongList). In eclipse-collections 12, a BoxedMutable[type]List will be released. Once available,
-     * Conjure[type]List should be replaced with that.
-     */
-
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
     public static List<Integer> newNonNullIntegerList() {
         return new ConjureIntegerList(new IntArrayList());
+    }
+
+    // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
+    public static List<Integer> newNonNullIntegerList(int[] integers) {
+        return new ConjureIntegerList(IntArrayList.newListWith(integers));
     }
 
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
@@ -188,6 +199,11 @@ public final class ConjureCollections {
     }
 
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
+    public static List<Boolean> newNonNullBooleanList(boolean[] booleans) {
+        return new ConjureBooleanList(BooleanArrayList.newListWith(booleans));
+    }
+
+    // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
     public static List<Boolean> newNonNullBooleanList(Iterable<Boolean> iterable) {
         List<Boolean> booleanList;
         if (iterable instanceof Collection) {
@@ -206,6 +222,18 @@ public final class ConjureCollections {
     }
 
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
+    public static List<SafeLong> newNonNullSafeLongList(long[] longs) {
+        for (long value : longs) {
+            if (!safeLongCheck(value)) {
+                throw new SafeIllegalArgumentException(
+                        "number must be safely representable in javascript i.e. lie between -9007199254740991 and "
+                                + "9007199254740991");
+            }
+        }
+        return new ConjureSafeLongList(LongArrayList.newListWith(longs));
+    }
+
+    // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
     public static List<SafeLong> newNonNullSafeLongList(Iterable<SafeLong> iterable) {
         List<SafeLong> safeLongList;
         if (iterable instanceof Collection) {
@@ -216,5 +244,9 @@ public final class ConjureCollections {
         addAll(safeLongList, iterable);
 
         return safeLongList;
+    }
+
+    private static boolean safeLongCheck(long value) {
+        return SafeLong.MIN_VALUE.longValue() <= value && value <= SafeLong.MAX_VALUE.longValue();
     }
 }

--- a/conjure-lib/src/test/java/com/palantir/conjure/java/lib/internal/ConjureCollectionsTest.java
+++ b/conjure-lib/src/test/java/com/palantir/conjure/java/lib/internal/ConjureCollectionsTest.java
@@ -54,10 +54,15 @@ public class ConjureCollectionsTest {
         doubleList.clear();
         assertThat(doubleList).hasSize(0);
 
-        doubleList = ConjureCollections.newNonNullDoubleList(new double[] {0.1, 0.2, 0.3});
+        double[] rawList = new double[] {0.1, 0.2, 0.3};
+        doubleList = ConjureCollections.newNonNullDoubleList(rawList);
         assertThat(doubleList).hasSize(3);
         assertThat(doubleList.get(0)).isEqualTo(0.1);
         assertThat(doubleList.get(1)).isEqualTo(0.2);
+        assertThat(doubleList.get(2)).isEqualTo(0.3);
+
+        // Check we made a copy of the array
+        rawList[0] = 0.4;
         assertThat(doubleList.get(2)).isEqualTo(0.3);
     }
 
@@ -90,11 +95,15 @@ public class ConjureCollectionsTest {
         safeLongList.clear();
         assertThat(safeLongList).hasSize(0);
 
-        safeLongList = ConjureCollections.newNonNullSafeLongList(new long[] {1L, 2L, 3L});
+        long[] rawList = new long[] {1L, 2L, 3L};
+        safeLongList = ConjureCollections.newNonNullSafeLongList(rawList);
         assertThat(safeLongList).hasSize(3);
         assertThat(safeLongList.get(0)).isEqualTo(SafeLong.of(1L));
         assertThat(safeLongList.get(1)).isEqualTo(SafeLong.of(2L));
         assertThat(safeLongList.get(2)).isEqualTo(SafeLong.of(3L));
+
+        rawList[0] = 42L;
+        assertThat(safeLongList.get(0)).isEqualTo(SafeLong.of(1L));
 
         assertThatExceptionOfType(SafeIllegalArgumentException.class)
                 .isThrownBy(() -> ConjureCollections.newNonNullSafeLongList(

--- a/conjure-lib/src/test/java/com/palantir/conjure/java/lib/internal/ConjureCollectionsTest.java
+++ b/conjure-lib/src/test/java/com/palantir/conjure/java/lib/internal/ConjureCollectionsTest.java
@@ -17,8 +17,10 @@
 package com.palantir.conjure.java.lib.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import com.palantir.conjure.java.lib.SafeLong;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -51,6 +53,12 @@ public class ConjureCollectionsTest {
 
         doubleList.clear();
         assertThat(doubleList).hasSize(0);
+
+        doubleList = ConjureCollections.newNonNullDoubleList(new double[] {0.1, 0.2, 0.3});
+        assertThat(doubleList).hasSize(3);
+        assertThat(doubleList.get(0)).isEqualTo(0.1);
+        assertThat(doubleList.get(1)).isEqualTo(0.2);
+        assertThat(doubleList.get(2)).isEqualTo(0.3);
     }
 
     @Test
@@ -81,5 +89,15 @@ public class ConjureCollectionsTest {
 
         safeLongList.clear();
         assertThat(safeLongList).hasSize(0);
+
+        safeLongList = ConjureCollections.newNonNullSafeLongList(new long[] {1L, 2L, 3L});
+        assertThat(safeLongList).hasSize(3);
+        assertThat(safeLongList.get(0)).isEqualTo(SafeLong.of(1L));
+        assertThat(safeLongList.get(1)).isEqualTo(SafeLong.of(2L));
+        assertThat(safeLongList.get(2)).isEqualTo(SafeLong.of(3L));
+
+        assertThatExceptionOfType(SafeIllegalArgumentException.class)
+                .isThrownBy(() -> ConjureCollections.newNonNullSafeLongList(
+                        new long[] {1L, 2L, SafeLong.MAX_VALUE.longValue() + 1}));
     }
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Add back optimization removed here: https://github.com/palantir/conjure-java/pull/2274#discussion_r1546622698

This will allow clients to just track primitive arrays internally which will be a nice perf improvement.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

