### PR TITLE
[Feature] Add Serialization Optimization for Primitive Collection Types

### DIFF
--- a/changelog/@unreleased/pr-2386.v2.yml
+++ b/changelog/@unreleased/pr-2386.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[FR] Add Serialization Optimization for Primitive Collection Types'
+  links:
+  - https://github.com/palantir/conjure-java/pull/2386

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveExample.java
@@ -1,0 +1,181 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.errorprone.annotations.CheckReturnValue;
+import com.palantir.conjure.java.lib.internal.ConjureCollections;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@JsonDeserialize(builder = PrimitiveExample.Builder.class)
+@Generated("com.palantir.conjure.java.types.BeanGenerator")
+public final class PrimitiveExample {
+    private final List<Integer> ints;
+
+    private final List<Double> doubles;
+
+    private int memoizedHashCode;
+
+    private PrimitiveExample(List<Integer> ints, List<Double> doubles) {
+        validateFields(ints, doubles);
+        this.ints = ConjureCollections.unmodifiableList(ints);
+        this.doubles = ConjureCollections.unmodifiableList(doubles);
+    }
+
+    @JsonProperty("ints")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<Integer> getInts() {
+        return this.ints;
+    }
+
+    @JsonProperty("doubles")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<Double> getDoubles() {
+        return this.doubles;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof PrimitiveExample && equalTo((PrimitiveExample) other));
+    }
+
+    private boolean equalTo(PrimitiveExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.ints.equals(other.ints) && this.doubles.equals(other.doubles);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = memoizedHashCode;
+        if (result == 0) {
+            int hash = 1;
+            hash = 31 * hash + this.ints.hashCode();
+            hash = 31 * hash + this.doubles.hashCode();
+            result = hash;
+            memoizedHashCode = result;
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "PrimitiveExample{ints: " + ints + ", doubles: " + doubles + '}';
+    }
+
+    public static PrimitiveExample of(List<Integer> ints, List<Double> doubles) {
+        return builder().ints(ints).doubles(doubles).build();
+    }
+
+    private static void validateFields(List<Integer> ints, List<Double> doubles) {
+        List<String> missingFields = null;
+        missingFields = addFieldIfMissing(missingFields, ints, "ints");
+        missingFields = addFieldIfMissing(missingFields, doubles, "doubles");
+        if (missingFields != null) {
+            throw new SafeIllegalArgumentException(
+                    "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
+        }
+    }
+
+    private static List<String> addFieldIfMissing(List<String> prev, Object fieldValue, String fieldName) {
+        List<String> missingFields = prev;
+        if (fieldValue == null) {
+            if (missingFields == null) {
+                missingFields = new ArrayList<>(2);
+            }
+            missingFields.add(fieldName);
+        }
+        return missingFields;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder {
+        boolean _buildInvoked;
+
+        private List<Integer> ints = ConjureCollections.newNonNullIntegerList();
+
+        private List<Double> doubles = ConjureCollections.newNonNullDoubleList();
+
+        private Builder() {}
+
+        public Builder from(PrimitiveExample other) {
+            checkNotBuilt();
+            ints(other.getInts());
+            doubles(other.getDoubles());
+            return this;
+        }
+
+        @JsonSetter(value = "ints", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
+        public Builder ints(@Nonnull Iterable<Integer> ints) {
+            checkNotBuilt();
+            this.ints =
+                    ConjureCollections.newNonNullIntegerList(Preconditions.checkNotNull(ints, "ints cannot be null"));
+            return this;
+        }
+
+        public Builder addAllInts(@Nonnull Iterable<Integer> ints) {
+            checkNotBuilt();
+            ConjureCollections.addAllAndCheckNonNull(
+                    this.ints, Preconditions.checkNotNull(ints, "ints cannot be null"));
+            return this;
+        }
+
+        public Builder ints(int ints) {
+            checkNotBuilt();
+            Preconditions.checkNotNull(ints, "ints cannot be null");
+            this.ints.add(ints);
+            return this;
+        }
+
+        @JsonSetter(value = "doubles", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
+        public Builder doubles(@Nonnull Iterable<Double> doubles) {
+            checkNotBuilt();
+            this.doubles = ConjureCollections.newNonNullDoubleList(
+                    Preconditions.checkNotNull(doubles, "doubles cannot be null"));
+            return this;
+        }
+
+        public Builder addAllDoubles(@Nonnull Iterable<Double> doubles) {
+            checkNotBuilt();
+            ConjureCollections.addAllAndCheckNonNull(
+                    this.doubles, Preconditions.checkNotNull(doubles, "doubles cannot be null"));
+            return this;
+        }
+
+        public Builder doubles(double doubles) {
+            checkNotBuilt();
+            Preconditions.checkNotNull(doubles, "doubles cannot be null");
+            this.doubles.add(doubles);
+            return this;
+        }
+
+        @CheckReturnValue
+        public PrimitiveExample build() {
+            checkNotBuilt();
+            this._buildInvoked = true;
+            return new PrimitiveExample(ints, doubles);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+        }
+    }
+}

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/NonNullCollectionsTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/NonNullCollectionsTest.java
@@ -25,12 +25,15 @@ import com.fasterxml.jackson.databind.exc.InvalidNullException;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.product.CovariantListExample;
 import com.palantir.product.ListExample;
+import com.palantir.product.PrimitiveExample;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 public class NonNullCollectionsTest {
-    private static final ObjectMapper objectMapper = ObjectMappers.newClientObjectMapper();
+    private static final ObjectMapper clientMapper = ObjectMappers.newClientObjectMapper();
+    private static final ObjectMapper serverMapper = ObjectMappers.newServerJsonMapper();
 
     @Test
     public void throwsNpe() {
@@ -55,7 +58,7 @@ public class NonNullCollectionsTest {
                 .optionalItems(Collections.singleton(Optional.empty()))
                 .build();
 
-        assertThat(objectMapper.readValue(objectMapper.writeValueAsString(listExample), ListExample.class))
+        assertThat(clientMapper.readValue(clientMapper.writeValueAsString(listExample), ListExample.class))
                 .isEqualTo(listExample);
 
         // non-null collections will add "contentNulls = Nulls.FAIL" to the JsonSetter annotation. This will cause deser
@@ -64,12 +67,30 @@ public class NonNullCollectionsTest {
                 .addAllItems(Collections.singleton(Optional.empty()))
                 .build();
         assertThatExceptionOfType(InvalidNullException.class)
-                .isThrownBy(() -> objectMapper.readValue(
-                        objectMapper.writeValueAsString(covariantListExample), CovariantListExample.class));
+                .isThrownBy(() -> clientMapper.readValue(
+                        clientMapper.writeValueAsString(covariantListExample), CovariantListExample.class));
 
         // Similarly, setting a null in the builder also breaks
         assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> CovariantListExample.builder()
                 .addAllItems(Collections.singleton(null))
                 .build());
+    }
+
+    @Test
+    public void testSerDeOptimizationRespectsConjureEmptyCollections() throws JsonProcessingException {
+        PrimitiveExample expected = PrimitiveExample.builder().build();
+        assertThat(clientMapper.writeValueAsString(expected))
+                .describedAs("Does not serialize any empty collections, even when optimizing for primitives")
+                .isEqualTo("{}");
+    }
+
+    @Test
+    public void testSerializationRoundtrip() throws JsonProcessingException {
+        PrimitiveExample expected = PrimitiveExample.builder()
+                .ints(List.of(1, 2, 3))
+                .doubles(List.of(1.1, 2.2, 3.3))
+                .build();
+        String serialized = serverMapper.writeValueAsString(expected);
+        assertThat(expected).isEqualTo(clientMapper.readValue(serialized, PrimitiveExample.class));
     }
 }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
@@ -169,6 +169,21 @@ public final class ObjectGeneratorTests {
     }
 
     @Test
+    public void testObjectGenerator_primitiveCollections() throws IOException {
+        ConjureDefinition def =
+                Conjure.parse(ImmutableList.of(new File("src/test/resources/primitive-collections.yml")));
+        List<Path> files = new GenerationCoordinator(
+                        MoreExecutors.directExecutor(),
+                        ImmutableSet.of(new ObjectGenerator(Options.builder()
+                                .excludeEmptyCollections(true)
+                                .nonNullCollections(true)
+                                .build())))
+                .emit(def, tempDir);
+
+        assertThatFilesAreTheSame(files, REFERENCE_FILES_FOLDER);
+    }
+
+    @Test
     public void testConjureImports() throws IOException {
         ConjureDefinition conjure = Conjure.parse(ImmutableList.of(
                 new File("src/test/resources/example-conjure-imports.yml"),

--- a/conjure-java-core/src/test/resources/primitive-collections.yml
+++ b/conjure-java-core/src/test/resources/primitive-collections.yml
@@ -1,0 +1,8 @@
+types:
+  definitions:
+    default-package: com.palantir.product
+    objects:
+      PrimitiveExample:
+        fields:
+          ints: list<integer>
+          doubles: list<double>

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
@@ -38,8 +38,33 @@ public final class ConjureCollections {
         // cannot instantiate
     }
 
+    /*
+     * This is bizarre. Allow me to explain...
+     *
+     * We do _not_ want to expose the Conjure*List types externally
+     * but we also want the optimizations they provide to make it thru
+     * to jackson for serialization. So the runtime type needs to be
+     * preserved while also not exposing the type :phew:.
+     *
+     * To achieve this we have to do some gymnastics surrounding the type
+     * system. We need this to return the type of the list given, but also
+     * return specific Conjure types when detected. This requires that we
+     * erase the type info, but we know this is safe because we are directly
+     * returning the same type which is by definition the identity function.
+     * Therefore the input List<T> is the same types as the output List<T>.
+     */
     public static <T> List<T> unmodifiableList(List<T> list) {
-        return Collections.unmodifiableList(list);
+        // Return the unmodifiable version of the Eclipse types
+        if (list instanceof ConjureIntegerList) {
+            return (List<T>) ((ConjureIntegerList) list).asUnmodifiable();
+        } else if (list instanceof ConjureDoubleList) {
+            return (List<T>) ((ConjureDoubleList) list).asUnmodifiable();
+        } else if (list instanceof ConjureSafeLongList) {
+            return (List<T>) ((ConjureSafeLongList) list).asUnmodifiable();
+        } else {
+            // Otherwise use the JDK types
+            return Collections.unmodifiableList(list);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureDoubleList.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureDoubleList.java
@@ -16,10 +16,11 @@
 
 package com.palantir.conjure.java.lib.internal;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.AbstractList;
 import java.util.Collection;
 import java.util.RandomAccess;
-import org.eclipse.collections.impl.list.mutable.primitive.DoubleArrayList;
+import org.eclipse.collections.api.list.primitive.MutableDoubleList;
 import org.eclipse.collections.impl.utility.Iterate;
 
 /**
@@ -27,9 +28,9 @@ import org.eclipse.collections.impl.utility.Iterate;
  * a BoxedMutableDoubleList will be released. Once available, ConjureDoubleList should be replaced with that.
  */
 final class ConjureDoubleList extends AbstractList<Double> implements RandomAccess {
-    private final DoubleArrayList delegate;
+    private final MutableDoubleList delegate;
 
-    ConjureDoubleList(DoubleArrayList delegate) {
+    ConjureDoubleList(MutableDoubleList delegate) {
         this.delegate = delegate;
     }
 
@@ -68,5 +69,16 @@ final class ConjureDoubleList extends AbstractList<Double> implements RandomAcce
     @Override
     public Double set(int index, Double element) {
         return delegate.set(index, element);
+    }
+
+    ConjureDoubleList asUnmodifiable() {
+        return new ConjureDoubleList(delegate.asUnmodifiable());
+    }
+
+    // Cannot be named 'toArray' as that conflicts with the #toArray in AbstractList
+    // This is a serialization optimization that avoids boxing, but does copy
+    @JsonValue
+    double[] jacksonSerialize() {
+        return delegate.toArray();
     }
 }

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureIntegerList.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureIntegerList.java
@@ -16,10 +16,11 @@
 
 package com.palantir.conjure.java.lib.internal;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.AbstractList;
 import java.util.Collection;
 import java.util.RandomAccess;
-import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
+import org.eclipse.collections.api.list.primitive.MutableIntList;
 import org.eclipse.collections.impl.utility.Iterate;
 
 /**
@@ -27,9 +28,9 @@ import org.eclipse.collections.impl.utility.Iterate;
  * a BoxedMutableIntList will be released. Once available, ConjureIntegerList should be replaced with that.
  */
 final class ConjureIntegerList extends AbstractList<Integer> implements RandomAccess {
-    private final IntArrayList delegate;
+    private final MutableIntList delegate;
 
-    ConjureIntegerList(IntArrayList delegate) {
+    ConjureIntegerList(MutableIntList delegate) {
         this.delegate = delegate;
     }
 
@@ -68,5 +69,16 @@ final class ConjureIntegerList extends AbstractList<Integer> implements RandomAc
     @Override
     public Integer set(int index, Integer element) {
         return delegate.set(index, element);
+    }
+
+    ConjureIntegerList asUnmodifiable() {
+        return new ConjureIntegerList(delegate.asUnmodifiable());
+    }
+
+    // Cannot be named 'toArray' as that conflicts with the #toArray in AbstractList
+    // This is a serialization optimization that avoids boxing, but does copy
+    @JsonValue
+    int[] jacksonSerialize() {
+        return delegate.toArray();
     }
 }

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureSafeLongList.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureSafeLongList.java
@@ -16,11 +16,12 @@
 
 package com.palantir.conjure.java.lib.internal;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.conjure.java.lib.SafeLong;
 import java.util.AbstractList;
 import java.util.Collection;
 import java.util.RandomAccess;
-import org.eclipse.collections.impl.list.mutable.primitive.LongArrayList;
+import org.eclipse.collections.api.list.primitive.MutableLongList;
 import org.eclipse.collections.impl.utility.Iterate;
 
 /**
@@ -28,9 +29,9 @@ import org.eclipse.collections.impl.utility.Iterate;
  * with SafeLongs.
  */
 final class ConjureSafeLongList extends AbstractList<SafeLong> implements RandomAccess {
-    private final LongArrayList delegate;
+    private final MutableLongList delegate;
 
-    ConjureSafeLongList(LongArrayList delegate) {
+    ConjureSafeLongList(MutableLongList delegate) {
         this.delegate = delegate;
     }
 
@@ -69,5 +70,16 @@ final class ConjureSafeLongList extends AbstractList<SafeLong> implements Random
     @Override
     public SafeLong set(int index, SafeLong element) {
         return SafeLong.of(delegate.set(index, element.longValue()));
+    }
+
+    ConjureSafeLongList asUnmodifiable() {
+        return new ConjureSafeLongList(delegate.asUnmodifiable());
+    }
+
+    // Cannot be named 'toArray' as that conflicts with the #toArray in AbstractList
+    // This is a serialization optimization that avoids boxing, but does copy
+    @JsonValue
+    long[] jacksonSerialize() {
+        return delegate.toArray();
     }
 }


### PR DESCRIPTION
## Before this PR
When Jackson attempted to serialize a primitive collection type, e.g. `ConjureDoubleList`, it utilized Jackon's default serializers, specifically `IndexedListSerializer`. This makes sense when you remember that `ConjureDoubleList` [does not have an implemented serializer](https://github.com/palantir/conjure-java/blob/17ac7361a1d16261dfa119e3ef307b64d8361b58/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureDoubleList.java#L29), so at best its going to be treated like List<Double> at time of serialization. This causes unnecessary boxing no matter how optimally you this collection stores the primitive types. You can see evidence of these points in the debugging screenshot below:

![image](https://github.com/user-attachments/assets/d7010dac-0d07-4f95-ab5e-54332489f8a5)

## After this PR
Adds serialization paths that avoid boxing and directly leverage Jackson primitive serialization routines.

~I purposely didn't implement this feature for `ConjureBooleanList` because it does not have a simple serialized format that benefits from primitive optimization. i.e. it expands a single bit out to `true` or `false` over the wire. Frankly, this type feels like it was added for completeness and not for usefulness. A dense `boolean[]` is abstractly a bit mask and if that is the intent should have its own type. I think the existence of this class is just maintenance overhead at this point.~ This has been removed https://github.com/palantir/conjure-java/pull/2390

## Possible downsides?
Creates an alternative path for serialization that needs to match the default serialization paths.

