### PR TITLE
[idea - do not merge] better snapshot testing with a JUnit extension

### DIFF
--- a/conjure-java-core-tests/build.gradle
+++ b/conjure-java-core-tests/build.gradle
@@ -1,0 +1,110 @@
+buildscript {
+    repositories {
+        mavenCentral() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }
+    }
+    dependencies {
+        classpath 'org.yaml:snakeyaml:1.23'
+        classpath 'com.palantir.conjure:conjure-api-objects:4.50.0'
+        classpath 'com.palantir.conjure:conjure-core:4.50.0'
+        classpath 'com.palantir.javapoet:javapoet:0.5.0'
+        classpath 'com.atlassian.commonmark:commonmark:0.12.1'
+        classpath 'org.yaml:snakeyaml:2.3'
+        classpath files("${project(':conjure-java-core').buildDir}/classes/java/main")
+    }
+}
+
+plugins {
+    id 'java'
+}
+
+sourceSets {
+    tests {
+        java {
+            srcDir 'src/tests'
+        }
+    }
+    myExample {
+        java {
+            srcDirs 'src/myExampleTest**'
+        }
+    }
+
+    example {
+        java {
+            srcDirs.each { dir->
+                srcDir dir
+            }
+        }
+    }
+}
+
+dependencies {
+    compileOnly gradleApi()
+    // verify that compileJava on conjure-java-core runs before this task
+    implementation project(':conjure-java-core')
+}
+
+
+import com.palantir.conjure.defs.Conjure
+import com.palantir.conjure.java.Options
+import com.palantir.conjure.spec.ConjureDefinition
+import com.palantir.conjure.java.types.ObjectGenerator
+import org.yaml.snakeyaml.LoaderOptions
+import org.yaml.snakeyaml.Yaml
+
+class TestTask extends DefaultTask {
+
+    private static Map<String, Object> parseYaml(String yaml) {
+        LoaderOptions options = new LoaderOptions()
+        return new Yaml(options).load(yaml)
+    }
+
+    @TaskAction
+    void run() {
+        String testSpec = """
+testNoStaticFactoryGenerated:
+  docs: 'some docs here'
+  path: example-types.yml
+  generators:
+    - object:
+        options:
+          preferObjectBuilders: true
+"""
+//        getLogger().lifecycle("hello from TestTask")
+//        def yamlDef = parseYaml(testSpec)
+//        // For each test case in the testSpec
+//        for (String testCase : yamlDef.keySet()) {
+//            getLogger().lifecycle("testCase: " + testCase)
+//            Map<String, Object> testCaseDef = yamlDef.get(testCase)
+//            getLogger().lifecycle("testCaseDef: " + testCaseDef)
+//
+//            // Create a new directory under src for the test case
+//            def directory = new File("${project.getRootDir()}/conjure-java-core-tests/src/${testCase}")
+//            directory.mkdirs()
+//
+//            getLogger().lifecycle("generators: " + testCaseDef.get("generators"))
+//            for (Map<String, Object> generator : testCaseDef.get("generators")) {
+//                getLogger().lifecycle("generator: " + generator)
+//                getLogger().lifecycle("options: " + generator.get("options"))
+//            }
+//        }
+
+
+
+        File defYaml = new File("${project.getRootDir()}/conjure-java-core-tests/src/test/resources/example-types.yml");
+        ConjureDefinition definition = Conjure.parse(List.of(defYaml))
+        ObjectGenerator objectGenerator = new ObjectGenerator(Options.builder()
+                .useImmutableBytes(true)
+                .strictObjects(true)
+                .nonNullCollections(true)
+                .excludeEmptyOptionals(true)
+                .unionsWithUnknownValues(true)
+                .jetbrainsContractAnnotations(true)
+                .build())
+        def files = objectGenerator.generate(definition).map {it -> it.toString()}
+        getLogger().lifecycle("Generated files: ${files.toList()}")
+
+    }
+}
+
+tasks.register("testTask", TestTask)

--- a/conjure-java-core-tests/build.gradle
+++ b/conjure-java-core-tests/build.gradle
@@ -23,27 +23,26 @@ sourceSets {
             srcDir 'src/tests'
         }
     }
-    myExample {
-        java {
-            srcDirs 'src/myExampleTest**'
-        }
-    }
 
-    example {
+    sourceSetTest {
         java {
-            srcDirs.each { dir->
-                srcDir dir
-            }
+            srcDirs 'src/main/exampleTest'
         }
     }
 }
+
+idea {
+    module {
+        sourceDirs += sourceSets.sourceSetTest.java.srcDirs
+    }
+}
+
 
 dependencies {
     compileOnly gradleApi()
     // verify that compileJava on conjure-java-core runs before this task
-    implementation project(':conjure-java-core')
+    // implementation project(':conjure-java-core')
 }
-
 
 import com.palantir.conjure.defs.Conjure
 import com.palantir.conjure.java.Options

--- a/conjure-java-core-tests/build.gradle
+++ b/conjure-java-core-tests/build.gradle
@@ -26,7 +26,15 @@ sourceSets {
 
     sourceSetTest {
         java {
-            srcDirs 'src/main/exampleTest'
+            // iterate through directories in src/main
+            def srcMain = file("src/main")
+            if (srcMain.exists() && srcMain.isDirectory()) {
+                srcMain.listFiles().each { srcDir ->
+                    if (srcDir.isDirectory() && srcDir.name.startsWith("exampleTest")) {
+                        srcDirs srcDir
+                    }
+                }
+            }
         }
     }
 }

--- a/conjure-java-core-tests/src/main/exampleTest/com/palantir/product/SourceSetTest.java
+++ b/conjure-java-core-tests/src/main/exampleTest/com/palantir/product/SourceSetTest.java
@@ -1,0 +1,3 @@
+package com.palantir.product;
+
+record SourceSetTest(String example, String test) {}

--- a/conjure-java-core-tests/src/main/exampleTestTwo/com/palantir/product/SourceSetTestTwo.java
+++ b/conjure-java-core-tests/src/main/exampleTestTwo/com/palantir/product/SourceSetTestTwo.java
@@ -1,0 +1,1 @@
+record SourceSetTestTwo(sdjklf){}

--- a/conjure-java-core-tests/src/main/java/com/palantir/conjure/TestTask.java
+++ b/conjure-java-core-tests/src/main/java/com/palantir/conjure/TestTask.java
@@ -21,7 +21,5 @@ import org.gradle.api.tasks.TaskAction;
 
 public final class TestTask extends DefaultTask {
     @TaskAction
-    void action() {
-        System.out.println("hello");
-    }
+    void action() {}
 }

--- a/conjure-java-core-tests/src/main/java/com/palantir/conjure/TestTask.java
+++ b/conjure-java-core-tests/src/main/java/com/palantir/conjure/TestTask.java
@@ -1,0 +1,27 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+
+public final class TestTask extends DefaultTask {
+    @TaskAction
+    void action() {
+        System.out.println("hello");
+    }
+}

--- a/conjure-java-core-tests/src/myExampleTest/com/palantir/product/RecordOne.java
+++ b/conjure-java-core-tests/src/myExampleTest/com/palantir/product/RecordOne.java
@@ -1,0 +1,19 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.com.palantir.product;
+
+public class RecordOne {}

--- a/conjure-java-core-tests/src/myExampleTestTwo/com/palantir/product/RecordTwo.java
+++ b/conjure-java-core-tests/src/myExampleTestTwo/com/palantir/product/RecordTwo.java
@@ -1,0 +1,3 @@
+package com.palantir.product;
+
+public class RecordTwo {}

--- a/conjure-java-core-tests/src/test/resources/example-types.yml
+++ b/conjure-java-core-tests/src/test/resources/example-types.yml
@@ -1,0 +1,7 @@
+types:
+  definitions:
+    default-package: com.palantir.product
+    objects:
+      StringExample:
+        fields:
+          string: string

--- a/conjure-java-core/build.gradle
+++ b/conjure-java-core/build.gradle
@@ -122,3 +122,46 @@ tasks.withType(JavaCompile) {
     // this complains about the integrationInput directory
     options.errorprone.disable 'StrictUnusedVariable'
 }
+
+/**
+buildscript {
+    repositories {
+        mavenCentral() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }
+    }
+    dependencies {
+        classpath files('build/classes/java/main')
+        classpath 'org.yaml:snakeyaml:1.23'
+        classpath 'com.palantir.conjure:conjure-api-objects:4.50.0'
+        classpath 'com.palantir.conjure:conjure-core:4.50.0'
+    }
+}
+
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.conjure.defs.Conjure;
+
+tasks.register('HelloTask') {
+    dependsOn tasks.compileJava
+    doLast {
+        def urls = sourceSets.main.runtimeClasspath.files.collect { it.toURI().toURL() } as URL[]
+        def classloader = new URLClassLoader(urls, ClassLoader.getSystemClassLoader())
+        def GenerationCoordinator = classloader.loadClass('com.palantir.conjure.java.GenerationCoordinator')
+
+        def ObjectGenerator = classloader.loadClass('com.palantir.conjure.java.types.ObjectGenerator')
+        // def ConjureDefinition = classloader.loadClass('com.palantir.conjure.spec.ConjureDefinition')
+        // def Conjure = classloader.loadClass('com.palantir.conjure.defs.Conjure')
+        def Options = classloader.loadClass('com.palantir.conjure.java.Options')
+        // Construct an Options object
+        def options = Options.builder().nonNullCollections(true).strictObjects(true).build()
+        // Create a temp directory under build
+        def tempDir = file("src/test/generated")
+        def file = new File("${project.rootDir}/conjure-java-core/src/test/resources/example-types.yml")
+        def definition = Conjure.parse(List.of(file));
+        List<Path> files = GenerationCoordinator.getDeclaredConstructor()
+                .newInstance(MoreExecutors.directExecutor(),
+                        Set.of(ObjectGenerator.getDeclaredConstructor().newInstance(options)),
+                        Options.invokeMethod("empty"))
+                .invokeMethod("emit", definition, tempDir.toPath());
+        println("Hello from a gradle task!")
+    }
+}
+ */

--- a/conjure-java-core/src/expect/UndertowServiceGeneratorTests/testEndpointWithNameCollisionsSnapshot/com/palantir/product/NameCollisionServiceEndpoints.java
+++ b/conjure-java-core/src/expect/UndertowServiceGeneratorTests/testEndpointWithNameCollisionsSnapshot/com/palantir/product/NameCollisionServiceEndpoints.java
@@ -1,0 +1,215 @@
+package com.palantir.product;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.conjure.java.undertow.lib.Deserializer;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.RequestContext;
+import com.palantir.conjure.java.undertow.lib.Serializer;
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.tokens.auth.AuthHeader;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderMap;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import io.undertow.util.PathTemplateMatch;
+import io.undertow.util.StatusCodes;
+import java.io.IOException;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.services.UndertowServiceHandlerGenerator")
+public final class NameCollisionServiceEndpoints implements UndertowService {
+    private final UndertowNameCollisionService delegate;
+
+    private NameCollisionServiceEndpoints(UndertowNameCollisionService delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(UndertowNameCollisionService delegate) {
+        return new NameCollisionServiceEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return ImmutableList.of(
+                new IntEndpoint(runtime, delegate),
+                new NoContextEndpoint(runtime, delegate),
+                new ContextEndpoint(runtime, delegate));
+    }
+
+    private static final class IntEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final UndertowNameCollisionService delegate;
+
+        private final Deserializer<String> deserializer;
+
+        private final Serializer<String> serializer;
+
+        IntEndpoint(UndertowRuntime runtime, UndertowNameCollisionService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            RequestContext requestContext = runtime.contexts().createContext(exchange, this);
+            String deserializer_ = deserializer.deserialize(exchange);
+            Map<String, String> pathParams =
+                    exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
+            String runtime_ = runtime.plainSerDe().deserializeString(pathParams.get("runtime"));
+            requestContext.requestArg(SafeArg.of("runtime", runtime_));
+            HeaderMap headerParams = exchange.getRequestHeaders();
+            String serializer_ = runtime.plainSerDe().deserializeString(headerParams.get("Serializer"));
+            requestContext.requestArg(SafeArg.of("serializer", serializer_));
+            Map<String, Deque<String>> queryParams = exchange.getQueryParameters();
+            String authHeader_ = runtime.plainSerDe().deserializeString(queryParams.get("authHeader"));
+            requestContext.requestArg(SafeArg.of("authHeader", authHeader_));
+            String long_ = runtime.plainSerDe().deserializeString(queryParams.get("long"));
+            requestContext.requestArg(SafeArg.of("long", long_));
+            String delegate_ = runtime.plainSerDe().deserializeString(queryParams.get("delegate"));
+            requestContext.requestArg(SafeArg.of("delegate", delegate_));
+            String result_ = runtime.plainSerDe().deserializeString(queryParams.get("result"));
+            requestContext.requestArg(SafeArg.of("result", result_));
+            String result = delegate.int_(
+                    authHeader, serializer_, runtime_, authHeader_, long_, delegate_, result_, deserializer_);
+            serializer.serialize(result, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/{runtime}";
+        }
+
+        @Override
+        public String serviceName() {
+            return "NameCollisionService";
+        }
+
+        @Override
+        public String name() {
+            return "int";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class NoContextEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final UndertowNameCollisionService delegate;
+
+        private final Deserializer<String> deserializer;
+
+        NoContextEndpoint(UndertowRuntime runtime, UndertowNameCollisionService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {}, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            String requestContext_ = deserializer.deserialize(exchange);
+            delegate.noContext(requestContext_);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/no/context";
+        }
+
+        @Override
+        public String serviceName() {
+            return "NameCollisionService";
+        }
+
+        @Override
+        public String name() {
+            return "noContext";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class ContextEndpoint implements HttpHandler, Endpoint {
+        private static final ImmutableSet<String> TAGS = ImmutableSet.of("server-request-context");
+
+        private final UndertowRuntime runtime;
+
+        private final UndertowNameCollisionService delegate;
+
+        private final Deserializer<String> deserializer;
+
+        ContextEndpoint(UndertowRuntime runtime, UndertowNameCollisionService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {}, this);
+        }
+
+        @Override
+        public Set<String> tags() {
+            return TAGS;
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            RequestContext requestContext = runtime.contexts().createContext(exchange, this);
+            String requestContext_ = deserializer.deserialize(exchange);
+            delegate.context(requestContext_, requestContext);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/context";
+        }
+
+        @Override
+        public String serviceName() {
+            return "NameCollisionService";
+        }
+
+        @Override
+        public String name() {
+            return "context";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}

--- a/conjure-java-core/src/expect/UndertowServiceGeneratorTests/testEndpointWithNameCollisionsSnapshot/com/palantir/product/UndertowNameCollisionService.java
+++ b/conjure-java-core/src/expect/UndertowServiceGeneratorTests/testEndpointWithNameCollisionsSnapshot/com/palantir/product/UndertowNameCollisionService.java
@@ -1,0 +1,26 @@
+package com.palantir.product;
+
+import com.palantir.conjure.java.undertow.lib.RequestContext;
+import com.palantir.logsafe.Safe;
+import com.palantir.tokens.auth.AuthHeader;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
+public interface UndertowNameCollisionService {
+    /** @apiNote {@code POST /{runtime}} */
+    String int_(
+            AuthHeader authHeader,
+            @Safe String serializer,
+            @Safe String runtime,
+            @Safe String authHeader_,
+            @Safe String long_,
+            @Safe String delegate,
+            @Safe String result,
+            @Safe String deserializer);
+
+    /** @apiNote {@code POST /no/context} */
+    void noContext(String requestContext);
+
+    /** @apiNote {@code POST /context} */
+    void context(String requestContext_, RequestContext requestContext);
+}

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceGeneratorTests.java
@@ -22,6 +22,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.conjure.defs.Conjure;
+import com.palantir.conjure.java.expecttest.core.SnapshotTest;
+import com.palantir.conjure.java.expecttest.core.SnapshotTester;
+import com.palantir.conjure.java.expecttest.ext.ExpectTestExtension;
 import com.palantir.conjure.java.services.UndertowServiceGenerator;
 import com.palantir.conjure.spec.ConjureDefinition;
 import java.io.File;
@@ -32,12 +35,15 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(ExpectTestExtension.class)
 public final class UndertowServiceGeneratorTests extends TestBase {
+
     @TempDir
     public File tempDir;
 
@@ -79,6 +85,15 @@ public final class UndertowServiceGeneratorTests extends TestBase {
                         MoreExecutors.directExecutor(), ImmutableSet.of(new UndertowServiceGenerator(Options.empty())))
                 .emit(def, tempDir);
         validateGeneratorOutput(files, Paths.get("src/test/resources/test/api"), ".undertow.binary");
+    }
+
+    @Test
+    public void testEndpointWithNameCollisionsSnapshot(@SnapshotTest SnapshotTester expect) throws IOException {
+        expect.expect(
+                tempDir.toPath(),
+                new UndertowServiceGenerator(
+                        Options.builder().undertowServicePrefix(true).build()),
+                Conjure.parse(ImmutableList.of(new File("src/test/resources/dangerous-name-service.yml"))));
     }
 
     @Test

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/expecttest/core/SnapshotTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/expecttest/core/SnapshotTest.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.expecttest.core;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// JUnit needs to access this annotation at runtime.
+@Retention(RetentionPolicy.RUNTIME)
+// Annotate test methods
+@Target(ElementType.PARAMETER)
+public @interface SnapshotTest {}

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/expecttest/core/SnapshotTester.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/expecttest/core/SnapshotTester.java
@@ -73,6 +73,5 @@ public final class SnapshotTester {
         return Path.of("src/expect/" + testClass + "/" + testMethod);
     }
 
-    // Smarter diff
-    private String diff(String contents1, String contents2) {}
+    // TODO(pm): smarter file diff.
 }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/expecttest/core/SnapshotTester.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/expecttest/core/SnapshotTester.java
@@ -1,0 +1,78 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.expecttest.core;
+
+import static org.assertj.core.api.Assertions.fail;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.conjure.java.GenerationCoordinator;
+import com.palantir.conjure.java.Generator;
+import com.palantir.conjure.spec.ConjureDefinition;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+public final class SnapshotTester {
+    private final String testClass;
+    private final String testMethod;
+
+    public SnapshotTester(String testClass, String testMethod) {
+        this.testClass = testClass;
+        this.testMethod = testMethod;
+    }
+
+    public void expect(Path tempDir, Generator codeGenerator, ConjureDefinition def) throws IOException {
+        File src = Files.createDirectory(tempDir.resolve("src")).toFile();
+        List<Path> files = new GenerationCoordinator(MoreExecutors.directExecutor(), ImmutableSet.of(codeGenerator))
+                .emit(def, src);
+        Path outputDir = testDirectory();
+        // The output dir should actually create directories for the packages in the generated code
+        if (!outputDir.toFile().exists()) {
+            Files.createDirectories(outputDir);
+        }
+        for (Path file : files) {
+            Path relativePath = src.toPath().relativize(file);
+            Path output = outputDir.resolve(relativePath);
+            if (Boolean.parseBoolean(System.getProperty("recreate", "false"))) {
+                Files.createDirectories(output.getParent());
+                Files.deleteIfExists(output);
+                Files.copy(file, output);
+            }
+            if (!readFromFile(file).equals(readFromFile(output))) {
+                fail("Generated file does not match expected file: " + relativePath);
+            }
+        }
+    }
+
+    private static String readFromFile(Path file) {
+        try {
+            return Files.readString(file);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Path testDirectory() {
+        return Path.of("src/expect/" + testClass + "/" + testMethod);
+    }
+
+    // Smarter diff
+    private String diff(String contents1, String contents2) {}
+}

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/expecttest/ext/ExpectTestExtension.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/expecttest/ext/ExpectTestExtension.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.expecttest.ext;
+
+import com.palantir.conjure.java.expecttest.core.SnapshotTest;
+import com.palantir.conjure.java.expecttest.core.SnapshotTester;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+public final class ExpectTestExtension implements ParameterResolver {
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        return parameterContext.isAnnotated(SnapshotTest.class)
+                && parameterContext.getParameter().getType().equals(SnapshotTester.class);
+    }
+
+    @Override
+    public SnapshotTester resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        return new SnapshotTester(
+                extensionContext.getRequiredTestClass().getSimpleName(),
+                extensionContext.getRequiredTestMethod().getName());
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,7 @@ rootProject.name = 'palantir-conjure-java'
 
 include 'conjure-java'
 include 'conjure-java-core'
+include 'conjure-java-core-tests'
 include 'conjure-java-client-verifier'
 include 'conjure-java-client-verifier:verification-server-api'
 include 'conjure-java-server-verifier'


### PR DESCRIPTION
## Before this PR
Currently we test the output of various code [Generators](https://github.com/palantir/conjure-java/blob/develop/conjure-java-core/src/main/java/com/palantir/conjure/java/Generator.java) by checking in the expected source files in an [integrationInput](https://github.com/palantir/conjure-java/tree/develop/conjure-java-core/src/integrationInput) directory, and [comparing the output of the generated code to files in that directory](https://github.com/palantir/conjure-java/blob/develop/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceGeneratorTests.java#L81). When there is an update in the generated code, we re-create the reference files by setting an environment variable (`recreate`) before running tests.

Problem: we store all of the reference files in one directory. This makes it tedious to test multiple configurations which generate the same files. 
- For example, when testing an update that omits static factories, we checked in [a new conjure definition](https://github.com/palantir/conjure-java/blob/develop/conjure-java-core/src/test/resources/example-types-no-static-factory.yml) with new types, when we could have used [the existing file](https://github.com/palantir/conjure-java/blob/develop/conjure-java-core/src/test/resources/example-types.yml) and set [the relevant flag when testing code gen](https://github.com/palantir/conjure-java/blob/develop/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java#L186)

## After this PR
We can remove some of the tedium with our snapshot testing setup by having a JUnit extension (and maybe Gradle plugin - see downsides section) handle the generation and update of the directories and files associated with each test.

Annotating a parameter of a JUnit test (with `@SnapshotTest` in this case) will trigger the JUnit extension which will construct a `SnapshotTest` object with required test context (like test name) used for getting the directory of the reference files.

## Possible downsides?
- No nice tooling to update expected results (yet). Snapshot testing libraries in other languages have tools which provide a nice dev-experience when updating tests. See [jest (ts)](https://jestjs.io/docs/snapshot-testing#interactive-snapshot-mode), [insta (rust)](https://insta.rs/docs/quickstart/#:~:text=(words)%3B%0A%7D-,Reviewing%20Snapshots,-The%20recommended%20flow) or [ppx_expect (ocaml)](https://blog.janestreet.com/the-joy-of-expect-tests/)
  - it's possible to build a gradle plugin to have a similar dev-ex.
  - I found [this library](https://github.com/origin-energy/java-snapshot-testing) in Java, but I only see the `update-snapshot` flag which acts like our `recreate`
- Not a huge drawback. Lots of sources files checked into the repository: we'll have to check in the full set of files generated by each configuration we test.

