### PR TITLE
[Fix] Fix Staged Builder Compilation Issue and Strict Staged Builder Deserialization

### DIFF
--- a/changelog/@unreleased/pr-2438.v2.yml
+++ b/changelog/@unreleased/pr-2438.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '[Fix] Fix Staged Builder Compilation Issue and Strict Staged Builder
+    Deserialization'
+  links:
+  - https://github.com/palantir/conjure-java/pull/2438

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveExample.java
@@ -17,19 +17,27 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
-@JsonDeserialize(builder = PrimitiveExample.Builder.class)
+@JsonDeserialize(builder = PrimitiveExample.DefaultBuilder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
 public final class PrimitiveExample {
+    private final int field;
+
     private final List<Integer> ints;
 
     private final List<Double> doubles;
 
     private int memoizedHashCode;
 
-    private PrimitiveExample(List<Integer> ints, List<Double> doubles) {
+    private PrimitiveExample(int field, List<Integer> ints, List<Double> doubles) {
         validateFields(ints, doubles);
+        this.field = field;
         this.ints = ConjureCollections.unmodifiableList(ints);
         this.doubles = ConjureCollections.unmodifiableList(doubles);
+    }
+
+    @JsonProperty("field")
+    public int getField() {
+        return this.field;
     }
 
     @JsonProperty("ints")
@@ -55,7 +63,7 @@ public final class PrimitiveExample {
                 && this.memoizedHashCode != other.memoizedHashCode) {
             return false;
         }
-        return this.ints.equals(other.ints) && this.doubles.equals(other.doubles);
+        return this.field == other.field && this.ints.equals(other.ints) && this.doubles.equals(other.doubles);
     }
 
     @Override
@@ -63,6 +71,7 @@ public final class PrimitiveExample {
         int result = memoizedHashCode;
         if (result == 0) {
             int hash = 1;
+            hash = 31 * hash + this.field;
             hash = 31 * hash + this.ints.hashCode();
             hash = 31 * hash + this.doubles.hashCode();
             result = hash;
@@ -73,11 +82,11 @@ public final class PrimitiveExample {
 
     @Override
     public String toString() {
-        return "PrimitiveExample{ints: " + ints + ", doubles: " + doubles + '}';
+        return "PrimitiveExample{field: " + field + ", ints: " + ints + ", doubles: " + doubles + '}';
     }
 
-    public static PrimitiveExample of(List<Integer> ints, List<Double> doubles) {
-        return builder().ints(ints).doubles(doubles).build();
+    public static PrimitiveExample of(int field, List<Integer> ints, List<Double> doubles) {
+        return builder().field(field).ints(ints).doubles(doubles).build();
     }
 
     private static void validateFields(List<Integer> ints, List<Double> doubles) {
@@ -101,28 +110,107 @@ public final class PrimitiveExample {
         return missingFields;
     }
 
-    public static Builder builder() {
-        return new Builder();
+    public static FieldStageBuilder builder() {
+        return new DefaultBuilder();
+    }
+
+    public interface FieldStageBuilder {
+        Completed_StageBuilder field(@Nonnull int field);
+
+        Builder from(PrimitiveExample other);
+    }
+
+    public interface Completed_StageBuilder {
+        @CheckReturnValue
+        PrimitiveExample build();
+
+        Completed_StageBuilder ints(@Nonnull Iterable<Integer> ints);
+
+        Completed_StageBuilder addAllInts(@Nonnull Iterable<Integer> ints);
+
+        Completed_StageBuilder addAllInts(@Nonnull int... ints);
+
+        Completed_StageBuilder ints(int ints);
+
+        Completed_StageBuilder doubles(@Nonnull Iterable<Double> doubles);
+
+        Completed_StageBuilder addAllDoubles(@Nonnull Iterable<Double> doubles);
+
+        Completed_StageBuilder addAllDoubles(@Nonnull double... doubles);
+
+        Completed_StageBuilder doubles(double doubles);
+    }
+
+    public interface Builder extends FieldStageBuilder, Completed_StageBuilder {
+        @Override
+        Builder field(@Nonnull int field);
+
+        @Override
+        Builder from(PrimitiveExample other);
+
+        @CheckReturnValue
+        @Override
+        PrimitiveExample build();
+
+        @Override
+        Builder ints(@Nonnull Iterable<Integer> ints);
+
+        @Override
+        Builder addAllInts(@Nonnull Iterable<Integer> ints);
+
+        @Override
+        Builder addAllInts(@Nonnull int... ints);
+
+        @Override
+        Builder ints(int ints);
+
+        @Override
+        Builder doubles(@Nonnull Iterable<Double> doubles);
+
+        @Override
+        Builder addAllDoubles(@Nonnull Iterable<Double> doubles);
+
+        @Override
+        Builder addAllDoubles(@Nonnull double... doubles);
+
+        @Override
+        Builder doubles(double doubles);
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static final class Builder {
+    static final class DefaultBuilder implements Builder {
         boolean _buildInvoked;
+
+        private int field;
 
         private List<Integer> ints = ConjureCollections.newNonNullIntegerList();
 
         private List<Double> doubles = ConjureCollections.newNonNullDoubleList();
 
-        private Builder() {}
+        private boolean _fieldInitialized = false;
 
+        private DefaultBuilder() {}
+
+        @Override
         public Builder from(PrimitiveExample other) {
             checkNotBuilt();
+            field(other.getField());
             ints(other.getInts());
             doubles(other.getDoubles());
             return this;
         }
 
+        @Override
+        @JsonSetter("field")
+        public Builder field(int field) {
+            checkNotBuilt();
+            this.field = field;
+            this._fieldInitialized = true;
+            return this;
+        }
+
+        @Override
         public Builder ints(@Nonnull Iterable<Integer> ints) {
             checkNotBuilt();
             this.ints =
@@ -130,6 +218,7 @@ public final class PrimitiveExample {
             return this;
         }
 
+        @Override
         @JsonSetter(value = "ints", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder addAllInts(@Nonnull int... ints) {
             checkNotBuilt();
@@ -137,6 +226,7 @@ public final class PrimitiveExample {
             return this;
         }
 
+        @Override
         public Builder addAllInts(@Nonnull Iterable<Integer> ints) {
             checkNotBuilt();
             ConjureCollections.addAllAndCheckNonNull(
@@ -144,6 +234,7 @@ public final class PrimitiveExample {
             return this;
         }
 
+        @Override
         public Builder ints(int ints) {
             checkNotBuilt();
             Preconditions.checkNotNull(ints, "ints cannot be null");
@@ -151,6 +242,7 @@ public final class PrimitiveExample {
             return this;
         }
 
+        @Override
         public Builder doubles(@Nonnull Iterable<Double> doubles) {
             checkNotBuilt();
             this.doubles = ConjureCollections.newNonNullDoubleList(
@@ -158,6 +250,7 @@ public final class PrimitiveExample {
             return this;
         }
 
+        @Override
         @JsonSetter(value = "doubles", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder addAllDoubles(@Nonnull double... doubles) {
             checkNotBuilt();
@@ -166,6 +259,7 @@ public final class PrimitiveExample {
             return this;
         }
 
+        @Override
         public Builder addAllDoubles(@Nonnull Iterable<Double> doubles) {
             checkNotBuilt();
             ConjureCollections.addAllAndCheckNonNull(
@@ -173,6 +267,7 @@ public final class PrimitiveExample {
             return this;
         }
 
+        @Override
         public Builder doubles(double doubles) {
             checkNotBuilt();
             Preconditions.checkNotNull(doubles, "doubles cannot be null");
@@ -180,11 +275,33 @@ public final class PrimitiveExample {
             return this;
         }
 
+        private void validatePrimitiveFieldsHaveBeenInitialized() {
+            List<String> missingFields = null;
+            missingFields = addFieldIfMissing(missingFields, _fieldInitialized, "field");
+            if (missingFields != null) {
+                throw new SafeIllegalArgumentException(
+                        "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
+            }
+        }
+
+        private static List<String> addFieldIfMissing(List<String> prev, boolean initialized, String fieldName) {
+            List<String> missingFields = prev;
+            if (!initialized) {
+                if (missingFields == null) {
+                    missingFields = new ArrayList<>(1);
+                }
+                missingFields.add(fieldName);
+            }
+            return missingFields;
+        }
+
+        @Override
         @CheckReturnValue
         public PrimitiveExample build() {
             checkNotBuilt();
             this._buildInvoked = true;
-            return new PrimitiveExample(ints, doubles);
+            validatePrimitiveFieldsHaveBeenInitialized();
+            return new PrimitiveExample(field, ints, doubles);
         }
 
         private void checkNotBuilt() {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveStrictExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/PrimitiveStrictExample.java
@@ -1,0 +1,187 @@
+package com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.errorprone.annotations.CheckReturnValue;
+import com.palantir.conjure.java.lib.internal.ConjureCollections;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@JsonDeserialize(builder = PrimitiveStrictExample.DefaultBuilder.class)
+@Generated("com.palantir.conjure.java.types.BeanGenerator")
+public final class PrimitiveStrictExample {
+    private final List<Integer> ints;
+
+    private final List<Double> doubles;
+
+    private int memoizedHashCode;
+
+    private PrimitiveStrictExample(List<Integer> ints, List<Double> doubles) {
+        validateFields(ints, doubles);
+        this.ints = ConjureCollections.unmodifiableList(ints);
+        this.doubles = ConjureCollections.unmodifiableList(doubles);
+    }
+
+    @JsonProperty("ints")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<Integer> getInts() {
+        return this.ints;
+    }
+
+    @JsonProperty("doubles")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<Double> getDoubles() {
+        return this.doubles;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof PrimitiveStrictExample && equalTo((PrimitiveStrictExample) other));
+    }
+
+    private boolean equalTo(PrimitiveStrictExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.ints.equals(other.ints) && this.doubles.equals(other.doubles);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = memoizedHashCode;
+        if (result == 0) {
+            int hash = 1;
+            hash = 31 * hash + this.ints.hashCode();
+            hash = 31 * hash + this.doubles.hashCode();
+            result = hash;
+            memoizedHashCode = result;
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "PrimitiveStrictExample{ints: " + ints + ", doubles: " + doubles + '}';
+    }
+
+    public static PrimitiveStrictExample of(List<Integer> ints, List<Double> doubles) {
+        return builder().ints(ints).doubles(doubles).build();
+    }
+
+    private static void validateFields(List<Integer> ints, List<Double> doubles) {
+        List<String> missingFields = null;
+        missingFields = addFieldIfMissing(missingFields, ints, "ints");
+        missingFields = addFieldIfMissing(missingFields, doubles, "doubles");
+        if (missingFields != null) {
+            throw new SafeIllegalArgumentException(
+                    "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
+        }
+    }
+
+    private static List<String> addFieldIfMissing(List<String> prev, Object fieldValue, String fieldName) {
+        List<String> missingFields = prev;
+        if (fieldValue == null) {
+            if (missingFields == null) {
+                missingFields = new ArrayList<>(2);
+            }
+            missingFields.add(fieldName);
+        }
+        return missingFields;
+    }
+
+    public static IntsStageBuilder builder() {
+        return new DefaultBuilder();
+    }
+
+    public interface IntsStageBuilder {
+        DoublesStageBuilder ints(@Nonnull Iterable<Integer> ints);
+
+        Builder from(PrimitiveStrictExample other);
+    }
+
+    public interface DoublesStageBuilder {
+        Completed_StageBuilder doubles(@Nonnull Iterable<Double> doubles);
+    }
+
+    public interface Completed_StageBuilder {
+        @CheckReturnValue
+        PrimitiveStrictExample build();
+    }
+
+    public interface Builder extends IntsStageBuilder, DoublesStageBuilder, Completed_StageBuilder {
+        @Override
+        Builder ints(@Nonnull Iterable<Integer> ints);
+
+        @Override
+        Builder from(PrimitiveStrictExample other);
+
+        @Override
+        Builder doubles(@Nonnull Iterable<Double> doubles);
+
+        @CheckReturnValue
+        @Override
+        PrimitiveStrictExample build();
+    }
+
+    @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static final class DefaultBuilder implements Builder {
+        boolean _buildInvoked;
+
+        private List<Integer> ints = ConjureCollections.newNonNullIntegerList();
+
+        private List<Double> doubles = ConjureCollections.newNonNullDoubleList();
+
+        private DefaultBuilder() {}
+
+        @Override
+        public Builder from(PrimitiveStrictExample other) {
+            checkNotBuilt();
+            ints(other.getInts());
+            doubles(other.getDoubles());
+            return this;
+        }
+
+        @Override
+        @JsonSetter(value = "ints", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
+        public Builder ints(@Nonnull Iterable<Integer> ints) {
+            checkNotBuilt();
+            this.ints =
+                    ConjureCollections.newNonNullIntegerList(Preconditions.checkNotNull(ints, "ints cannot be null"));
+            return this;
+        }
+
+        @Override
+        @JsonSetter(value = "doubles", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
+        public Builder doubles(@Nonnull Iterable<Double> doubles) {
+            checkNotBuilt();
+            this.doubles = ConjureCollections.newNonNullDoubleList(
+                    Preconditions.checkNotNull(doubles, "doubles cannot be null"));
+            return this;
+        }
+
+        @Override
+        @CheckReturnValue
+        public PrimitiveStrictExample build() {
+            checkNotBuilt();
+            this._buildInvoked = true;
+            return new PrimitiveStrictExample(ints, doubles);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+        }
+    }
+}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -181,7 +181,7 @@ public final class BeanBuilderGenerator {
         List<EnrichedField> allFields = enrichFields(typeDef.getFields());
         List<TypeSpec> interfaces =
                 generateIntermediateStageInterfaces(objectClass, builderClass, typeMapper, allFields, safetyEvaluator);
-        interfaces.add(generateBuilderFinalStageInterface(objectClass, typeMapper, List.of(), safetyEvaluator));
+        interfaces.add(generateBuilderFinalStageInterface(List.of()));
         specBuilder.addTypes(interfaces);
 
         addBuilderInterfaceAndMethod(specBuilder, interfaces);
@@ -212,13 +212,9 @@ public final class BeanBuilderGenerator {
 
         List<TypeSpec> interfaces = generateIntermediateStageInterfaces(
                 objectClass, builderClass, typeMapper, fieldsNeedingBuilderStage, safetyEvaluator);
-        interfaces.add(generateBuilderFinalStageInterface(
-                objectClass,
-                typeMapper,
-                allFields.stream()
-                        .filter(field -> !fieldsNeedingBuilderStage.contains(field))
-                        .collect(Collectors.toList()),
-                safetyEvaluator));
+        interfaces.add(generateBuilderFinalStageInterface(allFields.stream()
+                .filter(field -> !fieldsNeedingBuilderStage.contains(field))
+                .collect(Collectors.toList())));
         specBuilder.addTypes(interfaces);
         addBuilderInterfaceAndMethod(specBuilder, interfaces);
 
@@ -331,8 +327,7 @@ public final class BeanBuilderGenerator {
         return interfaces.stream().map(TypeSpec.Builder::build).collect(Collectors.toList());
     }
 
-    private static TypeSpec generateBuilderFinalStageInterface(
-            ClassName objectClass, TypeMapper typeMapper, List<EnrichedField> fields, SafetyEvaluator safetyEvaluator) {
+    private TypeSpec generateBuilderFinalStageInterface(List<EnrichedField> fields) {
         ClassName completedStageClass = stageBuilderInterfaceName(objectClass, "completed_");
         return TypeSpec.interfaceBuilder(completedStageClass)
                 .addModifiers(Modifier.PUBLIC)
@@ -342,8 +337,7 @@ public final class BeanBuilderGenerator {
                         .returns(Primitives.box(objectClass))
                         .build())
                 .addMethods(fields.stream()
-                        .map(field -> generateMethodsForFinalStageInterfaceField(
-                                field, typeMapper, completedStageClass, safetyEvaluator))
+                        .map(field -> generateMethodsForFinalStageInterfaceField(field, completedStageClass))
                         .flatMap(List::stream)
                         .collect(Collectors.toList()))
                 .build();
@@ -353,8 +347,7 @@ public final class BeanBuilderGenerator {
         return enclosingClass.nestedClass(StringUtils.capitalize(stageName) + "StageBuilder");
     }
 
-    private static List<MethodSpec> generateMethodsForFinalStageInterfaceField(
-            EnrichedField enriched, TypeMapper typeMapper, ClassName returnClass, SafetyEvaluator safetyEvaluator) {
+    private List<MethodSpec> generateMethodsForFinalStageInterfaceField(EnrichedField enriched, ClassName returnClass) {
         List<MethodSpec> methodSpecs = new ArrayList<>();
         Type type = enriched.conjureDef().getType();
         FieldDefinition definition = enriched.conjureDef();
@@ -380,6 +373,12 @@ public final class BeanBuilderGenerator {
                             "addAll", enriched, typeMapper, returnClass, safetyEvaluator)
                     .addModifiers(Modifier.ABSTRACT)
                     .build());
+            if (isPrimitiveOptimized(type)) {
+                methodSpecs.add(BeanBuilderAuxiliarySettersUtils.createPrimitiveCollectionSetterBuilder(
+                                enriched, typeMapper, returnClass, safetyEvaluator)
+                        .addModifiers(Modifier.ABSTRACT)
+                        .build());
+            }
             methodSpecs.add(BeanBuilderAuxiliarySettersUtils.createItemSetterBuilder(
                             enriched, type.accept(TypeVisitor.LIST).getItemType(), typeMapper, returnClass, safety)
                     .addModifiers(Modifier.ABSTRACT)
@@ -604,7 +603,7 @@ public final class BeanBuilderGenerator {
         // Each field tends to fan out into many setters
         Collection<MethodSpec> setters = Lists.newArrayListWithExpectedSize(fields.size() * 5);
         for (EnrichedField field : fields) {
-            setters.add(createSetter(field, typesMap, override));
+            setters.add(createSetter(field, typesMap, override, strict));
             if (!strict || field.conjureDef().getType().accept(TypeVisitor.IS_OPTIONAL)) {
                 setters.addAll(createAuxiliarySetters(field, typesMap, override));
             }
@@ -615,7 +614,8 @@ public final class BeanBuilderGenerator {
     private MethodSpec createSetter(
             EnrichedField enriched,
             Map<com.palantir.conjure.spec.TypeName, TypeDefinition> typesMap,
-            boolean override) {
+            boolean override,
+            boolean strict) {
         FieldSpec field = enriched.poetSpec();
         Type type = enriched.conjureDef().getType();
 
@@ -640,7 +640,12 @@ public final class BeanBuilderGenerator {
         // Certain type combinations and feature flags may produce highly optimized code paths.
         // These optimized paths include deserialization, so if it isn't enabled we should add the
         // simple deserializer.
-        if (!isPrimitiveOptimized(type)) {
+        //
+        // At the moment we are excluding strict staged builders from the optimization
+        // however there was an issue that when generating strict builders we assumed
+        // that another setter would be added later. This is not the case for strict staged
+        // builders.
+        if (!isPrimitiveOptimized(type) || strict) {
             setterBuilder.addAnnotation(createJacksonSetterAnnotation(enriched, typesMap));
         }
 
@@ -810,9 +815,7 @@ public final class BeanBuilderGenerator {
         ImmutableList.Builder<MethodSpec> builder = ImmutableList.builder();
 
         if (type.accept(TypeVisitor.IS_LIST)) {
-            CollectionType collectionType = getCollectionType(type);
-            if (collectionType.getConjureCollectionType().isPrimitiveCollection()
-                    && collectionType.useNonNullFactory()) {
+            if (isPrimitiveOptimized(type)) {
                 builder.add(createPrimitiveCollectionSetter(enriched, typesMap, override));
             }
 
@@ -1127,9 +1130,15 @@ public final class BeanBuilderGenerator {
     }
 
     private boolean isPrimitiveOptimized(Type type) {
-        return type.accept(TypeVisitor.IS_LIST)
-                // Check above guards the getCollectionType call below
-                && getCollectionType(type).getConjureCollectionType().isPrimitiveCollection();
+        if (type.accept(TypeVisitor.IS_LIST)) {
+            // The if statement above guards the call to this method
+            // which can only operate on list types
+            CollectionType collectionType = getCollectionType(type);
+            return collectionType.getConjureCollectionType().isPrimitiveCollection()
+                    && collectionType.useNonNullFactory();
+        }
+
+        return false;
     }
 
     private enum ConjureCollectionNullHandlingMode {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/NonNullCollectionsTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/NonNullCollectionsTest.java
@@ -26,6 +26,7 @@ import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.product.CovariantListExample;
 import com.palantir.product.ListExample;
 import com.palantir.product.PrimitiveExample;
+import com.palantir.product.PrimitiveStrictExample;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -78,7 +79,10 @@ public class NonNullCollectionsTest {
 
     @Test
     public void testSerDeOptimizationRespectsConjureEmptyCollections() throws JsonProcessingException {
-        PrimitiveExample expected = PrimitiveExample.builder().build();
+        PrimitiveStrictExample expected = PrimitiveStrictExample.builder()
+                .ints(Collections.emptyList())
+                .doubles(Collections.emptyList())
+                .build();
         assertThat(clientMapper.writeValueAsString(expected))
                 .describedAs("Does not serialize any empty collections, even when optimizing for primitives")
                 .isEqualTo("{}");
@@ -87,10 +91,23 @@ public class NonNullCollectionsTest {
     @Test
     public void testSerializationRoundtrip() throws JsonProcessingException {
         PrimitiveExample expected = PrimitiveExample.builder()
+                .field(1)
+                .addAllInts(1, 2, 3)
+                .addAllDoubles(1.1, 2.2, 3.3)
+                .build();
+        String serialized = serverMapper.writeValueAsString(expected);
+        assertThat(expected).isEqualTo(clientMapper.readValue(serialized, PrimitiveExample.class));
+    }
+
+    // We had an issue where the primitive optimization removed the JsonSetter from the final builder
+    // which would fail this test
+    @Test
+    public void testStrictStagedDeserializationRoundtrips() throws JsonProcessingException {
+        PrimitiveStrictExample expected = PrimitiveStrictExample.builder()
                 .ints(List.of(1, 2, 3))
                 .doubles(List.of(1.1, 2.2, 3.3))
                 .build();
         String serialized = serverMapper.writeValueAsString(expected);
-        assertThat(expected).isEqualTo(clientMapper.readValue(serialized, PrimitiveExample.class));
+        assertThat(expected).isEqualTo(clientMapper.readValue(serialized, PrimitiveStrictExample.class));
     }
 }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/ObjectGeneratorTests.java
@@ -177,6 +177,23 @@ public final class ObjectGeneratorTests {
                         ImmutableSet.of(new ObjectGenerator(Options.builder()
                                 .excludeEmptyCollections(true)
                                 .nonNullCollections(true)
+                                .useStagedBuilders(true)
+                                .build())))
+                .emit(def, tempDir);
+
+        assertThatFilesAreTheSame(files, REFERENCE_FILES_FOLDER);
+    }
+
+    @Test
+    public void testObjectGenerator_primitiveCollectionsStrictStaged() throws IOException {
+        ConjureDefinition def =
+                Conjure.parse(ImmutableList.of(new File("src/test/resources/primitive-collections-strict.yml")));
+        List<Path> files = new GenerationCoordinator(
+                        MoreExecutors.directExecutor(),
+                        ImmutableSet.of(new ObjectGenerator(Options.builder()
+                                .excludeEmptyCollections(true)
+                                .nonNullCollections(true)
+                                .useStrictStagedBuilders(true)
                                 .build())))
                 .emit(def, tempDir);
 

--- a/conjure-java-core/src/test/resources/primitive-collections-strict.yml
+++ b/conjure-java-core/src/test/resources/primitive-collections-strict.yml
@@ -2,10 +2,7 @@ types:
   definitions:
     default-package: com.palantir.product
     objects:
-      PrimitiveExample:
+      PrimitiveStrictExample:
         fields:
-          # staged builders don't generate the intermediary
-          # types without required fields
-          field: integer
           ints: list<integer>
           doubles: list<double>


### PR DESCRIPTION
## Before this PR
There was an issue with `useStageBuilders` where the intermediary interface was missing the optimized setters. Additionally, while looking into this I noticed that when using `useStrictStagedBuilders` the code paths would inadvertently drop the `JsonSetter` assuming that another setter would be added for the optimal path.

## After this PR
Adds the setters to the intermediary interface and restores the `JsonSetter` on strict builder setters.


