### PR TITLE
Support nested service interfaces

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ buildscript {
         classpath 'com.palantir.jakartapackagealignment:jakarta-package-alignment:0.6.0'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:2.69.0'
         classpath 'com.palantir.suppressible-error-prone:gradle-suppressible-error-prone:2.9.0'
-        classpath 'gradle.plugin.org.inferred:gradle-processors:3.7.0'
         classpath 'org.revapi:gradle-revapi:1.8.0'
     }
 }
@@ -88,7 +87,6 @@ allprojects {
 
 subprojects {
     apply plugin: 'java-library'
-    apply plugin: 'org.inferred.processors'
     apply plugin: 'com.palantir.baseline-class-uniqueness'
 
     tasks.withType(JavaCompile) {

--- a/changelog/@unreleased/pr-2551.v2.yml
+++ b/changelog/@unreleased/pr-2551.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: '`conjure-undertow-annotations` now supports service interfaces nested
+    in other classes.'
+  links:
+  - https://github.com/palantir/conjure-java/pull/2551

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessor.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessor.java
@@ -34,6 +34,7 @@ import com.palantir.goethe.Goethe;
 import com.palantir.goethe.GoetheException;
 import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.JavaFile;
+import com.palantir.javapoet.TypeName;
 import com.palantir.javapoet.TypeSpec;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.Preconditions;
@@ -162,9 +163,7 @@ public final class ConjureUndertowAnnotationProcessor extends AbstractProcessor 
             return maybeEndpoints.stream().map(Optional::get).collect(Collectors.toList());
         });
 
-        ClassName serviceInterface = ClassName.get(
-                MoreElements.getPackage(annotatedType).getQualifiedName().toString(),
-                annotatedType.getSimpleName().toString());
+        ClassName serviceInterface = (ClassName) TypeName.get(annotatedType.asType());
 
         ServiceDefinition serviceDefinition = ImmutableServiceDefinition.builder()
                 .serviceInterface(serviceInterface)

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ServiceDefinition.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ServiceDefinition.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.java.undertow.processor.data;
 
 import com.palantir.javapoet.ClassName;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -28,7 +29,8 @@ public interface ServiceDefinition {
     @Value.Derived
     default ClassName undertowService() {
         return ClassName.get(
-                serviceInterface().packageName(), serviceInterface().simpleName() + "Endpoints");
+                serviceInterface().packageName(),
+                serviceInterface().simpleNames().stream().collect(Collectors.joining("", "", "Endpoints")));
     }
 
     @Value.Derived

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
@@ -37,6 +37,7 @@ import com.palantir.conjure.java.undertow.processor.sample.MismatchedPathParam;
 import com.palantir.conjure.java.undertow.processor.sample.MultipleBodyInterface;
 import com.palantir.conjure.java.undertow.processor.sample.NameClashContextParam;
 import com.palantir.conjure.java.undertow.processor.sample.NameClashExchangeParam;
+import com.palantir.conjure.java.undertow.processor.sample.NestedInterface;
 import com.palantir.conjure.java.undertow.processor.sample.OptionalPrimitives;
 import com.palantir.conjure.java.undertow.processor.sample.OverloadedResource;
 import com.palantir.conjure.java.undertow.processor.sample.ParameterConstructorThrows;
@@ -65,6 +66,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
 import org.junit.jupiter.api.Test;
@@ -78,6 +80,12 @@ public class ConjureUndertowAnnotationProcessorTest {
     @Test
     public void testExampleFileCompiles() {
         assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, SimpleInterface.class);
+    }
+
+    @Test
+    public void testNestedExampleFileCompiles() {
+        assertTestFileCompileAndMatches(
+                TEST_CLASSES_BASE_DIR, NestedInterface.class, NestedInterface.SimpleInterface.class);
     }
 
     @Test
@@ -258,15 +266,20 @@ public class ConjureUndertowAnnotationProcessorTest {
         assertTestFileCompileAndMatches(TEST_CLASSES_BASE_DIR, TaggedEndpoints.class);
     }
 
-    private void assertTestFileCompileAndMatches(Path basePath, Class<?> clazz) {
-        Compilation compilation = compileTestClass(basePath, clazz);
+    private void assertTestFileCompileAndMatches(Path basePath, Class<?> fileClass, Class<?>... serviceClasses) {
+        Compilation compilation = compileTestClass(basePath, fileClass);
         assertThat(compilation).succeededWithoutWarnings();
-        String generatedClassName = clazz.getSimpleName() + "Endpoints";
-        String generatedFqnClassName = clazz.getPackage().getName() + "." + generatedClassName;
-        String generatedClassFileRelativePath = generatedFqnClassName.replaceAll("\\.", "/") + ".java";
-        assertThat(compilation.generatedFile(StandardLocation.SOURCE_OUTPUT, generatedClassFileRelativePath))
-                .hasValueSatisfying(
-                        javaFileObject -> assertContentsMatch(javaFileObject, generatedClassFileRelativePath));
+
+        List<Class<?>> classes = serviceClasses.length > 0 ? List.of(serviceClasses) : List.of(fileClass);
+
+        classes.forEach(clazz -> {
+            String generatedClassFileRelativePath =
+                    clazz.getName().replace(".", "/").replace("$", "") + "Endpoints.java";
+            assertThat(compilation.generatedFile(StandardLocation.SOURCE_OUTPUT, generatedClassFileRelativePath))
+                    .hasValueSatisfying(javaFileObject -> {
+                        assertContentsMatch(javaFileObject, generatedClassFileRelativePath);
+                    });
+        });
     }
 
     private Compilation compileTestClass(Path basePath, Class<?> clazz) {

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/NestedInterface.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/NestedInterface.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.palantir.conjure.java.undertow.annotations.Handle;
+import com.palantir.conjure.java.undertow.annotations.HttpMethod;
+
+public class NestedInterface {
+
+    public interface SimpleInterface {
+
+        @Handle(method = HttpMethod.GET, path = "/ping")
+        void ping();
+    }
+}

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/NestedInterfaceSimpleInterfaceEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/NestedInterfaceSimpleInterfaceEndpoints.java.generated
@@ -1,0 +1,76 @@
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import io.undertow.util.StatusCodes;
+import java.lang.Exception;
+import java.lang.Override;
+import java.lang.String;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.undertow.processor.generate.ConjureUndertowEndpointsGenerator")
+public final class NestedInterfaceSimpleInterfaceEndpoints implements UndertowService {
+    private final NestedInterface.SimpleInterface delegate;
+
+    private NestedInterfaceSimpleInterfaceEndpoints(NestedInterface.SimpleInterface delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(NestedInterface.SimpleInterface delegate) {
+        return new NestedInterfaceSimpleInterfaceEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return ImmutableList.of(new PingEndpoint(runtime, delegate));
+    }
+
+    private static final class PingEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final NestedInterface.SimpleInterface delegate;
+
+        PingEndpoint(UndertowRuntime runtime, NestedInterface.SimpleInterface delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            this.delegate.ping();
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/ping";
+        }
+
+        @Override
+        public String serviceName() {
+            return "SimpleInterface";
+        }
+
+        @Override
+        public String name() {
+            return "ping";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
Service interfaces can now be generated from nested classes.

```java
class Outer {
    public interface MyService {
        @Handle(method = HttpMethod.GET, path = "/get")
        String get();
    }
}
```

Currently, if you try to add these annotations to a nested interface, it generates code that fails to compile.

The equivalent PR for `dialogue-annotations-processor` is in https://github.com/palantir/dialogue/pull/2591.