### PR TITLE
Singleton beans use a JsonCreator with mode=PROPERTIES

### DIFF
--- a/changelog/@unreleased/pr-2351.v2.yml
+++ b/changelog/@unreleased/pr-2351.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Singleton beans use a JsonCreator with mode=PROPERTIES
+  links:
+  - https://github.com/palantir/conjure-java/pull/2351

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyObjectExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EmptyObjectExample.java
@@ -19,7 +19,7 @@ public final class EmptyObjectExample {
         return "EmptyObjectExample{}";
     }
 
-    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public static EmptyObjectExample of() {
         return INSTANCE;
     }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/strict/EmptyObjectNotStrict.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/strict/EmptyObjectNotStrict.java
@@ -21,7 +21,7 @@ public final class EmptyObjectNotStrict {
         return "EmptyObjectNotStrict{}";
     }
 
-    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public static EmptyObjectNotStrict of() {
         return INSTANCE;
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyObjectExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/EmptyObjectExample.java
@@ -21,7 +21,7 @@ public final class EmptyObjectExample {
         return "EmptyObjectExample{}";
     }
 
-    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public static EmptyObjectExample of() {
         return INSTANCE;
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -405,7 +405,7 @@ public final class BeanGenerator {
         return MethodSpec.methodBuilder("of")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .returns(objectClass)
-                .addAnnotation(ConjureAnnotations.delegatingJsonCreator())
+                .addAnnotation(ConjureAnnotations.propertiesJsonCreator())
                 .addCode("return $L;", SINGLETON_INSTANCE_NAME)
                 .build();
     }


### PR DESCRIPTION
See the discussion here:
https://github.com/FasterXML/jackson-databind/issues/4688#issuecomment-2330537868

Ideally we can avoid deserialization failures for existing code, but it's better to align our usage with the maintainers vision either way :-)

==COMMIT_MSG==
Singleton beans use a JsonCreator with mode=PROPERTIES
==COMMIT_MSG==
