### PR TITLE
Update ErrorGenerator.java

### DIFF
--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ErrorGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ErrorGenerator.java
@@ -77,11 +77,14 @@ public final class ErrorGenerator implements Generator {
             ErrorNamespace namespace, List<ErrorDefinition> errorTypeDefinitions) {
         return errorTypeDefinitions.stream()
                 .map(errorDef -> {
-                    CodeBlock initializer = CodeBlock.of(
-                            "ErrorType.create(ErrorType.Code.$L, \"$L:$L\")",
-                            errorDef.getCode().get(),
-                            namespace.get(),
-                            errorDef.getErrorName().getName());
+                    CodeBlock.Builder initializerBuilder = CodeBlock.builder()
+                            .add("ErrorType.create(ErrorType.Code.$L, \"$L:$L\")",
+                                    errorDef.getCode().get(),
+                                    namespace.get(),
+                                    errorDef.getErrorName().getName());
+                    errorDef.getDocs().ifPresent(docs ->
+                            initializerBuilder.add("\n// $L", docs.get()));
+                    CodeBlock initializer = initializerBuilder.build();
                     FieldSpec.Builder fieldSpecBuilder = FieldSpec.builder(
                                     ClassName.get(ErrorType.class),
                                     CaseFormat.UPPER_CAMEL.to(


### PR DESCRIPTION
https://github.com/palantir/conjure-java/issues/2510

## Before this PR
We had no way to add the error.yml docs to the ErrorType. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add the error.yml docs to the ErrorType object for use by the runtime lib
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

