### PR TITLE
[Feature] Non-boxing 'addAll' Methods for Primitive Types

### DIFF
--- a/changelog/@unreleased/pr-2389.v2.yml
+++ b/changelog/@unreleased/pr-2389.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: '[Feature] Non-boxing ''addAll'' Methods for Primitive Types'
+  links:
+  - https://github.com/palantir/conjure-java/pull/2389

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
@@ -234,6 +234,13 @@ public final class ListExample {
             return this;
         }
 
+        public Builder addAllPrimitiveItems(@Nonnull int... primitiveItems) {
+            checkNotBuilt();
+            ConjureCollections.addAllToIntegerList(
+                    this.primitiveItems, Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
+            return this;
+        }
+
         public Builder addAllPrimitiveItems(@Nonnull Iterable<Integer> primitiveItems) {
             checkNotBuilt();
             ConjureCollections.addAllAndCheckNonNull(
@@ -253,6 +260,13 @@ public final class ListExample {
             checkNotBuilt();
             this.doubleItems = ConjureCollections.newNonNullDoubleList(
                     Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
+            return this;
+        }
+
+        public Builder addAllDoubleItems(@Nonnull double... doubleItems) {
+            checkNotBuilt();
+            ConjureCollections.addAllToDoubleList(
+                    this.doubleItems, Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null"));
             return this;
         }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderAuxiliarySettersUtils.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderAuxiliarySettersUtils.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.java.types;
 
 import com.palantir.conjure.java.ConjureAnnotations;
+import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.conjure.java.types.BeanGenerator.EnrichedField;
 import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.java.util.Primitives;
@@ -28,6 +29,7 @@ import com.palantir.conjure.spec.OptionalType;
 import com.palantir.conjure.spec.PrimitiveType;
 import com.palantir.conjure.spec.Type;
 import com.palantir.conjure.visitor.TypeVisitor;
+import com.palantir.javapoet.ArrayTypeName;
 import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.CodeBlock;
 import com.palantir.javapoet.FieldSpec;
@@ -39,11 +41,43 @@ import java.util.Optional;
 import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
 
-public final class BeanBuilderAuxiliarySettersUtils {
+final class BeanBuilderAuxiliarySettersUtils {
 
     private BeanBuilderAuxiliarySettersUtils() {}
 
-    public static MethodSpec.Builder createCollectionSetterBuilder(
+    static MethodSpec.Builder createPrimitiveCollectionSetterBuilder(
+            EnrichedField enriched, TypeMapper typeMapper, ClassName returnClass, SafetyEvaluator safetyEvaluator) {
+        FieldSpec field = enriched.poetSpec();
+        FieldDefinition definition = enriched.conjureDef();
+        TypeName innerTypeName = extractInnerTypeFromList(definition, typeMapper, safetyEvaluator);
+
+        return MethodSpec.methodBuilder("addAll" + StringUtils.capitalize(field.name()))
+                .addJavadoc(Javadoc.render(definition.getDocs(), definition.getDeprecated())
+                        .map(rendered -> CodeBlock.of("$L", rendered))
+                        .orElseGet(() -> CodeBlock.builder().build()))
+                .addAnnotations(ConjureAnnotations.deprecation(definition.getDeprecated()))
+                .addModifiers(Modifier.PUBLIC)
+                // Forces the array argument to instead be variadic
+                .varargs()
+                .addParameter(Parameters.nonnullParameter(ArrayTypeName.of(innerTypeName), field.name()))
+                .returns(returnClass);
+    }
+
+    private static TypeName extractInnerTypeFromList(
+            FieldDefinition conjureDef, TypeMapper typeMapper, SafetyEvaluator safetyEvaluator) {
+        Type innerType = conjureDef.getType().accept(TypeVisitor.LIST).getItemType();
+        TypeName boxedTypeName = typeMapper.getClassName(innerType);
+
+        // SafeLong is just a special case of long
+        if (boxedTypeName.equals(ClassName.get(SafeLong.class))) {
+            return ConjureAnnotations.withSafety(TypeName.LONG, safetyEvaluator.getUsageTimeSafety(conjureDef));
+        } else {
+            return ConjureAnnotations.withSafety(
+                    Primitives.unbox(boxedTypeName), safetyEvaluator.getUsageTimeSafety(conjureDef));
+        }
+    }
+
+    static MethodSpec.Builder createCollectionSetterBuilder(
             String prefix,
             EnrichedField enriched,
             TypeMapper typeMapper,
@@ -66,7 +100,7 @@ public final class BeanBuilderAuxiliarySettersUtils {
                         field.name()));
     }
 
-    public static MethodSpec.Builder createOptionalSetterBuilder(
+    static MethodSpec.Builder createOptionalSetterBuilder(
             EnrichedField enriched, TypeMapper typeMapper, ClassName returnClass, SafetyEvaluator safetyEvaluator) {
         FieldSpec field = enriched.poetSpec();
         OptionalType type = enriched.conjureDef().getType().accept(TypeVisitor.OPTIONAL);
@@ -78,7 +112,7 @@ public final class BeanBuilderAuxiliarySettersUtils {
                         field.name()));
     }
 
-    public static MethodSpec.Builder createItemSetterBuilder(
+    static MethodSpec.Builder createItemSetterBuilder(
             EnrichedField enriched,
             Type itemType,
             TypeMapper typeMapper,
@@ -89,7 +123,7 @@ public final class BeanBuilderAuxiliarySettersUtils {
                 .addParameter(ConjureAnnotations.withSafety(typeMapper.getClassName(itemType), safety), field.name());
     }
 
-    public static MethodSpec.Builder createMapSetterBuilder(
+    static MethodSpec.Builder createMapSetterBuilder(
             EnrichedField enriched, TypeMapper typeMapper, ClassName returnClass) {
         MapType type = enriched.conjureDef().getType().accept(TypeVisitor.MAP);
         return publicSetter(enriched, returnClass)
@@ -97,7 +131,7 @@ public final class BeanBuilderAuxiliarySettersUtils {
                 .addParameter(typeMapper.getClassName(type.getValueType()), "value");
     }
 
-    public static MethodSpec.Builder publicSetter(EnrichedField enriched, ClassName returnClass) {
+    static MethodSpec.Builder publicSetter(EnrichedField enriched, ClassName returnClass) {
         FieldDefinition definition = enriched.conjureDef();
         return MethodSpec.methodBuilder(enriched.poetSpec().name())
                 .addJavadoc(Javadoc.render(definition.getDocs(), definition.getDeprecated())
@@ -108,7 +142,7 @@ public final class BeanBuilderAuxiliarySettersUtils {
                 .returns(returnClass);
     }
 
-    public static TypeName widenParameterIfPossible(
+    static TypeName widenParameterIfPossible(
             TypeName current, Type type, TypeMapper typeMapper, Optional<LogSafety> safety) {
         if (type.accept(TypeVisitor.IS_LIST)) {
             Type innerType = type.accept(TypeVisitor.LIST).getItemType();
@@ -147,7 +181,7 @@ public final class BeanBuilderAuxiliarySettersUtils {
 
     // we want to widen containers of anything that's not a primitive, a conjure reference or an optional
     // since we know all of those are final.
-    public static boolean isWidenableContainedType(Type containedType) {
+    static boolean isWidenableContainedType(Type containedType) {
         return containedType.accept(new DefaultTypeVisitor<Boolean>() {
             @Override
             public Boolean visitPrimitive(PrimitiveType value) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -671,6 +671,26 @@ public final class BeanBuilderGenerator {
                 .build();
     }
 
+    private MethodSpec createPrimitiveCollectionSetter(EnrichedField enriched, boolean override) {
+        FieldSpec field = enriched.poetSpec();
+        Type type = enriched.conjureDef().getType();
+
+        CollectionType collectionType = getCollectionType(type);
+        return BeanBuilderAuxiliarySettersUtils.createPrimitiveCollectionSetterBuilder(
+                        enriched, typeMapper, builderClass, safetyEvaluator)
+                .addAnnotations(ConjureAnnotations.override(override))
+                .addCode(verifyNotBuilt())
+                .addCode(CodeBlocks.statement(
+                        "$1T.addAllTo$2L(this.$3N, $4L)",
+                        ConjureCollections.class,
+                        collectionType.getConjureCollectionType().getCollectionName(),
+                        field.name(),
+                        Expressions.requireNonNull(
+                                field.name(), enriched.fieldName().get() + " cannot be null")))
+                .addStatement("return this")
+                .build();
+    }
+
     @SuppressWarnings("checkstyle:CyclomaticComplexity")
     private CodeBlock typeAwareAssignment(EnrichedField enriched, Type type, boolean shouldClearFirst) {
         FieldSpec spec = enriched.poetSpec();
@@ -767,10 +787,19 @@ public final class BeanBuilderGenerator {
         Type type = enriched.conjureDef().getType();
         Optional<LogSafety> safety = safetyEvaluator.getUsageTimeSafety(enriched.conjureDef());
 
+        ImmutableList.Builder<MethodSpec> builder = ImmutableList.builder();
+
         if (type.accept(TypeVisitor.IS_LIST)) {
-            return ImmutableList.of(
+            CollectionType collectionType = getCollectionType(type);
+            if (collectionType.getConjureCollectionType().isPrimitiveCollection()
+                    && collectionType.useNonNullFactory()) {
+                builder.add(createPrimitiveCollectionSetter(enriched, override));
+            }
+
+            builder.add(
                     createCollectionSetter("addAll", enriched, override),
                     createItemSetter(enriched, type.accept(TypeVisitor.LIST).getItemType(), override, safety));
+            return builder.build();
         }
 
         if (type.accept(TypeVisitor.IS_SET)) {
@@ -822,7 +851,9 @@ public final class BeanBuilderGenerator {
     private static final EnumSet<PrimitiveType.Value> OPTIONAL_PRIMITIVES =
             EnumSet.of(PrimitiveType.Value.INTEGER, PrimitiveType.Value.DOUBLE, PrimitiveType.Value.BOOLEAN);
 
-    /** Check if the optionalType contains a primitive boolean, double or integer. */
+    /**
+     * Check if the optionalType contains a primitive boolean, double or integer.
+     */
     private boolean isPrimitiveOptional(OptionalType optionalType) {
         return optionalType.getItemType().accept(TypeVisitor.IS_PRIMITIVE)
                 && OPTIONAL_PRIMITIVES.contains(
@@ -1041,24 +1072,37 @@ public final class BeanBuilderGenerator {
     }
 
     private enum ConjureCollectionType {
-        LIST("List"),
-        DOUBLE_LIST("DoubleList"),
-        INTEGER_LIST("IntegerList"),
+        LIST("List", false),
+        DOUBLE_LIST("DoubleList", true),
+        INTEGER_LIST("IntegerList", true),
         // Eclipse has a BooleanList type, but this use case implies
         // bit mask and it doesn't serialize efficiently as a collection
         // so let's just use the "naive" boxed collection
-        BOOLEAN_LIST("List"),
-        SAFE_LONG_LIST("SafeLongList"),
-        SET("Set");
+        BOOLEAN_LIST("List", false),
+        // SafeLong is unique in this list. While it is technically backed with a long
+        // its logical limitations are captured in the boxed type SafeLong. Meaning,
+        // you must either expose this "implementation detail" on the public API or
+        // accept that you cannot optimize away the boxing. For now, given the focus
+        // on doubles, let's delay this optimization and have it as a separate discussion.
+        // Technically this type could be optimized at rest, but that would require a more
+        // complex enum to represent this trinary. So for now this is disabled.
+        SAFE_LONG_LIST("SafeLongList", false),
+        SET("Set", false);
 
         private final String collectionName;
+        private final Boolean primitiveCollection;
 
-        ConjureCollectionType(String collectionName) {
+        ConjureCollectionType(String collectionName, boolean primitiveCollection) {
             this.collectionName = collectionName;
+            this.primitiveCollection = primitiveCollection;
         }
 
         public String getCollectionName() {
             return collectionName;
+        }
+
+        public Boolean isPrimitiveCollection() {
+            return primitiveCollection;
         }
     }
 

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/SafeLong.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/SafeLong.java
@@ -26,9 +26,6 @@ public final class SafeLong implements Comparable<SafeLong> {
     private static final long MIN_SAFE_VALUE = -(1L << 53) + 1;
     private static final long MAX_SAFE_VALUE = (1L << 53) - 1;
 
-    public static final SafeLong MAX_VALUE = SafeLong.of(MAX_SAFE_VALUE);
-    public static final SafeLong MIN_VALUE = SafeLong.of(MIN_SAFE_VALUE);
-
     private final long longValue;
 
     private SafeLong(long longValue) {

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
@@ -170,8 +170,12 @@ public final class ConjureCollections {
 
     // This method modifies a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
     public static void addAllToDoubleList(Collection<Double> addTo, double[] elementsToAdd) {
-        for (double el : elementsToAdd) {
-            addTo.add(el);
+        if (addTo instanceof ConjureDoubleList) {
+            ((ConjureDoubleList) addTo).addAll(elementsToAdd);
+        } else {
+            for (double el : elementsToAdd) {
+                addTo.add(el);
+            }
         }
     }
 
@@ -195,8 +199,12 @@ public final class ConjureCollections {
 
     // This method modifies a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
     public static void addAllToIntegerList(Collection<Integer> addTo, int[] elementsToAdd) {
-        for (int el : elementsToAdd) {
-            addTo.add(el);
+        if (addTo instanceof ConjureIntegerList) {
+            ((ConjureIntegerList) addTo).addAll(elementsToAdd);
+        } else {
+            for (int el : elementsToAdd) {
+                addTo.add(el);
+            }
         }
     }
 

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureDoubleList.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureDoubleList.java
@@ -55,6 +55,10 @@ final class ConjureDoubleList extends AbstractList<Double> implements RandomAcce
         return delegate.addAllAtIndex(index, target);
     }
 
+    void addAll(double[] source) {
+        this.delegate.addAll(source);
+    }
+
     @Override
     public Double remove(int index) {
         return delegate.removeAtIndex(index);

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureIntegerList.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureIntegerList.java
@@ -55,6 +55,10 @@ final class ConjureIntegerList extends AbstractList<Integer> implements RandomAc
         return delegate.addAllAtIndex(index, target);
     }
 
+    void addAll(int[] source) {
+        this.delegate.addAll(source);
+    }
+
     @Override
     public Integer remove(int index) {
         return delegate.removeAtIndex(index);


### PR DESCRIPTION
## Before this PR
This is an alternative variant of https://github.com/palantir/conjure-java/pull/2312 which attempts to fix the boxing overhead merely introduced by the shape of our API (primitive types on both sides of the abstraction). However, there was some objection to that approach due to some stylistic and API design disagreements. This alternative seeks to remedy some of those concerns by following some "prior art" from libraries we accept / use all the time - Immutables.

Immutables will generate a vararg `addAll` variant for a `List` collection of some primitive boxed type. For example, `List<Double>` will produce something like:

```
public final Builder addField(double... elements)
```

## After this PR
This change first punches a hole through from the underlying eclipse-collections types e.g. `DoubleList` which has routines like `public boolean addAll(double... source)` which allow for direct, non-boxed, additions to the type.

Then, taking Immutables as inspiration, I wired up our codegen to leverage this abstraction. This alternative design addresses the mutability concerns as this API clearly communicates how data will be owned moving forward (i.e. copied). This implementation also addresses the concerns of having a setter that resets the type may cause order of operations bugs in the field while populating the builder.

## Of Note
Yes... I am aware that the `Iterable` variant is a setter in the builder e.g.:

```
@JsonSetter(value = "primitiveItems", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
public Builder primitiveItems(@Nonnull Iterable<Integer> primitiveItems) {
        checkNotBuilt();
        this.primitiveItems = ConjureCollections.newNonNullIntegerList(
                Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null"));
        return this;
}
```

This feels like a design oversight (IMO) seeing as how `primitiveItems` is already initialized statically and `newNonNullIntegerList` simply performs a copy using `addAll`. Removing it from the field will be considerable work, so this will need to be inconsistent for the time being. And also previous design deficiencies cannot justify future designs.

## Tangent
Sorry if this is getting off topic, but that `Iterable` variant seems destined to be used incorrectly. Imagine the following code:

```java
// Has a field List<String> items
SomeConjureObject.Builder builder = SomeConjureObject.builder();
String firstToAdd = "first";
List<String> someOtherStrings = List.of(...);

// Clearly an adder
builder.items(firstToAdd);
// Adder? Setter? Setter! No longer contains firstToAdd
builder.items(someOtherStrings);

// Or how about this
// Imagine your code starts off like this
String firstToAdd = "first";
String secondToAdd = someMethod();
builder.items(firstToAdd);
builder.items(secondToAdd);

// But later the API of someMethod changes and now returns a List<String>
// the type checker is happy but now (below) is a setter and no longer
// contains firstToAdd
builder.items(secondToAdd);
```

Either way, necessary or not, I do not love the invalid state that is further representable on this API by adding an additional similarly named setter.