### PR TITLE
Change default value of `dangerousDoNotUseEnableEndpointAssociatedErrors` to false

### DIFF
--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/Options.java
@@ -210,14 +210,11 @@ public interface Options {
      * This flag has been temporarily added to help us iterate on a safer rollout strategy for endpoint-associated
      * errors.
      * <p>
-     * It is initially set to true, but will quickly be set to false.
-     * <p>
-     * It will also eventually be removed, and you should not use it without letting the Conjure maintainers know.
-     * Otherwise, a future upgrade will break your builds.
+     * This flag will eventually be removed, and you should not use it without letting the Conjure maintainers know.
      */
     @Value.Default
     default boolean dangerousDoNotUseEnableEndpointAssociatedErrors() {
-        return true;
+        return false;
     }
 
     /**

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/parameterized/TestCases.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/parameterized/TestCases.java
@@ -274,6 +274,7 @@ public final class TestCases {
                             .nonNullCollections(true)
                             .excludeEmptyOptionals(true)
                             .jetbrainsContractAnnotations(true)
+                            .dangerousDoNotUseEnableEndpointAssociatedErrors(true)
                             .build())
                     .generatorTypes(List.of(
                             GeneratorType.UNDERTOW,
@@ -335,6 +336,7 @@ public final class TestCases {
                             Path.of("src/test/resources/errors-for-endpoints.yml")))
                     .options(Options.builder()
                             .generateDialogueEndpointErrorResultTypes(true)
+                            .dangerousDoNotUseEnableEndpointAssociatedErrors(true)
                             .build())
                     .generatorTypes(List.of(
                             GeneratorType.OBJECT,

--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -248,7 +248,7 @@ public final class ConjureJavaCli implements Runnable {
 
         @CommandLine.Option(
                 names = "--dangerousDoNotUseEnableEndpointAssociatedErrors",
-                defaultValue = "true",
+                defaultValue = "false",
                 description = "Generate endpoint associated errors as EndpointServiceExceptions. "
                         + "This feature is currently not supported.")
         private boolean dangerousDoNotUseEnableEndpointAssociatedErrors;


### PR DESCRIPTION
## Before this PR
Internally, we've completed migrating repositories that would like to use the feature into explicitly setting the flag to `true`. Let's change the default value of the flag to false to avoid future users from adopting the feature temporarily.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Change default value of `dangerousDoNotUseEnableEndpointAssociatedErrors` to false
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

