### PR TITLE
conjure-undertow streamed binary response bodies protect against early closure

### DIFF
--- a/changelog/@unreleased/pr-2352.v2.yml
+++ b/changelog/@unreleased/pr-2352.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: conjure-undertow streamed binary response bodies protect against early
+    closure
+  links:
+  - https://github.com/palantir/conjure-java/pull/2352

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryService.java
@@ -56,7 +56,9 @@ public interface EteBinaryService {
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
     @ClientEndpoint(method = "GET", path = "/binary/failure")
     StreamingOutput getBinaryFailure(
-            @HeaderParam("Authorization") @NotNull AuthHeader authHeader, @QueryParam("numBytes") int numBytes);
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @QueryParam("numBytes") int numBytes,
+            @QueryParam("useTryWithResources") boolean useTryWithResources);
 
     @GET
     @Path("binary/aliased")

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceAsync.java
@@ -44,7 +44,7 @@ public interface EteBinaryServiceAsync {
      * @apiNote {@code GET /binary/failure}
      */
     @ClientEndpoint(method = "GET", path = "/binary/failure")
-    ListenableFuture<InputStream> getBinaryFailure(AuthHeader authHeader, int numBytes);
+    ListenableFuture<InputStream> getBinaryFailure(AuthHeader authHeader, int numBytes, boolean useTryWithResources);
 
     /** @apiNote {@code GET /binary/aliased} */
     @ClientEndpoint(method = "GET", path = "/binary/aliased")
@@ -122,10 +122,12 @@ public interface EteBinaryServiceAsync {
             }
 
             @Override
-            public ListenableFuture<InputStream> getBinaryFailure(AuthHeader authHeader, int numBytes) {
+            public ListenableFuture<InputStream> getBinaryFailure(
+                    AuthHeader authHeader, int numBytes, boolean useTryWithResources) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putQueryParams("numBytes", _plainSerDe.serializeInteger(numBytes));
+                _request.putQueryParams("useTryWithResources", _plainSerDe.serializeBoolean(useTryWithResources));
                 return _runtime.clients()
                         .call(
                                 getBinaryFailureChannel,

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceBlocking.java
@@ -47,7 +47,7 @@ public interface EteBinaryServiceBlocking {
      */
     @ClientEndpoint(method = "GET", path = "/binary/failure")
     @MustBeClosed
-    InputStream getBinaryFailure(AuthHeader authHeader, int numBytes);
+    InputStream getBinaryFailure(AuthHeader authHeader, int numBytes, boolean useTryWithResources);
 
     /** @apiNote {@code GET /binary/aliased} */
     @ClientEndpoint(method = "GET", path = "/binary/aliased")
@@ -124,10 +124,11 @@ public interface EteBinaryServiceBlocking {
             }
 
             @Override
-            public InputStream getBinaryFailure(AuthHeader authHeader, int numBytes) {
+            public InputStream getBinaryFailure(AuthHeader authHeader, int numBytes, boolean useTryWithResources) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putQueryParams("numBytes", _plainSerDe.serializeInteger(numBytes));
+                _request.putQueryParams("useTryWithResources", _plainSerDe.serializeBoolean(useTryWithResources));
                 return _runtime.clients()
                         .callBlocking(
                                 getBinaryFailureChannel,

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/EteBinaryServiceEndpoints.java
@@ -241,7 +241,9 @@ public final class EteBinaryServiceEndpoints implements UndertowService {
             AuthHeader authHeader = runtime.auth().header(exchange);
             Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
             int numBytes = runtime.plainSerDe().deserializeInteger(queryParams.get("numBytes"));
-            BinaryResponseBody result = delegate.getBinaryFailure(authHeader, numBytes);
+            boolean useTryWithResources =
+                    runtime.plainSerDe().deserializeBoolean(queryParams.get("useTryWithResources"));
+            BinaryResponseBody result = delegate.getBinaryFailure(authHeader, numBytes, useTryWithResources);
             runtime.bodySerDe().serialize(result, exchange);
         }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteBinaryService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowEteBinaryService.java
@@ -25,7 +25,7 @@ public interface UndertowEteBinaryService {
      *
      * @apiNote {@code GET /binary/failure}
      */
-    BinaryResponseBody getBinaryFailure(AuthHeader authHeader, int numBytes);
+    BinaryResponseBody getBinaryFailure(AuthHeader authHeader, int numBytes, boolean useTryWithResources);
 
     /** @apiNote {@code GET /binary/aliased} */
     Optional<BinaryResponseBody> getAliased(AuthHeader authHeader);

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/EteBinaryResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/EteBinaryResource.java
@@ -62,13 +62,21 @@ final class EteBinaryResource implements EteBinaryService {
     }
 
     @Override
-    public StreamingOutput getBinaryFailure(AuthHeader _authHeader, int numBytes) {
-        return responseBody -> {
+    public StreamingOutput getBinaryFailure(AuthHeader _authHeader, int numBytes, boolean tryWithResources) {
+        StreamingOutput streamingOutput = responseBody -> {
             byte[] data = new byte[numBytes];
             new Random().nextBytes(data);
             responseBody.write(data);
             throw new SafeRuntimeException("failure");
         };
+        if (tryWithResources) {
+            return responseBody -> {
+                try (responseBody) {
+                    streamingOutput.write(responseBody);
+                }
+            };
+        }
+        return streamingOutput;
     }
 
     @Override

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowBinaryResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowBinaryResource.java
@@ -62,8 +62,8 @@ final class UndertowBinaryResource implements UndertowEteBinaryService {
     }
 
     @Override
-    public BinaryResponseBody getBinaryFailure(AuthHeader _authHeader, int numBytes) {
-        return responseBody -> {
+    public BinaryResponseBody getBinaryFailure(AuthHeader _authHeader, int numBytes, boolean tryWithResources) {
+        BinaryResponseBody binaryResponseBody = responseBody -> {
             byte[] buffer = new byte[Math.min(8 * 1024, numBytes)];
             int remainingBytes = numBytes;
             while (remainingBytes > 0) {
@@ -74,6 +74,14 @@ final class UndertowBinaryResource implements UndertowEteBinaryService {
             }
             throw new SafeRuntimeException("failure");
         };
+        if (tryWithResources) {
+            return responseBody -> {
+                try (responseBody) {
+                    binaryResponseBody.write(responseBody);
+                }
+            };
+        }
+        return binaryResponseBody;
     }
 
     @Override

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -433,7 +433,19 @@ public final class UndertowServiceEteTest extends TestBase {
         try (InputStream response = binaryClient.getBinaryFailure(
                 AuthHeader.valueOf("authHeader"),
                 // Write more bytes than one buffer
-                20000)) {
+                20000,
+                false)) {
+            assertThatThrownBy(response::readAllBytes).isInstanceOf(IOException.class);
+        }
+    }
+
+    @Test
+    public void testBinaryServerSideFailureAfterManyBytesSentTryWithResources() throws IOException {
+        try (InputStream response = binaryClient.getBinaryFailure(
+                AuthHeader.valueOf("authHeader"),
+                // Write more bytes than one buffer
+                20000,
+                true)) {
             assertThatThrownBy(response::readAllBytes).isInstanceOf(IOException.class);
         }
     }
@@ -443,7 +455,21 @@ public final class UndertowServiceEteTest extends TestBase {
         assertThatThrownBy(() -> {
                     try {
                         binaryClient
-                                .getBinaryFailure(AuthHeader.valueOf("authHeader"), 1)
+                                .getBinaryFailure(AuthHeader.valueOf("authHeader"), 1, false)
+                                .close();
+                    } catch (UncheckedExecutionException e) {
+                        throw e.getCause();
+                    }
+                })
+                .isInstanceOf(RemoteException.class);
+    }
+
+    @Test
+    public void testBinaryServerSideFailureAfterFewBytesSentTryWithResources() {
+        assertThatThrownBy(() -> {
+                    try {
+                        binaryClient
+                                .getBinaryFailure(AuthHeader.valueOf("authHeader"), 1, true)
                                 .close();
                     } catch (UncheckedExecutionException e) {
                         throw e.getCause();

--- a/conjure-java-core/src/test/resources/ete-binary.yml
+++ b/conjure-java-core/src/test/resources/ete-binary.yml
@@ -41,6 +41,9 @@ services:
           numBytes:
             type: integer
             param-type: query
+          useTryWithResources:
+            type: boolean
+            param-type: query
         docs: Throws an exception after partially writing a binary response.
         returns: binary
       getAliased:

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/UnclosableOutputStream.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/UnclosableOutputStream.java
@@ -67,6 +67,6 @@ final class UnclosableOutputStream extends OutputStream {
 
     @Override
     public String toString() {
-        return "CloseShieldingOutputStream{" + delegate + '}';
+        return "UnclosableOutputStream{" + delegate + '}';
     }
 }

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/UnclosableOutputStream.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/UnclosableOutputStream.java
@@ -1,0 +1,72 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.exceptions.SafeIoException;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/** Helper stream used in {@link ConjureBodySerDe} to make error propagation easier. */
+final class UnclosableOutputStream extends OutputStream {
+
+    private final OutputStream delegate;
+    private boolean closeCalled;
+
+    UnclosableOutputStream(OutputStream delegate) {
+        this.delegate = Preconditions.checkNotNull(delegate, "Delegate is required");
+    }
+
+    @Override
+    public void write(int value) throws IOException {
+        assertOpen();
+        delegate.write(value);
+    }
+
+    @Override
+    public void write(byte[] buffer) throws IOException {
+        assertOpen();
+        delegate.write(buffer);
+    }
+
+    @Override
+    public void write(byte[] buffer, int off, int len) throws IOException {
+        assertOpen();
+        delegate.write(buffer, off, len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        delegate.flush();
+    }
+
+    @Override
+    public void close() {
+        closeCalled = true;
+    }
+
+    private void assertOpen() throws IOException {
+        if (closeCalled) {
+            throw new SafeIoException("Stream is closed");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "CloseShieldingOutputStream{" + delegate + '}';
+    }
+}

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/UnclosableOutputStreamTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/UnclosableOutputStreamTest.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class UnclosableOutputStreamTest {
+
+    @Test
+    void testClosure() throws IOException {
+        OutputStream delegate = Mockito.mock(OutputStream.class);
+        UnclosableOutputStream stream = new UnclosableOutputStream(delegate);
+        stream.write(1);
+        Mockito.verify(delegate).write(1);
+        // Close the unclosable stream
+        stream.close();
+        // Closure mustn't be passed through
+        Mockito.verify(delegate, Mockito.never()).close();
+        // Writes to the wrapper must fail because that "view" is closed
+        assertThatThrownBy(() -> stream.write(1)).isInstanceOf(IOException.class);
+        // Flush may still be passed through
+        stream.flush();
+        Mockito.verify(delegate).flush();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+}


### PR DESCRIPTION
There's a common pattern where folks use a try-with-resources block on the response stream. While it's generally good practice to close our resources, the webserver is responsible for this one, and closing it in a finally block can prevent us from relaying errors to clients! By blocking close calls to the delegate, we can allow folks to close all the things, while providing accurate failure information to clients :-]

==COMMIT_MSG==
conjure-undertow streamed binary response bodies protect against early closure
==COMMIT_MSG==
