### PR TITLE
Produce a 4xx response code when clients disconnect

### DIFF
--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encodings.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Encodings.java
@@ -28,7 +28,6 @@ import com.palantir.conjure.java.undertow.lib.TypeMarker;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
-import com.palantir.logsafe.exceptions.SafeIoException;
 import java.io.IOException;
 
 // TODO(rfink): Consider async Jackson, see
@@ -72,7 +71,15 @@ public final class Encodings {
             ObjectWriter writer = mapper.writerFor(mapper.constructType(type.getType()));
             return (value, output) -> {
                 Preconditions.checkNotNull(value, "cannot serialize null value");
-                writer.writeValue(output, value);
+                try {
+                    writer.writeValue(output, value);
+                } catch (IOException e) {
+                    throw FrameworkException.ioFailure(
+                            "Failed to serialize and write response",
+                            e,
+                            SafeArg.of("contentType", getContentType()),
+                            SafeArg.of("type", type));
+                }
             };
         }
 
@@ -109,7 +116,7 @@ public final class Encodings {
                             SafeArg.of("contentType", getContentType()),
                             SafeArg.of("type", type));
                 } catch (IOException e) {
-                    throw new SafeIoException(
+                    throw FrameworkException.ioFailure(
                             "Failed to deserialize request",
                             e,
                             SafeArg.of("contentType", getContentType()),

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/FrameworkException.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/FrameworkException.java
@@ -19,10 +19,12 @@ package com.palantir.conjure.java.undertow.runtime;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.ErrorType.Code;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeLoggable;
 import io.undertow.util.StatusCodes;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /** Internal type to signal a conjure protocol-level failure with a specific response code. */
 final class FrameworkException extends RuntimeException implements SafeLoggable {
@@ -31,6 +33,7 @@ final class FrameworkException extends RuntimeException implements SafeLoggable 
             ErrorType.create(ErrorType.Code.INVALID_ARGUMENT, "Conjure:UnprocessableEntity");
     private static final ErrorType UNSUPPORTED_MEDIA_TYPE =
             ErrorType.create(ErrorType.Code.INVALID_ARGUMENT, "Conjure:UnsupportedMediaType");
+    private static final ErrorType IO_ERROR = ErrorType.create(Code.CUSTOM_CLIENT, "Conjure:Io");
 
     private final String logMessage;
     private final List<Arg<?>> arguments;
@@ -52,6 +55,11 @@ final class FrameworkException extends RuntimeException implements SafeLoggable 
 
     static FrameworkException unsupportedMediaType(@CompileTimeConstant String message, Arg<?>... args) {
         return new FrameworkException(message, UNSUPPORTED_MEDIA_TYPE, StatusCodes.UNSUPPORTED_MEDIA_TYPE, null, args);
+    }
+
+    static FrameworkException ioFailure(
+            @CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... args) {
+        return new FrameworkException(message, IO_ERROR, IO_ERROR.httpErrorCode(), cause, args);
     }
 
     @Override

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/EncodingsTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/EncodingsTest.java
@@ -203,6 +203,51 @@ final class EncodingsTest {
         assertThat(smile.supportsContentType("application/unknown")).isFalse();
     }
 
+    @Test
+    void deserializeIoExceptionIsClientError() {
+        assertThatThrownBy(() -> deserialize(new ThrowingInputStream(), new TypeMarker<String>() {}))
+                .isInstanceOf(FrameworkException.class)
+                .hasMessageContaining("Failed to deserialize")
+                .matches(exception -> ((FrameworkException) exception).getStatusCode() == 400, "Expected 400 status");
+    }
+
+    @Test
+    void serializeIoExceptionIsClientError() {
+        assertThatThrownBy(() -> serialize("value", new ThrowingOutputStream()))
+                .isInstanceOf(FrameworkException.class)
+                .hasMessageContaining("Failed to serialize")
+                .matches(exception -> ((FrameworkException) exception).getStatusCode() == 400, "Expected 400 status");
+    }
+
+    private static final class ThrowingInputStream extends InputStream {
+
+        private static IOException fail() {
+            return new IOException("expected");
+        }
+
+        @Override
+        public int read() throws IOException {
+            throw fail();
+        }
+
+        @Override
+        public int read(byte[] _buffer, int _off, int _len) throws IOException {
+            throw fail();
+        }
+    }
+
+    private static final class ThrowingOutputStream extends OutputStream {
+
+        private static IOException fail() {
+            return new IOException("expected");
+        }
+
+        @Override
+        public void write(int _value) throws IOException {
+            throw fail();
+        }
+    }
+
     private static InputStream asStream(String data) {
         return new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
     }


### PR DESCRIPTION
==COMMIT_MSG==
Produce a 4xx response code when clients disconnect
==COMMIT_MSG==


I'm not sure that I like this approach, instead we should wrap the streams themselves to detect whether a client has disconnected, otherwise we risk over-broadly catching IOExceptions thrown by the serializer or deserializer code which aren't directly attributable to a closed connection.