### PR TITLE
Add All Primitive Collection Types to the Test Example

### DIFF
--- a/conjure-java-core/src/integrationInput/java/primitivecollections/com/palantir/product/PrimitiveExample.java
+++ b/conjure-java-core/src/integrationInput/java/primitivecollections/com/palantir/product/PrimitiveExample.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.errorprone.annotations.CheckReturnValue;
+import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.conjure.java.lib.internal.ConjureCollections;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
@@ -26,13 +27,20 @@ public final class PrimitiveExample {
 
     private final List<Double> doubles;
 
+    private final List<SafeLong> longs;
+
+    private final List<Boolean> bools;
+
     private int memoizedHashCode;
 
-    private PrimitiveExample(int field, List<Integer> ints, List<Double> doubles) {
-        validateFields(ints, doubles);
+    private PrimitiveExample(
+            int field, List<Integer> ints, List<Double> doubles, List<SafeLong> longs, List<Boolean> bools) {
+        validateFields(ints, doubles, longs, bools);
         this.field = field;
         this.ints = ConjureCollections.unmodifiableList(ints);
         this.doubles = ConjureCollections.unmodifiableList(doubles);
+        this.longs = ConjureCollections.unmodifiableList(longs);
+        this.bools = ConjureCollections.unmodifiableList(bools);
     }
 
     @JsonProperty("field")
@@ -52,6 +60,28 @@ public final class PrimitiveExample {
         return this.doubles;
     }
 
+    /**
+     * This primitive type is stored optimally, but does not have boxing optimizations.
+     *
+     * <p>This type was added in case we choose to change that later we have a comparison.
+     */
+    @JsonProperty("longs")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<SafeLong> getLongs() {
+        return this.longs;
+    }
+
+    /**
+     * This primitive type is intentionally not optimized
+     *
+     * <p>This type was added in case we choose to change that later we have a comparison.
+     */
+    @JsonProperty("bools")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<Boolean> getBools() {
+        return this.bools;
+    }
+
     @Override
     public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof PrimitiveExample && equalTo((PrimitiveExample) other));
@@ -63,7 +93,11 @@ public final class PrimitiveExample {
                 && this.memoizedHashCode != other.memoizedHashCode) {
             return false;
         }
-        return this.field == other.field && this.ints.equals(other.ints) && this.doubles.equals(other.doubles);
+        return this.field == other.field
+                && this.ints.equals(other.ints)
+                && this.doubles.equals(other.doubles)
+                && this.longs.equals(other.longs)
+                && this.bools.equals(other.bools);
     }
 
     @Override
@@ -74,6 +108,8 @@ public final class PrimitiveExample {
             hash = 31 * hash + this.field;
             hash = 31 * hash + this.ints.hashCode();
             hash = 31 * hash + this.doubles.hashCode();
+            hash = 31 * hash + this.longs.hashCode();
+            hash = 31 * hash + this.bools.hashCode();
             result = hash;
             memoizedHashCode = result;
         }
@@ -82,17 +118,17 @@ public final class PrimitiveExample {
 
     @Override
     public String toString() {
-        return "PrimitiveExample{field: " + field + ", ints: " + ints + ", doubles: " + doubles + '}';
+        return "PrimitiveExample{field: " + field + ", ints: " + ints + ", doubles: " + doubles + ", longs: " + longs
+                + ", bools: " + bools + '}';
     }
 
-    public static PrimitiveExample of(int field, List<Integer> ints, List<Double> doubles) {
-        return builder().field(field).ints(ints).doubles(doubles).build();
-    }
-
-    private static void validateFields(List<Integer> ints, List<Double> doubles) {
+    private static void validateFields(
+            List<Integer> ints, List<Double> doubles, List<SafeLong> longs, List<Boolean> bools) {
         List<String> missingFields = null;
         missingFields = addFieldIfMissing(missingFields, ints, "ints");
         missingFields = addFieldIfMissing(missingFields, doubles, "doubles");
+        missingFields = addFieldIfMissing(missingFields, longs, "longs");
+        missingFields = addFieldIfMissing(missingFields, bools, "bools");
         if (missingFields != null) {
             throw new SafeIllegalArgumentException(
                     "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
@@ -103,7 +139,7 @@ public final class PrimitiveExample {
         List<String> missingFields = prev;
         if (fieldValue == null) {
             if (missingFields == null) {
-                missingFields = new ArrayList<>(2);
+                missingFields = new ArrayList<>(4);
             }
             missingFields.add(fieldName);
         }
@@ -139,6 +175,48 @@ public final class PrimitiveExample {
         Completed_StageBuilder addAllDoubles(@Nonnull double... doubles);
 
         Completed_StageBuilder doubles(double doubles);
+
+        /**
+         * This primitive type is stored optimally, but does not have boxing optimizations.
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        Completed_StageBuilder longs(@Nonnull Iterable<SafeLong> longs);
+
+        /**
+         * This primitive type is stored optimally, but does not have boxing optimizations.
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        Completed_StageBuilder addAllLongs(@Nonnull Iterable<SafeLong> longs);
+
+        /**
+         * This primitive type is stored optimally, but does not have boxing optimizations.
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        Completed_StageBuilder longs(SafeLong longs);
+
+        /**
+         * This primitive type is intentionally not optimized
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        Completed_StageBuilder bools(@Nonnull Iterable<Boolean> bools);
+
+        /**
+         * This primitive type is intentionally not optimized
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        Completed_StageBuilder addAllBools(@Nonnull Iterable<Boolean> bools);
+
+        /**
+         * This primitive type is intentionally not optimized
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        Completed_StageBuilder bools(boolean bools);
     }
 
     public interface Builder extends FieldStageBuilder, Completed_StageBuilder {
@@ -175,6 +253,54 @@ public final class PrimitiveExample {
 
         @Override
         Builder doubles(double doubles);
+
+        /**
+         * This primitive type is stored optimally, but does not have boxing optimizations.
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        @Override
+        Builder longs(@Nonnull Iterable<SafeLong> longs);
+
+        /**
+         * This primitive type is stored optimally, but does not have boxing optimizations.
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        @Override
+        Builder addAllLongs(@Nonnull Iterable<SafeLong> longs);
+
+        /**
+         * This primitive type is stored optimally, but does not have boxing optimizations.
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        @Override
+        Builder longs(SafeLong longs);
+
+        /**
+         * This primitive type is intentionally not optimized
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        @Override
+        Builder bools(@Nonnull Iterable<Boolean> bools);
+
+        /**
+         * This primitive type is intentionally not optimized
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        @Override
+        Builder addAllBools(@Nonnull Iterable<Boolean> bools);
+
+        /**
+         * This primitive type is intentionally not optimized
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        @Override
+        Builder bools(boolean bools);
     }
 
     @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
@@ -188,6 +314,10 @@ public final class PrimitiveExample {
 
         private List<Double> doubles = ConjureCollections.newNonNullDoubleList();
 
+        private List<SafeLong> longs = ConjureCollections.newNonNullSafeLongList();
+
+        private List<Boolean> bools = ConjureCollections.newNonNullList();
+
         private boolean _fieldInitialized = false;
 
         private DefaultBuilder() {}
@@ -198,6 +328,8 @@ public final class PrimitiveExample {
             field(other.getField());
             ints(other.getInts());
             doubles(other.getDoubles());
+            longs(other.getLongs());
+            bools(other.getBools());
             return this;
         }
 
@@ -275,6 +407,85 @@ public final class PrimitiveExample {
             return this;
         }
 
+        /**
+         * This primitive type is stored optimally, but does not have boxing optimizations.
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        @Override
+        @JsonSetter(value = "longs", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
+        public Builder longs(@Nonnull Iterable<SafeLong> longs) {
+            checkNotBuilt();
+            this.longs = ConjureCollections.newNonNullSafeLongList(
+                    Preconditions.checkNotNull(longs, "longs cannot be null"));
+            return this;
+        }
+
+        /**
+         * This primitive type is stored optimally, but does not have boxing optimizations.
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        @Override
+        public Builder addAllLongs(@Nonnull Iterable<SafeLong> longs) {
+            checkNotBuilt();
+            ConjureCollections.addAllAndCheckNonNull(
+                    this.longs, Preconditions.checkNotNull(longs, "longs cannot be null"));
+            return this;
+        }
+
+        /**
+         * This primitive type is stored optimally, but does not have boxing optimizations.
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        @Override
+        public Builder longs(SafeLong longs) {
+            checkNotBuilt();
+            Preconditions.checkNotNull(longs, "longs cannot be null");
+            this.longs.add(longs);
+            return this;
+        }
+
+        /**
+         * This primitive type is intentionally not optimized
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        @Override
+        @JsonSetter(value = "bools", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
+        public Builder bools(@Nonnull Iterable<Boolean> bools) {
+            checkNotBuilt();
+            this.bools = ConjureCollections.newNonNullList(Preconditions.checkNotNull(bools, "bools cannot be null"));
+            return this;
+        }
+
+        /**
+         * This primitive type is intentionally not optimized
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        @Override
+        public Builder addAllBools(@Nonnull Iterable<Boolean> bools) {
+            checkNotBuilt();
+            ConjureCollections.addAllAndCheckNonNull(
+                    this.bools, Preconditions.checkNotNull(bools, "bools cannot be null"));
+            return this;
+        }
+
+        /**
+         * This primitive type is intentionally not optimized
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        @Override
+        public Builder bools(boolean bools) {
+            checkNotBuilt();
+            Preconditions.checkNotNull(bools, "bools cannot be null");
+            this.bools.add(bools);
+            return this;
+        }
+
         private void validatePrimitiveFieldsHaveBeenInitialized() {
             List<String> missingFields = null;
             missingFields = addFieldIfMissing(missingFields, _fieldInitialized, "field");
@@ -301,7 +512,7 @@ public final class PrimitiveExample {
             checkNotBuilt();
             this._buildInvoked = true;
             validatePrimitiveFieldsHaveBeenInitialized();
-            return new PrimitiveExample(field, ints, doubles);
+            return new PrimitiveExample(field, ints, doubles, longs, bools);
         }
 
         private void checkNotBuilt() {

--- a/conjure-java-core/src/integrationInput/java/strictprimitivecollections/com/palantir/product/PrimitiveStrictExample.java
+++ b/conjure-java-core/src/integrationInput/java/strictprimitivecollections/com/palantir/product/PrimitiveStrictExample.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.errorprone.annotations.CheckReturnValue;
+import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.conjure.java.lib.internal.ConjureCollections;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
@@ -24,12 +25,19 @@ public final class PrimitiveStrictExample {
 
     private final List<Double> doubles;
 
+    private final List<SafeLong> longs;
+
+    private final List<Boolean> bools;
+
     private int memoizedHashCode;
 
-    private PrimitiveStrictExample(List<Integer> ints, List<Double> doubles) {
-        validateFields(ints, doubles);
+    private PrimitiveStrictExample(
+            List<Integer> ints, List<Double> doubles, List<SafeLong> longs, List<Boolean> bools) {
+        validateFields(ints, doubles, longs, bools);
         this.ints = ConjureCollections.unmodifiableList(ints);
         this.doubles = ConjureCollections.unmodifiableList(doubles);
+        this.longs = ConjureCollections.unmodifiableList(longs);
+        this.bools = ConjureCollections.unmodifiableList(bools);
     }
 
     @JsonProperty("ints")
@@ -44,6 +52,28 @@ public final class PrimitiveStrictExample {
         return this.doubles;
     }
 
+    /**
+     * This primitive type is stored optimally, but does not have boxing optimizations.
+     *
+     * <p>This type was added in case we choose to change that later we have a comparison.
+     */
+    @JsonProperty("longs")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<SafeLong> getLongs() {
+        return this.longs;
+    }
+
+    /**
+     * This primitive type is intentionally not optimized
+     *
+     * <p>This type was added in case we choose to change that later we have a comparison.
+     */
+    @JsonProperty("bools")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<Boolean> getBools() {
+        return this.bools;
+    }
+
     @Override
     public boolean equals(@Nullable Object other) {
         return this == other || (other instanceof PrimitiveStrictExample && equalTo((PrimitiveStrictExample) other));
@@ -55,7 +85,10 @@ public final class PrimitiveStrictExample {
                 && this.memoizedHashCode != other.memoizedHashCode) {
             return false;
         }
-        return this.ints.equals(other.ints) && this.doubles.equals(other.doubles);
+        return this.ints.equals(other.ints)
+                && this.doubles.equals(other.doubles)
+                && this.longs.equals(other.longs)
+                && this.bools.equals(other.bools);
     }
 
     @Override
@@ -65,6 +98,8 @@ public final class PrimitiveStrictExample {
             int hash = 1;
             hash = 31 * hash + this.ints.hashCode();
             hash = 31 * hash + this.doubles.hashCode();
+            hash = 31 * hash + this.longs.hashCode();
+            hash = 31 * hash + this.bools.hashCode();
             result = hash;
             memoizedHashCode = result;
         }
@@ -73,17 +108,17 @@ public final class PrimitiveStrictExample {
 
     @Override
     public String toString() {
-        return "PrimitiveStrictExample{ints: " + ints + ", doubles: " + doubles + '}';
+        return "PrimitiveStrictExample{ints: " + ints + ", doubles: " + doubles + ", longs: " + longs + ", bools: "
+                + bools + '}';
     }
 
-    public static PrimitiveStrictExample of(List<Integer> ints, List<Double> doubles) {
-        return builder().ints(ints).doubles(doubles).build();
-    }
-
-    private static void validateFields(List<Integer> ints, List<Double> doubles) {
+    private static void validateFields(
+            List<Integer> ints, List<Double> doubles, List<SafeLong> longs, List<Boolean> bools) {
         List<String> missingFields = null;
         missingFields = addFieldIfMissing(missingFields, ints, "ints");
         missingFields = addFieldIfMissing(missingFields, doubles, "doubles");
+        missingFields = addFieldIfMissing(missingFields, longs, "longs");
+        missingFields = addFieldIfMissing(missingFields, bools, "bools");
         if (missingFields != null) {
             throw new SafeIllegalArgumentException(
                     "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
@@ -94,7 +129,7 @@ public final class PrimitiveStrictExample {
         List<String> missingFields = prev;
         if (fieldValue == null) {
             if (missingFields == null) {
-                missingFields = new ArrayList<>(2);
+                missingFields = new ArrayList<>(4);
             }
             missingFields.add(fieldName);
         }
@@ -112,7 +147,15 @@ public final class PrimitiveStrictExample {
     }
 
     public interface DoublesStageBuilder {
-        Completed_StageBuilder doubles(@Nonnull Iterable<Double> doubles);
+        LongsStageBuilder doubles(@Nonnull Iterable<Double> doubles);
+    }
+
+    public interface LongsStageBuilder {
+        BoolsStageBuilder longs(@Nonnull Iterable<SafeLong> longs);
+    }
+
+    public interface BoolsStageBuilder {
+        Completed_StageBuilder bools(@Nonnull Iterable<Boolean> bools);
     }
 
     public interface Completed_StageBuilder {
@@ -120,7 +163,12 @@ public final class PrimitiveStrictExample {
         PrimitiveStrictExample build();
     }
 
-    public interface Builder extends IntsStageBuilder, DoublesStageBuilder, Completed_StageBuilder {
+    public interface Builder
+            extends IntsStageBuilder,
+                    DoublesStageBuilder,
+                    LongsStageBuilder,
+                    BoolsStageBuilder,
+                    Completed_StageBuilder {
         @Override
         Builder ints(@Nonnull Iterable<Integer> ints);
 
@@ -129,6 +177,12 @@ public final class PrimitiveStrictExample {
 
         @Override
         Builder doubles(@Nonnull Iterable<Double> doubles);
+
+        @Override
+        Builder longs(@Nonnull Iterable<SafeLong> longs);
+
+        @Override
+        Builder bools(@Nonnull Iterable<Boolean> bools);
 
         @CheckReturnValue
         @Override
@@ -144,6 +198,10 @@ public final class PrimitiveStrictExample {
 
         private List<Double> doubles = ConjureCollections.newNonNullDoubleList();
 
+        private List<SafeLong> longs = ConjureCollections.newNonNullSafeLongList();
+
+        private List<Boolean> bools = ConjureCollections.newNonNullList();
+
         private DefaultBuilder() {}
 
         @Override
@@ -151,6 +209,8 @@ public final class PrimitiveStrictExample {
             checkNotBuilt();
             ints(other.getInts());
             doubles(other.getDoubles());
+            longs(other.getLongs());
+            bools(other.getBools());
             return this;
         }
 
@@ -172,12 +232,39 @@ public final class PrimitiveStrictExample {
             return this;
         }
 
+        /**
+         * This primitive type is stored optimally, but does not have boxing optimizations.
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        @Override
+        @JsonSetter(value = "longs", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
+        public Builder longs(@Nonnull Iterable<SafeLong> longs) {
+            checkNotBuilt();
+            this.longs = ConjureCollections.newNonNullSafeLongList(
+                    Preconditions.checkNotNull(longs, "longs cannot be null"));
+            return this;
+        }
+
+        /**
+         * This primitive type is intentionally not optimized
+         *
+         * <p>This type was added in case we choose to change that later we have a comparison.
+         */
+        @Override
+        @JsonSetter(value = "bools", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
+        public Builder bools(@Nonnull Iterable<Boolean> bools) {
+            checkNotBuilt();
+            this.bools = ConjureCollections.newNonNullList(Preconditions.checkNotNull(bools, "bools cannot be null"));
+            return this;
+        }
+
         @Override
         @CheckReturnValue
         public PrimitiveStrictExample build() {
             checkNotBuilt();
             this._buildInvoked = true;
-            return new PrimitiveStrictExample(ints, doubles);
+            return new PrimitiveStrictExample(ints, doubles, longs, bools);
         }
 
         private void checkNotBuilt() {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/NonNullCollectionsTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/NonNullCollectionsTest.java
@@ -24,6 +24,7 @@ import allexamples.com.palantir.product.ListExample;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidNullException;
+import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import java.util.Collections;
 import java.util.List;
@@ -82,6 +83,8 @@ public class NonNullCollectionsTest {
         PrimitiveStrictExample expected = PrimitiveStrictExample.builder()
                 .ints(Collections.emptyList())
                 .doubles(Collections.emptyList())
+                .longs(Collections.emptyList())
+                .bools(Collections.emptyList())
                 .build();
         assertThat(clientMapper.writeValueAsString(expected))
                 .describedAs("Does not serialize any empty collections, even when optimizing for primitives")
@@ -106,6 +109,8 @@ public class NonNullCollectionsTest {
         PrimitiveStrictExample expected = PrimitiveStrictExample.builder()
                 .ints(List.of(1, 2, 3))
                 .doubles(List.of(1.1, 2.2, 3.3))
+                .longs(List.of(SafeLong.of(1L), SafeLong.of(2L), SafeLong.of(3L)))
+                .bools(List.of(true, false))
                 .build();
         String serialized = serverMapper.writeValueAsString(expected);
         assertThat(expected).isEqualTo(clientMapper.readValue(serialized, PrimitiveStrictExample.class));

--- a/conjure-java-core/src/test/resources/primitive-collections-strict.yml
+++ b/conjure-java-core/src/test/resources/primitive-collections-strict.yml
@@ -6,3 +6,15 @@ types:
         fields:
           ints: list<integer>
           doubles: list<double>
+          longs:
+            type: list<safelong>
+            docs: |
+              This primitive type is stored optimally, but does not have boxing optimizations.
+              
+              This type was added in case we choose to change that later we have a comparison.
+          bools:
+            type: list<boolean>
+            docs: |
+              This primitive type is intentionally not optimized
+              
+              This type was added in case we choose to change that later we have a comparison.

--- a/conjure-java-core/src/test/resources/primitive-collections.yml
+++ b/conjure-java-core/src/test/resources/primitive-collections.yml
@@ -9,3 +9,16 @@ types:
           field: integer
           ints: list<integer>
           doubles: list<double>
+          # this is stored optimally but does not have boxing optimizations
+          longs:
+            type: list<safelong>
+            docs: |
+              This primitive type is stored optimally, but does not have boxing optimizations.
+              
+              This type was added in case we choose to change that later we have a comparison.
+          bools:
+            type: list<boolean>
+            docs: |
+              This primitive type is intentionally not optimized
+              
+              This type was added in case we choose to change that later we have a comparison.

--- a/conjure-java-core/src/test/resources/primitive-collections.yml
+++ b/conjure-java-core/src/test/resources/primitive-collections.yml
@@ -9,7 +9,6 @@ types:
           field: integer
           ints: list<integer>
           doubles: list<double>
-          # this is stored optimally but does not have boxing optimizations
           longs:
             type: list<safelong>
             docs: |


### PR DESCRIPTION
## Before this PR
I was making some changes in https://github.com/palantir/conjure-java/pull/2464 and was wondering if I had written a bug that might cause the other types to behave incorrectly. 

## After this PR
I added all the primitive collection types (optimized or not) so that when future changes land I can easily notice if I correctly targeted only the types I care about.

## Possible downsides?
I used a type documentation intentionally. I figured that in the future someone will notice the difference in the generated code and presume it is a bug. This way the docs are right there inline with the type.

