### PR TITLE
More descriptive error messages when generation fails due to invalid query param type

### DIFF
--- a/changelog/@unreleased/pr-2474.v2.yml
+++ b/changelog/@unreleased/pr-2474.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: More descriptive error messages when generation fails due to invalid
+    query param types
+  links:
+  - https://github.com/palantir/conjure-java/pull/2474

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -79,6 +79,7 @@ import com.palantir.javapoet.TypeName;
 import com.palantir.javapoet.TypeSpec;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
 import io.undertow.server.HttpHandler;
@@ -1144,21 +1145,28 @@ final class UndertowServiceHandlerGenerator {
     private static String deserializeFunctionName(Type type) {
         if (type.accept(TypeVisitor.IS_PRIMITIVE)) {
             return "deserialize" + TypeFunctions.primitiveTypeName(type.accept(TypeFunctions.PRIMITIVE_VISITOR));
-        } else if (type.accept(TypeVisitor.IS_OPTIONAL)
-                && type.accept(TypeVisitor.OPTIONAL).getItemType().accept(TypeVisitor.IS_PRIMITIVE)) {
+        } else if (type.accept(TypeVisitor.IS_OPTIONAL)) {
+            if (!type.accept(TypeVisitor.OPTIONAL).getItemType().accept(TypeVisitor.IS_PRIMITIVE)) {
+                throw new SafeIllegalStateException(
+                        "Optional element type must be primitive", SafeArg.of("type", type));
+            }
             PrimitiveType innerPrimitiveType =
                     type.accept(TypeFunctions.OPTIONAL_VISITOR).getItemType().accept(TypeFunctions.PRIMITIVE_VISITOR);
             return "deserializeOptional" + TypeFunctions.primitiveTypeName(innerPrimitiveType);
-        } else if (type.accept(TypeVisitor.IS_LIST)
-                && type.accept(TypeVisitor.LIST).getItemType().accept(TypeVisitor.IS_PRIMITIVE)) {
+        } else if (type.accept(TypeVisitor.IS_LIST)) {
+            if (!type.accept(TypeVisitor.LIST).getItemType().accept(TypeVisitor.IS_PRIMITIVE)) {
+                throw new SafeIllegalStateException("List element type must be primitive", SafeArg.of("type", type));
+            }
             Type subtype = type.accept(TypeVisitor.LIST).getItemType();
             return deserializeFunctionName(subtype) + "List";
-        } else if (type.accept(TypeVisitor.IS_SET)
-                && type.accept(TypeVisitor.SET).getItemType().accept(TypeVisitor.IS_PRIMITIVE)) {
+        } else if (type.accept(TypeVisitor.IS_SET)) {
+            if (!type.accept(TypeVisitor.SET).getItemType().accept(TypeVisitor.IS_PRIMITIVE)) {
+                throw new SafeIllegalStateException("Set element type must be primitive", SafeArg.of("type", type));
+            }
             Type subtype = type.accept(TypeVisitor.SET).getItemType();
             return deserializeFunctionName(subtype) + "Set";
         } else {
-            throw new IllegalStateException("unknown type: " + type);
+            throw new SafeIllegalStateException("unknown type", SafeArg.of("type", type));
         }
     }
 


### PR DESCRIPTION
## Before this PR
Deserialization of query parameters of type `<container>[<container>[T]]` are ambiguous. If we encounter an empty value over the wire, we're not able to disambiguate an empty collection from a missing value. We throw an error with the message "unknown type" which isn't as descriptive as it could be.

Additionally, we should throw an error earlier during Conjure definition validation [defined in this class](https://github.com/palantir/conjure/blob/02104ee75653303258f1f3b149361139e46aa0de/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureDefinitionValidator.java#L56) cc: @kunalrkak 

## After this PR
==COMMIT_MSG==
More descriptive error messages when generation fails due to invalid query param types
==COMMIT_MSG==

## Possible downsides?


