### PR TITLE
Add test for Cache-Control override

### DIFF
--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/NoCachingResponseHandlerTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/NoCachingResponseHandlerTest.java
@@ -61,4 +61,13 @@ public class NoCachingResponseHandlerTest {
         assertThat(connection.getHeaderField(HttpHeaders.CACHE_CONTROL))
                 .isEqualTo("no-cache, no-store, must-revalidate");
     }
+
+    @Test
+    public void testCacheControl_override() throws IOException {
+        URL url = new URL("http://localhost:12345?override=true");
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod("GET");
+        connection.getHeaderField(HttpHeaders.CACHE_CONTROL);
+        assertThat(connection.getHeaderField(HttpHeaders.CACHE_CONTROL)).isEqualTo("custom override");
+    }
 }


### PR DESCRIPTION
It looks like we intended to write a test for this case, but simply forgot.