### PR TITLE
add support for triggering callback after auth token has been set

### DIFF
--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureAuthorizationExtractor.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureAuthorizationExtractor.java
@@ -54,9 +54,11 @@ final class ConjureAuthorizationExtractor implements AuthorizationExtractor {
             ErrorType.create(ErrorType.Code.UNAUTHORIZED, "Conjure:MalformedCredentials");
 
     private final PlainSerDe plainSerDe;
+    private final JsonWebTokenHandler jsonWebTokenHandler;
 
-    ConjureAuthorizationExtractor(PlainSerDe plainSerDe) {
+    ConjureAuthorizationExtractor(PlainSerDe plainSerDe, JsonWebTokenHandler jsonWebTokenHandler) {
         this.plainSerDe = plainSerDe;
+        this.jsonWebTokenHandler = jsonWebTokenHandler;
     }
 
     /**
@@ -96,6 +98,9 @@ final class ConjureAuthorizationExtractor implements AuthorizationExtractor {
             jwt.getUnverifiedTokenId().ifPresent(tokenIdSetter);
             jwt.getUnverifiedOrganizationId().ifPresent(organizationIdSetter);
         }
+
+        // may throw
+        jsonWebTokenHandler.handle(exchange, parsedJwt);
     }
 
     /**

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureUndertowRuntime.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureUndertowRuntime.java
@@ -27,15 +27,9 @@ import com.palantir.conjure.java.undertow.lib.MarkerCallback;
 import com.palantir.conjure.java.undertow.lib.PlainSerDe;
 import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
 import com.palantir.logsafe.Preconditions;
-import com.palantir.tokens.auth.AuthHeader;
-import com.palantir.tokens.auth.BearerToken;
-import com.palantir.tokens.auth.UnverifiedJsonWebToken;
-import io.undertow.server.HttpServerExchange;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.function.BiConsumer;
 
 /** {@link ConjureUndertowRuntime} provides functionality required by generated handlers. */
 public final class ConjureUndertowRuntime implements UndertowRuntime {
@@ -52,8 +46,7 @@ public final class ConjureUndertowRuntime implements UndertowRuntime {
                 builder.encodings.isEmpty()
                         ? ImmutableList.of(Encodings.json(), Encodings.smile(), Encodings.cbor())
                         : builder.encodings);
-        this.auth = new OnSetRequestTokenAuthExtractor(
-                new ConjureAuthorizationExtractor(plainSerDe()), builder.onSetRequestToken);
+        this.auth = new ConjureAuthorizationExtractor(plainSerDe(), builder.jsonWebTokenHandler);
         this.exceptionHandler = builder.exceptionHandler;
         this.markerCallback = MarkerCallbacks.fold(builder.paramMarkers);
         this.async = new ConjureAsyncRequestProcessing(builder.asyncTimeout, builder.exceptionHandler);
@@ -104,8 +97,7 @@ public final class ConjureUndertowRuntime implements UndertowRuntime {
         private Duration asyncTimeout = Duration.ofMinutes(3);
         private ExceptionHandler exceptionHandler = ConjureExceptions.INSTANCE;
         private RequestArgHandler requestArgHandler = DefaultRequestArgHandler.INSTANCE;
-        private BiConsumer<HttpServerExchange, Optional<UnverifiedJsonWebToken>> onSetRequestToken =
-                (_exchange, _token) -> {};
+        private JsonWebTokenHandler jsonWebTokenHandler = (_exchange, _token) -> {};
         private final List<Encoding> encodings = new ArrayList<>();
         private final List<ParamMarker> paramMarkers = new ArrayList<>();
 
@@ -142,50 +134,13 @@ public final class ConjureUndertowRuntime implements UndertowRuntime {
         }
 
         @CanIgnoreReturnValue
-        public Builder onSetRequestToken(BiConsumer<HttpServerExchange, Optional<UnverifiedJsonWebToken>> callback) {
-            onSetRequestToken = callback;
+        public Builder jsonWebTokenHandler(JsonWebTokenHandler value) {
+            jsonWebTokenHandler = Preconditions.checkNotNull(value, "jsonWebTokenHandler is required");
             return this;
         }
 
         public ConjureUndertowRuntime build() {
             return new ConjureUndertowRuntime(this);
-        }
-    }
-
-    private static final class OnSetRequestTokenAuthExtractor implements AuthorizationExtractor {
-        private final AuthorizationExtractor delegate;
-        private final BiConsumer<HttpServerExchange, Optional<UnverifiedJsonWebToken>> onSetRequestToken;
-
-        private OnSetRequestTokenAuthExtractor(
-                AuthorizationExtractor delegate,
-                BiConsumer<HttpServerExchange, Optional<UnverifiedJsonWebToken>> onSetRequestToken) {
-            this.delegate = delegate;
-            this.onSetRequestToken = onSetRequestToken;
-        }
-
-        @Override
-        public AuthHeader header(HttpServerExchange exchange) {
-            AuthHeader result = delegate.header(exchange);
-            Optional<UnverifiedJsonWebToken> token = exchange.getAttachment(Attachments.UNVERIFIED_JWT);
-            Preconditions.checkNotNull(token, "jwt in exchange attachment is null");
-            onSetRequestToken.accept(exchange, token);
-            return result;
-        }
-
-        @Override
-        public BearerToken cookie(HttpServerExchange exchange, String cookieName) {
-            BearerToken result = delegate.cookie(exchange, cookieName);
-            Optional<UnverifiedJsonWebToken> token = exchange.getAttachment(Attachments.UNVERIFIED_JWT);
-            Preconditions.checkNotNull(token, "jwt in exchange attachment is null");
-            onSetRequestToken.accept(exchange, token);
-            return result;
-        }
-
-        @Override
-        public void setRequestToken(HttpServerExchange exchange, Optional<UnverifiedJsonWebToken> token) {
-            delegate.setRequestToken(exchange, token);
-            // may throw
-            onSetRequestToken.accept(exchange, token);
         }
     }
 }

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/JsonWebTokenHandler.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/JsonWebTokenHandler.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import com.palantir.tokens.auth.UnverifiedJsonWebToken;
+import io.undertow.server.HttpServerExchange;
+import java.util.Optional;
+
+/**
+ * Configuration point for servers add a callback to be invoked when an auth token
+ * has been parsed, but before the remainder of the request handling proceeds.
+ *
+ * See also {@link ConjureUndertowRuntime.Builder#jsonWebTokenHandler(JsonWebTokenHandler)}.
+ */
+public interface JsonWebTokenHandler {
+    void handle(HttpServerExchange exchange, Optional<UnverifiedJsonWebToken> token);
+}


### PR DESCRIPTION
## Before this PR
Runtime will try to parse and inject an auth token, but provides no mechanism for consumers to apply any extra business logic based on the token value before a handler is actually invoked.

## After this PR
add support for triggering callback after auth token has been set

This allows consumers to hook into the AuthorizationExtractor encapsulated by ConjureUndertowRuntime and make early decisions about request processing based on the extracted token.

The expected use case is to be able to e.g. implement rate limiting or other business logic using data within a JWT that can be done without any extra validation, but should happen just before actual request handlers are invoked.

==COMMIT_MSG==
add support for triggering callback after auth token has been set
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

