### PR TITLE
Add validation for snapshot folder contents

### DIFF
--- a/changelog/@unreleased/pr-2480.v2.yml
+++ b/changelog/@unreleased/pr-2480.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Add a test to ensure only registered test case content exists in the
+    snapshot testing folder.
+  links:
+  - https://github.com/palantir/conjure-java/pull/2480

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/parameterized/ParameterizedConjureGenerationTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/parameterized/ParameterizedConjureGenerationTest.java
@@ -28,14 +28,23 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public final class ParameterizedConjureGenerationTest {
     private static final String REFERENCE_FILES_FOLDER = "src/integrationInput/java";
+    private static final String RESERVED_NON_GENERATED_PREFIX = "nongenerated";
 
     @TempDir
     public File tempDir;
@@ -46,6 +55,7 @@ public final class ParameterizedConjureGenerationTest {
 
     @ParameterizedTest
     @MethodSource("getTestCases")
+    @Order(1)
     void testGeneratedCode(ParameterizedTestCase testCase) throws IOException {
         ConjureDefinition def =
                 Conjure.parse(testCase.files().stream().map(Path::toFile).toList());
@@ -54,6 +64,26 @@ public final class ParameterizedConjureGenerationTest {
                 .emit(def, tempDir);
 
         assertThatFilesAreTheSame(files, testCase);
+    }
+
+    @Test
+    @Order(2)
+    void validateOnlyRegisteredPackagesPresent() {
+        File referenceFilesFolder = new File(REFERENCE_FILES_FOLDER);
+        File[] files = referenceFilesFolder.listFiles();
+
+        assertThat(files).isNotNull();
+        Set<String> actualPackages = Arrays.stream(files)
+                .filter(File::isDirectory)
+                .map(File::getName)
+                .collect(Collectors.toSet());
+        Set<String> expectedPackages = getTestCases().stream()
+                .map(ParameterizedTestCase::packagePrefix)
+                .collect(Collectors.toSet());
+        expectedPackages.add(RESERVED_NON_GENERATED_PREFIX);
+        assertThat(actualPackages)
+                .as("Only registered test cases should check-in generated code")
+                .containsExactlyInAnyOrderElementsOf(expectedPackages);
     }
 
     private void assertThatFilesAreTheSame(List<Path> files, ParameterizedTestCase testCase) throws IOException {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Follow-up from https://github.com/palantir/conjure-java/pull/2456#discussion_r1961983538
Adds a test to validate the packages in the snapshot testing folder. This will fail if: 
1. A test case is removed but the corresponding package root in the snapshot testing directory is not deleted
2. Generated objects are checked into the directory but are not registered as a test case

This will just serve as a rough guardrail to make sure contributors use the testing framework when generating new reference objects.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds a test to ensure only registered test case content exists in the snapshot testing folder.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

