### PR TITLE
Add flag to exclude generation of async Dialogue interfaces

### DIFF
--- a/changelog/@unreleased/pr-2423.v2.yml
+++ b/changelog/@unreleased/pr-2423.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add flag to exclude generation of async Dialogue interfaces
+  links:
+  - https://github.com/palantir/conjure-java/pull/2423

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
@@ -169,6 +169,15 @@ public interface Options {
         return false;
     }
 
+    /**
+     * Java 24's loom support removes the need for async interfaces. When set to true, only Dialogue interfaces for
+     * blocking clients will be generated. The Dialogue async interfaces will not be generated.
+     */
+    @Value.Default
+    default boolean excludeDialogueAsyncInterfaces() {
+        return false;
+    }
+
     Optional<String> packagePrefix();
 
     Optional<String> apiVersion();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueServiceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueServiceGenerator.java
@@ -24,6 +24,7 @@ import com.palantir.conjure.java.types.SpecializeBinaryClassNameVisitor;
 import com.palantir.conjure.java.types.TypeMapper;
 import com.palantir.conjure.java.util.TypeFunctions;
 import com.palantir.conjure.spec.ConjureDefinition;
+import com.palantir.conjure.spec.ServiceDefinition;
 import com.palantir.conjure.spec.TypeDefinition;
 import com.palantir.conjure.spec.TypeName;
 import com.palantir.dialogue.BinaryRequestBody;
@@ -32,6 +33,8 @@ import com.palantir.javapoet.JavaFile;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -82,13 +85,30 @@ public final class DialogueServiceGenerator implements Generator {
                 StaticFactoryMethodType.BLOCKING);
 
         return conjureDefinition.getServices().stream()
-                .flatMap(serviceDef -> !serviceDef.getEndpoints().isEmpty()
-                        ? Stream.of(
-                                endpoints.endpointsClass(serviceDef),
-                                interfaceGenerator.generateBlocking(serviceDef, blockingGenerator),
-                                interfaceGenerator.generateAsync(serviceDef, asyncGenerator))
-                        : Stream.of(
-                                interfaceGenerator.generateBlocking(serviceDef, blockingGenerator),
-                                interfaceGenerator.generateAsync(serviceDef, asyncGenerator)));
+                .flatMap(serviceDef -> generateFilesForService(
+                        options.excludeDialogueAsyncInterfaces(),
+                        serviceDef,
+                        endpoints,
+                        interfaceGenerator,
+                        blockingGenerator,
+                        asyncGenerator));
+    }
+
+    private static Stream<JavaFile> generateFilesForService(
+            boolean excludeDialogueAsyncInterfaces,
+            ServiceDefinition serviceDef,
+            DialogueEndpointsGenerator endpointsGenerator,
+            DialogueInterfaceGenerator interfaceGenerator,
+            StaticFactoryMethodGenerator blockingGenerator,
+            StaticFactoryMethodGenerator asyncGenerator) {
+        List<JavaFile> files = new ArrayList<>(/* initialCapacity= */ 3);
+        if (!serviceDef.getEndpoints().isEmpty()) {
+            files.add(endpointsGenerator.endpointsClass(serviceDef));
+        }
+        files.add(interfaceGenerator.generateBlocking(serviceDef, blockingGenerator));
+        if (!excludeDialogueAsyncInterfaces) {
+            files.add(interfaceGenerator.generateAsync(serviceDef, asyncGenerator));
+        }
+        return files.stream();
     }
 }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/DialogueServiceGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/DialogueServiceGeneratorTests.java
@@ -31,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Locale;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
@@ -97,11 +98,27 @@ public final class DialogueServiceGeneratorTests extends TestBase {
         validateGeneratorOutput(files, Paths.get("src/integrationInput/java/com/palantir/product"));
     }
 
+    @Test
+    public void testServiceGeneration_excludeDialogueAsyncInterfaces() {
+        List<Path> files = getGeneratedFilesForDef(
+                "example-service",
+                Options.builder().excludeDialogueAsyncInterfaces(true).build());
+        List<String> fileNames =
+                files.stream().map(Path::getFileName).map(Path::toString).toList();
+        assertThat(fileNames).noneMatch(name -> name.toLowerCase(Locale.ROOT).contains("async"));
+    }
+
     private void testServiceGeneration(String conjureFile) throws IOException {
+        validateGeneratorOutput(
+                getGeneratedFilesForDef(conjureFile, Options.empty()),
+                Paths.get("src/test/resources/test/api"),
+                ".dialogue");
+    }
+
+    private List<Path> getGeneratedFilesForDef(String conjureFile, Options options) {
         ConjureDefinition def = Conjure.parse(ImmutableList.of(new File("src/test/resources/" + conjureFile + ".yml")));
-        List<Path> files = new GenerationCoordinator(
-                        MoreExecutors.directExecutor(), ImmutableSet.of(new DialogueServiceGenerator(Options.empty())))
+        return new GenerationCoordinator(
+                        MoreExecutors.directExecutor(), ImmutableSet.of(new DialogueServiceGenerator(options)))
                 .emit(def, folder);
-        validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".dialogue");
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,8 @@ The recommended way to use conjure-java is via a build tool like [gradle-conjure
                      legacy 'javax' packages.
         --externalFallbackTypes
                      Java external type imports are generated using their fallback type.
+        --excludeDialogueAsyncInterfaces
+                     Exclude the generation of asynchronous interfaces for Dialogue clients.
 
 ### Known Tag Values
 


### PR DESCRIPTION
## Before this PR
With Java 24's Loom feature, we will no longer need to use async interfaces. 

## After this PR
This PR introduces a flag `excludeDialogueAsyncInterfaces` that, when set, does not generate the async Dialogue interfaces. This will help with roll-out of the future Conjure version where async interfaces are no longer generated at all. If devs use async interfaces, and the flag is set, there should be a compile-break, so there is no risk of runtime errors with this change.

==COMMIT_MSG==
Add flag to exclude generation of async Dialogue interfaces
==COMMIT_MSG==

## Possible downsides?


