### PR TITLE
Add `dangerousDoNotUseEnableEndpointAssociatedErrors` option to gate endpoint error generation

### DIFF
--- a/changelog/@unreleased/pr-2577.v2.yml
+++ b/changelog/@unreleased/pr-2577.v2.yml
@@ -1,5 +1,6 @@
 type: improvement
 improvement:
   description: Add `dangerousEnableEndpointAssociatedErrors` option to gate endpoint
+    error generation
   links:
   - https://github.com/palantir/conjure-java/pull/2577

--- a/changelog/@unreleased/pr-2577.v2.yml
+++ b/changelog/@unreleased/pr-2577.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add `dangerousEnableEndpointAssociatedErrors` option to gate endpoint
+  links:
+  - https://github.com/palantir/conjure-java/pull/2577

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
@@ -203,10 +203,17 @@ public interface Options {
     }
 
     /**
-     * Enabling this option will cause parameters of errors that are associated with an endpoint to be serialized as
-     * JSON. This is a wire break and can cause errors for clients that parse error parameters. Do not enable this.
+     * Enabling this option will enable associating errors with endpoints, which currently causes parameters of these
+     * errors to be serialized as JSON. This is a wire break and can cause errors for clients that parse error
+     * parameters. Do not enable this.
      * <p>
-     * For rollout, this value is initially set to true. In the future, this value will be set to false.
+     * This flag has been temporarily added to help us iterate on a safer rollout strategy for endpoint-associated
+     * errors.
+     * <p>
+     * It is initially set to true, but will quickly be set to false.
+     * <p>
+     * It will also eventually be removed, and you should not use it without letting the Conjure maintainers know.
+     * Otherwise, a future upgrade will break your builds.
      */
     @Value.Default
     default boolean dangerousDoNotUseEnableEndpointAssociatedErrors() {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
@@ -209,7 +209,7 @@ public interface Options {
      * For rollout, this value is initially set to true. In the future, this value will be set to false.
      */
     @Value.Default
-    default boolean dangerousEnableEndpointAssociatedErrors() {
+    default boolean dangerousDoNotUseEnableEndpointAssociatedErrors() {
         return true;
     }
 

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
@@ -203,6 +203,17 @@ public interface Options {
     }
 
     /**
+     * Enabling this option will cause parameters of errors that are associated with an endpoint to be serialized as
+     * JSON. This is a wire break and can cause errors for clients that parse error parameters. Do not enable this.
+     * <p>
+     * For rollout, this value is initially set to true. In the future, this value will be set to false.
+     */
+    @Value.Default
+    default boolean dangerousEnableEndpointAssociatedErrors() {
+        return true;
+    }
+
+    /**
      * Makes immutable copies of collections for union and alias types, respecting the --nonNullCollections flag.
      */
     @Value.Default

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EndpointErrorGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EndpointErrorGenerator.java
@@ -62,7 +62,7 @@ public final class EndpointErrorGenerator implements Generator {
         SafetyEvaluator safetyEvaluator = new SafetyEvaluator(types);
         TypeMapper typeMapper = new TypeMapper(types, options);
         DeclaredEndpointErrors endpointErrors = DeclaredEndpointErrors.from(definition);
-        if (!options.dangerousEnableEndpointAssociatedErrors()
+        if (!options.dangerousDoNotUseEnableEndpointAssociatedErrors()
                 && !endpointErrors.errors().isEmpty()) {
             List<String> errorNames =
                     endpointErrors.errors().stream().map(ErrorTypeName::getName).toList();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EndpointErrorGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EndpointErrorGenerator.java
@@ -58,9 +58,6 @@ public final class EndpointErrorGenerator implements Generator {
 
     @Override
     public Stream<JavaFile> generate(ConjureDefinition definition) {
-        Map<com.palantir.conjure.spec.TypeName, TypeDefinition> types = TypeFunctions.toTypesMap(definition);
-        SafetyEvaluator safetyEvaluator = new SafetyEvaluator(types);
-        TypeMapper typeMapper = new TypeMapper(types, options);
         DeclaredEndpointErrors endpointErrors = DeclaredEndpointErrors.from(definition);
         if (!options.dangerousDoNotUseEnableEndpointAssociatedErrors()
                 && !endpointErrors.errors().isEmpty()) {
@@ -70,6 +67,9 @@ public final class EndpointErrorGenerator implements Generator {
                     "Errors are associated with endpoints. This feature is currently not supported.",
                     SafeArg.of("errors", errorNames));
         }
+        Map<com.palantir.conjure.spec.TypeName, TypeDefinition> types = TypeFunctions.toTypesMap(definition);
+        SafetyEvaluator safetyEvaluator = new SafetyEvaluator(types);
+        TypeMapper typeMapper = new TypeMapper(types, options);
         return ErrorGenerationUtils.getNamespacedErrorsFromDefinitions(definition.getErrors()).stream()
                 .flatMap(namespacedErrors -> {
                     List<ErrorDefinition> filteredErrorDefinitions = namespacedErrors.errors().stream()

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EndpointErrorGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EndpointErrorGenerator.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.types;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CaseFormat;
 import com.palantir.conjure.java.ConjureAnnotations;
 import com.palantir.conjure.java.Generator;
@@ -52,6 +53,13 @@ public final class EndpointErrorGenerator implements Generator {
 
     private final Options options;
 
+    @VisibleForTesting
+    static final String NOT_SUPPORTED_ERROR_MESSAGE =
+            "Errors are associated with endpoints. This feature has been temporarily disabled while we iterate through"
+                + " issues with its rollout. If this is blocking you or you need this immediately, please reach out to"
+                + " the Conjure maintainers at https://github.com/palantir/conjure-java/issues so we can help support"
+                + " your needs.";
+
     public EndpointErrorGenerator(Options options) {
         this.options = options;
     }
@@ -63,9 +71,7 @@ public final class EndpointErrorGenerator implements Generator {
                 && !endpointErrors.errors().isEmpty()) {
             List<String> errorNames =
                     endpointErrors.errors().stream().map(ErrorTypeName::getName).toList();
-            throw new SafeIllegalStateException(
-                    "Errors are associated with endpoints. This feature is currently not supported.",
-                    SafeArg.of("errors", errorNames));
+            throw new SafeIllegalStateException(NOT_SUPPORTED_ERROR_MESSAGE, SafeArg.of("errors", errorNames));
         }
         Map<com.palantir.conjure.spec.TypeName, TypeDefinition> types = TypeFunctions.toTypesMap(definition);
         SafetyEvaluator safetyEvaluator = new SafetyEvaluator(types);

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EndpointErrorGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EndpointErrorGenerator.java
@@ -29,6 +29,7 @@ import com.palantir.conjure.java.util.TypeFunctions;
 import com.palantir.conjure.spec.ConjureDefinition;
 import com.palantir.conjure.spec.ErrorDefinition;
 import com.palantir.conjure.spec.ErrorNamespace;
+import com.palantir.conjure.spec.ErrorTypeName;
 import com.palantir.conjure.spec.TypeDefinition;
 import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.CodeBlock;
@@ -36,6 +37,8 @@ import com.palantir.javapoet.JavaFile;
 import com.palantir.javapoet.MethodSpec;
 import com.palantir.javapoet.ParameterSpec;
 import com.palantir.javapoet.TypeSpec;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -59,6 +62,14 @@ public final class EndpointErrorGenerator implements Generator {
         SafetyEvaluator safetyEvaluator = new SafetyEvaluator(types);
         TypeMapper typeMapper = new TypeMapper(types, options);
         DeclaredEndpointErrors endpointErrors = DeclaredEndpointErrors.from(definition);
+        if (!options.dangerousEnableEndpointAssociatedErrors()
+                && !endpointErrors.errors().isEmpty()) {
+            List<String> errorNames =
+                    endpointErrors.errors().stream().map(ErrorTypeName::getName).toList();
+            throw new SafeIllegalStateException(
+                    "Errors are associated with endpoints. This feature is currently not supported.",
+                    SafeArg.of("errors", errorNames));
+        }
         return ErrorGenerationUtils.getNamespacedErrorsFromDefinitions(definition.getErrors()).stream()
                 .flatMap(namespacedErrors -> {
                     List<ErrorDefinition> filteredErrorDefinitions = namespacedErrors.errors().stream()

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EndpointErrorGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EndpointErrorGeneratorTests.java
@@ -79,10 +79,11 @@ public final class EndpointErrorGeneratorTests {
     @Test
     public void testThrowsExceptionWhenOptionIsFalseAndEndpointErrorsExist() {
         // Create an EndpointErrorGenerator with the option set to false
-        EndpointErrorGenerator generator = new EndpointErrorGenerator(
-                Options.builder().dangerousEnableEndpointAssociatedErrors(false).build());
+        EndpointErrorGenerator generator = new EndpointErrorGenerator(Options.builder()
+                .dangerousDoNotUseEnableEndpointAssociatedErrors(false)
+                .build());
 
-        // Verify that an exception is thrown, and that it contians the name of the error associated with the endpoint
+        // Verify that an exception is thrown, and that it contains the name of the error associated with the endpoint
         assertThatThrownBy(() -> generator.generate(definition))
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageContaining("Errors are associated with endpoints. This feature is currently not supported.")
@@ -92,8 +93,9 @@ public final class EndpointErrorGeneratorTests {
     @Test
     public void testNoExceptionThrownWhenOptionIsTrueAndEndpointErrorsExist() {
         // Create an EndpointErrorGenerator with the option set to true
-        EndpointErrorGenerator generator = new EndpointErrorGenerator(
-                Options.builder().dangerousEnableEndpointAssociatedErrors(true).build());
+        EndpointErrorGenerator generator = new EndpointErrorGenerator(Options.builder()
+                .dangerousDoNotUseEnableEndpointAssociatedErrors(true)
+                .build());
 
         // Verify that no exception is thrown
         assertThatCode(() -> generator.generate(definition)).doesNotThrowAnyException();

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EndpointErrorGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EndpointErrorGeneratorTests.java
@@ -1,0 +1,101 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.types;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.palantir.conjure.java.Options;
+import com.palantir.conjure.spec.ConjureDefinition;
+import com.palantir.conjure.spec.EndpointDefinition;
+import com.palantir.conjure.spec.EndpointError;
+import com.palantir.conjure.spec.EndpointName;
+import com.palantir.conjure.spec.ErrorCode;
+import com.palantir.conjure.spec.ErrorDefinition;
+import com.palantir.conjure.spec.ErrorNamespace;
+import com.palantir.conjure.spec.ErrorTypeName;
+import com.palantir.conjure.spec.HttpMethod;
+import com.palantir.conjure.spec.HttpPath;
+import com.palantir.conjure.spec.ServiceDefinition;
+import com.palantir.conjure.spec.TypeName;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public final class EndpointErrorGeneratorTests {
+
+    private ConjureDefinition definition;
+    private static final String ERROR_NAME = "TestError";
+
+    @BeforeEach
+    public void beforeEach() {
+        // Create a ConjureDefinition with an error and associate the error with an endpoint
+        ErrorDefinition errorDefinition = ErrorDefinition.builder()
+                .errorName(TypeName.of(ERROR_NAME, "com.palantir.test"))
+                .code(ErrorCode.CUSTOM_SERVER)
+                .namespace(ErrorNamespace.of("TestService"))
+                .build();
+
+        EndpointDefinition endpoint = EndpointDefinition.builder()
+                .endpointName(EndpointName.of("testEndpoint"))
+                .httpMethod(HttpMethod.GET)
+                .httpPath(HttpPath.of("/test"))
+                .errors(EndpointError.builder()
+                        .error(ErrorTypeName.builder()
+                                .name(ERROR_NAME)
+                                .package_("com.palantir.test")
+                                .namespace(ErrorNamespace.of("TestService"))
+                                .build())
+                        .build())
+                .build();
+
+        ServiceDefinition service = ServiceDefinition.builder()
+                .serviceName(TypeName.of("TestService", "com.palantir.test"))
+                .endpoints(List.of(endpoint))
+                .build();
+
+        definition = ConjureDefinition.builder()
+                .version(1)
+                .errors(List.of(errorDefinition))
+                .services(List.of(service))
+                .build();
+    }
+
+    @Test
+    public void testThrowsExceptionWhenOptionIsFalseAndEndpointErrorsExist() {
+        // Create an EndpointErrorGenerator with the option set to false
+        EndpointErrorGenerator generator = new EndpointErrorGenerator(
+                Options.builder().dangerousEnableEndpointAssociatedErrors(false).build());
+
+        // Verify that an exception is thrown, and that it contians the name of the error associated with the endpoint
+        assertThatThrownBy(() -> generator.generate(definition))
+                .isInstanceOf(SafeIllegalStateException.class)
+                .hasMessageContaining("Errors are associated with endpoints. This feature is currently not supported.")
+                .hasMessageContaining(ERROR_NAME);
+    }
+
+    @Test
+    public void testNoExceptionThrownWhenOptionIsTrueAndEndpointErrorsExist() {
+        // Create an EndpointErrorGenerator with the option set to true
+        EndpointErrorGenerator generator = new EndpointErrorGenerator(
+                Options.builder().dangerousEnableEndpointAssociatedErrors(true).build());
+
+        // Verify that no exception is thrown
+        assertThatCode(() -> generator.generate(definition)).doesNotThrowAnyException();
+    }
+}

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EndpointErrorGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EndpointErrorGeneratorTests.java
@@ -34,47 +34,33 @@ import com.palantir.conjure.spec.ServiceDefinition;
 import com.palantir.conjure.spec.TypeName;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public final class EndpointErrorGeneratorTests {
-
-    private ConjureDefinition definition;
     private static final String ERROR_NAME = "TestError";
-
-    @BeforeEach
-    public void beforeEach() {
-        // Create a ConjureDefinition with an error and associate the error with an endpoint
-        ErrorDefinition errorDefinition = ErrorDefinition.builder()
-                .errorName(TypeName.of(ERROR_NAME, "com.palantir.test"))
-                .code(ErrorCode.CUSTOM_SERVER)
-                .namespace(ErrorNamespace.of("TestService"))
-                .build();
-
-        EndpointDefinition endpoint = EndpointDefinition.builder()
-                .endpointName(EndpointName.of("testEndpoint"))
-                .httpMethod(HttpMethod.GET)
-                .httpPath(HttpPath.of("/test"))
-                .errors(EndpointError.builder()
-                        .error(ErrorTypeName.builder()
-                                .name(ERROR_NAME)
-                                .package_("com.palantir.test")
-                                .namespace(ErrorNamespace.of("TestService"))
-                                .build())
-                        .build())
-                .build();
-
-        ServiceDefinition service = ServiceDefinition.builder()
-                .serviceName(TypeName.of("TestService", "com.palantir.test"))
-                .endpoints(List.of(endpoint))
-                .build();
-
-        definition = ConjureDefinition.builder()
-                .version(1)
-                .errors(List.of(errorDefinition))
-                .services(List.of(service))
-                .build();
-    }
+    private static final ConjureDefinition DEFINITION = ConjureDefinition.builder()
+            .version(1)
+            .errors(List.of(ErrorDefinition.builder()
+                    .errorName(TypeName.of(ERROR_NAME, "com.palantir.test"))
+                    .code(ErrorCode.CUSTOM_SERVER)
+                    .namespace(ErrorNamespace.of("TestService"))
+                    .build()))
+            .services(List.of(ServiceDefinition.builder()
+                    .serviceName(TypeName.of("TestService", "com.palantir.test"))
+                    .endpoints(List.of(EndpointDefinition.builder()
+                            .endpointName(EndpointName.of("testEndpoint"))
+                            .httpMethod(HttpMethod.GET)
+                            .httpPath(HttpPath.of("/test"))
+                            .errors(EndpointError.builder()
+                                    .error(ErrorTypeName.builder()
+                                            .name(ERROR_NAME)
+                                            .package_("com.palantir.test")
+                                            .namespace(ErrorNamespace.of("TestService"))
+                                            .build())
+                                    .build())
+                            .build()))
+                    .build()))
+            .build();
 
     @Test
     public void testThrowsExceptionWhenOptionIsFalseAndEndpointErrorsExist() {
@@ -84,7 +70,7 @@ public final class EndpointErrorGeneratorTests {
                 .build());
 
         // Verify that an exception is thrown, and that it contains the name of the error associated with the endpoint
-        assertThatThrownBy(() -> generator.generate(definition))
+        assertThatThrownBy(() -> generator.generate(DEFINITION))
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageContaining("Errors are associated with endpoints. This feature is currently not supported.")
                 .hasMessageContaining(ERROR_NAME);
@@ -98,6 +84,6 @@ public final class EndpointErrorGeneratorTests {
                 .build());
 
         // Verify that no exception is thrown
-        assertThatCode(() -> generator.generate(definition)).doesNotThrowAnyException();
+        assertThatCode(() -> generator.generate(DEFINITION)).doesNotThrowAnyException();
     }
 }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EndpointErrorGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EndpointErrorGeneratorTests.java
@@ -38,28 +38,49 @@ import org.junit.jupiter.api.Test;
 
 public final class EndpointErrorGeneratorTests {
     private static final String ERROR_NAME = "TestError";
+    private static final EndpointDefinition ENDPOINT_DEF = EndpointDefinition.builder()
+            .endpointName(EndpointName.of("testEndpoint"))
+            .httpMethod(HttpMethod.GET)
+            .httpPath(HttpPath.of("/test"))
+            .build();
+
+    private static final EndpointDefinition ENDPOINT_DEF_WITH_ERROR = EndpointDefinition.builder()
+            .from(ENDPOINT_DEF)
+            .errors(EndpointError.builder()
+                    .error(ErrorTypeName.builder()
+                            .name(ERROR_NAME)
+                            .package_("com.palantir.test")
+                            .namespace(ErrorNamespace.of("TestService"))
+                            .build())
+                    .build())
+            .build();
+
+    private static final ServiceDefinition SERVICE_DEF = ServiceDefinition.builder()
+            .serviceName(TypeName.of("TestService", "com.palantir.test"))
+            .endpoints(List.of(ENDPOINT_DEF))
+            .build();
+
+    private static final ServiceDefinition SERVICE_DEF_WITH_ENDPOINT_ERROR = ServiceDefinition.builder()
+            .from(SERVICE_DEF)
+            .endpoints(List.of(ENDPOINT_DEF_WITH_ERROR))
+            .build();
+
     private static final ConjureDefinition DEFINITION = ConjureDefinition.builder()
             .version(1)
+            .services(List.of(ServiceDefinition.builder()
+                    .serviceName(TypeName.of("TestService", "com.palantir.test"))
+                    .endpoints(List.of(ENDPOINT_DEF))
+                    .build()))
+            .build();
+
+    private static final ConjureDefinition DEFINITION_WITH_ENDPOINT_ERROR = ConjureDefinition.builder()
+            .from(DEFINITION)
             .errors(List.of(ErrorDefinition.builder()
                     .errorName(TypeName.of(ERROR_NAME, "com.palantir.test"))
                     .code(ErrorCode.CUSTOM_SERVER)
                     .namespace(ErrorNamespace.of("TestService"))
                     .build()))
-            .services(List.of(ServiceDefinition.builder()
-                    .serviceName(TypeName.of("TestService", "com.palantir.test"))
-                    .endpoints(List.of(EndpointDefinition.builder()
-                            .endpointName(EndpointName.of("testEndpoint"))
-                            .httpMethod(HttpMethod.GET)
-                            .httpPath(HttpPath.of("/test"))
-                            .errors(EndpointError.builder()
-                                    .error(ErrorTypeName.builder()
-                                            .name(ERROR_NAME)
-                                            .package_("com.palantir.test")
-                                            .namespace(ErrorNamespace.of("TestService"))
-                                            .build())
-                                    .build())
-                            .build()))
-                    .build()))
+            .services(List.of(SERVICE_DEF_WITH_ENDPOINT_ERROR))
             .build();
 
     @Test
@@ -70,9 +91,9 @@ public final class EndpointErrorGeneratorTests {
                 .build());
 
         // Verify that an exception is thrown, and that it contains the name of the error associated with the endpoint
-        assertThatThrownBy(() -> generator.generate(DEFINITION))
+        assertThatThrownBy(() -> generator.generate(DEFINITION_WITH_ENDPOINT_ERROR))
                 .isInstanceOf(SafeIllegalStateException.class)
-                .hasMessageContaining("Errors are associated with endpoints. This feature is currently not supported.")
+                .hasMessageContaining(EndpointErrorGenerator.NOT_SUPPORTED_ERROR_MESSAGE)
                 .hasMessageContaining(ERROR_NAME);
     }
 
@@ -81,6 +102,17 @@ public final class EndpointErrorGeneratorTests {
         // Create an EndpointErrorGenerator with the option set to true
         EndpointErrorGenerator generator = new EndpointErrorGenerator(Options.builder()
                 .dangerousDoNotUseEnableEndpointAssociatedErrors(true)
+                .build());
+
+        // Verify that no exception is thrown
+        assertThatCode(() -> generator.generate(DEFINITION_WITH_ENDPOINT_ERROR)).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testNoExceptionThrownWhenOptionIsFalseeAndNoEndpointErrorsExist() {
+        // Create an EndpointErrorGenerator with the option set to true
+        EndpointErrorGenerator generator = new EndpointErrorGenerator(Options.builder()
+                .dangerousDoNotUseEnableEndpointAssociatedErrors(false)
                 .build());
 
         // Verify that no exception is thrown

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -246,6 +246,13 @@ public final class ConjureJavaCli implements Runnable {
                         + "--nonNullCollections flag.")
         private boolean defensiveCollections;
 
+        @CommandLine.Option(
+                names = "--dangerousEnableEndpointAssociatedErrors",
+                defaultValue = "true",
+                description = "Generate endpoint associated errors as EndpointServiceExceptions. "
+                        + "This feature is currently not supported.")
+        private boolean dangerousEnableEndpointAssociatedErrors;
+
         @SuppressWarnings("unused")
         @CommandLine.Unmatched
         private List<String> unmatchedOptions;
@@ -319,6 +326,7 @@ public final class ConjureJavaCli implements Runnable {
                             .preferObjectBuilders(preferObjectBuilders)
                             .generateDialogueEndpointErrorResultTypes(generateDialogueEndpointErrorResultTypes)
                             .defensiveCollections(defensiveCollections)
+                            .dangerousEnableEndpointAssociatedErrors(dangerousEnableEndpointAssociatedErrors)
                             .build())
                     .build();
         }

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -247,11 +247,11 @@ public final class ConjureJavaCli implements Runnable {
         private boolean defensiveCollections;
 
         @CommandLine.Option(
-                names = "--dangerousEnableEndpointAssociatedErrors",
+                names = "--dangerousDoNotUseEnableEndpointAssociatedErrors",
                 defaultValue = "true",
                 description = "Generate endpoint associated errors as EndpointServiceExceptions. "
                         + "This feature is currently not supported.")
-        private boolean dangerousEnableEndpointAssociatedErrors;
+        private boolean dangerousDoNotUseEnableEndpointAssociatedErrors;
 
         @SuppressWarnings("unused")
         @CommandLine.Unmatched
@@ -326,7 +326,8 @@ public final class ConjureJavaCli implements Runnable {
                             .preferObjectBuilders(preferObjectBuilders)
                             .generateDialogueEndpointErrorResultTypes(generateDialogueEndpointErrorResultTypes)
                             .defensiveCollections(defensiveCollections)
-                            .dangerousEnableEndpointAssociatedErrors(dangerousEnableEndpointAssociatedErrors)
+                            .dangerousDoNotUseEnableEndpointAssociatedErrors(
+                                    dangerousDoNotUseEnableEndpointAssociatedErrors)
                             .build())
                     .build();
         }


### PR DESCRIPTION
## Before this PR
When errors are associated with endpoints, they are generated as subtypes of `EndpointServiceException`. The parameters of these exceptions are serialized as JSON, while previously error parameters were serialized with `Object.toString`. This wire break can cause failures when clients parse error parameters expecting the previous `Object.toString` serialization format. 

We'd like to **temporarily** stop supporting usage of the endpoint associated error feature and build some tooling to enable migration of _all_ error parameters to JSON.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add `dangerousEnableEndpointAssociatedErrors` option to gate endpoint
==COMMIT_MSG==

## Rollout
Currently, endpoint associated error generation is supported. Initially, the value of the `dangerousEnableEndpointAssociatedErrors` flag is set to true, matching the current behavior. In a future PR, after updating the consumers of this feature to set the flag to `true` explicitly, I will change the default value to `false`.

Eventually, I'd like to remove this flag once we have migrated all error parameters to be serialized as JSON.

## Possible downsides?

