### PR TITLE
nit: Make `ReturnTypeMapper` package-private

### DIFF
--- a/changelog/@unreleased/pr-2472.v2.yml
+++ b/changelog/@unreleased/pr-2472.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: 'nit: Make ReturnTypeMapper package-private'
+  links:
+  - https://github.com/palantir/conjure-java/pull/2472

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/ReturnTypeMapper.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/ReturnTypeMapper.java
@@ -25,23 +25,23 @@ import com.palantir.javapoet.ParameterizedTypeName;
 import com.palantir.javapoet.TypeName;
 import java.util.Optional;
 
-public final class ReturnTypeMapper {
+final class ReturnTypeMapper {
     private static final ClassName LISTENABLE_FUTURE = ClassName.get(ListenableFuture.class);
     private final TypeMapper returnTypes;
 
-    public ReturnTypeMapper(TypeMapper returnTypes) {
+    ReturnTypeMapper(TypeMapper returnTypes) {
         this.returnTypes = returnTypes;
     }
 
-    public TypeName baseType(Type type) {
+    TypeName baseType(Type type) {
         return returnTypes.getClassName(type);
     }
 
-    public TypeName baseType(Optional<Type> type) {
+    TypeName baseType(Optional<Type> type) {
         return type.map(this::baseType).orElse(TypeName.VOID);
     }
 
-    public TypeName async(Optional<Type> type) {
+    TypeName async(Optional<Type> type) {
         return ParameterizedTypeName.get(LISTENABLE_FUTURE, Primitives.box(baseType(type)));
     }
 }


### PR DESCRIPTION
## Before this PR
`ReturnTypeMapper` is needlessly public. It should not be used outside of conjure-java's Dialogue client generation code.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
nit: Make ReturnTypeMapper package-private
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

