### PR TITLE
Reduce Optional allocations in SafetyEvaluator

### DIFF
--- a/changelog/@unreleased/pr-2433.v2.yml
+++ b/changelog/@unreleased/pr-2433.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Reduce Optional allocations in SafetyEvaluator
+  links:
+  - https://github.com/palantir/conjure-java/pull/2433

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/SafetyEvaluator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/SafetyEvaluator.java
@@ -16,6 +16,8 @@
 
 package com.palantir.conjure.java.types;
 
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Table;
 import com.palantir.conjure.java.util.TypeFunctions;
 import com.palantir.conjure.spec.AliasDefinition;
 import com.palantir.conjure.spec.ArgumentDefinition;
@@ -37,17 +39,23 @@ import com.palantir.conjure.spec.TypeName;
 import com.palantir.conjure.spec.UnionDefinition;
 import com.palantir.logsafe.Preconditions;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 public final class SafetyEvaluator {
+
+    // Make a constant to avoid allocating a new Optional every time we process a type definition for safety
+    private static final Optional<LogSafety> OPTIONAL_OF_SAFE = Optional.of(LogSafety.SAFE);
+
     /**
      * Enums contain an unknown variant, however we assume that the unknown variant is only used
      * for past and future values which are known at compile-time in that version.
      */
-    public static final Optional<LogSafety> ENUM_SAFETY = Optional.of(LogSafety.SAFE);
+    public static final Optional<LogSafety> ENUM_SAFETY = OPTIONAL_OF_SAFE;
     /**
      * Unknown variant should be considered unsafe because we don't know what kind of data it may contain,
      * however this makes rollout much more challenging, so we will ratchet unknown safety once we have
@@ -137,7 +145,7 @@ public final class SafetyEvaluator {
         @Override
         public Optional<LogSafety> visitObject(ObjectDefinition value) {
             return with(value.getTypeName(), () -> {
-                Optional<LogSafety> safety = Optional.of(LogSafety.SAFE);
+                Optional<LogSafety> safety = OPTIONAL_OF_SAFE;
                 for (FieldDefinition field : value.getFields()) {
                     safety = combine(safety, getSafety(field.getType(), field.getSafety()));
                 }
@@ -164,7 +172,7 @@ public final class SafetyEvaluator {
         private Optional<LogSafety> with(TypeName typeName, Supplier<Optional<LogSafety>> task) {
             if (!inProgress.add(typeName)) {
                 // Given recursive evaluation, we return the least restrictive type: SAFE.
-                return Optional.of(LogSafety.SAFE);
+                return OPTIONAL_OF_SAFE;
             }
             Optional<LogSafety> result = task.get();
             if (!inProgress.remove(typeName)) {
@@ -298,7 +306,29 @@ public final class SafetyEvaluator {
         }
     }
 
+    private static final Table<Optional<LogSafety>, Optional<LogSafety>, Optional<LogSafety>> COMBINE_TABLE =
+            computeCombineTable();
+
+    private static Table<Optional<LogSafety>, Optional<LogSafety>, Optional<LogSafety>> computeCombineTable() {
+        List<Optional<LogSafety>> allValues = Stream.concat(
+                        Stream.of(Optional.<LogSafety>empty()),
+                        LogSafety.values().stream().map(Optional::of))
+                .toList();
+        ImmutableTable.Builder<Optional<LogSafety>, Optional<LogSafety>, Optional<LogSafety>> builder =
+                ImmutableTable.builder();
+        for (Optional<LogSafety> left : allValues) {
+            for (Optional<LogSafety> right : allValues) {
+                builder.put(left, right, computeCombine(left, right));
+            }
+        }
+        return builder.buildOrThrow();
+    }
+
     public static Optional<LogSafety> combine(Optional<LogSafety> one, Optional<LogSafety> two) {
+        return Preconditions.checkNotNull(COMBINE_TABLE.get(one, two), "Missing an entry in the combine table");
+    }
+
+    private static Optional<LogSafety> computeCombine(Optional<LogSafety> one, Optional<LogSafety> two) {
         if (one.isPresent() && two.isPresent()) {
             return Optional.of(combine(one.get(), two.get()));
         }
@@ -307,7 +337,7 @@ public final class SafetyEvaluator {
                 .filter(value -> !LogSafety.SAFE.equals(value));
     }
 
-    public static LogSafety combine(LogSafety one, LogSafety two) {
+    private static LogSafety combine(LogSafety one, LogSafety two) {
         LogSafety.Value first = one.get();
         LogSafety.Value second = two.get();
         if (first == LogSafety.Value.UNKNOWN || second == LogSafety.Value.UNKNOWN) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/SafetyEvaluator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/SafetyEvaluator.java
@@ -324,10 +324,6 @@ public final class SafetyEvaluator {
         return builder.buildOrThrow();
     }
 
-    public static Optional<LogSafety> combine(Optional<LogSafety> one, Optional<LogSafety> two) {
-        return Preconditions.checkNotNull(COMBINE_TABLE.get(one, two), "Missing an entry in the combine table");
-    }
-
     private static Optional<LogSafety> computeCombine(Optional<LogSafety> one, Optional<LogSafety> two) {
         if (one.isPresent() && two.isPresent()) {
             return Optional.of(combine(one.get(), two.get()));
@@ -350,6 +346,10 @@ public final class SafetyEvaluator {
             return LogSafety.UNSAFE;
         }
         return one;
+    }
+
+    public static Optional<LogSafety> combine(Optional<LogSafety> one, Optional<LogSafety> two) {
+        return Preconditions.checkNotNull(COMBINE_TABLE.get(one, two), "Missing an entry in the combine table");
     }
 
     public static boolean allows(Optional<LogSafety> required, Optional<LogSafety> given) {


### PR DESCRIPTION
## Before this PR
This SafetyEvaluator class allocates Optional objects on its hot path and this allocation shows up in JFRs of the gradle daemon in a large internal project.

## After this PR
==COMMIT_MSG==
Reduce Optional allocations in SafetyEvaluator
==COMMIT_MSG==

This PR reduces Optional allocation by two techniques:
1. introduce a constant OPTIONAL_OF_SAFE.  Because the contained value is immutable (a conjure enum) we can create once and safely reuse where we were previously allocating a new Optional wrapper.
2. precompute an access table for the combine() method, which takes two optional safety values and returns a combined safety value.  There are only (3 values + 1 empty) * (3 values + 1 empty) => 16 entries in this precomputed table, so memory usage is negligible.  

Together, these save significant amounts of allocation, ~65% of 3GiB => ~2GiB by my reading of this JFR screenshots.

See 3 screenshots (large so not including inline):

1. https://github.com/user-attachments/assets/795a1c3c-226d-4c1f-ba40-06f949245e93 (36% of Optional allocations)
2. https://github.com/user-attachments/assets/e12cc152-34c8-4e0a-9c2f-f924ce9c0214 (25% of Optional allocations)
5. https://github.com/user-attachments/assets/eda37bdf-d8e9-4bbb-b60c-7542167d0de9 (4% of Optional allocations)

## Possible downsides?
- There could be a bug in the logic precomputing the table, but the unit tests look very thorough and didn't catch any issues. the `Preconditions.checkNotNull` would fail fast if there was a missing entry of the table.  The previous logic is used unchanged, just with this caching table in front.
- I considered using a Caffeine cache, but it would've required allocating Pair wrappers, and the Guava Table does not.  Guava ImmutableTable will also use a dense implementation DenseImmutableTable so there is little overhead.