### PR TITLE
[Improvement] Primitive Optimized Singular Addition Implementation

### DIFF
--- a/changelog/@unreleased/pr-2486.v2.yml
+++ b/changelog/@unreleased/pr-2486.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[Improvement] Primitive Optimized Singular Addition Implementation'
+  links:
+  - https://github.com/palantir/conjure-java/pull/2486

--- a/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/ListExample.java
@@ -251,7 +251,7 @@ public final class ListExample {
         public Builder primitiveItems(int primitiveItems) {
             checkNotBuilt();
             Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null");
-            this.primitiveItems.add(primitiveItems);
+            ConjureCollections.addToIntegerList(this.primitiveItems, primitiveItems);
             return this;
         }
 
@@ -280,7 +280,7 @@ public final class ListExample {
         public Builder doubleItems(double doubleItems) {
             checkNotBuilt();
             Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null");
-            this.doubleItems.add(doubleItems);
+            ConjureCollections.addToDoubleList(this.doubleItems, doubleItems);
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/primitivecollections/com/palantir/product/PrimitiveExample.java
+++ b/conjure-java-core/src/integrationInput/java/primitivecollections/com/palantir/product/PrimitiveExample.java
@@ -370,7 +370,7 @@ public final class PrimitiveExample {
         public Builder ints(int ints) {
             checkNotBuilt();
             Preconditions.checkNotNull(ints, "ints cannot be null");
-            this.ints.add(ints);
+            ConjureCollections.addToIntegerList(this.ints, ints);
             return this;
         }
 
@@ -403,7 +403,7 @@ public final class PrimitiveExample {
         public Builder doubles(double doubles) {
             checkNotBuilt();
             Preconditions.checkNotNull(doubles, "doubles cannot be null");
-            this.doubles.add(doubles);
+            ConjureCollections.addToDoubleList(this.doubles, doubles);
             return this;
         }
 

--- a/conjure-java-core/src/integrationInput/java/template/com/palantir/product/ListExample.java
+++ b/conjure-java-core/src/integrationInput/java/template/com/palantir/product/ListExample.java
@@ -251,7 +251,7 @@ public final class ListExample {
         public Builder primitiveItems(int primitiveItems) {
             checkNotBuilt();
             Preconditions.checkNotNull(primitiveItems, "primitiveItems cannot be null");
-            this.primitiveItems.add(primitiveItems);
+            ConjureCollections.addToIntegerList(this.primitiveItems, primitiveItems);
             return this;
         }
 
@@ -280,7 +280,7 @@ public final class ListExample {
         public Builder doubleItems(double doubleItems) {
             checkNotBuilt();
             Preconditions.checkNotNull(doubleItems, "doubleItems cannot be null");
-            this.doubleItems.add(doubleItems);
+            ConjureCollections.addToDoubleList(this.doubleItems, doubleItems);
             return this;
         }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -603,16 +603,25 @@ public final class BeanBuilderGenerator {
         Collection<MethodSpec> setters = Lists.newArrayListWithExpectedSize(fields.size() * 5);
         for (EnrichedField field : fields) {
             Type type = field.conjureDef().getType();
+            Optional<LogSafety> safety = safetyEvaluator.getUsageTimeSafety(field.conjureDef());
+            boolean isPrimitiveOptimized = isPrimitiveOptimized(type);
 
             // Add all the base required setters
             setters.add(createSetter(field, typesMap, override));
-            // Add any primitive setters, which are required when optimized as they handle deserialization
-            if (isPrimitiveOptimized(type)) {
+            // Add the primitive setter, this is required when optimized as they handle deserialization
+            if (isPrimitiveOptimized) {
                 setters.add(createPrimitiveCollectionSetter(field, typesMap, override, strict));
             }
+
+            // Strict builders do not allow for additive setting by design
             // Non-strict builders have various additional QOL overloads
-            if (!strict || type.accept(TypeVisitor.IS_OPTIONAL)) {
-                setters.addAll(createAuxiliarySetters(field, override));
+            if (!strict) {
+                setters.addAll(createCollectionAdditiveSetters(field, override, safety, isPrimitiveOptimized));
+            }
+
+            // Optionals always have the optional setter, it is not additive
+            if (type.accept(TypeVisitor.IS_OPTIONAL)) {
+                setters.add(createOptionalSetter(field, override));
             }
         }
         return setters;
@@ -822,16 +831,22 @@ public final class BeanBuilderGenerator {
         return type.accept(TypeVisitor.IS_BINARY) && !options.useImmutableBytes();
     }
 
-    private List<MethodSpec> createAuxiliarySetters(EnrichedField enriched, boolean override) {
+    private List<MethodSpec> createCollectionAdditiveSetters(
+            EnrichedField enriched, boolean override, Optional<LogSafety> safety, boolean isPrimitiveOptimized) {
         Type type = enriched.conjureDef().getType();
-        Optional<LogSafety> safety = safetyEvaluator.getUsageTimeSafety(enriched.conjureDef());
 
         ImmutableList.Builder<MethodSpec> builder = ImmutableList.builder();
 
         if (type.accept(TypeVisitor.IS_LIST)) {
-            builder.add(
-                    createCollectionSetter("addAll", enriched, override),
-                    createItemSetter(enriched, type.accept(TypeVisitor.LIST).getItemType(), override, safety));
+            builder.add(createCollectionSetter("addAll", enriched, override));
+
+            if (isPrimitiveOptimized) {
+                builder.add(createPrimitiveItemSetter(enriched, override, safety));
+            } else {
+                builder.add(
+                        createItemSetter(enriched, type.accept(TypeVisitor.LIST).getItemType(), override, safety));
+            }
+
             return builder.build();
         }
 
@@ -844,10 +859,6 @@ public final class BeanBuilderGenerator {
         if (type.accept(TypeVisitor.IS_MAP)) {
             return ImmutableList.of(
                     createCollectionSetter("putAll", enriched, override), createMapSetter(enriched, override));
-        }
-
-        if (type.accept(TypeVisitor.IS_OPTIONAL)) {
-            return ImmutableList.of(createOptionalSetter(enriched, override));
         }
 
         return ImmutableList.of();
@@ -907,6 +918,27 @@ public final class BeanBuilderGenerator {
         }
 
         return builder.addStatement("this.$1N.add($1N)", field.name())
+                .addStatement("return this")
+                .build();
+    }
+
+    private MethodSpec createPrimitiveItemSetter(EnrichedField enriched, boolean override, Optional<LogSafety> safety) {
+        FieldSpec field = enriched.poetSpec();
+        Type type = enriched.conjureDef().getType();
+        Type itemType = type.accept(TypeVisitor.LIST).getItemType();
+
+        CollectionType collectionType = getCollectionType(type);
+        return BeanBuilderAuxiliarySettersUtils.createItemSetterBuilder(
+                        enriched, itemType, typeMapper, builderClass, safety)
+                .addAnnotations(ConjureAnnotations.override(override))
+                .addCode(verifyNotBuilt())
+                .addStatement(Expressions.requireNonNull(
+                        field.name(), enriched.fieldName().get() + " cannot be null"))
+                .addCode(CodeBlocks.statement(
+                        "$1T.addTo$2L(this.$3N, $3N)",
+                        ConjureCollections.class,
+                        collectionType.getConjureCollectionType().getCollectionName(),
+                        field.name()))
                 .addStatement("return this")
                 .build();
     }


### PR DESCRIPTION
## Before this PR
Before the singular additions methods e.g. `public Builder ints(int ints)` would leverage `boolean add(E e)` from the `Collection` interface. This would cause each addition to be boxed before it is unboxed at rest.

## After this PR
Now the implementation delegates to a non-boxing addition path when it is a primitive list. This brings singular additions inline with the bulk addition optimizations.

