### PR TITLE
Enable primitive collection optimization by default

### DIFF
--- a/changelog/@unreleased/pr-2317.v2.yml
+++ b/changelog/@unreleased/pr-2317.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Enable primitive collection by default
+  links:
+  - https://github.com/palantir/conjure-java/pull/2317

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
@@ -175,7 +175,7 @@ public interface Options {
      */
     @Value.Default
     default boolean primitiveOptimizedCollections() {
-        return false;
+        return true;
     }
 
     Optional<String> packagePrefix();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
@@ -169,15 +169,6 @@ public interface Options {
         return false;
     }
 
-    /**
-     * When set, enables codegen for primitive optimized collections.
-     * This feature is experimental and subject to change.
-     */
-    @Value.Default
-    default boolean primitiveOptimizedCollections() {
-        return true;
-    }
-
     Optional<String> packagePrefix();
 
     Optional<String> apiVersion();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
@@ -166,7 +166,7 @@ public interface Options {
     /** When set, external type imports are generated as their fallback types. */
     @Value.Default
     default boolean externalFallbackTypes() {
-        return fals;
+        return false;
     }
 
     Optional<String> packagePrefix();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
@@ -166,7 +166,7 @@ public interface Options {
     /** When set, external type imports are generated as their fallback types. */
     @Value.Default
     default boolean externalFallbackTypes() {
-        return false;
+        return fals;
     }
 
     Optional<String> packagePrefix();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -563,7 +563,7 @@ public final class BeanBuilderGenerator {
         FieldSpec.Builder spec = FieldSpec.builder(typeName, JavaNameSanitizer.sanitize(fieldName), Modifier.PRIVATE);
         if (type.accept(TypeVisitor.IS_LIST) || type.accept(TypeVisitor.IS_SET)) {
             CollectionType collectionType = getCollectionType(type);
-            if (collectionType.useNonNullFactory() && options.primitiveOptimizedCollections()) {
+            if (collectionType.useNonNullFactory()) {
                 spec.initializer(
                         "$1T.newNonNull$2L()",
                         ConjureCollections.class,
@@ -952,11 +952,6 @@ public final class BeanBuilderGenerator {
                 if (!options.nonNullCollections()) {
                     return new CollectionType(
                             ConjureCollectionType.LIST, ConjureCollectionNullHandlingMode.NULLABLE_COLLECTION_FACTORY);
-                }
-
-                if (!options.primitiveOptimizedCollections()) {
-                    return new CollectionType(
-                            ConjureCollectionType.LIST, ConjureCollectionNullHandlingMode.NON_NULL_COLLECTION_FACTORY);
                 }
 
                 return value.getItemType().accept(new DefaultTypeVisitor<>() {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
@@ -25,6 +25,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.conjure.defs.Conjure;
 import com.palantir.conjure.java.GenerationCoordinator;
 import com.palantir.conjure.java.Options;
+import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.conjure.spec.AliasDefinition;
 import com.palantir.conjure.spec.ConjureDefinition;
 import com.palantir.conjure.spec.ErrorCode;
@@ -43,6 +44,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -56,6 +58,8 @@ public final class ObjectGeneratorTests {
 
     @Test
     public void testObjectGenerator_allExamples() throws IOException {
+        List<SafeLong> longs = new ArrayList<>();
+        assertThat(longs).hasSize(0);
         ConjureDefinition def = Conjure.parse(ImmutableList.of(new File("src/test/resources/example-types.yml")));
         List<Path> files = new GenerationCoordinator(
                         MoreExecutors.directExecutor(),
@@ -66,7 +70,6 @@ public final class ObjectGeneratorTests {
                                 .excludeEmptyOptionals(true)
                                 .unionsWithUnknownValues(true)
                                 .jetbrainsContractAnnotations(true)
-                                .primitiveOptimizedCollections(true)
                                 .build())))
                 .emit(def, tempDir);
 

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
@@ -25,7 +25,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.conjure.defs.Conjure;
 import com.palantir.conjure.java.GenerationCoordinator;
 import com.palantir.conjure.java.Options;
-import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.conjure.spec.AliasDefinition;
 import com.palantir.conjure.spec.ConjureDefinition;
 import com.palantir.conjure.spec.ErrorCode;
@@ -44,7 +43,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -58,8 +56,6 @@ public final class ObjectGeneratorTests {
 
     @Test
     public void testObjectGenerator_allExamples() throws IOException {
-        List<SafeLong> longs = new ArrayList<>();
-        assertThat(longs).hasSize(0);
         ConjureDefinition def = Conjure.parse(ImmutableList.of(new File("src/test/resources/example-types.yml")));
         List<Path> files = new GenerationCoordinator(
                         MoreExecutors.directExecutor(),

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -229,12 +229,6 @@ public final class ConjureJavaCli implements Runnable {
                 description = "Java external type imports are generated using their fallback type.")
         private boolean externalFallbackTypes;
 
-        @CommandLine.Option(
-                names = "--primitiveOptimizedCollections",
-                defaultValue = "false",
-                description = "Enables codegen for primitive optimized collections.")
-        private boolean primitiveOptimizedCollections;
-
         @SuppressWarnings("unused")
         @CommandLine.Unmatched
         private List<String> unmatchedOptions;
@@ -303,7 +297,6 @@ public final class ConjureJavaCli implements Runnable {
                             .excludeEmptyCollections(excludeEmptyCollections)
                             .unionsWithUnknownValues(unionsWithUnknownValues)
                             .externalFallbackTypes(externalFallbackTypes)
-                            .primitiveOptimizedCollections(primitiveOptimizedCollections)
                             .build())
                     .build();
         }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
primitive collection changes should have rolled out so lets flip the flag. It is still gatekept by the `nonNullCollections` flag

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

