### PR TITLE
nit: Use value from Optional.map lambda closure

### DIFF
--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/Javadoc.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/Javadoc.java
@@ -82,7 +82,7 @@ public final class Javadoc {
                         + JavaNameSanitizer.sanitizeParameterName(
                                 argument.getArgName().get(), endpoint)
                         + " "
-                        + Javadoc.render(argument.getDocs().get()));
+                        + Javadoc.render(docs));
     }
 
     public static String getRequestLine(HttpMethod httpMethod, HttpPath httpPath) {


### PR DESCRIPTION
## After this PR

[Drive-by from this PR](https://github.com/palantir/conjure-java/pull/2401#discussion_r1834982968)

Instead of recomputing the value from the Optional, use the value from Optional.map lambda closure.
< no changelog >
