### PR TITLE
Respect `Accept-Conjure-Error-Parameter-Format`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,6 @@ allprojects {
 
     repositories {
         mavenCentral() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }
-        mavenLocal()
     }
 
     configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ allprojects {
 
     repositories {
         mavenCentral() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }
+        mavenLocal()
     }
 
     configurations.all {

--- a/changelog/@unreleased/pr-2588.v2.yml
+++ b/changelog/@unreleased/pr-2588.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: When the `Accept-Conjure-Error-Parameter-Format`  header is `JSON`,
+    servers serialize error parameters as JSON, instead of using `Objects.toString`.
+  links:
+  - https://github.com/palantir/conjure-java/pull/2588

--- a/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/DialogueEteEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/DialogueEteEndpoints.java
@@ -845,6 +845,43 @@ enum DialogueEteEndpoints implements Endpoint {
         }
     },
 
+    /**
+     * This endpoint is used to test that the <code>Accept-Conjure-Error-Parameter-Format</code> header is respected.
+     * Specifically, that error parameters are serialized as JSON when the header is set to <code>JSON</code>.
+     */
+    jsonErrorsHeader {
+        private final PathTemplate pathTemplate = PathTemplate.builder()
+                .fixed("base")
+                .fixed("errors")
+                .fixed("header")
+                .build();
+
+        @Override
+        public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+            pathTemplate.fill(params, url);
+        }
+
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.GET;
+        }
+
+        @Override
+        public String serviceName() {
+            return "EteService";
+        }
+
+        @Override
+        public String endpointName() {
+            return "jsonErrorsHeader";
+        }
+
+        @Override
+        public String version() {
+            return "1.2.3";
+        }
+    },
+
     aliasLongEndpoint {
         private final PathTemplate pathTemplate =
                 PathTemplate.builder().fixed("base").fixed("alias-long").build();

--- a/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/EteServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/EteServiceAsync.java
@@ -167,6 +167,15 @@ public interface EteServiceAsync {
     @ClientEndpoint(method = "GET", path = "/base/enum/header")
     ListenableFuture<SimpleEnum> enumHeader(AuthHeader authHeader, SimpleEnum headerParameter);
 
+    /**
+     * This endpoint is used to test that the <code>Accept-Conjure-Error-Parameter-Format</code> header is respected.
+     * Specifically, that error parameters are serialized as JSON when the header is set to <code>JSON</code>.
+     *
+     * @apiNote {@code GET /base/errors/header}
+     */
+    @ClientEndpoint(method = "GET", path = "/base/errors/header")
+    ListenableFuture<String> jsonErrorsHeader(AuthHeader authHeader, String headerParameter);
+
     /** @apiNote {@code GET /base/alias-long} */
     @ClientEndpoint(method = "GET", path = "/base/alias-long")
     ListenableFuture<Optional<LongAlias>> aliasLongEndpoint(AuthHeader authHeader, Optional<LongAlias> input);
@@ -362,6 +371,12 @@ public interface EteServiceAsync {
 
             private final Deserializer<SimpleEnum> enumHeaderDeserializer =
                     _runtime.bodySerDe().deserializer(new TypeMarker<SimpleEnum>() {});
+
+            private final EndpointChannel jsonErrorsHeaderChannel =
+                    _endpointChannelFactory.endpoint(DialogueEteEndpoints.jsonErrorsHeader);
+
+            private final Deserializer<String> jsonErrorsHeaderDeserializer =
+                    _runtime.bodySerDe().deserializer(new TypeMarker<String>() {});
 
             private final EndpointChannel aliasLongEndpointChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.aliasLongEndpoint);
@@ -644,6 +659,15 @@ public interface EteServiceAsync {
                 _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putHeaderParams("Custom-Header", Objects.toString(headerParameter));
                 return _runtime.clients().call(enumHeaderChannel, _request.build(), enumHeaderDeserializer);
+            }
+
+            @Override
+            public ListenableFuture<String> jsonErrorsHeader(AuthHeader authHeader, String headerParameter) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.putHeaderParams(
+                        "Accept-Conjure-Error-Parameter-Format", _plainSerDe.serializeString(headerParameter));
+                return _runtime.clients().call(jsonErrorsHeaderChannel, _request.build(), jsonErrorsHeaderDeserializer);
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/EteServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/EteServiceBlocking.java
@@ -166,6 +166,15 @@ public interface EteServiceBlocking {
     @ClientEndpoint(method = "GET", path = "/base/enum/header")
     SimpleEnum enumHeader(AuthHeader authHeader, SimpleEnum headerParameter);
 
+    /**
+     * This endpoint is used to test that the <code>Accept-Conjure-Error-Parameter-Format</code> header is respected.
+     * Specifically, that error parameters are serialized as JSON when the header is set to <code>JSON</code>.
+     *
+     * @apiNote {@code GET /base/errors/header}
+     */
+    @ClientEndpoint(method = "GET", path = "/base/errors/header")
+    String jsonErrorsHeader(AuthHeader authHeader, String headerParameter);
+
     /** @apiNote {@code GET /base/alias-long} */
     @ClientEndpoint(method = "GET", path = "/base/alias-long")
     Optional<LongAlias> aliasLongEndpoint(AuthHeader authHeader, Optional<LongAlias> input);
@@ -361,6 +370,12 @@ public interface EteServiceBlocking {
 
             private final Deserializer<SimpleEnum> enumHeaderDeserializer =
                     _runtime.bodySerDe().deserializer(new TypeMarker<SimpleEnum>() {});
+
+            private final EndpointChannel jsonErrorsHeaderChannel =
+                    _endpointChannelFactory.endpoint(DialogueEteEndpoints.jsonErrorsHeader);
+
+            private final Deserializer<String> jsonErrorsHeaderDeserializer =
+                    _runtime.bodySerDe().deserializer(new TypeMarker<String>() {});
 
             private final EndpointChannel aliasLongEndpointChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.aliasLongEndpoint);
@@ -639,6 +654,16 @@ public interface EteServiceBlocking {
                 _request.putHeaderParams("Authorization", authHeader.toString());
                 _request.putHeaderParams("Custom-Header", Objects.toString(headerParameter));
                 return _runtime.clients().callBlocking(enumHeaderChannel, _request.build(), enumHeaderDeserializer);
+            }
+
+            @Override
+            public String jsonErrorsHeader(AuthHeader authHeader, String headerParameter) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.putHeaderParams(
+                        "Accept-Conjure-Error-Parameter-Format", _plainSerDe.serializeString(headerParameter));
+                return _runtime.clients()
+                        .callBlocking(jsonErrorsHeaderChannel, _request.build(), jsonErrorsHeaderDeserializer);
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/jersey/com/palantir/product/EteService.java
+++ b/conjure-java-core/src/integrationInput/java/jersey/com/palantir/product/EteService.java
@@ -200,6 +200,17 @@ public interface EteService {
             @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
             @HeaderParam("Custom-Header") SimpleEnum headerParameter);
 
+    /**
+     * This endpoint is used to test that the <code>Accept-Conjure-Error-Parameter-Format</code> header is respected.
+     * Specifically, that error parameters are serialized as JSON when the header is set to <code>JSON</code>.
+     */
+    @GET
+    @Path("base/errors/header")
+    @ClientEndpoint(method = "GET", path = "/base/errors/header")
+    String jsonErrorsHeader(
+            @HeaderParam("Authorization") @NotNull AuthHeader authHeader,
+            @HeaderParam("Accept-Conjure-Error-Parameter-Format") String headerParameter);
+
     @GET
     @Path("base/alias-long")
     @ClientEndpoint(method = "GET", path = "/base/alias-long")

--- a/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/EteServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/EteServiceEndpoints.java
@@ -72,6 +72,7 @@ public final class EteServiceEndpoints implements UndertowService {
                 new EnumListQueryEndpoint(runtime, delegate),
                 new OptionalEnumQueryEndpoint(runtime, delegate),
                 new EnumHeaderEndpoint(runtime, delegate),
+                new JsonErrorsHeaderEndpoint(runtime, delegate),
                 new AliasLongEndpointEndpoint(runtime, delegate),
                 new ComplexQueryParametersEndpoint(runtime, delegate),
                 new ReceiveListOfOptionalsEndpoint(runtime, delegate),
@@ -1366,6 +1367,55 @@ public final class EteServiceEndpoints implements UndertowService {
         @Override
         public String name() {
             return "enumHeader";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class JsonErrorsHeaderEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final UndertowEteService delegate;
+
+        private final Serializer<String> serializer;
+
+        JsonErrorsHeaderEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            HeaderMap headerParams = exchange.getRequestHeaders();
+            String headerParameter =
+                    runtime.plainSerDe().deserializeString(headerParams.get("Accept-Conjure-Error-Parameter-Format"));
+            String result = delegate.jsonErrorsHeader(authHeader, headerParameter);
+            serializer.serialize(result, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.GET;
+        }
+
+        @Override
+        public String template() {
+            return "/base/errors/header";
+        }
+
+        @Override
+        public String serviceName() {
+            return "EteService";
+        }
+
+        @Override
+        public String name() {
+            return "jsonErrorsHeader";
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/UndertowEteService.java
+++ b/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/UndertowEteService.java
@@ -116,6 +116,14 @@ public interface UndertowEteService {
     /** @apiNote {@code GET /base/enum/header} */
     SimpleEnum enumHeader(AuthHeader authHeader, SimpleEnum headerParameter);
 
+    /**
+     * This endpoint is used to test that the <code>Accept-Conjure-Error-Parameter-Format</code> header is respected.
+     * Specifically, that error parameters are serialized as JSON when the header is set to <code>JSON</code>.
+     *
+     * @apiNote {@code GET /base/errors/header}
+     */
+    String jsonErrorsHeader(AuthHeader authHeader, String headerParameter);
+
     /** @apiNote {@code GET /base/alias-long} */
     Optional<LongAlias> aliasLongEndpoint(AuthHeader authHeader, Optional<LongAlias> input);
 

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyEteResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyEteResource.java
@@ -174,6 +174,11 @@ public class JerseyEteResource implements EteService {
     }
 
     @Override
+    public String jsonErrorsHeader(AuthHeader authHeader, String _headerParameter) {
+        return "hello!";
+    }
+
+    @Override
     public Optional<LongAlias> aliasLongEndpoint(AuthHeader _authHeader, Optional<LongAlias> input) {
         return input;
     }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyEteResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/JerseyEteResource.java
@@ -175,6 +175,7 @@ public class JerseyEteResource implements EteService {
 
     @Override
     public String jsonErrorsHeader(AuthHeader authHeader, String _headerParameter) {
+        // Conjure-Java has not supported Jersey for a while. We are not testing the error serialization feature here.
         return "hello!";
     }
 

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowEteResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowEteResource.java
@@ -21,6 +21,7 @@ import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
+import errors.com.palantir.product.ConjureErrors;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.nio.charset.StandardCharsets;
@@ -170,6 +171,14 @@ public final class UndertowEteResource implements UndertowEteService {
     @Override
     public SimpleEnum enumHeader(AuthHeader _authHeader, SimpleEnum headerParameter) {
         return headerParameter;
+    }
+
+    @Override
+    public String jsonErrorsHeader(AuthHeader authHeader, String headerParameter) {
+        if (headerParameter.equals("JSON") || headerParameter.equals("TOSTRING")) {
+            throw ConjureErrors.invalidServiceDefinition("my-service-string", Optional.of(SimpleEnum.VALUE));
+        }
+        return "hello!";
     }
 
     @Override

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowEteResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowEteResource.java
@@ -175,10 +175,7 @@ public final class UndertowEteResource implements UndertowEteService {
 
     @Override
     public String jsonErrorsHeader(AuthHeader authHeader, String headerParameter) {
-        if (headerParameter.equals("JSON") || headerParameter.equals("TOSTRING")) {
-            throw ConjureErrors.invalidServiceDefinition("my-service-string", Optional.of(SimpleEnum.VALUE));
-        }
-        return "hello!";
+        throw ConjureErrors.invalidServiceDefinition("my-service-string", Optional.of(SimpleEnum.VALUE));
     }
 
     @Override

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -62,6 +62,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import jersey.com.palantir.product.EmptyPathService;
@@ -543,6 +544,23 @@ public final class UndertowServiceEteTest extends TestBase {
                 .isInstanceOfSatisfying(RemoteException.class, re -> {
                     assertThat(re.getStatus()).isEqualTo(422);
                 });
+    }
+
+    @Test
+    public void testErrorParametersSerializedAsJson() {
+        try {
+            client.jsonErrorsHeader(AuthHeader.valueOf("authHeader"), "JSON");
+        } catch (RemoteException e) {
+            assertThat(e.getError().parameters()).containsExactlyInAnyOrderEntriesOf(Map.of("serviceName", "my-service-string",
+                    "serviceDef", SimpleEnum.VALUE.toString()));
+        }
+
+        try {
+            client.jsonErrorsHeader(AuthHeader.valueOf("authHeader"), "TOSTRING");
+        } catch (RemoteException e) {
+            assertThat(e.getError().parameters()).containsExactlyInAnyOrderEntriesOf(Map.of("serviceName", "my-service-string",
+                    "serviceDef", "Optional[VALUE]"));
+        }
     }
 
     private static HttpURLConnection openConnectionToTestApi(String path) throws IOException {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -551,15 +551,17 @@ public final class UndertowServiceEteTest extends TestBase {
         try {
             client.jsonErrorsHeader(AuthHeader.valueOf("authHeader"), "JSON");
         } catch (RemoteException e) {
-            assertThat(e.getError().parameters()).containsExactlyInAnyOrderEntriesOf(Map.of("serviceName", "my-service-string",
-                    "serviceDef", SimpleEnum.VALUE.toString()));
+            assertThat(e.getError().parameters())
+                    .containsExactlyInAnyOrderEntriesOf(
+                            Map.of("serviceName", "my-service-string", "serviceDef", SimpleEnum.VALUE.toString()));
         }
 
         try {
             client.jsonErrorsHeader(AuthHeader.valueOf("authHeader"), "TOSTRING");
         } catch (RemoteException e) {
-            assertThat(e.getError().parameters()).containsExactlyInAnyOrderEntriesOf(Map.of("serviceName", "my-service-string",
-                    "serviceDef", "Optional[VALUE]"));
+            assertThat(e.getError().parameters())
+                    .containsExactlyInAnyOrderEntriesOf(
+                            Map.of("serviceName", "my-service-string", "serviceDef", "Optional[VALUE]"));
         }
     }
 

--- a/conjure-java-core/src/test/resources/ete-service.yml
+++ b/conjure-java-core/src/test/resources/ete-service.yml
@@ -205,6 +205,18 @@ services:
             type: SimpleEnum
         returns: SimpleEnum
 
+      jsonErrorsHeader:
+        http: GET /errors/header
+        docs: |
+          This endpoint is used to test that the `Accept-Conjure-Error-Parameter-Format` header is respected. 
+          Specifically, that error parameters are serialized as JSON when the header is set to `JSON`.
+        args:
+          headerParameter:
+            param-type: header
+            param-id: Accept-Conjure-Error-Parameter-Format
+            type: string
+        returns: string
+
       aliasLongEndpoint:
         http: GET /alias-long
         args:

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureError.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureError.java
@@ -92,7 +92,12 @@ record ConjureError(
         return new ConjureError(errorType.code().name(), errorType.name(), exception.getErrorInstanceId(), parameters);
     }
 
-    static ConjureError fromServiceExceptionWithJsonParameters(ServiceException exception) {
+    /**
+     * Creates a {@link ConjureError} from a {@link ServiceException} where the parameter values are serialized as JSON.
+     * Currently, this should only be used when clients send a request with a custom header specifying the parameter
+     * serialization format: <code>Accept-Conjure-Error-Parameter-Format</code> with value <code>JSON</code>.
+     */
+    static ConjureError fromServiceExceptionWithJsonSerializedParameterValues(ServiceException exception) {
         Map<String, Object> parameters = getParametersFromArgs(exception.getArgs());
         ErrorType errorType = exception.getErrorType();
         return new ConjureError(errorType.code().name(), errorType.name(), exception.getErrorInstanceId(), parameters);
@@ -119,6 +124,10 @@ record ConjureError(
                 && (!(obj instanceof OptionalDouble optionalDouble) || optionalDouble.isPresent());
     }
 
+    /**
+     * Construct the parameters map from the provided arguments. Parameters are included if they are not null and not
+     * {@link Optional#empty}.
+     */
     private static Map<String, Object> getParametersFromArgs(Iterable<Arg<?>> args) {
         Map<String, Object> parameters = new HashMap<>();
         for (Arg<?> arg : args) {

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureError.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureError.java
@@ -66,12 +66,7 @@ record ConjureError(
     }
 
     static ConjureError fromCheckedServiceException(CheckedServiceException exception) {
-        Map<String, Object> parameters = new HashMap<>();
-        for (Arg<?> arg : exception.getArgs()) {
-            if (shouldIncludeArgInParameters(arg)) {
-                parameters.put(arg.getName(), arg.getValue());
-            }
-        }
+        Map<String, Object> parameters = getParametersFromArgs(exception.getArgs());
         return new ConjureError(
                 exception.getErrorType().code().name(),
                 exception.getErrorType().name(),
@@ -80,12 +75,7 @@ record ConjureError(
     }
 
     static ConjureError fromEndpointServiceException(EndpointServiceException exception) {
-        Map<String, Object> parameters = new HashMap<>();
-        for (Arg<?> arg : exception.getArgs()) {
-            if (shouldIncludeArgInParameters(arg)) {
-                parameters.put(arg.getName(), arg.getValue());
-            }
-        }
+        Map<String, Object> parameters = getParametersFromArgs(exception.getArgs());
         return new ConjureError(
                 exception.getErrorType().code().name(),
                 exception.getErrorType().name(),
@@ -98,6 +88,12 @@ record ConjureError(
         for (Arg<?> arg : exception.getArgs()) {
             parameters.put(arg.getName(), Objects.toString(arg.getValue()));
         }
+        ErrorType errorType = exception.getErrorType();
+        return new ConjureError(errorType.code().name(), errorType.name(), exception.getErrorInstanceId(), parameters);
+    }
+
+    static ConjureError fromServiceExceptionWithJsonParameters(ServiceException exception) {
+        Map<String, Object> parameters = getParametersFromArgs(exception.getArgs());
         ErrorType errorType = exception.getErrorType();
         return new ConjureError(errorType.code().name(), errorType.name(), exception.getErrorInstanceId(), parameters);
     }
@@ -121,5 +117,15 @@ record ConjureError(
                 && (!(obj instanceof OptionalInt optionalInt) || optionalInt.isPresent())
                 && (!(obj instanceof OptionalLong optionalLong) || optionalLong.isPresent())
                 && (!(obj instanceof OptionalDouble optionalDouble) || optionalDouble.isPresent());
+    }
+
+    private static Map<String, Object> getParametersFromArgs(Iterable<Arg<?>> args) {
+        Map<String, Object> parameters = new HashMap<>();
+        for (Arg<?> arg : args) {
+            if (shouldIncludeArgInParameters(arg)) {
+                parameters.put(arg.getName(), arg.getValue());
+            }
+        }
+        return parameters;
     }
 }

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
@@ -18,6 +18,9 @@ package com.palantir.conjure.java.undertow.runtime;
 
 import com.google.common.util.concurrent.RateLimiter;
 import com.palantir.conjure.java.api.errors.CheckedServiceException;
+import com.palantir.conjure.java.api.errors.ConjureErrorParameterFormat;
+import com.palantir.conjure.java.api.errors.ConjureErrorParameterFormats;
+import com.palantir.conjure.java.api.errors.ConjureErrorParameterFormats.ConjureErrorParameterFormatRequestDecodingAdapter;
 import com.palantir.conjure.java.api.errors.EndpointServiceException;
 import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.QosException;
@@ -35,6 +38,7 @@ import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import io.undertow.io.UndertowOutputStream;
 import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderMap;
 import io.undertow.util.Headers;
 import io.undertow.util.HttpString;
 import java.io.IOException;
@@ -60,6 +64,15 @@ public enum ConjureExceptions implements ExceptionHandler {
     // Log at most once every second
     private static final RateLimiter qosLoggingRateLimiter = RateLimiter.create(1);
 
+    private enum ConjureErrorParamsDecoder implements ConjureErrorParameterFormatRequestDecodingAdapter<HeaderMap> {
+        INSTANCE;
+
+        @Override
+        public String getFirstHeader(HeaderMap response, String headerName) {
+            return response.getFirst(headerName);
+        }
+    }
+
     @SuppressWarnings("CyclomaticComplexity")
     @Override
     public void handle(HttpServerExchange exchange, Throwable throwable) {
@@ -71,7 +84,13 @@ public enum ConjureExceptions implements ExceptionHandler {
             // Conjure.
             checkedServiceException(exchange, checkedServiceException);
         } else if (throwable instanceof ServiceException serviceException) {
-            serviceException(exchange, serviceException);
+            Optional<ConjureErrorParameterFormat> maybeErrorParamFormatHeader = ConjureErrorParameterFormats.parseFromRequest(exchange.getRequestHeaders(), ConjureErrorParamsDecoder.INSTANCE);
+            if ( maybeErrorParamFormatHeader.isPresent()
+                    && maybeErrorParamFormatHeader.get().equals(ConjureErrorParameterFormat.JSON_FORMAT)) {
+                serviceExceptionWithJsonParameterValues(exchange, serviceException);
+            } else {
+                serviceException(exchange, serviceException);
+            }
         } else if (throwable instanceof QosException qosException) {
             qosException(exchange, qosException);
         } else if (throwable instanceof RemoteException remoteException) {
@@ -119,6 +138,14 @@ public enum ConjureExceptions implements ExceptionHandler {
         writeResponse(
                 exchange,
                 Optional.of(ConjureError.fromServiceException(exception)),
+                exception.getErrorType().httpErrorCode());
+    }
+
+    private static void serviceExceptionWithJsonParameterValues(HttpServerExchange exchange, ServiceException exception) {
+        log(exception);
+        writeResponse(
+                exchange,
+                Optional.of(ConjureError.fromServiceExceptionWithJsonParameters(exception)),
                 exception.getErrorType().httpErrorCode());
     }
 

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
@@ -64,15 +64,6 @@ public enum ConjureExceptions implements ExceptionHandler {
     // Log at most once every second
     private static final RateLimiter qosLoggingRateLimiter = RateLimiter.create(1);
 
-    private enum ConjureErrorParamsDecoder implements ConjureErrorParameterFormatRequestDecodingAdapter<HeaderMap> {
-        INSTANCE;
-
-        @Override
-        public String getFirstHeader(HeaderMap response, String headerName) {
-            return response.getFirst(headerName);
-        }
-    }
-
     @SuppressWarnings("CyclomaticComplexity")
     @Override
     public void handle(HttpServerExchange exchange, Throwable throwable) {
@@ -84,13 +75,7 @@ public enum ConjureExceptions implements ExceptionHandler {
             // Conjure.
             checkedServiceException(exchange, checkedServiceException);
         } else if (throwable instanceof ServiceException serviceException) {
-            Optional<ConjureErrorParameterFormat> maybeErrorParamFormatHeader = ConjureErrorParameterFormats.parseFromRequest(exchange.getRequestHeaders(), ConjureErrorParamsDecoder.INSTANCE);
-            if ( maybeErrorParamFormatHeader.isPresent()
-                    && maybeErrorParamFormatHeader.get().equals(ConjureErrorParameterFormat.JSON_FORMAT)) {
-                serviceExceptionWithJsonParameterValues(exchange, serviceException);
-            } else {
-                serviceException(exchange, serviceException);
-            }
+            serviceException(exchange, serviceException);
         } else if (throwable instanceof QosException qosException) {
             qosException(exchange, qosException);
         } else if (throwable instanceof RemoteException remoteException) {
@@ -134,19 +119,29 @@ public enum ConjureExceptions implements ExceptionHandler {
     }
 
     private static void serviceException(HttpServerExchange exchange, ServiceException exception) {
-        log(exception);
+        Optional<ConjureErrorParameterFormat> maybeErrorParamFormatHeader =
+                ConjureErrorParameterFormats.parseFromRequest(
+                        exchange.getRequestHeaders(), ConjureErrorParamsDecoder.INSTANCE);
+        ConjureError conjureError;
+        if (maybeErrorParamFormatHeader.isPresent()
+                && maybeErrorParamFormatHeader.get().equals(ConjureErrorParameterFormat.JSON_FORMAT)) {
+            logWithSerializationFormat(exception, true);
+            conjureError = ConjureError.fromServiceExceptionWithJsonParameters(exception);
+        } else {
+            logWithSerializationFormat(exception, false);
+            conjureError = ConjureError.fromServiceException(exception);
+        }
         writeResponse(
-                exchange,
-                Optional.of(ConjureError.fromServiceException(exception)),
-                exception.getErrorType().httpErrorCode());
+                exchange, Optional.of(conjureError), exception.getErrorType().httpErrorCode());
     }
 
-    private static void serviceExceptionWithJsonParameterValues(HttpServerExchange exchange, ServiceException exception) {
-        log(exception);
-        writeResponse(
-                exchange,
-                Optional.of(ConjureError.fromServiceExceptionWithJsonParameters(exception)),
-                exception.getErrorType().httpErrorCode());
+    private enum ConjureErrorParamsDecoder implements ConjureErrorParameterFormatRequestDecodingAdapter<HeaderMap> {
+        INSTANCE;
+
+        @Override
+        public String getFirstHeader(HeaderMap response, String headerName) {
+            return response.getFirst(headerName);
+        }
     }
 
     private static void qosException(HttpServerExchange exchange, QosException qosException) {
@@ -280,6 +275,25 @@ public enum ConjureExceptions implements ExceptionHandler {
             undertowOutputStream.resetBuffer();
         }
         return false;
+    }
+
+    private static void logWithSerializationFormat(
+            ServiceException serviceException, boolean isUsingJsonSerializationForParameters) {
+        if (serviceException.getErrorType().httpErrorCode() / 100 == 4 /* client error */) {
+            log.info(
+                    "Error handling request",
+                    SafeArg.of("errorInstanceId", serviceException.getErrorInstanceId()),
+                    SafeArg.of("errorName", serviceException.getErrorType().name()),
+                    SafeArg.of("isUsingJsonSerializationForParameters", isUsingJsonSerializationForParameters),
+                    serviceException);
+        } else {
+            log.error(
+                    "Error handling request",
+                    SafeArg.of("errorInstanceId", serviceException.getErrorInstanceId()),
+                    SafeArg.of("errorName", serviceException.getErrorType().name()),
+                    SafeArg.of("isUsingJsonSerializationForParameters", isUsingJsonSerializationForParameters),
+                    serviceException);
+        }
     }
 
     private static void log(ServiceException serviceException, Throwable exceptionForLogging) {

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
@@ -124,8 +124,11 @@ public enum ConjureExceptions implements ExceptionHandler {
                         exchange.getRequestHeaders(), ConjureErrorParamsDecoder.INSTANCE);
 
         boolean isHeaderPresent = maybeErrorParamFormatHeader.isPresent();
-        boolean isJsonErrorParameterValueFormat =
-                isHeaderPresent && maybeErrorParamFormatHeader.get().equals(ConjureErrorParameterFormat.JSON_FORMAT);
+        boolean isJsonErrorParameterValueFormat = isHeaderPresent
+                && maybeErrorParamFormatHeader
+                        .get()
+                        .toString()
+                        .equalsIgnoreCase(ConjureErrorParameterFormat.JSON_FORMAT.toString());
 
         // Log unrecognized format if present but not JSON
         if (isHeaderPresent && !isJsonErrorParameterValueFormat) {

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureExceptions.java
@@ -122,15 +122,24 @@ public enum ConjureExceptions implements ExceptionHandler {
         Optional<ConjureErrorParameterFormat> maybeErrorParamFormatHeader =
                 ConjureErrorParameterFormats.parseFromRequest(
                         exchange.getRequestHeaders(), ConjureErrorParamsDecoder.INSTANCE);
-        ConjureError conjureError;
-        if (maybeErrorParamFormatHeader.isPresent()
-                && maybeErrorParamFormatHeader.get().equals(ConjureErrorParameterFormat.JSON_FORMAT)) {
-            logWithSerializationFormat(exception, true);
-            conjureError = ConjureError.fromServiceExceptionWithJsonParameters(exception);
-        } else {
-            logWithSerializationFormat(exception, false);
-            conjureError = ConjureError.fromServiceException(exception);
+
+        boolean isHeaderPresent = maybeErrorParamFormatHeader.isPresent();
+        boolean isJsonErrorParameterValueFormat =
+                isHeaderPresent && maybeErrorParamFormatHeader.get().equals(ConjureErrorParameterFormat.JSON_FORMAT);
+
+        // Log unrecognized format if present but not JSON
+        if (isHeaderPresent && !isJsonErrorParameterValueFormat) {
+            log.info(
+                    "Unrecognized Conjure error parameter format header",
+                    SafeArg.of("headerValue", maybeErrorParamFormatHeader.get()));
         }
+
+        // Use the appropriate serialization based on format
+        logWithSerializationFormat(exception, isJsonErrorParameterValueFormat);
+        ConjureError conjureError = isJsonErrorParameterValueFormat
+                ? ConjureError.fromServiceExceptionWithJsonSerializedParameterValues(exception)
+                : ConjureError.fromServiceException(exception);
+
         writeResponse(
                 exchange, Optional.of(conjureError), exception.getErrorType().httpErrorCode());
     }
@@ -139,8 +148,8 @@ public enum ConjureExceptions implements ExceptionHandler {
         INSTANCE;
 
         @Override
-        public String getFirstHeader(HeaderMap response, String headerName) {
-            return response.getFirst(headerName);
+        public String getFirstHeader(HeaderMap requestHeaderMap, String headerName) {
+            return requestHeaderMap.getFirst(headerName);
         }
     }
 
@@ -346,10 +355,6 @@ public enum ConjureExceptions implements ExceptionHandler {
                             "errorName", endpointServiceException.getErrorType().name()),
                     endpointServiceException);
         }
-    }
-
-    private static void log(ServiceException exception) {
-        log(exception, exception);
     }
 
     private static void setFailure(HttpServerExchange exchange, Throwable failure) {


### PR DESCRIPTION
## Before this PR
Need to merge the [PR the introduces the Accept-Conjure-Error-Parameter-Format header first](https://github.com/palantir/conjure-java-runtime-api/pull/1398).

Currently, error parameters are serialized using `Objects.toString`. We'd like to enable clients to receive JSON parameters as well. In order to safely migrate error parameter serialization formats, clients should be able to specify the parameter format they expect from servers.


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
When the `Accept-Conjure-Error-Parameter-Format`  header is `JSON`, servers serialize error parameters as JSON, instead of using `Objects.toString`.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

