### PR TITLE
Deserialize sets preserving order in union and alias types

### DIFF
--- a/changelog/@unreleased/pr-2467.v2.yml
+++ b/changelog/@unreleased/pr-2467.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Instructs Jackson to deserialize sets within union and alias types
+    as `LinkedHashSet`s in order to preserve element ordering.
+  links:
+  - https://github.com/palantir/conjure-java/pull/2467

--- a/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/SetAlias.java
+++ b/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/SetAlias.java
@@ -2,8 +2,10 @@ package allexamples.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.logsafe.Preconditions;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -60,7 +62,7 @@ public final class SetAlias {
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static SetAlias of(@Nonnull Set<String> value) {
+    public static SetAlias of(@Nonnull @JsonDeserialize(as = LinkedHashSet.class) Set<String> value) {
         return new SetAlias(value);
     }
 

--- a/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/UnionTypeExample.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
@@ -18,6 +19,7 @@ import com.palantir.logsafe.Unsafe;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1182,7 +1184,9 @@ public final class UnionTypeExample {
         private final Set<String> value;
 
         @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-        private SetWrapper(@JsonSetter(value = "set", nulls = Nulls.AS_EMPTY) @Nonnull Set<String> value) {
+        private SetWrapper(
+                @JsonSetter(value = "set", nulls = Nulls.AS_EMPTY) @JsonDeserialize(as = LinkedHashSet.class) @Nonnull
+                        Set<String> value) {
             Preconditions.checkNotNull(value, "set cannot be null");
             this.value = value;
         }

--- a/conjure-java-core/src/integrationInput/java/excludeemptycollections/com/palantir/product/CollectionsTestAliasSet.java
+++ b/conjure-java-core/src/integrationInput/java/excludeemptycollections/com/palantir/product/CollectionsTestAliasSet.java
@@ -2,8 +2,10 @@ package excludeemptycollections.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.logsafe.Preconditions;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -60,7 +62,7 @@ public final class CollectionsTestAliasSet {
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static CollectionsTestAliasSet of(@Nonnull Set<Integer> value) {
+    public static CollectionsTestAliasSet of(@Nonnull @JsonDeserialize(as = LinkedHashSet.class) Set<Integer> value) {
         return new CollectionsTestAliasSet(value);
     }
 

--- a/conjure-java-core/src/integrationInput/java/template/com/palantir/product/SetAlias.java
+++ b/conjure-java-core/src/integrationInput/java/template/com/palantir/product/SetAlias.java
@@ -2,8 +2,10 @@ package template.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.logsafe.Preconditions;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -60,7 +62,7 @@ public final class SetAlias {
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static SetAlias of(@Nonnull Set<String> value) {
+    public static SetAlias of(@Nonnull @JsonDeserialize(as = LinkedHashSet.class) Set<String> value) {
         return new SetAlias(value);
     }
 

--- a/conjure-java-core/src/integrationInput/java/template/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/template/com/palantir/product/UnionTypeExample.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
@@ -87,7 +88,7 @@ public final class UnionTypeExample {
         return new UnionTypeExample(new ListWrapper(value));
     }
 
-    public static UnionTypeExample set(LinkedHashSet<String> value) {
+    public static UnionTypeExample set(Set<String> value) {
         return new UnionTypeExample(new SetWrapper(value));
     }
 
@@ -1173,7 +1174,9 @@ public final class UnionTypeExample {
         private final Set<String> value;
 
         @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-        private SetWrapper(@JsonSetter(value = "set", nulls = Nulls.AS_EMPTY) @Nonnull Set<String> value) {
+        private SetWrapper(
+                @JsonSetter(value = "set", nulls = Nulls.AS_EMPTY) @JsonDeserialize(as = LinkedHashSet.class) @Nonnull
+                        Set<String> value) {
             Preconditions.checkNotNull(value, "set cannot be null");
             this.value = value;
         }

--- a/conjure-java-core/src/integrationInput/java/template/com/palantir/product/UnionTypeExample.java
+++ b/conjure-java-core/src/integrationInput/java/template/com/palantir/product/UnionTypeExample.java
@@ -18,6 +18,7 @@ import com.palantir.logsafe.Unsafe;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -86,7 +87,7 @@ public final class UnionTypeExample {
         return new UnionTypeExample(new ListWrapper(value));
     }
 
-    public static UnionTypeExample set(Set<String> value) {
+    public static UnionTypeExample set(LinkedHashSet<String> value) {
         return new UnionTypeExample(new SetWrapper(value));
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.java.types;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.ConjureAnnotations;
 import com.palantir.conjure.java.Options;
@@ -51,6 +52,7 @@ import com.palantir.logsafe.Safe;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -134,7 +136,7 @@ public final class AliasGenerator {
         spec.addMethod(MethodSpec.methodBuilder("of")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .addAnnotation(ConjureAnnotations.delegatingJsonCreator())
-                .addParameter(Parameters.nonnullParameter(aliasTypeName, "value"))
+                .addParameter(getAliasFactoryParameter(typeDef.getAlias(), aliasTypeName))
                 .returns(thisClass)
                 .addStatement("return new $T(value)", thisClass)
                 .build());
@@ -226,6 +228,19 @@ public final class AliasGenerator {
                 .skipJavaLangImports(true)
                 .indent("    ")
                 .build();
+    }
+
+    private static ParameterSpec getAliasFactoryParameter(Type aliasType, TypeName aliasTypeName) {
+        ParameterSpec parameterSpec = Parameters.nonnullParameter(aliasTypeName, "value");
+        if (aliasType.accept(TypeVisitor.IS_SET)) {
+            AnnotationSpec deserializeAnnotation = AnnotationSpec.builder(JsonDeserialize.class)
+                    .addMember("as", "$T.class", LinkedHashSet.class)
+                    .build();
+            return parameterSpec.toBuilder()
+                    .addAnnotation(deserializeAnnotation)
+                    .build();
+        }
+        return parameterSpec;
     }
 
     private static void addEmptyMethod(TypeSpec.Builder spec, TypeName thisClass) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -746,7 +746,7 @@ public final class UnionGenerator {
                                     .addParameter(ParameterSpec.builder(memberType, VALUE_FIELD_NAME)
                                             .addAnnotation(
                                                     wrapperConstructorParameterAnnotation(memberTypeDef, typesMap))
-                                            .addAnnotations(maybeAddDeserializationAnnotation(memberTypeDef))
+                                            .addAnnotations(deserializationAnnotationForSets(memberTypeDef))
                                             .addAnnotation(Nonnull.class)
                                             .build())
                                     .addStatement(
@@ -796,7 +796,7 @@ public final class UnionGenerator {
                 .collect(Collectors.toList());
     }
 
-    private static Iterable<AnnotationSpec> maybeAddDeserializationAnnotation(FieldDefinition field) {
+    private static Iterable<AnnotationSpec> deserializationAnnotationForSets(FieldDefinition field) {
         if (field.getType().accept(TypeVisitor.IS_SET)) {
             return List.of(AnnotationSpec.builder(JsonDeserialize.class)
                     .addMember("as", "$T.class", LinkedHashSet.class)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.PeekingIterator;
@@ -43,6 +44,7 @@ import com.palantir.conjure.spec.FieldName;
 import com.palantir.conjure.spec.Type;
 import com.palantir.conjure.spec.TypeDefinition;
 import com.palantir.conjure.spec.UnionDefinition;
+import com.palantir.conjure.visitor.TypeVisitor;
 import com.palantir.javapoet.AnnotationSpec;
 import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.CodeBlock;
@@ -61,6 +63,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -743,6 +746,7 @@ public final class UnionGenerator {
                                     .addParameter(ParameterSpec.builder(memberType, VALUE_FIELD_NAME)
                                             .addAnnotation(
                                                     wrapperConstructorParameterAnnotation(memberTypeDef, typesMap))
+                                            .addAnnotations(maybeAddDeserializationAnnotation(memberTypeDef))
                                             .addAnnotation(Nonnull.class)
                                             .build())
                                     .addStatement(
@@ -790,6 +794,15 @@ public final class UnionGenerator {
                     return typeBuilder.build();
                 })
                 .collect(Collectors.toList());
+    }
+
+    private static Iterable<AnnotationSpec> maybeAddDeserializationAnnotation(FieldDefinition field) {
+        if (field.getType().accept(TypeVisitor.IS_SET)) {
+            return List.of(AnnotationSpec.builder(JsonDeserialize.class)
+                    .addMember("as", "$T.class", LinkedHashSet.class)
+                    .build());
+        }
+        return List.of();
     }
 
     private static AnnotationSpec wrapperConstructorParameterAnnotation(

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -48,6 +48,7 @@ import allexamples.com.palantir.product.StringAliasTwo;
 import allexamples.com.palantir.product.StringExample;
 import allexamples.com.palantir.product.UnionTypeExample;
 import allexamples.com.palantir.product.UuidExample;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -60,6 +61,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -625,6 +627,24 @@ public final class WireFormatTests {
                         .optionalAlias(OptionalAlias.of(Optional.of("")))
                         .build()))
                 .isEqualTo("{\"optionalAlias\":\"\"}");
+    }
+
+    @Test
+    void testRoundTripSetOrderPreservation_alias() throws JsonProcessingException {
+        SetAlias original = SetAlias.of(new LinkedHashSet<>(List.of("one", "two", "3", "four", "5")));
+        String originalJson = mapper.writeValueAsString(original);
+        SetAlias recreated = mapper.readValue(originalJson, SetAlias.class);
+        String recreatedJson = mapper.writeValueAsString(recreated);
+        assertThat(recreatedJson).isEqualTo(originalJson);
+    }
+
+    @Test
+    void testRoundTripSetOrderPreservation_union() throws JsonProcessingException {
+        UnionTypeExample original = UnionTypeExample.set(new LinkedHashSet<>(List.of("one", "two", "3", "four", "5")));
+        String originalJson = mapper.writeValueAsString(original);
+        UnionTypeExample recreated = mapper.readValue(originalJson, UnionTypeExample.class);
+        String recreatedJson = mapper.writeValueAsString(recreated);
+        assertThat(recreatedJson).isEqualTo(originalJson);
     }
 
     private static final class TestVisitor implements UnionTypeExample.Visitor<Integer> {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -647,6 +647,16 @@ public final class WireFormatTests {
         assertThat(recreatedJson).isEqualTo(originalJson);
     }
 
+    @Test
+    void testRoundTripSetOrderPreservation_union_alias() throws JsonProcessingException {
+        UnionTypeExample original =
+                UnionTypeExample.setAlias(SetAlias.of(new LinkedHashSet<>(List.of("one", "two", "3", "four", "5"))));
+        String originalJson = mapper.writeValueAsString(original);
+        UnionTypeExample recreated = mapper.readValue(originalJson, UnionTypeExample.class);
+        String recreatedJson = mapper.writeValueAsString(recreated);
+        assertThat(recreatedJson).isEqualTo(originalJson);
+    }
+
     private static final class TestVisitor implements UnionTypeExample.Visitor<Integer> {
         @Override
         public Integer visitStringExample(StringExample stringExampleValue) {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Jackson deserializes sets into `HashSet`s by default, which loses any element ordering and means roundtrip serde is equal but not identical. Instructing Jackson to deserialize sets as `LinkedHashSet`s instead maintains order.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Instructs Jackson to deserialize sets within union and alias types as `LinkedHashSet`s in order to preserve element ordering.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
We never guaranteed ordering of sets so modifying this shouldn't be an issue.
