### PR TITLE
[Improvement] Leverage List Creation Facade for Future Optimizations

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestObject.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CollectionsTestObject.java
@@ -50,7 +50,7 @@ public final class CollectionsTestObject {
             CollectionsTestAliasSet aset,
             CollectionsTestAliasMap amap) {
         validateFields(items, itemsMap, optionalItem, itemsSet, alist, aset, amap);
-        this.items = Collections.unmodifiableList(items);
+        this.items = ConjureCollections.unmodifiableList(items);
         this.itemsMap = Collections.unmodifiableMap(itemsMap);
         this.optionalItem = optionalItem;
         this.itemsSet = Collections.unmodifiableSet(itemsSet);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/CovariantListExample.java
@@ -10,7 +10,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -28,8 +27,8 @@ public final class CovariantListExample {
 
     private CovariantListExample(List<Object> items, List<ExampleExternalReference> externalItems) {
         validateFields(items, externalItems);
-        this.items = Collections.unmodifiableList(items);
-        this.externalItems = Collections.unmodifiableList(externalItems);
+        this.items = ConjureCollections.unmodifiableList(items);
+        this.externalItems = ConjureCollections.unmodifiableList(externalItems);
     }
 
     @JsonProperty("items")

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongExample.java
@@ -11,7 +11,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -34,7 +33,7 @@ public final class ExternalLongExample {
         validateFields(optionalExternalLong, listExternalLong);
         this.externalLong = externalLong;
         this.optionalExternalLong = optionalExternalLong;
-        this.listExternalLong = Collections.unmodifiableList(listExternalLong);
+        this.listExternalLong = ConjureCollections.unmodifiableList(listExternalLong);
     }
 
     @JsonProperty("externalLong")

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ListExample.java
@@ -11,7 +11,6 @@ import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -47,13 +46,13 @@ public final class ListExample {
             List<List<String>> nestedItems) {
         validateFields(
                 items, primitiveItems, doubleItems, booleanItems, optionalItems, aliasOptionalItems, nestedItems);
-        this.items = Collections.unmodifiableList(items);
-        this.primitiveItems = Collections.unmodifiableList(primitiveItems);
-        this.doubleItems = Collections.unmodifiableList(doubleItems);
-        this.booleanItems = Collections.unmodifiableList(booleanItems);
-        this.optionalItems = Collections.unmodifiableList(optionalItems);
-        this.aliasOptionalItems = Collections.unmodifiableList(aliasOptionalItems);
-        this.nestedItems = Collections.unmodifiableList(nestedItems);
+        this.items = ConjureCollections.unmodifiableList(items);
+        this.primitiveItems = ConjureCollections.unmodifiableList(primitiveItems);
+        this.doubleItems = ConjureCollections.unmodifiableList(doubleItems);
+        this.booleanItems = ConjureCollections.unmodifiableList(booleanItems);
+        this.optionalItems = ConjureCollections.unmodifiableList(optionalItems);
+        this.aliasOptionalItems = ConjureCollections.unmodifiableList(aliasOptionalItems);
+        this.nestedItems = ConjureCollections.unmodifiableList(nestedItems);
     }
 
     @JsonProperty("items")

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ManyFieldExample.java
@@ -56,7 +56,7 @@ public final class ManyFieldExample {
         this.integer = integer;
         this.doubleValue = doubleValue;
         this.optionalItem = optionalItem;
-        this.items = Collections.unmodifiableList(items);
+        this.items = ConjureCollections.unmodifiableList(items);
         this.set = Collections.unmodifiableSet(set);
         this.map = Collections.unmodifiableMap(map);
         this.alias = alias;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleFieldsOnlyFinalStage.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/MultipleFieldsOnlyFinalStage.java
@@ -53,11 +53,11 @@ public final class MultipleFieldsOnlyFinalStage {
             Optional<String> optionalItemOld,
             Set<String> itemsSetOld) {
         validateFields(items, itemsMap, optionalItem, itemsSet, itemsOld, itemsMapOld, optionalItemOld, itemsSetOld);
-        this.items = Collections.unmodifiableList(items);
+        this.items = ConjureCollections.unmodifiableList(items);
         this.itemsMap = Collections.unmodifiableMap(itemsMap);
         this.optionalItem = optionalItem;
         this.itemsSet = Collections.unmodifiableSet(itemsSet);
-        this.itemsOld = Collections.unmodifiableList(itemsOld);
+        this.itemsOld = ConjureCollections.unmodifiableList(itemsOld);
         this.itemsMapOld = Collections.unmodifiableMap(itemsMapOld);
         this.optionalItemOld = optionalItemOld;
         this.itemsSetOld = Collections.unmodifiableSet(itemsSetOld);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeExternalLongExample.java
@@ -43,7 +43,7 @@ public final class SafeExternalLongExample {
         validateFields(optionalSafeExternalLong, safeExternalLongList, safeExternalLongSet);
         this.safeExternalLongValue = safeExternalLongValue;
         this.optionalSafeExternalLong = optionalSafeExternalLong;
-        this.safeExternalLongList = Collections.unmodifiableList(safeExternalLongList);
+        this.safeExternalLongList = ConjureCollections.unmodifiableList(safeExternalLongList);
         this.safeExternalLongSet = Collections.unmodifiableSet(safeExternalLongSet);
     }
 

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongExample.java
@@ -11,7 +11,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -29,7 +28,7 @@ public final class SafeLongExample {
     private SafeLongExample(SafeLong safeLongValue, List<SafeLong> safeLongList) {
         validateFields(safeLongValue, safeLongList);
         this.safeLongValue = safeLongValue;
-        this.safeLongList = Collections.unmodifiableList(safeLongList);
+        this.safeLongList = ConjureCollections.unmodifiableList(safeLongList);
     }
 
     @JsonProperty("safeLongValue")

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StrictFourFields.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StrictFourFields.java
@@ -44,7 +44,7 @@ public final class StrictFourFields {
             Optional<String> optionalItem,
             Map<ResourceIdentifier, String> mappedRids) {
         validateFields(myList, bearerTokenValue, optionalItem, mappedRids);
-        this.myList = Collections.unmodifiableList(myList);
+        this.myList = ConjureCollections.unmodifiableList(myList);
         this.bearerTokenValue = bearerTokenValue;
         this.optionalItem = optionalItem;
         this.mappedRids = Collections.unmodifiableMap(mappedRids);

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StrictMultipleDeprecatedAndUnsafeFields.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StrictMultipleDeprecatedAndUnsafeFields.java
@@ -55,7 +55,7 @@ public final class StrictMultipleDeprecatedAndUnsafeFields {
             Map<ResourceIdentifier, String> mappedRids,
             StrictFourFields strictFourFieldsObject) {
         validateFields(myList, bearerTokenValue, safeLongValue, optionalItem, mappedRids, strictFourFieldsObject);
-        this.myList = Collections.unmodifiableList(myList);
+        this.myList = ConjureCollections.unmodifiableList(myList);
         this.bearerTokenValue = bearerTokenValue;
         this.safeLongValue = safeLongValue;
         this.myInteger = myInteger;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StrictOneCollectionField.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StrictOneCollectionField.java
@@ -11,7 +11,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -26,7 +25,7 @@ public final class StrictOneCollectionField {
 
     private StrictOneCollectionField(List<String> myList) {
         validateFields(myList);
-        this.myList = Collections.unmodifiableList(myList);
+        this.myList = ConjureCollections.unmodifiableList(myList);
     }
 
     @JsonProperty("myList")

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/StrictThreeFields.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/StrictThreeFields.java
@@ -14,7 +14,6 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.tokens.auth.BearerToken;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -35,7 +34,7 @@ public final class StrictThreeFields {
 
     private StrictThreeFields(List<String> myList, BearerToken bearerTokenValue, Optional<String> optionalItem) {
         validateFields(myList, bearerTokenValue, optionalItem);
-        this.myList = Collections.unmodifiableList(myList);
+        this.myList = ConjureCollections.unmodifiableList(myList);
         this.bearerTokenValue = bearerTokenValue;
         this.optionalItem = optionalItem;
     }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/CovariantListExample.java
@@ -11,7 +11,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -29,8 +28,8 @@ public final class CovariantListExample {
 
     private CovariantListExample(List<Object> items, List<ExampleExternalReference> externalItems) {
         validateFields(items, externalItems);
-        this.items = Collections.unmodifiableList(items);
-        this.externalItems = Collections.unmodifiableList(externalItems);
+        this.items = ConjureCollections.unmodifiableList(items);
+        this.externalItems = ConjureCollections.unmodifiableList(externalItems);
     }
 
     @JsonProperty("items")

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongExample.java
@@ -12,7 +12,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -35,7 +34,7 @@ public final class ExternalLongExample {
         validateFields(optionalExternalLong, listExternalLong);
         this.externalLong = externalLong;
         this.optionalExternalLong = optionalExternalLong;
-        this.listExternalLong = Collections.unmodifiableList(listExternalLong);
+        this.listExternalLong = ConjureCollections.unmodifiableList(listExternalLong);
     }
 
     @JsonProperty("externalLong")

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ListExample.java
@@ -12,7 +12,6 @@ import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -48,13 +47,13 @@ public final class ListExample {
             List<List<String>> nestedItems) {
         validateFields(
                 items, primitiveItems, doubleItems, booleanItems, optionalItems, aliasOptionalItems, nestedItems);
-        this.items = Collections.unmodifiableList(items);
-        this.primitiveItems = Collections.unmodifiableList(primitiveItems);
-        this.doubleItems = Collections.unmodifiableList(doubleItems);
-        this.booleanItems = Collections.unmodifiableList(booleanItems);
-        this.optionalItems = Collections.unmodifiableList(optionalItems);
-        this.aliasOptionalItems = Collections.unmodifiableList(aliasOptionalItems);
-        this.nestedItems = Collections.unmodifiableList(nestedItems);
+        this.items = ConjureCollections.unmodifiableList(items);
+        this.primitiveItems = ConjureCollections.unmodifiableList(primitiveItems);
+        this.doubleItems = ConjureCollections.unmodifiableList(doubleItems);
+        this.booleanItems = ConjureCollections.unmodifiableList(booleanItems);
+        this.optionalItems = ConjureCollections.unmodifiableList(optionalItems);
+        this.aliasOptionalItems = ConjureCollections.unmodifiableList(aliasOptionalItems);
+        this.nestedItems = ConjureCollections.unmodifiableList(nestedItems);
     }
 
     @JsonProperty("items")

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ManyFieldExample.java
@@ -57,7 +57,7 @@ public final class ManyFieldExample {
         this.integer = integer;
         this.doubleValue = doubleValue;
         this.optionalItem = optionalItem;
-        this.items = Collections.unmodifiableList(items);
+        this.items = ConjureCollections.unmodifiableList(items);
         this.set = Collections.unmodifiableSet(set);
         this.map = Collections.unmodifiableMap(map);
         this.alias = alias;

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeExternalLongExample.java
@@ -44,7 +44,7 @@ public final class SafeExternalLongExample {
         validateFields(optionalSafeExternalLong, safeExternalLongList, safeExternalLongSet);
         this.safeExternalLongValue = safeExternalLongValue;
         this.optionalSafeExternalLong = optionalSafeExternalLong;
-        this.safeExternalLongList = Collections.unmodifiableList(safeExternalLongList);
+        this.safeExternalLongList = ConjureCollections.unmodifiableList(safeExternalLongList);
         this.safeExternalLongSet = Collections.unmodifiableSet(safeExternalLongSet);
     }
 

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeLongExample.java
@@ -12,7 +12,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -30,7 +29,7 @@ public final class SafeLongExample {
     private SafeLongExample(SafeLong safeLongValue, List<SafeLong> safeLongList) {
         validateFields(safeLongValue, safeLongList);
         this.safeLongValue = safeLongValue;
-        this.safeLongList = Collections.unmodifiableList(safeLongList);
+        this.safeLongList = ConjureCollections.unmodifiableList(safeLongList);
     }
 
     @JsonProperty("safeLongValue")

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Iterables;
 import com.palantir.conjure.CaseConverter;
 import com.palantir.conjure.java.ConjureAnnotations;
 import com.palantir.conjure.java.Options;
+import com.palantir.conjure.java.lib.internal.ConjureCollections;
 import com.palantir.conjure.java.util.JavaNameSanitizer;
 import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.java.util.Packages;
@@ -259,7 +260,7 @@ public final class BeanGenerator {
             // is private and necessarily called from the builder, which does its own defensive copying.
             if (field.conjureDef().getType().accept(TypeVisitor.IS_LIST)) {
                 // TODO(melliot): contribute a fix to JavaPoet that parses $T correctly for a JavaPoet FieldSpec
-                body.addStatement("this.$1N = $2T.unmodifiableList($1N)", spec, Collections.class);
+                body.addStatement("this.$1N = $2T.unmodifiableList($1N)", spec, ConjureCollections.class);
             } else if (field.conjureDef().getType().accept(TypeVisitor.IS_SET)) {
                 body.addStatement("this.$1N = $2T.unmodifiableSet($1N)", spec, Collections.class);
             } else if (field.conjureDef().getType().accept(TypeVisitor.IS_MAP)) {


### PR DESCRIPTION
## Before this PR
Unmodifiable lists were created using `Collections.unmodifiableList` which forces the returned type to be a `List<T>`

## After this PR
Leverages a facade through `ConjureCollections.unmodifiableList` which will allow us to route through some [later Jackson optimizations](https://github.com/palantir/conjure-java/pull/2386/files#diff-c7c23a70bf9b00504cc05e26d2bb08a161f4e036eadd36cd0e13efbbddb4e02cR56).

