### PR TITLE
Add a Bytes.Builder to avoid array copy

### DIFF
--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/Bytes.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/Bytes.java
@@ -24,11 +24,14 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.logsafe.Preconditions;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Objects;
 
 /** An immutable {@code byte[]} wrapper. */
 @JsonSerialize(using = Bytes.Serializer.class)
@@ -114,6 +117,14 @@ public final class Bytes {
         return new Bytes(safe);
     }
 
+    public static Builder builder(int capacity) {
+        return new Builder(capacity);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
     static final class Serializer extends JsonSerializer<Bytes> {
         @Override
         public void serialize(Bytes value, JsonGenerator gen, SerializerProvider _serializer) throws IOException {
@@ -126,6 +137,58 @@ public final class Bytes {
         public Bytes deserialize(JsonParser parser, DeserializationContext _ctxt) throws IOException {
             // Avoid making a copy of the value from jackson
             return new Bytes(parser.getBinaryValue());
+        }
+    }
+
+    public static final class Builder extends OutputStream {
+        private byte[] contents;
+        private boolean isBuilt;
+        private int count;
+
+        public Builder() {
+            this(32);
+        }
+
+        public Builder(int capacity) {
+            Preconditions.checkArgument(capacity > 0);
+            this.contents = new byte[capacity];
+            this.count = 0;
+        }
+
+        @Override
+        public synchronized void write(int inputByte) {
+            Preconditions.checkState(!isBuilt, "No writes are allowed because Immutable Bytes have already been built");
+            ensureCapacity(count + 1);
+            contents[count] = (byte) inputByte;
+            count += 1;
+        }
+
+        @Override
+        public synchronized void write(byte[] bytes, int off, int len) {
+            Preconditions.checkState(!isBuilt, "No writes are allowed because Immutable Bytes have already been built");
+            Objects.checkFromIndexSize(off, len, bytes.length);
+            ensureCapacity(count + len);
+            System.arraycopy(bytes, off, contents, count, len);
+            count += len;
+        }
+
+        public Bytes build() {
+            close();
+            return new Bytes(contents);
+        }
+
+        @Override
+        public synchronized void close() {
+            isBuilt = true;
+        }
+
+        private void ensureCapacity(int minCapacity) {
+            int oldCapacity = contents.length;
+            if (minCapacity - oldCapacity > 0) {
+                // This limit is taken from ArraysSupport::newLength
+                int newCapacity = Math.min(oldCapacity * 2, Integer.MAX_VALUE - 8);
+                contents = Arrays.copyOf(contents, newCapacity);
+            }
         }
     }
 }

--- a/conjure-lib/src/test/java/com/palantir/conjure/java/lib/BytesTests.java
+++ b/conjure-lib/src/test/java/com/palantir/conjure/java/lib/BytesTests.java
@@ -181,4 +181,22 @@ public final class BytesTests {
         ObjectMapper mapper = new ObjectMapper();
         assertThatThrownBy(() -> mapper.readValue("[]", Bytes.class)).isInstanceOf(JsonParseException.class);
     }
+
+    @Test
+    public void testBuilderRejectsWritesAfterBuild() {
+        try (Bytes.Builder builder = Bytes.builder(8)) {
+            byte[] input = new byte[] {0, 1, 2};
+            builder.write(input, 0, input.length);
+
+            Bytes immutable = builder.build();
+            byte[] test = new byte[input.length];
+            immutable.copyTo(test, 0, test.length);
+            assertThat(test).isEqualTo(input);
+
+            assertThatThrownBy(() -> builder.write(input, 0, input.length))
+                    .hasMessageContaining("No writes are allowed because Immutable Bytes have already been built");
+
+            assertThat(test).isEqualTo(input);
+        }
+    }
 }


### PR DESCRIPTION
## Before this PR
The only way to construct `conjure.lib.Bytes` is to make a byte array copy.

## After this PR
==COMMIT_MSG==
Add a Bytes.Builder to avoid array copy
==COMMIT_MSG==

`Bytes.Builder` is inspired by guava's `ImmutableList.Builder` and `ByteArrayOutputStream`. It's purpose is to allow users to safely create their byte array without having to copy it once they're ready to produce `Bytes`.

## Possible downsides?
Users who do not know how much they want to write could end up making several allocations to reach the desired byte array size.

I see no existing limits on the maximum size of the `Bytes` byte array. I think it's reasonable to add a stricter limit on the builder, but it may be confusing for one construction method to have limits when others do not.
