### PR TITLE
Remove our workaround for an old Javapoet class init deadlock

### DIFF
--- a/conjure-java/build.gradle
+++ b/conjure-java/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     implementation 'com.google.errorprone:error_prone_annotations'
     implementation 'com.google.guava:guava'
     implementation 'com.palantir.conjure:conjure-api-objects'
-    implementation 'com.palantir.javapoet:javapoet'
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'info.picocli:picocli'

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -33,7 +33,6 @@ import com.palantir.conjure.java.types.CheckedErrorGenerator;
 import com.palantir.conjure.java.types.ErrorGenerator;
 import com.palantir.conjure.java.types.ObjectGenerator;
 import com.palantir.conjure.spec.ConjureDefinition;
-import com.palantir.javapoet.ClassName;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.File;
 import java.io.IOException;
@@ -50,10 +49,6 @@ import picocli.CommandLine;
         mixinStandardHelpOptions = true,
         subcommands = ConjureJavaCli.GenerateCommand.class)
 public final class ConjureJavaCli implements Runnable {
-    // Load TypeName to prevent a deadlock
-    // https://github.com/square/javapoet/issues/637
-    @SuppressWarnings("unused")
-    private static final ClassName _loaded = ClassName.get(Runnable.class);
 
     public static void main(String[] args) {
         CommandLine.run(new ConjureJavaCli(), args);


### PR DESCRIPTION
https://github.com/square/javapoet/issues/637 impacted the original Square builds of Javapoet, however our fork fixed the bug in https://github.com/palantir/javapoet/pull/8

Relevant tech blog post from a few years ago here: https://blog.palantir.com/using-static-analysis-to-prevent-java-class-initialization-deadlocks-c2f31ca967d6

==COMMIT_MSG==
Remove our workaround for an old Javapoet class init deadlock
==COMMIT_MSG==

