### PR TITLE
[Fix] Restore Mistakenly Removed 'MAX_VALUE' and 'MIN_VALUE'

### DIFF
--- a/changelog/@unreleased/pr-2434.v2.yml
+++ b/changelog/@unreleased/pr-2434.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: '[Fix] Restore Mistakenly Removed ''MAX_VALUE'' and ''MIN_VALUE'''
+  links:
+  - https://github.com/palantir/conjure-java/pull/2434

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/SafeLong.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/SafeLong.java
@@ -26,6 +26,9 @@ public final class SafeLong implements Comparable<SafeLong> {
     private static final long MIN_SAFE_VALUE = -(1L << 53) + 1;
     private static final long MAX_SAFE_VALUE = (1L << 53) - 1;
 
+    public static final SafeLong MAX_VALUE = SafeLong.of(MAX_SAFE_VALUE);
+    public static final SafeLong MIN_VALUE = SafeLong.of(MIN_SAFE_VALUE);
+
     private final long longValue;
 
     private SafeLong(long longValue) {


### PR DESCRIPTION
I thought that I had added these in some intermediary commit and mistakenly removed these APIs which existed long before I showed up. My mistake.