### PR TITLE
remove bounds check on input 'long' values into 'alias: double'

### DIFF
--- a/changelog/@unreleased/pr-2421.v2.yml
+++ b/changelog/@unreleased/pr-2421.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: 'remove bounds check on input ''long'' values into ''alias: double'''
+  links:
+  - https://github.com/palantir/conjure-java/pull/2421

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedDouble.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/AliasedDouble.java
@@ -2,7 +2,6 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.palantir.conjure.java.lib.SafeLong;
 import java.math.BigDecimal;
 import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
@@ -55,8 +54,7 @@ public final class AliasedDouble implements Comparable<AliasedDouble> {
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static AliasedDouble of(long value) {
-        long safeValue = SafeLong.of(value).longValue();
-        return new AliasedDouble((double) safeValue);
+        return new AliasedDouble((double) value);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DoubleAliasExample.java
@@ -2,7 +2,6 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.palantir.conjure.java.lib.SafeLong;
 import java.math.BigDecimal;
 import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
@@ -55,8 +54,7 @@ public final class DoubleAliasExample implements Comparable<DoubleAliasExample> 
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static DoubleAliasExample of(long value) {
-        long safeValue = SafeLong.of(value).longValue();
-        return new DoubleAliasExample((double) safeValue);
+        return new DoubleAliasExample((double) value);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeDoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeDoubleAliasExample.java
@@ -2,7 +2,6 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.logsafe.Safe;
 import java.math.BigDecimal;
 import javax.annotation.Nullable;
@@ -58,8 +57,7 @@ public final class SafeDoubleAliasExample implements Comparable<SafeDoubleAliasE
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static SafeDoubleAliasExample of(@Safe long value) {
-        long safeValue = SafeLong.of(value).longValue();
-        return new SafeDoubleAliasExample((double) safeValue);
+        return new SafeDoubleAliasExample((double) value);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/DoubleAliasExample.java
@@ -2,7 +2,6 @@ package test.prefix.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.palantir.conjure.java.lib.SafeLong;
 import java.math.BigDecimal;
 import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
@@ -55,8 +54,7 @@ public final class DoubleAliasExample implements Comparable<DoubleAliasExample> 
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static DoubleAliasExample of(long value) {
-        long safeValue = SafeLong.of(value).longValue();
-        return new DoubleAliasExample((double) safeValue);
+        return new DoubleAliasExample((double) value);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeDoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeDoubleAliasExample.java
@@ -2,7 +2,6 @@ package test.prefix.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.logsafe.Safe;
 import java.math.BigDecimal;
 import javax.annotation.Nullable;
@@ -58,8 +57,7 @@ public final class SafeDoubleAliasExample implements Comparable<SafeDoubleAliasE
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static SafeDoubleAliasExample of(@Safe long value) {
-        long safeValue = SafeLong.of(value).longValue();
-        return new SafeDoubleAliasExample((double) safeValue);
+        return new SafeDoubleAliasExample((double) value);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.ConjureAnnotations;
 import com.palantir.conjure.java.Options;
-import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.java.util.Packages;
 import com.palantir.conjure.java.util.Primitives;
@@ -148,8 +147,7 @@ public final class AliasGenerator {
 
         if (isAliasOfDouble(typeDef)) {
             CodeBlock longCastCodeBlock = CodeBlock.builder()
-                    .addStatement("long safeValue = $T.of(value).longValue()", SafeLong.class)
-                    .addStatement("return new $T((double) safeValue)", thisClass)
+                    .addStatement("return new $T((double) value)", thisClass)
                     .build();
 
             CodeBlock intCastCodeBlock = CodeBlock.builder()


### PR DESCRIPTION
==COMMIT_MSG==
remove bounds check on input 'long' values into 'alias: double'
==COMMIT_MSG==

Aliases are meant to behave identically to the aliased type, however in this case we were imposing a restriction that was _not_ present in the non-aliased path. As described in the original PR, this mans the bounding is different based on the _shape_ of the input data: https://github.com/palantir/conjure-java/pull/1006#discussion_r453888358 e.g. the restriction would apply to `9007199254740993.0` but not `9007199254740993`.

The PR which implemented this bounds check primarily aimed to avoid deserialization failures for large input values, matching behavior of raw `double`. Removing the safelong intermediate check should produce more consistent behavior.