### PR TITLE
ConjureCollections uses forEach where possible

### DIFF
--- a/changelog/@unreleased/pr-2524.v2.yml
+++ b/changelog/@unreleased/pr-2524.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: ConjureCollections uses `Iterable#forEach` where possible to minimize
+    allocations and speed up iteration over collections.
+  links:
+  - https://github.com/palantir/conjure-java/pull/2524

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -674,7 +674,7 @@ public final class WireFormatTests {
     void testNullContentCollectionDeserialization_listAlias() {
         assertThatThrownBy(() -> mapper.readValue("[null]", ExampleDefensiveAliasedList.class))
                 .isInstanceOf(JsonMappingException.class)
-                .hasMessageContaining("iterable cannot contain null elements");
+                .hasMessageContaining("element cannot be null");
     }
 
     @Test
@@ -688,7 +688,7 @@ public final class WireFormatTests {
     void testNullContentCollectionDeserialization_setAlias() {
         assertThatThrownBy(() -> mapper.readValue("[null]", ExampleDefensiveAliasedSet.class))
                 .isInstanceOf(JsonMappingException.class)
-                .hasMessageContaining("iterable cannot contain null elements");
+                .hasMessageContaining("element cannot be null");
     }
 
     @Test
@@ -768,7 +768,7 @@ public final class WireFormatTests {
         assertThatThrownBy(() -> mapper.readValue(
                         "{\"type\":\"list\",\"list\":[null]}", ExampleDefensiveCollectionListsUnion.class))
                 .isInstanceOf(JsonMappingException.class)
-                .hasMessageContaining("iterable cannot contain null elements");
+                .hasMessageContaining("element cannot be null");
     }
 
     @Test
@@ -784,7 +784,7 @@ public final class WireFormatTests {
         assertThatThrownBy(() -> mapper.readValue(
                         "{\"type\":\"set\",\"set\":[null]}", ExampleDefensiveCollectionSetsUnion.class))
                 .isInstanceOf(JsonMappingException.class)
-                .hasMessageContaining("iterable cannot contain null elements");
+                .hasMessageContaining("element cannot be null");
     }
 
     @Test

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
@@ -18,9 +18,11 @@ package com.palantir.conjure.java.lib.internal;
 
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.logsafe.Preconditions;
+import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -41,8 +43,8 @@ public final class ConjureCollections {
     /*
      * This is bizarre. Allow me to explain...
      *
-     * We do _not_ want to expose the Conjure*List types externally
-     * but we also want the optimizations they provide to make it thru
+     * We do _not_ want to expose the Conjure*List types externally,
+     * but we also want the optimizations they provide to make it through
      * to jackson for serialization. So the runtime type needs to be
      * preserved while also not exposing the type :phew:.
      *
@@ -51,48 +53,64 @@ public final class ConjureCollections {
      * return specific Conjure types when detected. This requires that we
      * erase the type info, but we know this is safe because we are directly
      * returning the same type which is by definition the identity function.
-     * Therefore the input List<T> is the same types as the output List<T>.
+     * Therefore, the input List<T> is the same types as the output List<T>.
      */
     public static <T> List<T> unmodifiableList(List<T> list) {
         // Return the unmodifiable version of the Eclipse types
-        if (list instanceof ConjureIntegerList) {
-            return (List<T>) ((ConjureIntegerList) list).asUnmodifiable();
-        } else if (list instanceof ConjureDoubleList) {
-            return (List<T>) ((ConjureDoubleList) list).asUnmodifiable();
-        } else if (list instanceof ConjureSafeLongList) {
-            return (List<T>) ((ConjureSafeLongList) list).asUnmodifiable();
+        if (list instanceof ConjureIntegerList conjureIntegerList) {
+            return (List<T>) conjureIntegerList.asUnmodifiable();
+        } else if (list instanceof ConjureDoubleList conjureDoubleList) {
+            return (List<T>) conjureDoubleList.asUnmodifiable();
+        } else if (list instanceof ConjureSafeLongList conjureSafeLongList) {
+            return (List<T>) conjureSafeLongList.asUnmodifiable();
         } else {
             // Otherwise use the JDK types
             return Collections.unmodifiableList(list);
         }
     }
 
-    @SuppressWarnings("unchecked")
     public static <T> void addAll(Collection<T> addTo, Iterable<? extends T> elementsToAdd) {
         Preconditions.checkNotNull(elementsToAdd, "elementsToAdd cannot be null");
-        if (elementsToAdd instanceof Collection) {
+        if (elementsToAdd instanceof Collection<? extends T> collection) {
             // This special-casing allows us to take advantage of the more performant
             // ArrayList#addAll method which does a single System.arraycopy.
-            addTo.addAll((Collection<T>) elementsToAdd);
+            addTo.addAll(collection);
         } else {
             elementsToAdd.forEach(addTo::add);
         }
     }
 
-    @SuppressWarnings("unchecked")
     public static <T> void addAllAndCheckNonNull(Collection<T> addTo, Iterable<? extends T> elementsToAdd) {
         Preconditions.checkNotNull(elementsToAdd, "elementsToAdd cannot be null");
-        // If we know the number of elements we are adding and the addTo Collection is an ArrayList, we can eagerly
-        // resize it to only do one grow() of the array.
-        if (elementsToAdd instanceof Collection) {
-            Collection<T> collectionElementsToAdd = (Collection<T>) elementsToAdd;
-            if (addTo instanceof ArrayList) {
-                ((ArrayList<T>) addTo).ensureCapacity(collectionElementsToAdd.size() + addTo.size());
-            }
+        if (elementsToAdd instanceof Collection<? extends T> collection) {
+            // Some collections such as ArrayList support bulk addAll optimizations to avoid repeated resizing.
+            addTo.addAll(new AbstractCollection<>() {
+                @Override
+                public Iterator<T> iterator() {
+                    return new NonNullIterator<>(collection.iterator());
+                }
+
+                @Override
+                public Object[] toArray() {
+                    Object[] array = collection.toArray();
+                    for (Object element : array) {
+                        checkNotNullElement(element);
+                    }
+                    return array;
+                }
+
+                @Override
+                public int size() {
+                    return collection.size();
+                }
+            });
+        } else {
+            elementsToAdd.forEach(element -> addTo.add(checkNotNullElement(element)));
         }
-        elementsToAdd.forEach(element -> {
-            addTo.add(Preconditions.checkNotNull(element, "elementsToAdd cannot contain null elements"));
-        });
+    }
+
+    private static <T> T checkNotNullElement(T element) {
+        return Preconditions.checkNotNull(element, "element cannot be null");
     }
 
     // Prefer to use newList(iterable)
@@ -112,8 +130,8 @@ public final class ConjureCollections {
     @SuppressWarnings({"IllegalType", "NonApiType"}) // explicitly need to return mutable list for generated builders
     public static <T> LinkedHashSet<T> newLinkedHashSet(Iterable<? extends T> iterable) {
         Preconditions.checkNotNull(iterable, "iterable cannot be null");
-        if (iterable instanceof Collection) {
-            return new LinkedHashSet<>((Collection<T>) iterable);
+        if (iterable instanceof Collection<? extends T> collection) {
+            return new LinkedHashSet<>(collection);
         }
         LinkedHashSet<T> set = new LinkedHashSet<>();
         iterable.forEach(set::add);
@@ -134,7 +152,7 @@ public final class ConjureCollections {
 
     public static <T> List<T> newNonNullList(Iterable<? extends T> iterable) {
         List<T> arrayList = newList(iterable);
-        arrayList.forEach(item -> Preconditions.checkNotNull(item, "iterable cannot contain null elements"));
+        arrayList.forEach(ConjureCollections::checkNotNullElement);
         return arrayList;
     }
 
@@ -152,7 +170,7 @@ public final class ConjureCollections {
 
     public static <T> Set<T> newNonNullSet(Iterable<? extends T> iterable) {
         Set<T> set = newSet(iterable);
-        set.forEach(item -> Preconditions.checkNotNull(item, "iterable cannot contain null elements"));
+        set.forEach(ConjureCollections::checkNotNullElement);
         return set;
     }
 
@@ -285,6 +303,22 @@ public final class ConjureCollections {
     public static void addAllToSafeLongList(Collection<SafeLong> addTo, long[] elementsToAdd) {
         for (long el : elementsToAdd) {
             addTo.add(SafeLong.of(el));
+        }
+    }
+
+    private record NonNullIterator<T>(Iterator<? extends T> iterator) implements Iterator<T> {
+        private NonNullIterator(Iterator<? extends T> iterator) {
+            this.iterator = Preconditions.checkNotNull(iterator, "iterator cannot be null");
+        }
+
+        @Override
+        public boolean hasNext() {
+            return iterator().hasNext();
+        }
+
+        @Override
+        public T next() {
+            return checkNotNullElement(iterator().next());
         }
     }
 }

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
@@ -75,9 +75,7 @@ public final class ConjureCollections {
             // ArrayList#addAll method which does a single System.arraycopy.
             addTo.addAll((Collection<T>) elementsToAdd);
         } else {
-            for (T element : elementsToAdd) {
-                addTo.add(element);
-            }
+            elementsToAdd.forEach(addTo::add);
         }
     }
 
@@ -92,10 +90,9 @@ public final class ConjureCollections {
                 ((ArrayList<T>) addTo).ensureCapacity(collectionElementsToAdd.size() + addTo.size());
             }
         }
-        for (T element : elementsToAdd) {
-            Preconditions.checkNotNull(element, "elementsToAdd cannot contain null elements");
-            addTo.add(element);
-        }
+        elementsToAdd.forEach(element -> {
+            addTo.add(Preconditions.checkNotNull(element, "elementsToAdd cannot contain null elements"));
+        });
     }
 
     // Prefer to use newList(iterable)
@@ -107,9 +104,7 @@ public final class ConjureCollections {
             return new ArrayList<>((Collection<T>) iterable);
         }
         ArrayList<T> list = new ArrayList<>();
-        for (T item : iterable) {
-            list.add(item);
-        }
+        iterable.forEach(list::add);
         return list;
     }
 
@@ -121,9 +116,7 @@ public final class ConjureCollections {
             return new LinkedHashSet<>((Collection<T>) iterable);
         }
         LinkedHashSet<T> set = new LinkedHashSet<>();
-        for (T item : iterable) {
-            set.add(item);
-        }
+        iterable.forEach(set::add);
         return set;
     }
 
@@ -141,10 +134,7 @@ public final class ConjureCollections {
 
     public static <T> List<T> newNonNullList(Iterable<? extends T> iterable) {
         List<T> arrayList = newList(iterable);
-        for (T item : arrayList) {
-            Preconditions.checkNotNull(item, "iterable cannot contain null elements");
-        }
-
+        arrayList.forEach(item -> Preconditions.checkNotNull(item, "iterable cannot contain null elements"));
         return arrayList;
     }
 
@@ -162,10 +152,7 @@ public final class ConjureCollections {
 
     public static <T> Set<T> newNonNullSet(Iterable<? extends T> iterable) {
         Set<T> set = newSet(iterable);
-        for (T item : set) {
-            Preconditions.checkNotNull(item, "iterable cannot contain null elements");
-        }
-
+        set.forEach(item -> Preconditions.checkNotNull(item, "iterable cannot contain null elements"));
         return set;
     }
 

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
@@ -70,18 +70,17 @@ public final class ConjureCollections {
     }
 
     public static <T> void addAll(Collection<T> addTo, Iterable<? extends T> elementsToAdd) {
-        Preconditions.checkNotNull(elementsToAdd, "elementsToAdd cannot be null");
         if (elementsToAdd instanceof Collection<? extends T> collection) {
             // This special-casing allows us to take advantage of the more performant
             // ArrayList#addAll method which does a single System.arraycopy.
             addTo.addAll(collection);
         } else {
-            elementsToAdd.forEach(addTo::add);
+            Preconditions.checkNotNull(elementsToAdd, "elementsToAdd cannot be null")
+                    .forEach(addTo::add);
         }
     }
 
     public static <T> void addAllAndCheckNonNull(Collection<T> addTo, Iterable<? extends T> elementsToAdd) {
-        Preconditions.checkNotNull(elementsToAdd, "elementsToAdd cannot be null");
         if (elementsToAdd instanceof Collection<? extends T> collection) {
             // Some collections such as ArrayList support bulk addAll optimizations to avoid repeated resizing.
             addTo.addAll(new AbstractCollection<>() {
@@ -105,36 +104,31 @@ public final class ConjureCollections {
                 }
             });
         } else {
-            elementsToAdd.forEach(element -> addTo.add(checkNotNullElement(element)));
+            Preconditions.checkNotNull(elementsToAdd, "elementsToAdd cannot be null")
+                    .forEach(element -> addTo.add(checkNotNullElement(element)));
         }
-    }
-
-    private static <T> T checkNotNullElement(T element) {
-        return Preconditions.checkNotNull(element, "element cannot be null");
     }
 
     // Prefer to use newList(iterable)
     // explicitly need to return mutable list for generated builders
     @SuppressWarnings({"IllegalType", "unchecked", "NonApiType"})
     public static <T> ArrayList<T> newArrayList(Iterable<? extends T> iterable) {
-        Preconditions.checkNotNull(iterable, "iterable cannot be null");
-        if (iterable instanceof Collection) {
-            return new ArrayList<>((Collection<T>) iterable);
+        if (iterable instanceof Collection<? extends T> collection) {
+            return new ArrayList<>(collection);
         }
         ArrayList<T> list = new ArrayList<>();
-        iterable.forEach(list::add);
+        Preconditions.checkNotNull(iterable, "iterable cannot be null").forEach(list::add);
         return list;
     }
 
     // Prefer to use newSet(iterable)
     @SuppressWarnings({"IllegalType", "NonApiType"}) // explicitly need to return mutable list for generated builders
     public static <T> LinkedHashSet<T> newLinkedHashSet(Iterable<? extends T> iterable) {
-        Preconditions.checkNotNull(iterable, "iterable cannot be null");
         if (iterable instanceof Collection<? extends T> collection) {
             return new LinkedHashSet<>(collection);
         }
         LinkedHashSet<T> set = new LinkedHashSet<>();
-        iterable.forEach(set::add);
+        Preconditions.checkNotNull(iterable, "iterable cannot be null").forEach(set::add);
         return set;
     }
 
@@ -289,8 +283,8 @@ public final class ConjureCollections {
     // This method returns a list that can't handle nulls. Do not use this unless the nonNullCollections flag is set
     public static List<SafeLong> newNonNullSafeLongList(Iterable<SafeLong> iterable) {
         List<SafeLong> safeLongList;
-        if (iterable instanceof Collection) {
-            safeLongList = new ConjureSafeLongList(new LongArrayList(((Collection<SafeLong>) iterable).size()));
+        if (iterable instanceof Collection<SafeLong> collection) {
+            safeLongList = new ConjureSafeLongList(new LongArrayList(collection.size()));
         } else {
             safeLongList = new ConjureSafeLongList(new LongArrayList());
         }
@@ -304,6 +298,10 @@ public final class ConjureCollections {
         for (long el : elementsToAdd) {
             addTo.add(SafeLong.of(el));
         }
+    }
+
+    private static <T> T checkNotNullElement(T element) {
+        return Preconditions.checkNotNull(element, "element cannot be null");
     }
 
     private record NonNullIterator<T>(Iterator<? extends T> iterator) implements Iterator<T> {


### PR DESCRIPTION
## Before this PR

`ConjureCollections` used iterator based for loops

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
ConjureCollections uses `Iterable#forEach` where possible to minimize allocations and speed up iteration over collections.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

