### PR TITLE
Deconflict `cause` conjure error arguments

### DIFF
--- a/changelog/@unreleased/pr-2567.v2.yml
+++ b/changelog/@unreleased/pr-2567.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Deconflict `cause` conjure error arguments
+  links:
+  - https://github.com/palantir/conjure-java/pull/2567

--- a/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ConjureErrors.java
@@ -1,0 +1,27 @@
+package dialogueendpointresulttypes.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.RemoteException;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.types.ErrorGenerator")
+public final class ConjureErrors {
+    /** Cause argument conflicts with reserved Throwable cause parameter. */
+    public static final ErrorType CONFLICTING_CAUSE_SAFE_ARG =
+            ErrorType.create(ErrorType.Code.INTERNAL, "Conjure:ConflictingCauseSafeArg");
+
+    private ConjureErrors() {}
+
+    /** Returns true if the {@link RemoteException} is named Conjure:ConflictingCauseSafeArg */
+    public static boolean isConflictingCauseSafeArg(RemoteException remoteException) {
+        Preconditions.checkNotNull(remoteException, "remote exception must not be null");
+        return CONFLICTING_CAUSE_SAFE_ARG
+                .name()
+                .equals(remoteException.getError().errorName());
+    }
+
+    public static record ConflictingCauseSafeArgParameters(@JsonProperty("cause") @Safe String cause) {}
+}

--- a/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ConjureErrors.java
@@ -23,5 +23,6 @@ public final class ConjureErrors {
                 .equals(remoteException.getError().errorName());
     }
 
-    public static record ConflictingCauseSafeArgParameters(@JsonProperty("cause") @Safe String cause_) {}
+    public static record ConflictingCauseSafeArgParameters(
+            @JsonProperty("cause") @Safe String cause_, @JsonProperty("shouldThrow") @Safe boolean shouldThrow_) {}
 }

--- a/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ConjureErrors.java
@@ -23,5 +23,5 @@ public final class ConjureErrors {
                 .equals(remoteException.getError().errorName());
     }
 
-    public static record ConflictingCauseSafeArgParameters(@JsonProperty("cause") @Safe String cause) {}
+    public static record ConflictingCauseSafeArgParameters(@JsonProperty("cause") @Safe String cause_) {}
 }

--- a/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ConjureServerErrors.java
+++ b/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ConjureServerErrors.java
@@ -1,0 +1,38 @@
+package dialogueendpointresulttypes.com.palantir.product;
+
+import com.palantir.conjure.java.api.errors.EndpointServiceException;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.types.EndpointErrorGenerator")
+public final class ConjureServerErrors {
+    private ConjureServerErrors() {}
+
+    public static ConflictingCauseSafeArg conflictingCauseSafeArg(@Safe String cause) {
+        return new ConflictingCauseSafeArg(cause, null);
+    }
+
+    public static ConflictingCauseSafeArg conflictingCauseSafeArg(@Safe String cause, @Nullable Throwable cause) {
+        return new ConflictingCauseSafeArg(cause, cause);
+    }
+
+    /**
+     * Throws a {@link ConflictingCauseSafeArg} when {@code shouldThrow} is true.
+     *
+     * @param shouldThrow Cause the method to throw when true
+     * @param cause
+     */
+    public static void throwIfConflictingCauseSafeArg(boolean shouldThrow, @Safe String cause) {
+        if (shouldThrow) {
+            throw conflictingCauseSafeArg(cause);
+        }
+    }
+
+    public static final class ConflictingCauseSafeArg extends EndpointServiceException {
+        private ConflictingCauseSafeArg(@Safe String cause, @Nullable Throwable cause) {
+            super(ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG, cause, SafeArg.of("cause", cause));
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ConjureServerErrors.java
+++ b/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ConjureServerErrors.java
@@ -10,29 +10,36 @@ import javax.annotation.processing.Generated;
 public final class ConjureServerErrors {
     private ConjureServerErrors() {}
 
-    public static ConflictingCauseSafeArg conflictingCauseSafeArg(@Safe String cause_) {
-        return new ConflictingCauseSafeArg(cause_, null);
+    public static ConflictingCauseSafeArg conflictingCauseSafeArg(@Safe String cause_, @Safe boolean shouldThrow_) {
+        return new ConflictingCauseSafeArg(cause_, shouldThrow_, null);
     }
 
-    public static ConflictingCauseSafeArg conflictingCauseSafeArg(@Safe String cause_, @Nullable Throwable cause) {
-        return new ConflictingCauseSafeArg(cause_, cause);
+    public static ConflictingCauseSafeArg conflictingCauseSafeArg(
+            @Safe String cause_, @Safe boolean shouldThrow_, @Nullable Throwable cause) {
+        return new ConflictingCauseSafeArg(cause_, shouldThrow_, cause);
     }
 
     /**
      * Throws a {@link ConflictingCauseSafeArg} when {@code shouldThrow} is true.
      *
      * @param shouldThrow Cause the method to throw when true
-     * @param cause
+     * @param cause_
+     * @param shouldThrow_
      */
-    public static void throwIfConflictingCauseSafeArg(boolean shouldThrow, @Safe String cause) {
+    public static void throwIfConflictingCauseSafeArg(
+            boolean shouldThrow, @Safe String cause_, @Safe boolean shouldThrow_) {
         if (shouldThrow) {
-            throw conflictingCauseSafeArg(cause);
+            throw conflictingCauseSafeArg(cause_, shouldThrow_);
         }
     }
 
     public static final class ConflictingCauseSafeArg extends EndpointServiceException {
-        private ConflictingCauseSafeArg(@Safe String cause_, @Nullable Throwable cause) {
-            super(ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG, cause, SafeArg.of("cause", cause_));
+        private ConflictingCauseSafeArg(@Safe String cause_, @Safe boolean shouldThrow_, @Nullable Throwable cause) {
+            super(
+                    ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG,
+                    cause,
+                    SafeArg.of("cause", cause_),
+                    SafeArg.of("shouldThrow", shouldThrow_));
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ConjureServerErrors.java
+++ b/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ConjureServerErrors.java
@@ -10,12 +10,12 @@ import javax.annotation.processing.Generated;
 public final class ConjureServerErrors {
     private ConjureServerErrors() {}
 
-    public static ConflictingCauseSafeArg conflictingCauseSafeArg(@Safe String cause) {
-        return new ConflictingCauseSafeArg(cause, null);
+    public static ConflictingCauseSafeArg conflictingCauseSafeArg(@Safe String cause_) {
+        return new ConflictingCauseSafeArg(cause_, null);
     }
 
-    public static ConflictingCauseSafeArg conflictingCauseSafeArg(@Safe String cause, @Nullable Throwable cause) {
-        return new ConflictingCauseSafeArg(cause, cause);
+    public static ConflictingCauseSafeArg conflictingCauseSafeArg(@Safe String cause_, @Nullable Throwable cause) {
+        return new ConflictingCauseSafeArg(cause_, cause);
     }
 
     /**
@@ -31,8 +31,8 @@ public final class ConjureServerErrors {
     }
 
     public static final class ConflictingCauseSafeArg extends EndpointServiceException {
-        private ConflictingCauseSafeArg(@Safe String cause, @Nullable Throwable cause) {
-            super(ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG, cause, SafeArg.of("cause", cause));
+        private ConflictingCauseSafeArg(@Safe String cause_, @Nullable Throwable cause) {
+            super(ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG, cause, SafeArg.of("cause", cause_));
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ErrorService.java
+++ b/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ErrorService.java
@@ -10,8 +10,10 @@ public interface ErrorService {
     /**
      * @apiNote {@code POST /errors/basic}
      * @throws TestServerErrors.InvalidArgument
+     * @throws ConjureServerErrors.ConflictingCauseSafeArg
      */
-    String testBasicError(AuthHeader authHeader, boolean shouldThrowError) throws TestServerErrors.InvalidArgument;
+    String testBasicError(AuthHeader authHeader, boolean shouldThrowError)
+            throws TestServerErrors.InvalidArgument, ConjureServerErrors.ConflictingCauseSafeArg;
 
     /**
      * @apiNote {@code POST /errors/imported}

--- a/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ErrorServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ErrorServiceAsync.java
@@ -86,6 +86,9 @@ public interface ErrorServiceAsync {
                             .error(
                                     TestErrors.INVALID_ARGUMENT.name(),
                                     new TypeMarker<TestBasicErrorResponse.InvalidArgument>() {})
+                            .error(
+                                    ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG.name(),
+                                    new TypeMarker<TestBasicErrorResponse.ConflictingCauseSafeArg>() {})
                             .build());
 
             private final Serializer<Boolean> testImportedErrorSerializer =
@@ -270,7 +273,9 @@ public interface ErrorServiceAsync {
     }
 
     sealed interface TestBasicErrorResponse
-            permits TestBasicErrorResponse.Success, TestBasicErrorResponse.InvalidArgument {
+            permits TestBasicErrorResponse.Success,
+                    TestBasicErrorResponse.InvalidArgument,
+                    TestBasicErrorResponse.ConflictingCauseSafeArg {
         record Success(@JsonValue String value) implements TestBasicErrorResponse {
             public Success {
                 Preconditions.checkArgumentNotNull(value, "value cannot be null");
@@ -285,6 +290,17 @@ public interface ErrorServiceAsync {
                     @JsonProperty("errorInstanceId") @Safe String errorInstanceId,
                     @JsonProperty("parameters") TestErrors.InvalidArgumentParameters parameters) {
                 super(errorCode, TestErrors.INVALID_ARGUMENT.name(), errorInstanceId, parameters);
+            }
+        }
+
+        final class ConflictingCauseSafeArg extends EndpointError<ConjureErrors.ConflictingCauseSafeArgParameters>
+                implements TestBasicErrorResponse {
+            @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+            ConflictingCauseSafeArg(
+                    @JsonProperty("errorCode") @Safe String errorCode,
+                    @JsonProperty("errorInstanceId") @Safe String errorInstanceId,
+                    @JsonProperty("parameters") ConjureErrors.ConflictingCauseSafeArgParameters parameters) {
+                super(errorCode, ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG.name(), errorInstanceId, parameters);
             }
         }
     }

--- a/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ErrorServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ErrorServiceBlocking.java
@@ -84,6 +84,9 @@ public interface ErrorServiceBlocking {
                             .error(
                                     TestErrors.INVALID_ARGUMENT.name(),
                                     new TypeMarker<TestBasicErrorResponse.InvalidArgument>() {})
+                            .error(
+                                    ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG.name(),
+                                    new TypeMarker<TestBasicErrorResponse.ConflictingCauseSafeArg>() {})
                             .build());
 
             private final Serializer<Boolean> testImportedErrorSerializer =
@@ -267,7 +270,9 @@ public interface ErrorServiceBlocking {
     }
 
     sealed interface TestBasicErrorResponse
-            permits TestBasicErrorResponse.Success, TestBasicErrorResponse.InvalidArgument {
+            permits TestBasicErrorResponse.Success,
+                    TestBasicErrorResponse.InvalidArgument,
+                    TestBasicErrorResponse.ConflictingCauseSafeArg {
         record Success(@JsonValue String value) implements TestBasicErrorResponse {
             public Success {
                 Preconditions.checkArgumentNotNull(value, "value cannot be null");
@@ -282,6 +287,17 @@ public interface ErrorServiceBlocking {
                     @JsonProperty("errorInstanceId") @Safe String errorInstanceId,
                     @JsonProperty("parameters") TestErrors.InvalidArgumentParameters parameters) {
                 super(errorCode, TestErrors.INVALID_ARGUMENT.name(), errorInstanceId, parameters);
+            }
+        }
+
+        final class ConflictingCauseSafeArg extends EndpointError<ConjureErrors.ConflictingCauseSafeArgParameters>
+                implements TestBasicErrorResponse {
+            @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+            ConflictingCauseSafeArg(
+                    @JsonProperty("errorCode") @Safe String errorCode,
+                    @JsonProperty("errorInstanceId") @Safe String errorInstanceId,
+                    @JsonProperty("parameters") ConjureErrors.ConflictingCauseSafeArgParameters parameters) {
+                super(errorCode, ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG.name(), errorInstanceId, parameters);
             }
         }
     }

--- a/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ErrorServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/dialogueendpointresulttypes/com/palantir/product/ErrorServiceEndpoints.java
@@ -59,7 +59,8 @@ public final class ErrorServiceEndpoints implements UndertowService {
         }
 
         @Override
-        public void handleRequest(HttpServerExchange exchange) throws IOException, TestServerErrors.InvalidArgument {
+        public void handleRequest(HttpServerExchange exchange)
+                throws IOException, TestServerErrors.InvalidArgument, ConjureServerErrors.ConflictingCauseSafeArg {
             AuthHeader authHeader = runtime.auth().header(exchange);
             Boolean shouldThrowError = deserializer.deserialize(exchange);
             String result = delegate.testBasicError(authHeader, shouldThrowError);

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/ConjureErrors.java
@@ -14,6 +14,14 @@ import org.jetbrains.annotations.Contract;
 
 @Generated("com.palantir.conjure.java.types.ErrorGenerator")
 public final class ConjureErrors {
+    /** Cause argument conflicts with reserved Throwable cause parameter. */
+    public static final ErrorType CONFLICTING_CAUSE_SAFE_ARG =
+            ErrorType.create(ErrorType.Code.INTERNAL, "Conjure:ConflictingCauseSafeArg");
+
+    /** Cause argument conflicts with reserved Throwable cause parameter. */
+    public static final ErrorType CONFLICTING_CAUSE_UNAFE_ARG =
+            ErrorType.create(ErrorType.Code.INTERNAL, "Conjure:ConflictingCauseUnafeArg");
+
     /** Invalid Conjure service definition. */
     public static final ErrorType INVALID_SERVICE_DEFINITION =
             ErrorType.create(ErrorType.Code.INVALID_ARGUMENT, "Conjure:InvalidServiceDefinition");
@@ -23,6 +31,22 @@ public final class ConjureErrors {
             ErrorType.create(ErrorType.Code.INVALID_ARGUMENT, "Conjure:InvalidTypeDefinition");
 
     private ConjureErrors() {}
+
+    public static ServiceException conflictingCauseSafeArg(@Safe String cause) {
+        return new ServiceException(CONFLICTING_CAUSE_SAFE_ARG, SafeArg.of("cause", cause));
+    }
+
+    public static ServiceException conflictingCauseSafeArg(@Nullable Throwable cause, @Safe String cause) {
+        return new ServiceException(CONFLICTING_CAUSE_SAFE_ARG, cause, SafeArg.of("cause", cause));
+    }
+
+    public static ServiceException conflictingCauseUnafeArg(@Unsafe String cause) {
+        return new ServiceException(CONFLICTING_CAUSE_UNAFE_ARG, UnsafeArg.of("cause", cause));
+    }
+
+    public static ServiceException conflictingCauseUnafeArg(@Nullable Throwable cause, @Unsafe String cause) {
+        return new ServiceException(CONFLICTING_CAUSE_UNAFE_ARG, cause, UnsafeArg.of("cause", cause));
+    }
 
     /**
      * @param serviceName Name of the invalid service definition.
@@ -60,6 +84,32 @@ public final class ConjureErrors {
     }
 
     /**
+     * Throws a {@link ServiceException} of type ConflictingCauseSafeArg when {@code shouldThrow} is true.
+     *
+     * @param shouldThrow Cause the method to throw when true
+     * @param cause
+     */
+    @Contract("true, _ -> fail")
+    public static void throwIfConflictingCauseSafeArg(boolean shouldThrow, @Safe String cause) {
+        if (shouldThrow) {
+            throw conflictingCauseSafeArg(cause);
+        }
+    }
+
+    /**
+     * Throws a {@link ServiceException} of type ConflictingCauseUnafeArg when {@code shouldThrow} is true.
+     *
+     * @param shouldThrow Cause the method to throw when true
+     * @param cause
+     */
+    @Contract("true, _ -> fail")
+    public static void throwIfConflictingCauseUnafeArg(boolean shouldThrow, @Unsafe String cause) {
+        if (shouldThrow) {
+            throw conflictingCauseUnafeArg(cause);
+        }
+    }
+
+    /**
      * Throws a {@link ServiceException} of type InvalidServiceDefinition when {@code shouldThrow} is true.
      *
      * @param shouldThrow Cause the method to throw when true
@@ -87,6 +137,22 @@ public final class ConjureErrors {
         if (shouldThrow) {
             throw invalidTypeDefinition(typeName, typeDef);
         }
+    }
+
+    /** Returns true if the {@link RemoteException} is named Conjure:ConflictingCauseSafeArg */
+    public static boolean isConflictingCauseSafeArg(RemoteException remoteException) {
+        Preconditions.checkNotNull(remoteException, "remote exception must not be null");
+        return CONFLICTING_CAUSE_SAFE_ARG
+                .name()
+                .equals(remoteException.getError().errorName());
+    }
+
+    /** Returns true if the {@link RemoteException} is named Conjure:ConflictingCauseUnafeArg */
+    public static boolean isConflictingCauseUnafeArg(RemoteException remoteException) {
+        Preconditions.checkNotNull(remoteException, "remote exception must not be null");
+        return CONFLICTING_CAUSE_UNAFE_ARG
+                .name()
+                .equals(remoteException.getError().errorName());
     }
 
     /** Returns true if the {@link RemoteException} is named Conjure:InvalidServiceDefinition */

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/ConjureErrors.java
@@ -32,20 +32,20 @@ public final class ConjureErrors {
 
     private ConjureErrors() {}
 
-    public static ServiceException conflictingCauseSafeArg(@Safe String cause) {
-        return new ServiceException(CONFLICTING_CAUSE_SAFE_ARG, SafeArg.of("cause", cause));
+    public static ServiceException conflictingCauseSafeArg(@Safe String cause_) {
+        return new ServiceException(CONFLICTING_CAUSE_SAFE_ARG, SafeArg.of("cause", cause_));
     }
 
-    public static ServiceException conflictingCauseSafeArg(@Nullable Throwable cause, @Safe String cause) {
-        return new ServiceException(CONFLICTING_CAUSE_SAFE_ARG, cause, SafeArg.of("cause", cause));
+    public static ServiceException conflictingCauseSafeArg(@Nullable Throwable cause, @Safe String cause_) {
+        return new ServiceException(CONFLICTING_CAUSE_SAFE_ARG, cause, SafeArg.of("cause", cause_));
     }
 
-    public static ServiceException conflictingCauseUnafeArg(@Unsafe String cause) {
-        return new ServiceException(CONFLICTING_CAUSE_UNAFE_ARG, UnsafeArg.of("cause", cause));
+    public static ServiceException conflictingCauseUnafeArg(@Unsafe String cause_) {
+        return new ServiceException(CONFLICTING_CAUSE_UNAFE_ARG, UnsafeArg.of("cause", cause_));
     }
 
-    public static ServiceException conflictingCauseUnafeArg(@Nullable Throwable cause, @Unsafe String cause) {
-        return new ServiceException(CONFLICTING_CAUSE_UNAFE_ARG, cause, UnsafeArg.of("cause", cause));
+    public static ServiceException conflictingCauseUnafeArg(@Nullable Throwable cause, @Unsafe String cause_) {
+        return new ServiceException(CONFLICTING_CAUSE_UNAFE_ARG, cause, UnsafeArg.of("cause", cause_));
     }
 
     /**

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/ConjureErrors.java
@@ -19,8 +19,8 @@ public final class ConjureErrors {
             ErrorType.create(ErrorType.Code.INTERNAL, "Conjure:ConflictingCauseSafeArg");
 
     /** Cause argument conflicts with reserved Throwable cause parameter. */
-    public static final ErrorType CONFLICTING_CAUSE_UNAFE_ARG =
-            ErrorType.create(ErrorType.Code.INTERNAL, "Conjure:ConflictingCauseUnafeArg");
+    public static final ErrorType CONFLICTING_CAUSE_UNSAFE_ARG =
+            ErrorType.create(ErrorType.Code.INTERNAL, "Conjure:ConflictingCauseUnsafeArg");
 
     /** Invalid Conjure service definition. */
     public static final ErrorType INVALID_SERVICE_DEFINITION =
@@ -32,20 +32,32 @@ public final class ConjureErrors {
 
     private ConjureErrors() {}
 
-    public static ServiceException conflictingCauseSafeArg(@Safe String cause_) {
-        return new ServiceException(CONFLICTING_CAUSE_SAFE_ARG, SafeArg.of("cause", cause_));
+    public static ServiceException conflictingCauseSafeArg(@Safe String cause_, @Safe boolean shouldThrow_) {
+        return new ServiceException(
+                CONFLICTING_CAUSE_SAFE_ARG, SafeArg.of("cause", cause_), SafeArg.of("shouldThrow", shouldThrow_));
     }
 
-    public static ServiceException conflictingCauseSafeArg(@Nullable Throwable cause, @Safe String cause_) {
-        return new ServiceException(CONFLICTING_CAUSE_SAFE_ARG, cause, SafeArg.of("cause", cause_));
+    public static ServiceException conflictingCauseSafeArg(
+            @Nullable Throwable cause, @Safe String cause_, @Safe boolean shouldThrow_) {
+        return new ServiceException(
+                CONFLICTING_CAUSE_SAFE_ARG,
+                cause,
+                SafeArg.of("cause", cause_),
+                SafeArg.of("shouldThrow", shouldThrow_));
     }
 
-    public static ServiceException conflictingCauseUnafeArg(@Unsafe String cause_) {
-        return new ServiceException(CONFLICTING_CAUSE_UNAFE_ARG, UnsafeArg.of("cause", cause_));
+    public static ServiceException conflictingCauseUnsafeArg(@Unsafe String cause_, @Unsafe boolean shouldThrow_) {
+        return new ServiceException(
+                CONFLICTING_CAUSE_UNSAFE_ARG, UnsafeArg.of("cause", cause_), UnsafeArg.of("shouldThrow", shouldThrow_));
     }
 
-    public static ServiceException conflictingCauseUnafeArg(@Nullable Throwable cause, @Unsafe String cause_) {
-        return new ServiceException(CONFLICTING_CAUSE_UNAFE_ARG, cause, UnsafeArg.of("cause", cause_));
+    public static ServiceException conflictingCauseUnsafeArg(
+            @Nullable Throwable cause, @Unsafe String cause_, @Unsafe boolean shouldThrow_) {
+        return new ServiceException(
+                CONFLICTING_CAUSE_UNSAFE_ARG,
+                cause,
+                UnsafeArg.of("cause", cause_),
+                UnsafeArg.of("shouldThrow", shouldThrow_));
     }
 
     /**
@@ -87,25 +99,29 @@ public final class ConjureErrors {
      * Throws a {@link ServiceException} of type ConflictingCauseSafeArg when {@code shouldThrow} is true.
      *
      * @param shouldThrow Cause the method to throw when true
-     * @param cause
+     * @param cause_
+     * @param shouldThrow_
      */
-    @Contract("true, _ -> fail")
-    public static void throwIfConflictingCauseSafeArg(boolean shouldThrow, @Safe String cause) {
+    @Contract("true, _, _ -> fail")
+    public static void throwIfConflictingCauseSafeArg(
+            boolean shouldThrow, @Safe String cause_, @Safe boolean shouldThrow_) {
         if (shouldThrow) {
-            throw conflictingCauseSafeArg(cause);
+            throw conflictingCauseSafeArg(cause_, shouldThrow_);
         }
     }
 
     /**
-     * Throws a {@link ServiceException} of type ConflictingCauseUnafeArg when {@code shouldThrow} is true.
+     * Throws a {@link ServiceException} of type ConflictingCauseUnsafeArg when {@code shouldThrow} is true.
      *
      * @param shouldThrow Cause the method to throw when true
-     * @param cause
+     * @param cause_
+     * @param shouldThrow_
      */
-    @Contract("true, _ -> fail")
-    public static void throwIfConflictingCauseUnafeArg(boolean shouldThrow, @Unsafe String cause) {
+    @Contract("true, _, _ -> fail")
+    public static void throwIfConflictingCauseUnsafeArg(
+            boolean shouldThrow, @Unsafe String cause_, @Unsafe boolean shouldThrow_) {
         if (shouldThrow) {
-            throw conflictingCauseUnafeArg(cause);
+            throw conflictingCauseUnsafeArg(cause_, shouldThrow_);
         }
     }
 
@@ -147,10 +163,10 @@ public final class ConjureErrors {
                 .equals(remoteException.getError().errorName());
     }
 
-    /** Returns true if the {@link RemoteException} is named Conjure:ConflictingCauseUnafeArg */
-    public static boolean isConflictingCauseUnafeArg(RemoteException remoteException) {
+    /** Returns true if the {@link RemoteException} is named Conjure:ConflictingCauseUnsafeArg */
+    public static boolean isConflictingCauseUnsafeArg(RemoteException remoteException) {
         Preconditions.checkNotNull(remoteException, "remote exception must not be null");
-        return CONFLICTING_CAUSE_UNAFE_ARG
+        return CONFLICTING_CAUSE_UNSAFE_ARG
                 .name()
                 .equals(remoteException.getError().errorName());
     }

--- a/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/ConjureErrors.java
@@ -1,0 +1,23 @@
+package undertow.com.palantir.product;
+
+import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.RemoteException;
+import com.palantir.logsafe.Preconditions;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.types.ErrorGenerator")
+public final class ConjureErrors {
+    /** Cause argument conflicts with reserved Throwable cause parameter. */
+    public static final ErrorType CONFLICTING_CAUSE_SAFE_ARG =
+            ErrorType.create(ErrorType.Code.INTERNAL, "Conjure:ConflictingCauseSafeArg");
+
+    private ConjureErrors() {}
+
+    /** Returns true if the {@link RemoteException} is named Conjure:ConflictingCauseSafeArg */
+    public static boolean isConflictingCauseSafeArg(RemoteException remoteException) {
+        Preconditions.checkNotNull(remoteException, "remote exception must not be null");
+        return CONFLICTING_CAUSE_SAFE_ARG
+                .name()
+                .equals(remoteException.getError().errorName());
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/ConjureServerErrors.java
+++ b/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/ConjureServerErrors.java
@@ -11,30 +11,37 @@ import org.jetbrains.annotations.Contract;
 public final class ConjureServerErrors {
     private ConjureServerErrors() {}
 
-    public static ConflictingCauseSafeArg conflictingCauseSafeArg(@Safe String cause_) {
-        return new ConflictingCauseSafeArg(cause_, null);
+    public static ConflictingCauseSafeArg conflictingCauseSafeArg(@Safe String cause_, @Safe boolean shouldThrow_) {
+        return new ConflictingCauseSafeArg(cause_, shouldThrow_, null);
     }
 
-    public static ConflictingCauseSafeArg conflictingCauseSafeArg(@Safe String cause_, @Nullable Throwable cause) {
-        return new ConflictingCauseSafeArg(cause_, cause);
+    public static ConflictingCauseSafeArg conflictingCauseSafeArg(
+            @Safe String cause_, @Safe boolean shouldThrow_, @Nullable Throwable cause) {
+        return new ConflictingCauseSafeArg(cause_, shouldThrow_, cause);
     }
 
     /**
      * Throws a {@link ConflictingCauseSafeArg} when {@code shouldThrow} is true.
      *
      * @param shouldThrow Cause the method to throw when true
-     * @param cause
+     * @param cause_
+     * @param shouldThrow_
      */
-    @Contract("true, _ -> fail")
-    public static void throwIfConflictingCauseSafeArg(boolean shouldThrow, @Safe String cause) {
+    @Contract("true, _, _ -> fail")
+    public static void throwIfConflictingCauseSafeArg(
+            boolean shouldThrow, @Safe String cause_, @Safe boolean shouldThrow_) {
         if (shouldThrow) {
-            throw conflictingCauseSafeArg(cause);
+            throw conflictingCauseSafeArg(cause_, shouldThrow_);
         }
     }
 
     public static final class ConflictingCauseSafeArg extends EndpointServiceException {
-        private ConflictingCauseSafeArg(@Safe String cause_, @Nullable Throwable cause) {
-            super(ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG, cause, SafeArg.of("cause", cause_));
+        private ConflictingCauseSafeArg(@Safe String cause_, @Safe boolean shouldThrow_, @Nullable Throwable cause) {
+            super(
+                    ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG,
+                    cause,
+                    SafeArg.of("cause", cause_),
+                    SafeArg.of("shouldThrow", shouldThrow_));
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/ConjureServerErrors.java
+++ b/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/ConjureServerErrors.java
@@ -11,12 +11,12 @@ import org.jetbrains.annotations.Contract;
 public final class ConjureServerErrors {
     private ConjureServerErrors() {}
 
-    public static ConflictingCauseSafeArg conflictingCauseSafeArg(@Safe String cause) {
-        return new ConflictingCauseSafeArg(cause, null);
+    public static ConflictingCauseSafeArg conflictingCauseSafeArg(@Safe String cause_) {
+        return new ConflictingCauseSafeArg(cause_, null);
     }
 
-    public static ConflictingCauseSafeArg conflictingCauseSafeArg(@Safe String cause, @Nullable Throwable cause) {
-        return new ConflictingCauseSafeArg(cause, cause);
+    public static ConflictingCauseSafeArg conflictingCauseSafeArg(@Safe String cause_, @Nullable Throwable cause) {
+        return new ConflictingCauseSafeArg(cause_, cause);
     }
 
     /**
@@ -33,8 +33,8 @@ public final class ConjureServerErrors {
     }
 
     public static final class ConflictingCauseSafeArg extends EndpointServiceException {
-        private ConflictingCauseSafeArg(@Safe String cause, @Nullable Throwable cause) {
-            super(ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG, cause, SafeArg.of("cause", cause));
+        private ConflictingCauseSafeArg(@Safe String cause_, @Nullable Throwable cause) {
+            super(ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG, cause, SafeArg.of("cause", cause_));
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/ConjureServerErrors.java
+++ b/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/ConjureServerErrors.java
@@ -1,0 +1,40 @@
+package undertow.com.palantir.product;
+
+import com.palantir.conjure.java.api.errors.EndpointServiceException;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+import org.jetbrains.annotations.Contract;
+
+@Generated("com.palantir.conjure.java.types.EndpointErrorGenerator")
+public final class ConjureServerErrors {
+    private ConjureServerErrors() {}
+
+    public static ConflictingCauseSafeArg conflictingCauseSafeArg(@Safe String cause) {
+        return new ConflictingCauseSafeArg(cause, null);
+    }
+
+    public static ConflictingCauseSafeArg conflictingCauseSafeArg(@Safe String cause, @Nullable Throwable cause) {
+        return new ConflictingCauseSafeArg(cause, cause);
+    }
+
+    /**
+     * Throws a {@link ConflictingCauseSafeArg} when {@code shouldThrow} is true.
+     *
+     * @param shouldThrow Cause the method to throw when true
+     * @param cause
+     */
+    @Contract("true, _ -> fail")
+    public static void throwIfConflictingCauseSafeArg(boolean shouldThrow, @Safe String cause) {
+        if (shouldThrow) {
+            throw conflictingCauseSafeArg(cause);
+        }
+    }
+
+    public static final class ConflictingCauseSafeArg extends EndpointServiceException {
+        private ConflictingCauseSafeArg(@Safe String cause, @Nullable Throwable cause) {
+            super(ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG, cause, SafeArg.of("cause", cause));
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/ErrorServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/ErrorServiceEndpoints.java
@@ -59,7 +59,8 @@ public final class ErrorServiceEndpoints implements UndertowService {
         }
 
         @Override
-        public void handleRequest(HttpServerExchange exchange) throws IOException, TestServerErrors.InvalidArgument {
+        public void handleRequest(HttpServerExchange exchange)
+                throws IOException, TestServerErrors.InvalidArgument, ConjureServerErrors.ConflictingCauseSafeArg {
             AuthHeader authHeader = runtime.auth().header(exchange);
             Boolean shouldThrowError = deserializer.deserialize(exchange);
             String result = delegate.testBasicError(authHeader, shouldThrowError);

--- a/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/UndertowErrorService.java
+++ b/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/UndertowErrorService.java
@@ -10,8 +10,10 @@ public interface UndertowErrorService {
     /**
      * @apiNote {@code POST /errors/basic}
      * @throws TestServerErrors.InvalidArgument
+     * @throws ConjureServerErrors.ConflictingCauseSafeArg
      */
-    String testBasicError(AuthHeader authHeader, boolean shouldThrowError) throws TestServerErrors.InvalidArgument;
+    String testBasicError(AuthHeader authHeader, boolean shouldThrowError)
+            throws TestServerErrors.InvalidArgument, ConjureServerErrors.ConflictingCauseSafeArg;
 
     /**
      * @apiNote {@code POST /errors/imported}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EndpointErrorGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EndpointErrorGenerator.java
@@ -23,6 +23,7 @@ import com.palantir.conjure.java.Options;
 import com.palantir.conjure.java.api.errors.EndpointServiceException;
 import com.palantir.conjure.java.util.ErrorGenerationUtils;
 import com.palantir.conjure.java.util.ErrorGenerationUtils.DeclaredEndpointErrors;
+import com.palantir.conjure.java.util.JavaNameSanitizer;
 import com.palantir.conjure.java.util.Packages;
 import com.palantir.conjure.java.util.TypeFunctions;
 import com.palantir.conjure.spec.ConjureDefinition;
@@ -123,7 +124,10 @@ public final class EndpointErrorGenerator implements Generator {
 
         List<CodeBlock> args = new ArrayList<>(
                 Stream.concat(errorDefinition.getSafeArgs().stream(), errorDefinition.getUnsafeArgs().stream())
-                        .map(arg -> CodeBlock.of("$N", arg.getFieldName().get()))
+                        .map(arg -> CodeBlock.of(
+                                "$N",
+                                JavaNameSanitizer.sanitizeErrorParameterName(
+                                        arg.getFieldName().get())))
                         .toList());
         if (withCause) {
             args.add(CodeBlock.of("$N", "cause"));

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/ErrorGenerationUtils.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/ErrorGenerationUtils.java
@@ -256,7 +256,8 @@ public final class ErrorGenerationUtils {
                                 Stream.concat(
                                                 errorDefinition.getSafeArgs().stream(),
                                                 errorDefinition.getUnsafeArgs().stream())
-                                        .map(arg -> arg.getFieldName().get())
+                                        .map(arg -> JavaNameSanitizer.sanitizeErrorParameterName(
+                                                arg.getFieldName().get()))
                                         .collect(Collectors.toList())));
         if (errorType.isPresent()) {
             methodBuilder.addJavadoc(
@@ -295,8 +296,9 @@ public final class ErrorGenerationUtils {
                                 errorDefinition.getErrorName().getName(),
                                 arg.getFieldName()));
                     }
-                    return ParameterSpec.builder(
-                                    argumentTypeName, arg.getFieldName().get())
+                    String name = JavaNameSanitizer.sanitizeErrorParameterName(
+                            arg.getFieldName().get());
+                    return ParameterSpec.builder(argumentTypeName, name)
                             .addAnnotations(ConjureAnnotations.safety(underlyingTypeSafety))
                             .addJavadoc(
                                     "$L",

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/ErrorGenerationUtils.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/ErrorGenerationUtils.java
@@ -169,11 +169,14 @@ public final class ErrorGenerationUtils {
 
     private static void addLogSafeArgumentToMethodBuilder(
             TypeMapper typeMapper, MethodSpec.Builder methodBuilder, FieldDefinition argDefinition, boolean isSafe) {
-        String argName = argDefinition.getFieldName().get();
+        String argName = JavaNameSanitizer.sanitizeErrorParameterName(
+                argDefinition.getFieldName().get());
         methodBuilder.addParameter(
                 ErrorGenerationUtils.buildParameterWithSafetyAnnotation(typeMapper, argDefinition, isSafe));
         Class<?> clazz = isSafe ? SafeArg.class : UnsafeArg.class;
-        methodBuilder.addCode(",\n    $T.of($S, $L)", clazz, argName, argName);
+        // This will generate e.g. SafeArg.of("argName", argName) or SafeArg.of("cause", cause_) if deconflicted
+        methodBuilder.addCode(
+                ",\n    $T.of($S, $L)", clazz, argDefinition.getFieldName().get(), argName);
     }
 
     public static void addAllParametersWithSafetyAnnotationsToMethodBuilder(
@@ -199,7 +202,7 @@ public final class ErrorGenerationUtils {
         ParameterSpec.Builder parameterBuilder =
                 buildParameterWithSafetyAnnotationInternal(typeMapper, argDefinition, isSafe);
         parameterBuilder.addAnnotation(AnnotationSpec.builder(JsonProperty.class)
-                .addMember("value", "$S", argDefinition.getFieldName())
+                .addMember("value", "$S", argDefinition.getFieldName().get())
                 .build());
         return parameterBuilder.build();
     }
@@ -207,7 +210,8 @@ public final class ErrorGenerationUtils {
     private static ParameterSpec.Builder buildParameterWithSafetyAnnotationInternal(
             TypeMapper typeMapper, FieldDefinition argDefinition, boolean isSafe) {
         Optional<LogSafety> safety = Optional.of(isSafe ? LogSafety.SAFE : LogSafety.UNSAFE);
-        String argName = argDefinition.getFieldName().get();
+        String argName = JavaNameSanitizer.sanitizeErrorParameterName(
+                argDefinition.getFieldName().get());
         TypeName argType = ConjureAnnotations.withSafety(typeMapper.getClassName(argDefinition.getType()), safety);
         ParameterSpec.Builder parameterBuilder = ParameterSpec.builder(argType, argName);
         argDefinition

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/JavaNameSanitizer.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/JavaNameSanitizer.java
@@ -34,6 +34,8 @@ public final class JavaNameSanitizer {
 
     private static final ImmutableSet<String> RESERVED_FIELD_NAMES = ImmutableSet.of("memoizedHashCode");
 
+    private static final ImmutableSet<String> RESERVED_ERROR_PARAMETER_NAMES = ImmutableSet.of("cause");
+
     private static final ImmutableSet<String> RESERVED_METHOD_NAMES = ImmutableSet.of("getClass");
 
     /** Sanitizes the given {@link FieldName} for use as a java specifier. */
@@ -86,6 +88,11 @@ public final class JavaNameSanitizer {
             return sanitizeParameterName(escape(value), endpoint);
         }
         return value;
+    }
+
+    /** Sanitizes parameter names for errors. */
+    public static String sanitizeErrorParameterName(String input) {
+        return SourceVersion.isName(input) && !RESERVED_ERROR_PARAMETER_NAMES.contains(input) ? input : escape(input);
     }
 
     private static String sanitizeFieldName(String name) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/JavaNameSanitizer.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/JavaNameSanitizer.java
@@ -34,7 +34,7 @@ public final class JavaNameSanitizer {
 
     private static final ImmutableSet<String> RESERVED_FIELD_NAMES = ImmutableSet.of("memoizedHashCode");
 
-    private static final ImmutableSet<String> RESERVED_ERROR_PARAMETER_NAMES = ImmutableSet.of("cause");
+    private static final ImmutableSet<String> RESERVED_ERROR_PARAMETER_NAMES = ImmutableSet.of("cause", "shouldThrow");
 
     private static final ImmutableSet<String> RESERVED_METHOD_NAMES = ImmutableSet.of("getClass");
 

--- a/conjure-java-core/src/test/resources/example-endpoint-errors.yml
+++ b/conjure-java-core/src/test/resources/example-endpoint-errors.yml
@@ -33,6 +33,12 @@ types:
         code: INTERNAL
         safe-args:
           complicatedObjectMap: map<integer, ComplicatedObject>
+      ConflictingCauseSafeArg:
+        namespace: Conjure
+        docs: Cause argument conflicts with reserved Throwable cause parameter.
+        code: INTERNAL
+        safe-args:
+          cause: string
 services:
   ErrorService:
     name: Error Service
@@ -47,6 +53,7 @@ services:
         returns: string
         errors:
           - InvalidArgument
+          - ConflictingCauseSafeArg
       testImportedError:
         http: POST /imported
         args:

--- a/conjure-java-core/src/test/resources/example-endpoint-errors.yml
+++ b/conjure-java-core/src/test/resources/example-endpoint-errors.yml
@@ -39,6 +39,7 @@ types:
         code: INTERNAL
         safe-args:
           cause: string
+          shouldThrow: boolean
 services:
   ErrorService:
     name: Error Service

--- a/conjure-java-core/src/test/resources/example-errors.yml
+++ b/conjure-java-core/src/test/resources/example-errors.yml
@@ -37,9 +37,11 @@ types:
         code: INTERNAL
         safe-args:
           cause: string
-      ConflictingCauseUnafeArg:
+          shouldThrow: boolean
+      ConflictingCauseUnsafeArg:
         namespace: Conjure
         docs: Cause argument conflicts with reserved Throwable cause parameter.
         code: INTERNAL
         unsafe-args:
           cause: string
+          shouldThrow: boolean

--- a/conjure-java-core/src/test/resources/example-errors.yml
+++ b/conjure-java-core/src/test/resources/example-errors.yml
@@ -31,3 +31,15 @@ types:
         namespace: Conjure
         docs: Different package.
         code: INTERNAL
+      ConflictingCauseSafeArg:
+        namespace: Conjure
+        docs: Cause argument conflicts with reserved Throwable cause parameter.
+        code: INTERNAL
+        safe-args:
+          cause: string
+      ConflictingCauseUnafeArg:
+        namespace: Conjure
+        docs: Cause argument conflicts with reserved Throwable cause parameter.
+        code: INTERNAL
+        unsafe-args:
+          cause: string


### PR DESCRIPTION
## Before this PR
The conjure-java code generation for errors generates methods that take a `Throwable cause` parameter.

While [other places do parameter name deconfliction](https://github.com/palantir/conjure-java/blob/6ba3a53d2a04b2a1e65b0bf32f43e2c7ff799bb4/conjure-java-core/src/main/java/com/palantir/conjure/java/util/JavaNameSanitizer.java#L62-L89), the generated code will fail to compile if a `cause` argument is added to the conjure error definition.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Deconflict `cause` conjure error arguments
==COMMIT_MSG==

You can see the reproduction of the problem in https://github.com/palantir/conjure-java/pull/2567/commits/a9ef2ac69539a6364b817503521d7f7592c25a4b with the fix and its changes in https://github.com/palantir/conjure-java/pull/2567/commits/b7f21c5824a6aec8da62ddaa53b1728613ae8626

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

