### PR TITLE
Add example error with several parameter types

### DIFF
--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/another/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/another/ConjureErrors.java
@@ -11,34 +11,34 @@ import org.jetbrains.annotations.Contract;
 @Generated("com.palantir.conjure.java.types.ErrorGenerator")
 public final class ConjureErrors {
     /** Different package. */
-    public static final ErrorType DIFFERENT_PACKAGE =
-            ErrorType.create(ErrorType.Code.INTERNAL, "Conjure:DifferentPackage");
+    public static final ErrorType DIFFERENT_PACKAGE_ERROR =
+            ErrorType.create(ErrorType.Code.INTERNAL, "Conjure:DifferentPackageError");
 
     private ConjureErrors() {}
 
-    public static ServiceException differentPackage() {
-        return new ServiceException(DIFFERENT_PACKAGE);
+    public static ServiceException differentPackageError() {
+        return new ServiceException(DIFFERENT_PACKAGE_ERROR);
     }
 
-    public static ServiceException differentPackage(@Nullable Throwable cause) {
-        return new ServiceException(DIFFERENT_PACKAGE, cause);
+    public static ServiceException differentPackageError(@Nullable Throwable cause) {
+        return new ServiceException(DIFFERENT_PACKAGE_ERROR, cause);
     }
 
     /**
-     * Throws a {@link ServiceException} of type DifferentPackage when {@code shouldThrow} is true.
+     * Throws a {@link ServiceException} of type DifferentPackageError when {@code shouldThrow} is true.
      *
      * @param shouldThrow Cause the method to throw when true
      */
     @Contract("true -> fail")
-    public static void throwIfDifferentPackage(boolean shouldThrow) {
+    public static void throwIfDifferentPackageError(boolean shouldThrow) {
         if (shouldThrow) {
-            throw differentPackage();
+            throw differentPackageError();
         }
     }
 
-    /** Returns true if the {@link RemoteException} is named Conjure:DifferentPackage */
-    public static boolean isDifferentPackage(RemoteException remoteException) {
+    /** Returns true if the {@link RemoteException} is named Conjure:DifferentPackageError */
+    public static boolean isDifferentPackageError(RemoteException remoteException) {
         Preconditions.checkNotNull(remoteException, "remote exception must not be null");
-        return DIFFERENT_PACKAGE.name().equals(remoteException.getError().errorName());
+        return DIFFERENT_PACKAGE_ERROR.name().equals(remoteException.getError().errorName());
     }
 }

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/AnyExample.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/AnyExample.java
@@ -1,0 +1,162 @@
+package errors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.errorprone.annotations.CheckReturnValue;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@JsonDeserialize(builder = AnyExample.Builder.class)
+@Generated("com.palantir.conjure.java.types.BeanGenerator")
+public final class AnyExample {
+    private final Object anyValue;
+
+    private final Map<String, Object> anyMap;
+
+    private int memoizedHashCode;
+
+    private AnyExample(Object anyValue, Map<String, Object> anyMap) {
+        validateFields(anyValue, anyMap);
+        this.anyValue = anyValue;
+        this.anyMap = Collections.unmodifiableMap(anyMap);
+    }
+
+    @JsonProperty("anyValue")
+    public Object getAnyValue() {
+        return this.anyValue;
+    }
+
+    @JsonProperty("anyMap")
+    public Map<String, Object> getAnyMap() {
+        return this.anyMap;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof AnyExample && equalTo((AnyExample) other));
+    }
+
+    private boolean equalTo(AnyExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.anyValue.equals(other.anyValue) && this.anyMap.equals(other.anyMap);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = memoizedHashCode;
+        if (result == 0) {
+            int hash = 1;
+            hash = 31 * hash + this.anyValue.hashCode();
+            hash = 31 * hash + this.anyMap.hashCode();
+            result = hash;
+            memoizedHashCode = result;
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "AnyExample{anyValue: " + anyValue + ", anyMap: " + anyMap + '}';
+    }
+
+    public static AnyExample of(Object anyValue, Map<String, Object> anyMap) {
+        return builder().anyValue(anyValue).anyMap(anyMap).build();
+    }
+
+    private static void validateFields(Object anyValue, Map<String, Object> anyMap) {
+        List<String> missingFields = null;
+        missingFields = addFieldIfMissing(missingFields, anyValue, "anyValue");
+        missingFields = addFieldIfMissing(missingFields, anyMap, "anyMap");
+        if (missingFields != null) {
+            throw new SafeIllegalArgumentException(
+                    "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
+        }
+    }
+
+    private static List<String> addFieldIfMissing(List<String> prev, Object fieldValue, String fieldName) {
+        List<String> missingFields = prev;
+        if (fieldValue == null) {
+            if (missingFields == null) {
+                missingFields = new ArrayList<>(2);
+            }
+            missingFields.add(fieldName);
+        }
+        return missingFields;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder {
+        boolean _buildInvoked;
+
+        private Object anyValue;
+
+        private Map<String, Object> anyMap = new LinkedHashMap<>();
+
+        private Builder() {}
+
+        public Builder from(AnyExample other) {
+            checkNotBuilt();
+            anyValue(other.getAnyValue());
+            anyMap(other.getAnyMap());
+            return this;
+        }
+
+        @JsonSetter("anyValue")
+        public Builder anyValue(@Nonnull Object anyValue) {
+            checkNotBuilt();
+            this.anyValue = Preconditions.checkNotNull(anyValue, "anyValue cannot be null");
+            return this;
+        }
+
+        @JsonSetter(value = "anyMap", nulls = Nulls.SKIP)
+        public Builder anyMap(@Nonnull Map<String, Object> anyMap) {
+            checkNotBuilt();
+            this.anyMap = new LinkedHashMap<>(Preconditions.checkNotNull(anyMap, "anyMap cannot be null"));
+            return this;
+        }
+
+        public Builder putAllAnyMap(@Nonnull Map<String, Object> anyMap) {
+            checkNotBuilt();
+            this.anyMap.putAll(Preconditions.checkNotNull(anyMap, "anyMap cannot be null"));
+            return this;
+        }
+
+        public Builder anyMap(String key, Object value) {
+            checkNotBuilt();
+            this.anyMap.put(key, value);
+            return this;
+        }
+
+        @CheckReturnValue
+        public AnyExample build() {
+            checkNotBuilt();
+            this._buildInvoked = true;
+            return new AnyExample(anyValue, anyMap);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/CollectionAlias.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/CollectionAlias.java
@@ -1,0 +1,70 @@
+package errors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class CollectionAlias {
+    private static final CollectionAlias EMPTY = new CollectionAlias();
+
+    private final List<String> value;
+
+    private int memoizedHashCode;
+
+    private CollectionAlias(@Nonnull List<String> value) {
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
+    }
+
+    private CollectionAlias() {
+        this(Collections.emptyList());
+    }
+
+    @JsonValue
+    public List<String> get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof CollectionAlias && equalTo((CollectionAlias) other));
+    }
+
+    private boolean equalTo(CollectionAlias other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.value.equals(other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = memoizedHashCode;
+        if (result == 0) {
+            result = this.value.hashCode();
+            memoizedHashCode = result;
+        }
+        return result;
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static CollectionAlias of(@Nonnull List<String> value) {
+        return new CollectionAlias(value);
+    }
+
+    public static CollectionAlias empty() {
+        return EMPTY;
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/CollectionExample.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/CollectionExample.java
@@ -1,0 +1,219 @@
+package errors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.errorprone.annotations.CheckReturnValue;
+import com.palantir.conjure.java.lib.internal.ConjureCollections;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@JsonDeserialize(builder = CollectionExample.Builder.class)
+@Generated("com.palantir.conjure.java.types.BeanGenerator")
+public final class CollectionExample {
+    private final List<String> stringList;
+
+    private final Set<String> stringSet;
+
+    private final Map<String, String> stringMap;
+
+    private int memoizedHashCode;
+
+    private CollectionExample(List<String> stringList, Set<String> stringSet, Map<String, String> stringMap) {
+        validateFields(stringList, stringSet, stringMap);
+        this.stringList = ConjureCollections.unmodifiableList(stringList);
+        this.stringSet = Collections.unmodifiableSet(stringSet);
+        this.stringMap = Collections.unmodifiableMap(stringMap);
+    }
+
+    @JsonProperty("stringList")
+    public List<String> getStringList() {
+        return this.stringList;
+    }
+
+    @JsonProperty("stringSet")
+    public Set<String> getStringSet() {
+        return this.stringSet;
+    }
+
+    @JsonProperty("stringMap")
+    public Map<String, String> getStringMap() {
+        return this.stringMap;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof CollectionExample && equalTo((CollectionExample) other));
+    }
+
+    private boolean equalTo(CollectionExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.stringList.equals(other.stringList)
+                && this.stringSet.equals(other.stringSet)
+                && this.stringMap.equals(other.stringMap);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = memoizedHashCode;
+        if (result == 0) {
+            int hash = 1;
+            hash = 31 * hash + this.stringList.hashCode();
+            hash = 31 * hash + this.stringSet.hashCode();
+            hash = 31 * hash + this.stringMap.hashCode();
+            result = hash;
+            memoizedHashCode = result;
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "CollectionExample{stringList: " + stringList + ", stringSet: " + stringSet + ", stringMap: " + stringMap
+                + '}';
+    }
+
+    public static CollectionExample of(List<String> stringList, Set<String> stringSet, Map<String, String> stringMap) {
+        return builder()
+                .stringList(stringList)
+                .stringSet(stringSet)
+                .stringMap(stringMap)
+                .build();
+    }
+
+    private static void validateFields(List<String> stringList, Set<String> stringSet, Map<String, String> stringMap) {
+        List<String> missingFields = null;
+        missingFields = addFieldIfMissing(missingFields, stringList, "stringList");
+        missingFields = addFieldIfMissing(missingFields, stringSet, "stringSet");
+        missingFields = addFieldIfMissing(missingFields, stringMap, "stringMap");
+        if (missingFields != null) {
+            throw new SafeIllegalArgumentException(
+                    "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
+        }
+    }
+
+    private static List<String> addFieldIfMissing(List<String> prev, Object fieldValue, String fieldName) {
+        List<String> missingFields = prev;
+        if (fieldValue == null) {
+            if (missingFields == null) {
+                missingFields = new ArrayList<>(3);
+            }
+            missingFields.add(fieldName);
+        }
+        return missingFields;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder {
+        boolean _buildInvoked;
+
+        private List<String> stringList = ConjureCollections.newList();
+
+        private Set<String> stringSet = ConjureCollections.newSet();
+
+        private Map<String, String> stringMap = new LinkedHashMap<>();
+
+        private Builder() {}
+
+        public Builder from(CollectionExample other) {
+            checkNotBuilt();
+            stringList(other.getStringList());
+            stringSet(other.getStringSet());
+            stringMap(other.getStringMap());
+            return this;
+        }
+
+        @JsonSetter(value = "stringList", nulls = Nulls.SKIP)
+        public Builder stringList(@Nonnull Iterable<String> stringList) {
+            checkNotBuilt();
+            this.stringList =
+                    ConjureCollections.newList(Preconditions.checkNotNull(stringList, "stringList cannot be null"));
+            return this;
+        }
+
+        public Builder addAllStringList(@Nonnull Iterable<String> stringList) {
+            checkNotBuilt();
+            ConjureCollections.addAll(
+                    this.stringList, Preconditions.checkNotNull(stringList, "stringList cannot be null"));
+            return this;
+        }
+
+        public Builder stringList(String stringList) {
+            checkNotBuilt();
+            this.stringList.add(stringList);
+            return this;
+        }
+
+        @JsonSetter(value = "stringSet", nulls = Nulls.SKIP)
+        public Builder stringSet(@Nonnull Iterable<String> stringSet) {
+            checkNotBuilt();
+            this.stringSet =
+                    ConjureCollections.newSet(Preconditions.checkNotNull(stringSet, "stringSet cannot be null"));
+            return this;
+        }
+
+        public Builder addAllStringSet(@Nonnull Iterable<String> stringSet) {
+            checkNotBuilt();
+            ConjureCollections.addAll(
+                    this.stringSet, Preconditions.checkNotNull(stringSet, "stringSet cannot be null"));
+            return this;
+        }
+
+        public Builder stringSet(String stringSet) {
+            checkNotBuilt();
+            this.stringSet.add(stringSet);
+            return this;
+        }
+
+        @JsonSetter(value = "stringMap", nulls = Nulls.SKIP)
+        public Builder stringMap(@Nonnull Map<String, String> stringMap) {
+            checkNotBuilt();
+            this.stringMap = new LinkedHashMap<>(Preconditions.checkNotNull(stringMap, "stringMap cannot be null"));
+            return this;
+        }
+
+        public Builder putAllStringMap(@Nonnull Map<String, String> stringMap) {
+            checkNotBuilt();
+            this.stringMap.putAll(Preconditions.checkNotNull(stringMap, "stringMap cannot be null"));
+            return this;
+        }
+
+        public Builder stringMap(String key, String value) {
+            checkNotBuilt();
+            this.stringMap.put(key, value);
+            return this;
+        }
+
+        @CheckReturnValue
+        public CollectionExample build() {
+            checkNotBuilt();
+            this._buildInvoked = true;
+            return new CollectionExample(stringList, stringSet, stringMap);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/ComplexExample.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/ComplexExample.java
@@ -1,0 +1,234 @@
+package errors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.errorprone.annotations.CheckReturnValue;
+import com.palantir.conjure.java.lib.internal.ConjureCollections;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@JsonDeserialize(builder = ComplexExample.Builder.class)
+@Generated("com.palantir.conjure.java.types.BeanGenerator")
+public final class ComplexExample {
+    private final Map<StringAliasEx, Optional<List<ObjectReference>>> metadata;
+
+    private final EnumExample status;
+
+    private final List<UnionExample> variants;
+
+    private final Optional<Long> external;
+
+    private int memoizedHashCode;
+
+    private ComplexExample(
+            Map<StringAliasEx, Optional<List<ObjectReference>>> metadata,
+            EnumExample status,
+            List<UnionExample> variants,
+            Optional<Long> external) {
+        validateFields(metadata, status, variants, external);
+        this.metadata = Collections.unmodifiableMap(metadata);
+        this.status = status;
+        this.variants = ConjureCollections.unmodifiableList(variants);
+        this.external = external;
+    }
+
+    @JsonProperty("metadata")
+    public Map<StringAliasEx, Optional<List<ObjectReference>>> getMetadata() {
+        return this.metadata;
+    }
+
+    @JsonProperty("status")
+    public EnumExample getStatus() {
+        return this.status;
+    }
+
+    @JsonProperty("variants")
+    public List<UnionExample> getVariants() {
+        return this.variants;
+    }
+
+    @JsonProperty("external")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Optional<Long> getExternal() {
+        return this.external;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof ComplexExample && equalTo((ComplexExample) other));
+    }
+
+    private boolean equalTo(ComplexExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.metadata.equals(other.metadata)
+                && this.status.equals(other.status)
+                && this.variants.equals(other.variants)
+                && this.external.equals(other.external);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = memoizedHashCode;
+        if (result == 0) {
+            int hash = 1;
+            hash = 31 * hash + this.metadata.hashCode();
+            hash = 31 * hash + this.status.hashCode();
+            hash = 31 * hash + this.variants.hashCode();
+            hash = 31 * hash + this.external.hashCode();
+            result = hash;
+            memoizedHashCode = result;
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ComplexExample{metadata: " + metadata + ", status: " + status + ", variants: " + variants
+                + ", external: " + external + '}';
+    }
+
+    private static void validateFields(
+            Map<StringAliasEx, Optional<List<ObjectReference>>> metadata,
+            EnumExample status,
+            List<UnionExample> variants,
+            Optional<Long> external) {
+        List<String> missingFields = null;
+        missingFields = addFieldIfMissing(missingFields, metadata, "metadata");
+        missingFields = addFieldIfMissing(missingFields, status, "status");
+        missingFields = addFieldIfMissing(missingFields, variants, "variants");
+        missingFields = addFieldIfMissing(missingFields, external, "external");
+        if (missingFields != null) {
+            throw new SafeIllegalArgumentException(
+                    "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
+        }
+    }
+
+    private static List<String> addFieldIfMissing(List<String> prev, Object fieldValue, String fieldName) {
+        List<String> missingFields = prev;
+        if (fieldValue == null) {
+            if (missingFields == null) {
+                missingFields = new ArrayList<>(4);
+            }
+            missingFields.add(fieldName);
+        }
+        return missingFields;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder {
+        boolean _buildInvoked;
+
+        private Map<StringAliasEx, Optional<List<ObjectReference>>> metadata = new LinkedHashMap<>();
+
+        private EnumExample status;
+
+        private List<UnionExample> variants = ConjureCollections.newList();
+
+        private Optional<Long> external = Optional.empty();
+
+        private Builder() {}
+
+        public Builder from(ComplexExample other) {
+            checkNotBuilt();
+            metadata(other.getMetadata());
+            status(other.getStatus());
+            variants(other.getVariants());
+            external(other.getExternal());
+            return this;
+        }
+
+        @JsonSetter(value = "metadata", nulls = Nulls.SKIP, contentNulls = Nulls.AS_EMPTY)
+        public Builder metadata(@Nonnull Map<StringAliasEx, Optional<List<ObjectReference>>> metadata) {
+            checkNotBuilt();
+            this.metadata = new LinkedHashMap<>(Preconditions.checkNotNull(metadata, "metadata cannot be null"));
+            return this;
+        }
+
+        public Builder putAllMetadata(@Nonnull Map<StringAliasEx, Optional<List<ObjectReference>>> metadata) {
+            checkNotBuilt();
+            this.metadata.putAll(Preconditions.checkNotNull(metadata, "metadata cannot be null"));
+            return this;
+        }
+
+        public Builder metadata(StringAliasEx key, Optional<List<ObjectReference>> value) {
+            checkNotBuilt();
+            this.metadata.put(key, value);
+            return this;
+        }
+
+        @JsonSetter("status")
+        public Builder status(@Nonnull EnumExample status) {
+            checkNotBuilt();
+            this.status = Preconditions.checkNotNull(status, "status cannot be null");
+            return this;
+        }
+
+        @JsonSetter(value = "variants", nulls = Nulls.SKIP)
+        public Builder variants(@Nonnull Iterable<UnionExample> variants) {
+            checkNotBuilt();
+            this.variants = ConjureCollections.newList(Preconditions.checkNotNull(variants, "variants cannot be null"));
+            return this;
+        }
+
+        public Builder addAllVariants(@Nonnull Iterable<UnionExample> variants) {
+            checkNotBuilt();
+            ConjureCollections.addAll(this.variants, Preconditions.checkNotNull(variants, "variants cannot be null"));
+            return this;
+        }
+
+        public Builder variants(UnionExample variants) {
+            checkNotBuilt();
+            this.variants.add(variants);
+            return this;
+        }
+
+        @JsonSetter(value = "external", nulls = Nulls.SKIP)
+        public Builder external(@Nonnull Optional<? extends Long> external) {
+            checkNotBuilt();
+            this.external = Preconditions.checkNotNull(external, "external cannot be null")
+                    .map(Function.identity());
+            return this;
+        }
+
+        public Builder external(long external) {
+            checkNotBuilt();
+            this.external = Optional.of(Preconditions.checkNotNull(external, "external cannot be null"));
+            return this;
+        }
+
+        @CheckReturnValue
+        public ComplexExample build() {
+            checkNotBuilt();
+            this._buildInvoked = true;
+            return new ComplexExample(metadata, status, variants, external);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/ConjureErrors.java
@@ -22,6 +22,9 @@ public final class ConjureErrors {
     public static final ErrorType CONFLICTING_CAUSE_UNSAFE_ARG =
             ErrorType.create(ErrorType.Code.INTERNAL, "Conjure:ConflictingCauseUnsafeArg");
 
+    public static final ErrorType ERROR_WITH_COMPLEX_ARGS =
+            ErrorType.create(ErrorType.Code.INTERNAL, "Conjure:ErrorWithComplexArgs");
+
     /** Invalid Conjure service definition. */
     public static final ErrorType INVALID_SERVICE_DEFINITION =
             ErrorType.create(ErrorType.Code.INVALID_ARGUMENT, "Conjure:InvalidServiceDefinition");
@@ -58,6 +61,82 @@ public final class ConjureErrors {
                 cause,
                 UnsafeArg.of("cause", cause_),
                 UnsafeArg.of("shouldThrow", shouldThrow_));
+    }
+
+    public static ServiceException errorWithComplexArgs(
+            @Safe PrimitiveExample primitiveExample,
+            @Safe CollectionExample collectionExample,
+            @Safe NestedCollectionExample nestedCollectionExample,
+            @Safe OptionalExample optionalExample,
+            @Safe ObjectReference objectReference,
+            @Safe UnionExample unionExample,
+            @Safe EnumExample enumExample,
+            @Safe StringAliasEx stringAlias,
+            @Safe OptionalAlias optionalAlias,
+            @Safe CollectionAlias collectionAlias,
+            @Safe NestedAlias nestedAlias,
+            @Safe ExternalExample externalExample,
+            @Safe AnyExample anyExample,
+            @Safe EmptyObject emptyObject,
+            @Safe ComplexExample complexExample,
+            @Unsafe SafetyExample safetyExample) {
+        return new ServiceException(
+                ERROR_WITH_COMPLEX_ARGS,
+                SafeArg.of("primitiveExample", primitiveExample),
+                SafeArg.of("collectionExample", collectionExample),
+                SafeArg.of("nestedCollectionExample", nestedCollectionExample),
+                SafeArg.of("optionalExample", optionalExample),
+                SafeArg.of("objectReference", objectReference),
+                SafeArg.of("unionExample", unionExample),
+                SafeArg.of("enumExample", enumExample),
+                SafeArg.of("stringAlias", stringAlias),
+                SafeArg.of("optionalAlias", optionalAlias),
+                SafeArg.of("collectionAlias", collectionAlias),
+                SafeArg.of("nestedAlias", nestedAlias),
+                SafeArg.of("externalExample", externalExample),
+                SafeArg.of("anyExample", anyExample),
+                SafeArg.of("emptyObject", emptyObject),
+                SafeArg.of("complexExample", complexExample),
+                UnsafeArg.of("safetyExample", safetyExample));
+    }
+
+    public static ServiceException errorWithComplexArgs(
+            @Nullable Throwable cause,
+            @Safe PrimitiveExample primitiveExample,
+            @Safe CollectionExample collectionExample,
+            @Safe NestedCollectionExample nestedCollectionExample,
+            @Safe OptionalExample optionalExample,
+            @Safe ObjectReference objectReference,
+            @Safe UnionExample unionExample,
+            @Safe EnumExample enumExample,
+            @Safe StringAliasEx stringAlias,
+            @Safe OptionalAlias optionalAlias,
+            @Safe CollectionAlias collectionAlias,
+            @Safe NestedAlias nestedAlias,
+            @Safe ExternalExample externalExample,
+            @Safe AnyExample anyExample,
+            @Safe EmptyObject emptyObject,
+            @Safe ComplexExample complexExample,
+            @Unsafe SafetyExample safetyExample) {
+        return new ServiceException(
+                ERROR_WITH_COMPLEX_ARGS,
+                cause,
+                SafeArg.of("primitiveExample", primitiveExample),
+                SafeArg.of("collectionExample", collectionExample),
+                SafeArg.of("nestedCollectionExample", nestedCollectionExample),
+                SafeArg.of("optionalExample", optionalExample),
+                SafeArg.of("objectReference", objectReference),
+                SafeArg.of("unionExample", unionExample),
+                SafeArg.of("enumExample", enumExample),
+                SafeArg.of("stringAlias", stringAlias),
+                SafeArg.of("optionalAlias", optionalAlias),
+                SafeArg.of("collectionAlias", collectionAlias),
+                SafeArg.of("nestedAlias", nestedAlias),
+                SafeArg.of("externalExample", externalExample),
+                SafeArg.of("anyExample", anyExample),
+                SafeArg.of("emptyObject", emptyObject),
+                SafeArg.of("complexExample", complexExample),
+                UnsafeArg.of("safetyExample", safetyExample));
     }
 
     /**
@@ -126,6 +205,67 @@ public final class ConjureErrors {
     }
 
     /**
+     * Throws a {@link ServiceException} of type ErrorWithComplexArgs when {@code shouldThrow} is true.
+     *
+     * @param shouldThrow Cause the method to throw when true
+     * @param primitiveExample
+     * @param collectionExample
+     * @param nestedCollectionExample
+     * @param optionalExample
+     * @param objectReference
+     * @param unionExample
+     * @param enumExample
+     * @param stringAlias
+     * @param optionalAlias
+     * @param collectionAlias
+     * @param nestedAlias
+     * @param externalExample
+     * @param anyExample
+     * @param emptyObject
+     * @param complexExample
+     * @param safetyExample
+     */
+    @Contract("true, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ -> fail")
+    public static void throwIfErrorWithComplexArgs(
+            boolean shouldThrow,
+            @Safe PrimitiveExample primitiveExample,
+            @Safe CollectionExample collectionExample,
+            @Safe NestedCollectionExample nestedCollectionExample,
+            @Safe OptionalExample optionalExample,
+            @Safe ObjectReference objectReference,
+            @Safe UnionExample unionExample,
+            @Safe EnumExample enumExample,
+            @Safe StringAliasEx stringAlias,
+            @Safe OptionalAlias optionalAlias,
+            @Safe CollectionAlias collectionAlias,
+            @Safe NestedAlias nestedAlias,
+            @Safe ExternalExample externalExample,
+            @Safe AnyExample anyExample,
+            @Safe EmptyObject emptyObject,
+            @Safe ComplexExample complexExample,
+            @Unsafe SafetyExample safetyExample) {
+        if (shouldThrow) {
+            throw errorWithComplexArgs(
+                    primitiveExample,
+                    collectionExample,
+                    nestedCollectionExample,
+                    optionalExample,
+                    objectReference,
+                    unionExample,
+                    enumExample,
+                    stringAlias,
+                    optionalAlias,
+                    collectionAlias,
+                    nestedAlias,
+                    externalExample,
+                    anyExample,
+                    emptyObject,
+                    complexExample,
+                    safetyExample);
+        }
+    }
+
+    /**
      * Throws a {@link ServiceException} of type InvalidServiceDefinition when {@code shouldThrow} is true.
      *
      * @param shouldThrow Cause the method to throw when true
@@ -169,6 +309,12 @@ public final class ConjureErrors {
         return CONFLICTING_CAUSE_UNSAFE_ARG
                 .name()
                 .equals(remoteException.getError().errorName());
+    }
+
+    /** Returns true if the {@link RemoteException} is named Conjure:ErrorWithComplexArgs */
+    public static boolean isErrorWithComplexArgs(RemoteException remoteException) {
+        Preconditions.checkNotNull(remoteException, "remote exception must not be null");
+        return ERROR_WITH_COMPLEX_ARGS.name().equals(remoteException.getError().errorName());
     }
 
     /** Returns true if the {@link RemoteException} is named Conjure:InvalidServiceDefinition */

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/EmptyObject.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/EmptyObject.java
@@ -1,0 +1,28 @@
+package errors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.logsafe.Safe;
+import javax.annotation.processing.Generated;
+
+@Safe
+@JsonSerialize
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Generated("com.palantir.conjure.java.types.BeanGenerator")
+public final class EmptyObject {
+    private static final EmptyObject INSTANCE = new EmptyObject();
+
+    private EmptyObject() {}
+
+    @Override
+    @Safe
+    public String toString() {
+        return "EmptyObject{}";
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public static EmptyObject of() {
+        return INSTANCE;
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/EmptyUnion.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/EmptyUnion.java
@@ -1,0 +1,186 @@
+package errors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.types.UnionGenerator")
+public final class EmptyUnion {
+    private final Base value;
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    private EmptyUnion(Base value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    private Base getValue() {
+        return value;
+    }
+
+    public static EmptyUnion unknown(@Safe String type, Object value) {
+        switch (Preconditions.checkNotNull(type, "Type is required")) {
+            default:
+                return new EmptyUnion(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        }
+    }
+
+    public <T> T accept(Visitor<T> visitor) {
+        return value.accept(visitor);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof EmptyUnion && equalTo((EmptyUnion) other));
+    }
+
+    private boolean equalTo(EmptyUnion other) {
+        return this.value.equals(other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.value.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "EmptyUnion{value: " + value + '}';
+    }
+
+    public interface Visitor<T> {
+        T visitUnknown(@Safe String unknownType);
+
+        static <T> UnknownStageVisitorBuilder<T> builder() {
+            return new VisitorBuilder<T>();
+        }
+    }
+
+    private static final class VisitorBuilder<T>
+            implements UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
+        private Function<String, T> unknownVisitor;
+
+        @Override
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
+            Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
+            this.unknownVisitor = unknownVisitor;
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
+            this.unknownVisitor = unknownType -> {
+                throw new SafeIllegalArgumentException(
+                        "Unknown variant of the 'EmptyUnion' union", SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
+        public Visitor<T> build() {
+            final Function<String, T> unknownVisitor = this.unknownVisitor;
+            return new Visitor<T>() {
+                @Override
+                public T visitUnknown(String value) {
+                    return unknownVisitor.apply(value);
+                }
+            };
+        }
+    }
+
+    public interface UnknownStageVisitorBuilder<T> {
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
+    }
+
+    public interface Completed_StageVisitorBuilder<T> {
+        Visitor<T> build();
+    }
+
+    @JsonTypeInfo(
+            use = JsonTypeInfo.Id.NAME,
+            include = JsonTypeInfo.As.EXISTING_PROPERTY,
+            property = "type",
+            visible = true,
+            defaultImpl = UnknownWrapper.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private interface Base {
+        <T> T accept(Visitor<T> visitor);
+    }
+
+    private static final class UnknownWrapper implements Base {
+        private final String type;
+
+        private final Map<String, Object> value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private UnknownWrapper(@JsonProperty("type") String type) {
+            this(type, new HashMap<String, Object>());
+        }
+
+        private UnknownWrapper(@Nonnull String type, @Nonnull Map<String, Object> value) {
+            Preconditions.checkNotNull(type, "type cannot be null");
+            Preconditions.checkNotNull(value, "value cannot be null");
+            this.type = type;
+            this.value = value;
+        }
+
+        @JsonProperty
+        private String getType() {
+            return type;
+        }
+
+        @JsonAnyGetter
+        private Map<String, Object> getValue() {
+            return value;
+        }
+
+        @JsonAnySetter
+        private void put(String key, Object val) {
+            value.put(key, val);
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitUnknown(type);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof UnknownWrapper && equalTo((UnknownWrapper) other));
+        }
+
+        private boolean equalTo(UnknownWrapper other) {
+            return this.type.equals(other.type) && this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 1;
+            hash = 31 * hash + this.type.hashCode();
+            hash = 31 * hash + this.value.hashCode();
+            return hash;
+        }
+
+        @Override
+        public String toString() {
+            return "UnknownWrapper{type: " + type + ", value: " + value + '}';
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/EnumExample.java
@@ -1,0 +1,205 @@
+package errors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.errorprone.annotations.Immutable;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+/**
+ * This class is used instead of a native enum to support unknown values. Rather than throw an exception, the
+ * {@link EnumExample#valueOf} method defaults to a new instantiation of {@link EnumExample} where
+ * {@link EnumExample#get} will return {@link EnumExample.Value#UNKNOWN}.
+ *
+ * <p>For example, {@code EnumExample.valueOf("corrupted value").get()} will return {@link EnumExample.Value#UNKNOWN},
+ * but {@link EnumExample#toString} will return "corrupted value".
+ *
+ * <p>There is no method to access all instantiations of this class, since they cannot be known at compile time.
+ */
+@Generated("com.palantir.conjure.java.types.EnumGenerator")
+@Safe
+@Immutable
+public final class EnumExample {
+    public static final EnumExample A = new EnumExample(Value.A, "A");
+
+    public static final EnumExample B = new EnumExample(Value.B, "B");
+
+    private static final List<EnumExample> values = Collections.unmodifiableList(Arrays.asList(A, B));
+
+    private final Value value;
+
+    private final String string;
+
+    private EnumExample(Value value, String string) {
+        this.value = value;
+        this.string = string;
+    }
+
+    public Value get() {
+        return this.value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return this.string;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return (this == other)
+                || (this.value == Value.UNKNOWN
+                        && other instanceof EnumExample
+                        && this.string.equals(((EnumExample) other).string));
+    }
+
+    @Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static EnumExample valueOf(@Nonnull @Safe String value) {
+        Preconditions.checkNotNull(value, "value cannot be null");
+        String upperCasedValue = value.toUpperCase(Locale.ROOT);
+        switch (upperCasedValue) {
+            case "A":
+                return A;
+            case "B":
+                return B;
+            default:
+                return new EnumExample(Value.UNKNOWN, upperCasedValue);
+        }
+    }
+
+    public <T> T accept(Visitor<T> visitor) {
+        switch (value) {
+            case A:
+                return visitor.visitA();
+            case B:
+                return visitor.visitB();
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    public static List<EnumExample> values() {
+        return values;
+    }
+
+    @Generated("com.palantir.conjure.java.types.EnumGenerator")
+    public enum Value {
+        A,
+
+        B,
+
+        UNKNOWN
+    }
+
+    @Generated("com.palantir.conjure.java.types.EnumGenerator")
+    public interface Visitor<T> {
+        T visitA();
+
+        T visitB();
+
+        T visitUnknown(String unknownValue);
+
+        static <T> AStageVisitorBuilder<T> builder() {
+            return new VisitorBuilder<T>();
+        }
+    }
+
+    private static final class VisitorBuilder<T>
+            implements AStageVisitorBuilder<T>,
+                    BStageVisitorBuilder<T>,
+                    UnknownStageVisitorBuilder<T>,
+                    Completed_StageVisitorBuilder<T> {
+        private Supplier<T> aVisitor;
+
+        private Supplier<T> bVisitor;
+
+        private Function<@Safe String, T> unknownVisitor;
+
+        @Override
+        public BStageVisitorBuilder<T> visitA(@Nonnull Supplier<T> aVisitor) {
+            Preconditions.checkNotNull(aVisitor, "aVisitor cannot be null");
+            this.aVisitor = aVisitor;
+            return this;
+        }
+
+        @Override
+        public UnknownStageVisitorBuilder<T> visitB(@Nonnull Supplier<T> bVisitor) {
+            Preconditions.checkNotNull(bVisitor, "bVisitor cannot be null");
+            this.bVisitor = bVisitor;
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor) {
+            Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
+            this.unknownVisitor = unknownType -> unknownVisitor.apply(unknownType);
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
+            this.unknownVisitor = unknownType -> {
+                throw new SafeIllegalArgumentException(
+                        "Unknown variant of the 'EnumExample' union", SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
+        public Visitor<T> build() {
+            final Supplier<T> aVisitor = this.aVisitor;
+            final Supplier<T> bVisitor = this.bVisitor;
+            final Function<@Safe String, T> unknownVisitor = this.unknownVisitor;
+            return new Visitor<T>() {
+                @Override
+                public T visitA() {
+                    return aVisitor.get();
+                }
+
+                @Override
+                public T visitB() {
+                    return bVisitor.get();
+                }
+
+                @Override
+                public T visitUnknown(String unknownType) {
+                    return unknownVisitor.apply(unknownType);
+                }
+            };
+        }
+    }
+
+    public interface AStageVisitorBuilder<T> {
+        BStageVisitorBuilder<T> visitA(@Nonnull Supplier<T> aVisitor);
+    }
+
+    public interface BStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> visitB(@Nonnull Supplier<T> bVisitor);
+    }
+
+    public interface UnknownStageVisitorBuilder<T> {
+        Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
+    }
+
+    public interface Completed_StageVisitorBuilder<T> {
+        Visitor<T> build();
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/ExternalExample.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/ExternalExample.java
@@ -1,0 +1,185 @@
+package errors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.errorprone.annotations.CheckReturnValue;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@JsonDeserialize(builder = ExternalExample.Builder.class)
+@Generated("com.palantir.conjure.java.types.BeanGenerator")
+public final class ExternalExample {
+    private final long externalLong;
+
+    private final Optional<Long> optionalExternal;
+
+    private int memoizedHashCode;
+
+    private ExternalExample(long externalLong, Optional<Long> optionalExternal) {
+        validateFields(optionalExternal);
+        this.externalLong = externalLong;
+        this.optionalExternal = optionalExternal;
+    }
+
+    @JsonProperty("externalLong")
+    public long getExternalLong() {
+        return this.externalLong;
+    }
+
+    @JsonProperty("optionalExternal")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Optional<Long> getOptionalExternal() {
+        return this.optionalExternal;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof ExternalExample && equalTo((ExternalExample) other));
+    }
+
+    private boolean equalTo(ExternalExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.externalLong == other.externalLong && this.optionalExternal.equals(other.optionalExternal);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = memoizedHashCode;
+        if (result == 0) {
+            int hash = 1;
+            hash = 31 * hash + Long.hashCode(this.externalLong);
+            hash = 31 * hash + this.optionalExternal.hashCode();
+            result = hash;
+            memoizedHashCode = result;
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ExternalExample{externalLong: " + externalLong + ", optionalExternal: " + optionalExternal + '}';
+    }
+
+    public static ExternalExample of(long externalLong, long optionalExternal) {
+        return builder()
+                .externalLong(externalLong)
+                .optionalExternal(Optional.of(optionalExternal))
+                .build();
+    }
+
+    private static void validateFields(Optional<Long> optionalExternal) {
+        List<String> missingFields = null;
+        missingFields = addFieldIfMissing(missingFields, optionalExternal, "optionalExternal");
+        if (missingFields != null) {
+            throw new SafeIllegalArgumentException(
+                    "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
+        }
+    }
+
+    private static List<String> addFieldIfMissing(List<String> prev, Object fieldValue, String fieldName) {
+        List<String> missingFields = prev;
+        if (fieldValue == null) {
+            if (missingFields == null) {
+                missingFields = new ArrayList<>(1);
+            }
+            missingFields.add(fieldName);
+        }
+        return missingFields;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder {
+        boolean _buildInvoked;
+
+        private long externalLong;
+
+        private Optional<Long> optionalExternal = Optional.empty();
+
+        private boolean _externalLongInitialized = false;
+
+        private Builder() {}
+
+        public Builder from(ExternalExample other) {
+            checkNotBuilt();
+            externalLong(other.getExternalLong());
+            optionalExternal(other.getOptionalExternal());
+            return this;
+        }
+
+        @JsonSetter("externalLong")
+        public Builder externalLong(long externalLong) {
+            checkNotBuilt();
+            this.externalLong = externalLong;
+            this._externalLongInitialized = true;
+            return this;
+        }
+
+        @JsonSetter(value = "optionalExternal", nulls = Nulls.SKIP)
+        public Builder optionalExternal(@Nonnull Optional<? extends Long> optionalExternal) {
+            checkNotBuilt();
+            this.optionalExternal = Preconditions.checkNotNull(optionalExternal, "optionalExternal cannot be null")
+                    .map(Function.identity());
+            return this;
+        }
+
+        public Builder optionalExternal(long optionalExternal) {
+            checkNotBuilt();
+            this.optionalExternal =
+                    Optional.of(Preconditions.checkNotNull(optionalExternal, "optionalExternal cannot be null"));
+            return this;
+        }
+
+        private void validatePrimitiveFieldsHaveBeenInitialized() {
+            List<String> missingFields = null;
+            missingFields = addFieldIfMissing(missingFields, _externalLongInitialized, "externalLong");
+            if (missingFields != null) {
+                throw new SafeIllegalArgumentException(
+                        "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
+            }
+        }
+
+        private static List<String> addFieldIfMissing(List<String> prev, boolean initialized, String fieldName) {
+            List<String> missingFields = prev;
+            if (!initialized) {
+                if (missingFields == null) {
+                    missingFields = new ArrayList<>(1);
+                }
+                missingFields.add(fieldName);
+            }
+            return missingFields;
+        }
+
+        @CheckReturnValue
+        public ExternalExample build() {
+            checkNotBuilt();
+            this._buildInvoked = true;
+            validatePrimitiveFieldsHaveBeenInitialized();
+            return new ExternalExample(externalLong, optionalExternal);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/NestedAlias.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/NestedAlias.java
@@ -1,0 +1,52 @@
+package errors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@Safe
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class NestedAlias {
+    private final StringAliasEx value;
+
+    private NestedAlias(@Nonnull StringAliasEx value) {
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
+    }
+
+    @JsonValue
+    public StringAliasEx get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof NestedAlias && equalTo((NestedAlias) other));
+    }
+
+    private boolean equalTo(NestedAlias other) {
+        return this.value.equals(other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.value.hashCode();
+    }
+
+    public static NestedAlias valueOf(@Safe String value) {
+        return of(StringAliasEx.valueOf(value));
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static NestedAlias of(@Nonnull StringAliasEx value) {
+        return new NestedAlias(value);
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/NestedCollectionExample.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/NestedCollectionExample.java
@@ -1,0 +1,226 @@
+package errors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.errorprone.annotations.CheckReturnValue;
+import com.palantir.conjure.java.lib.internal.ConjureCollections;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@JsonDeserialize(builder = NestedCollectionExample.Builder.class)
+@Generated("com.palantir.conjure.java.types.BeanGenerator")
+public final class NestedCollectionExample {
+    private final List<List<String>> nestedList;
+
+    private final Map<String, Map<String, String>> nestedMap;
+
+    private final Map<String, List<ObjectReference>> mixedCollection;
+
+    private int memoizedHashCode;
+
+    private NestedCollectionExample(
+            List<List<String>> nestedList,
+            Map<String, Map<String, String>> nestedMap,
+            Map<String, List<ObjectReference>> mixedCollection) {
+        validateFields(nestedList, nestedMap, mixedCollection);
+        this.nestedList = ConjureCollections.unmodifiableList(nestedList);
+        this.nestedMap = Collections.unmodifiableMap(nestedMap);
+        this.mixedCollection = Collections.unmodifiableMap(mixedCollection);
+    }
+
+    @JsonProperty("nestedList")
+    public List<List<String>> getNestedList() {
+        return this.nestedList;
+    }
+
+    @JsonProperty("nestedMap")
+    public Map<String, Map<String, String>> getNestedMap() {
+        return this.nestedMap;
+    }
+
+    @JsonProperty("mixedCollection")
+    public Map<String, List<ObjectReference>> getMixedCollection() {
+        return this.mixedCollection;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof NestedCollectionExample && equalTo((NestedCollectionExample) other));
+    }
+
+    private boolean equalTo(NestedCollectionExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.nestedList.equals(other.nestedList)
+                && this.nestedMap.equals(other.nestedMap)
+                && this.mixedCollection.equals(other.mixedCollection);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = memoizedHashCode;
+        if (result == 0) {
+            int hash = 1;
+            hash = 31 * hash + this.nestedList.hashCode();
+            hash = 31 * hash + this.nestedMap.hashCode();
+            hash = 31 * hash + this.mixedCollection.hashCode();
+            result = hash;
+            memoizedHashCode = result;
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "NestedCollectionExample{nestedList: " + nestedList + ", nestedMap: " + nestedMap + ", mixedCollection: "
+                + mixedCollection + '}';
+    }
+
+    public static NestedCollectionExample of(
+            List<List<String>> nestedList,
+            Map<String, Map<String, String>> nestedMap,
+            Map<String, List<ObjectReference>> mixedCollection) {
+        return builder()
+                .nestedList(nestedList)
+                .nestedMap(nestedMap)
+                .mixedCollection(mixedCollection)
+                .build();
+    }
+
+    private static void validateFields(
+            List<List<String>> nestedList,
+            Map<String, Map<String, String>> nestedMap,
+            Map<String, List<ObjectReference>> mixedCollection) {
+        List<String> missingFields = null;
+        missingFields = addFieldIfMissing(missingFields, nestedList, "nestedList");
+        missingFields = addFieldIfMissing(missingFields, nestedMap, "nestedMap");
+        missingFields = addFieldIfMissing(missingFields, mixedCollection, "mixedCollection");
+        if (missingFields != null) {
+            throw new SafeIllegalArgumentException(
+                    "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
+        }
+    }
+
+    private static List<String> addFieldIfMissing(List<String> prev, Object fieldValue, String fieldName) {
+        List<String> missingFields = prev;
+        if (fieldValue == null) {
+            if (missingFields == null) {
+                missingFields = new ArrayList<>(3);
+            }
+            missingFields.add(fieldName);
+        }
+        return missingFields;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder {
+        boolean _buildInvoked;
+
+        private List<List<String>> nestedList = ConjureCollections.newList();
+
+        private Map<String, Map<String, String>> nestedMap = new LinkedHashMap<>();
+
+        private Map<String, List<ObjectReference>> mixedCollection = new LinkedHashMap<>();
+
+        private Builder() {}
+
+        public Builder from(NestedCollectionExample other) {
+            checkNotBuilt();
+            nestedList(other.getNestedList());
+            nestedMap(other.getNestedMap());
+            mixedCollection(other.getMixedCollection());
+            return this;
+        }
+
+        @JsonSetter(value = "nestedList", nulls = Nulls.SKIP)
+        public Builder nestedList(@Nonnull Iterable<? extends List<String>> nestedList) {
+            checkNotBuilt();
+            this.nestedList =
+                    ConjureCollections.newList(Preconditions.checkNotNull(nestedList, "nestedList cannot be null"));
+            return this;
+        }
+
+        public Builder addAllNestedList(@Nonnull Iterable<? extends List<String>> nestedList) {
+            checkNotBuilt();
+            ConjureCollections.addAll(
+                    this.nestedList, Preconditions.checkNotNull(nestedList, "nestedList cannot be null"));
+            return this;
+        }
+
+        public Builder nestedList(List<String> nestedList) {
+            checkNotBuilt();
+            this.nestedList.add(nestedList);
+            return this;
+        }
+
+        @JsonSetter(value = "nestedMap", nulls = Nulls.SKIP)
+        public Builder nestedMap(@Nonnull Map<String, Map<String, String>> nestedMap) {
+            checkNotBuilt();
+            this.nestedMap = new LinkedHashMap<>(Preconditions.checkNotNull(nestedMap, "nestedMap cannot be null"));
+            return this;
+        }
+
+        public Builder putAllNestedMap(@Nonnull Map<String, Map<String, String>> nestedMap) {
+            checkNotBuilt();
+            this.nestedMap.putAll(Preconditions.checkNotNull(nestedMap, "nestedMap cannot be null"));
+            return this;
+        }
+
+        public Builder nestedMap(String key, Map<String, String> value) {
+            checkNotBuilt();
+            this.nestedMap.put(key, value);
+            return this;
+        }
+
+        @JsonSetter(value = "mixedCollection", nulls = Nulls.SKIP)
+        public Builder mixedCollection(@Nonnull Map<String, List<ObjectReference>> mixedCollection) {
+            checkNotBuilt();
+            this.mixedCollection =
+                    new LinkedHashMap<>(Preconditions.checkNotNull(mixedCollection, "mixedCollection cannot be null"));
+            return this;
+        }
+
+        public Builder putAllMixedCollection(@Nonnull Map<String, List<ObjectReference>> mixedCollection) {
+            checkNotBuilt();
+            this.mixedCollection.putAll(Preconditions.checkNotNull(mixedCollection, "mixedCollection cannot be null"));
+            return this;
+        }
+
+        public Builder mixedCollection(String key, List<ObjectReference> value) {
+            checkNotBuilt();
+            this.mixedCollection.put(key, value);
+            return this;
+        }
+
+        @CheckReturnValue
+        public NestedCollectionExample build() {
+            checkNotBuilt();
+            this._buildInvoked = true;
+            return new NestedCollectionExample(nestedList, nestedMap, mixedCollection);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/ObjectReference.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/ObjectReference.java
@@ -1,0 +1,169 @@
+package errors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.errorprone.annotations.CheckReturnValue;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@JsonDeserialize(builder = ObjectReference.Builder.class)
+@Generated("com.palantir.conjure.java.types.BeanGenerator")
+public final class ObjectReference {
+    private final String name;
+
+    private final int value;
+
+    private int memoizedHashCode;
+
+    private ObjectReference(String name, int value) {
+        validateFields(name);
+        this.name = name;
+        this.value = value;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return this.name;
+    }
+
+    @JsonProperty("value")
+    public int getValue() {
+        return this.value;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof ObjectReference && equalTo((ObjectReference) other));
+    }
+
+    private boolean equalTo(ObjectReference other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.name.equals(other.name) && this.value == other.value;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = memoizedHashCode;
+        if (result == 0) {
+            int hash = 1;
+            hash = 31 * hash + this.name.hashCode();
+            hash = 31 * hash + this.value;
+            result = hash;
+            memoizedHashCode = result;
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ObjectReference{name: " + name + ", value: " + value + '}';
+    }
+
+    public static ObjectReference of(String name, int value) {
+        return builder().name(name).value(value).build();
+    }
+
+    private static void validateFields(String name) {
+        List<String> missingFields = null;
+        missingFields = addFieldIfMissing(missingFields, name, "name");
+        if (missingFields != null) {
+            throw new SafeIllegalArgumentException(
+                    "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
+        }
+    }
+
+    private static List<String> addFieldIfMissing(List<String> prev, Object fieldValue, String fieldName) {
+        List<String> missingFields = prev;
+        if (fieldValue == null) {
+            if (missingFields == null) {
+                missingFields = new ArrayList<>(1);
+            }
+            missingFields.add(fieldName);
+        }
+        return missingFields;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder {
+        boolean _buildInvoked;
+
+        private String name;
+
+        private int value;
+
+        private boolean _valueInitialized = false;
+
+        private Builder() {}
+
+        public Builder from(ObjectReference other) {
+            checkNotBuilt();
+            name(other.getName());
+            value(other.getValue());
+            return this;
+        }
+
+        @JsonSetter("name")
+        public Builder name(@Nonnull String name) {
+            checkNotBuilt();
+            this.name = Preconditions.checkNotNull(name, "name cannot be null");
+            return this;
+        }
+
+        @JsonSetter("value")
+        public Builder value(int value) {
+            checkNotBuilt();
+            this.value = value;
+            this._valueInitialized = true;
+            return this;
+        }
+
+        private void validatePrimitiveFieldsHaveBeenInitialized() {
+            List<String> missingFields = null;
+            missingFields = addFieldIfMissing(missingFields, _valueInitialized, "value");
+            if (missingFields != null) {
+                throw new SafeIllegalArgumentException(
+                        "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
+            }
+        }
+
+        private static List<String> addFieldIfMissing(List<String> prev, boolean initialized, String fieldName) {
+            List<String> missingFields = prev;
+            if (!initialized) {
+                if (missingFields == null) {
+                    missingFields = new ArrayList<>(1);
+                }
+                missingFields.add(fieldName);
+            }
+            return missingFields;
+        }
+
+        @CheckReturnValue
+        public ObjectReference build() {
+            checkNotBuilt();
+            this._buildInvoked = true;
+            validatePrimitiveFieldsHaveBeenInitialized();
+            return new ObjectReference(name, value);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/OptionalAlias.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/OptionalAlias.java
@@ -1,0 +1,60 @@
+package errors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@Safe
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class OptionalAlias {
+    private static final OptionalAlias EMPTY = new OptionalAlias();
+
+    private final Optional<@Safe String> value;
+
+    private OptionalAlias(@Nonnull Optional<@Safe String> value) {
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
+    }
+
+    private OptionalAlias() {
+        this(Optional.empty());
+    }
+
+    @JsonValue
+    public Optional<@Safe String> get() {
+        return value;
+    }
+
+    @Override
+    @Safe
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof OptionalAlias && equalTo((OptionalAlias) other));
+    }
+
+    private boolean equalTo(OptionalAlias other) {
+        return this.value.equals(other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.value.hashCode();
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static OptionalAlias of(@Nonnull Optional<@Safe String> value) {
+        return new OptionalAlias(value);
+    }
+
+    public static OptionalAlias empty() {
+        return EMPTY;
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/OptionalExample.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/OptionalExample.java
@@ -1,0 +1,210 @@
+package errors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.errorprone.annotations.CheckReturnValue;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@JsonDeserialize(builder = OptionalExample.Builder.class)
+@Generated("com.palantir.conjure.java.types.BeanGenerator")
+public final class OptionalExample {
+    private final Optional<String> optionalString;
+
+    private final Optional<ObjectReference> optionalObject;
+
+    private final Optional<List<String>> optionalCollection;
+
+    private int memoizedHashCode;
+
+    private OptionalExample(
+            Optional<String> optionalString,
+            Optional<ObjectReference> optionalObject,
+            Optional<List<String>> optionalCollection) {
+        validateFields(optionalString, optionalObject, optionalCollection);
+        this.optionalString = optionalString;
+        this.optionalObject = optionalObject;
+        this.optionalCollection = optionalCollection;
+    }
+
+    @JsonProperty("optionalString")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Optional<String> getOptionalString() {
+        return this.optionalString;
+    }
+
+    @JsonProperty("optionalObject")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Optional<ObjectReference> getOptionalObject() {
+        return this.optionalObject;
+    }
+
+    @JsonProperty("optionalCollection")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Optional<List<String>> getOptionalCollection() {
+        return this.optionalCollection;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof OptionalExample && equalTo((OptionalExample) other));
+    }
+
+    private boolean equalTo(OptionalExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.optionalString.equals(other.optionalString)
+                && this.optionalObject.equals(other.optionalObject)
+                && this.optionalCollection.equals(other.optionalCollection);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = memoizedHashCode;
+        if (result == 0) {
+            int hash = 1;
+            hash = 31 * hash + this.optionalString.hashCode();
+            hash = 31 * hash + this.optionalObject.hashCode();
+            hash = 31 * hash + this.optionalCollection.hashCode();
+            result = hash;
+            memoizedHashCode = result;
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "OptionalExample{optionalString: " + optionalString + ", optionalObject: " + optionalObject
+                + ", optionalCollection: " + optionalCollection + '}';
+    }
+
+    public static OptionalExample of(
+            String optionalString, ObjectReference optionalObject, List<String> optionalCollection) {
+        return builder()
+                .optionalString(Optional.of(optionalString))
+                .optionalObject(Optional.of(optionalObject))
+                .optionalCollection(Optional.of(optionalCollection))
+                .build();
+    }
+
+    private static void validateFields(
+            Optional<String> optionalString,
+            Optional<ObjectReference> optionalObject,
+            Optional<List<String>> optionalCollection) {
+        List<String> missingFields = null;
+        missingFields = addFieldIfMissing(missingFields, optionalString, "optionalString");
+        missingFields = addFieldIfMissing(missingFields, optionalObject, "optionalObject");
+        missingFields = addFieldIfMissing(missingFields, optionalCollection, "optionalCollection");
+        if (missingFields != null) {
+            throw new SafeIllegalArgumentException(
+                    "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
+        }
+    }
+
+    private static List<String> addFieldIfMissing(List<String> prev, Object fieldValue, String fieldName) {
+        List<String> missingFields = prev;
+        if (fieldValue == null) {
+            if (missingFields == null) {
+                missingFields = new ArrayList<>(3);
+            }
+            missingFields.add(fieldName);
+        }
+        return missingFields;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder {
+        boolean _buildInvoked;
+
+        private Optional<String> optionalString = Optional.empty();
+
+        private Optional<ObjectReference> optionalObject = Optional.empty();
+
+        private Optional<List<String>> optionalCollection = Optional.empty();
+
+        private Builder() {}
+
+        public Builder from(OptionalExample other) {
+            checkNotBuilt();
+            optionalString(other.getOptionalString());
+            optionalObject(other.getOptionalObject());
+            optionalCollection(other.getOptionalCollection());
+            return this;
+        }
+
+        @JsonSetter(value = "optionalString", nulls = Nulls.SKIP)
+        public Builder optionalString(@Nonnull Optional<String> optionalString) {
+            checkNotBuilt();
+            this.optionalString = Preconditions.checkNotNull(optionalString, "optionalString cannot be null");
+            return this;
+        }
+
+        public Builder optionalString(@Nonnull String optionalString) {
+            checkNotBuilt();
+            this.optionalString =
+                    Optional.of(Preconditions.checkNotNull(optionalString, "optionalString cannot be null"));
+            return this;
+        }
+
+        @JsonSetter(value = "optionalObject", nulls = Nulls.SKIP)
+        public Builder optionalObject(@Nonnull Optional<ObjectReference> optionalObject) {
+            checkNotBuilt();
+            this.optionalObject = Preconditions.checkNotNull(optionalObject, "optionalObject cannot be null");
+            return this;
+        }
+
+        public Builder optionalObject(@Nonnull ObjectReference optionalObject) {
+            checkNotBuilt();
+            this.optionalObject =
+                    Optional.of(Preconditions.checkNotNull(optionalObject, "optionalObject cannot be null"));
+            return this;
+        }
+
+        @JsonSetter(value = "optionalCollection", nulls = Nulls.SKIP)
+        public Builder optionalCollection(@Nonnull Optional<? extends List<String>> optionalCollection) {
+            checkNotBuilt();
+            this.optionalCollection = Preconditions.checkNotNull(
+                            optionalCollection, "optionalCollection cannot be null")
+                    .map(Function.identity());
+            return this;
+        }
+
+        public Builder optionalCollection(@Nonnull List<String> optionalCollection) {
+            checkNotBuilt();
+            this.optionalCollection =
+                    Optional.of(Preconditions.checkNotNull(optionalCollection, "optionalCollection cannot be null"));
+            return this;
+        }
+
+        @CheckReturnValue
+        public OptionalExample build() {
+            checkNotBuilt();
+            this._buildInvoked = true;
+            return new OptionalExample(optionalString, optionalObject, optionalCollection);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/PrimitiveExample.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/PrimitiveExample.java
@@ -1,0 +1,342 @@
+package errors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.errorprone.annotations.CheckReturnValue;
+import com.palantir.conjure.java.lib.Bytes;
+import com.palantir.conjure.java.lib.SafeLong;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.ri.ResourceIdentifier;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@JsonDeserialize(builder = PrimitiveExample.Builder.class)
+@Generated("com.palantir.conjure.java.types.BeanGenerator")
+public final class PrimitiveExample {
+    private final String stringVal;
+
+    private final int intVal;
+
+    private final SafeLong longVal;
+
+    private final double doubleVal;
+
+    private final boolean boolVal;
+
+    private final ResourceIdentifier ridVal;
+
+    private final UUID uuidVal;
+
+    private final OffsetDateTime datetimeVal;
+
+    private final Bytes binaryVal;
+
+    private int memoizedHashCode;
+
+    private PrimitiveExample(
+            String stringVal,
+            int intVal,
+            SafeLong longVal,
+            double doubleVal,
+            boolean boolVal,
+            ResourceIdentifier ridVal,
+            UUID uuidVal,
+            OffsetDateTime datetimeVal,
+            Bytes binaryVal) {
+        validateFields(stringVal, longVal, ridVal, uuidVal, datetimeVal, binaryVal);
+        this.stringVal = stringVal;
+        this.intVal = intVal;
+        this.longVal = longVal;
+        this.doubleVal = doubleVal;
+        this.boolVal = boolVal;
+        this.ridVal = ridVal;
+        this.uuidVal = uuidVal;
+        this.datetimeVal = datetimeVal;
+        this.binaryVal = binaryVal;
+    }
+
+    @JsonProperty("stringVal")
+    public String getStringVal() {
+        return this.stringVal;
+    }
+
+    @JsonProperty("intVal")
+    public int getIntVal() {
+        return this.intVal;
+    }
+
+    @JsonProperty("longVal")
+    public SafeLong getLongVal() {
+        return this.longVal;
+    }
+
+    @JsonProperty("doubleVal")
+    public double getDoubleVal() {
+        return this.doubleVal;
+    }
+
+    @JsonProperty("boolVal")
+    public boolean getBoolVal() {
+        return this.boolVal;
+    }
+
+    @JsonProperty("ridVal")
+    public ResourceIdentifier getRidVal() {
+        return this.ridVal;
+    }
+
+    @JsonProperty("uuidVal")
+    public UUID getUuidVal() {
+        return this.uuidVal;
+    }
+
+    @JsonProperty("datetimeVal")
+    public OffsetDateTime getDatetimeVal() {
+        return this.datetimeVal;
+    }
+
+    @JsonProperty("binaryVal")
+    public Bytes getBinaryVal() {
+        return this.binaryVal;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof PrimitiveExample && equalTo((PrimitiveExample) other));
+    }
+
+    private boolean equalTo(PrimitiveExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.stringVal.equals(other.stringVal)
+                && this.intVal == other.intVal
+                && this.longVal.equals(other.longVal)
+                && Double.doubleToLongBits(this.doubleVal) == Double.doubleToLongBits(other.doubleVal)
+                && this.boolVal == other.boolVal
+                && this.ridVal.equals(other.ridVal)
+                && this.uuidVal.equals(other.uuidVal)
+                && this.datetimeVal.isEqual(other.datetimeVal)
+                && this.binaryVal.equals(other.binaryVal);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = memoizedHashCode;
+        if (result == 0) {
+            int hash = 1;
+            hash = 31 * hash + this.stringVal.hashCode();
+            hash = 31 * hash + this.intVal;
+            hash = 31 * hash + this.longVal.hashCode();
+            hash = 31 * hash + Double.hashCode(this.doubleVal);
+            hash = 31 * hash + Boolean.hashCode(this.boolVal);
+            hash = 31 * hash + this.ridVal.hashCode();
+            hash = 31 * hash + this.uuidVal.hashCode();
+            hash = 31 * hash + this.datetimeVal.toInstant().hashCode();
+            hash = 31 * hash + this.binaryVal.hashCode();
+            result = hash;
+            memoizedHashCode = result;
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "PrimitiveExample{stringVal: " + stringVal + ", intVal: " + intVal + ", longVal: " + longVal
+                + ", doubleVal: " + doubleVal + ", boolVal: " + boolVal + ", ridVal: " + ridVal + ", uuidVal: "
+                + uuidVal + ", datetimeVal: " + datetimeVal + ", binaryVal: " + binaryVal + '}';
+    }
+
+    private static void validateFields(
+            String stringVal,
+            SafeLong longVal,
+            ResourceIdentifier ridVal,
+            UUID uuidVal,
+            OffsetDateTime datetimeVal,
+            Bytes binaryVal) {
+        List<String> missingFields = null;
+        missingFields = addFieldIfMissing(missingFields, stringVal, "stringVal");
+        missingFields = addFieldIfMissing(missingFields, longVal, "longVal");
+        missingFields = addFieldIfMissing(missingFields, ridVal, "ridVal");
+        missingFields = addFieldIfMissing(missingFields, uuidVal, "uuidVal");
+        missingFields = addFieldIfMissing(missingFields, datetimeVal, "datetimeVal");
+        missingFields = addFieldIfMissing(missingFields, binaryVal, "binaryVal");
+        if (missingFields != null) {
+            throw new SafeIllegalArgumentException(
+                    "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
+        }
+    }
+
+    private static List<String> addFieldIfMissing(List<String> prev, Object fieldValue, String fieldName) {
+        List<String> missingFields = prev;
+        if (fieldValue == null) {
+            if (missingFields == null) {
+                missingFields = new ArrayList<>(6);
+            }
+            missingFields.add(fieldName);
+        }
+        return missingFields;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder {
+        boolean _buildInvoked;
+
+        private String stringVal;
+
+        private int intVal;
+
+        private SafeLong longVal;
+
+        private double doubleVal;
+
+        private boolean boolVal;
+
+        private ResourceIdentifier ridVal;
+
+        private UUID uuidVal;
+
+        private OffsetDateTime datetimeVal;
+
+        private Bytes binaryVal;
+
+        private boolean _intValInitialized = false;
+
+        private boolean _doubleValInitialized = false;
+
+        private boolean _boolValInitialized = false;
+
+        private Builder() {}
+
+        public Builder from(PrimitiveExample other) {
+            checkNotBuilt();
+            stringVal(other.getStringVal());
+            intVal(other.getIntVal());
+            longVal(other.getLongVal());
+            doubleVal(other.getDoubleVal());
+            boolVal(other.getBoolVal());
+            ridVal(other.getRidVal());
+            uuidVal(other.getUuidVal());
+            datetimeVal(other.getDatetimeVal());
+            binaryVal(other.getBinaryVal());
+            return this;
+        }
+
+        @JsonSetter("stringVal")
+        public Builder stringVal(@Nonnull String stringVal) {
+            checkNotBuilt();
+            this.stringVal = Preconditions.checkNotNull(stringVal, "stringVal cannot be null");
+            return this;
+        }
+
+        @JsonSetter("intVal")
+        public Builder intVal(int intVal) {
+            checkNotBuilt();
+            this.intVal = intVal;
+            this._intValInitialized = true;
+            return this;
+        }
+
+        @JsonSetter("longVal")
+        public Builder longVal(@Nonnull SafeLong longVal) {
+            checkNotBuilt();
+            this.longVal = Preconditions.checkNotNull(longVal, "longVal cannot be null");
+            return this;
+        }
+
+        @JsonSetter("doubleVal")
+        public Builder doubleVal(double doubleVal) {
+            checkNotBuilt();
+            this.doubleVal = doubleVal;
+            this._doubleValInitialized = true;
+            return this;
+        }
+
+        @JsonSetter("boolVal")
+        public Builder boolVal(boolean boolVal) {
+            checkNotBuilt();
+            this.boolVal = boolVal;
+            this._boolValInitialized = true;
+            return this;
+        }
+
+        @JsonSetter("ridVal")
+        public Builder ridVal(@Nonnull ResourceIdentifier ridVal) {
+            checkNotBuilt();
+            this.ridVal = Preconditions.checkNotNull(ridVal, "ridVal cannot be null");
+            return this;
+        }
+
+        @JsonSetter("uuidVal")
+        public Builder uuidVal(@Nonnull UUID uuidVal) {
+            checkNotBuilt();
+            this.uuidVal = Preconditions.checkNotNull(uuidVal, "uuidVal cannot be null");
+            return this;
+        }
+
+        @JsonSetter("datetimeVal")
+        public Builder datetimeVal(@Nonnull OffsetDateTime datetimeVal) {
+            checkNotBuilt();
+            this.datetimeVal = Preconditions.checkNotNull(datetimeVal, "datetimeVal cannot be null");
+            return this;
+        }
+
+        @JsonSetter("binaryVal")
+        public Builder binaryVal(@Nonnull Bytes binaryVal) {
+            checkNotBuilt();
+            this.binaryVal = Preconditions.checkNotNull(binaryVal, "binaryVal cannot be null");
+            return this;
+        }
+
+        private void validatePrimitiveFieldsHaveBeenInitialized() {
+            List<String> missingFields = null;
+            missingFields = addFieldIfMissing(missingFields, _intValInitialized, "intVal");
+            missingFields = addFieldIfMissing(missingFields, _doubleValInitialized, "doubleVal");
+            missingFields = addFieldIfMissing(missingFields, _boolValInitialized, "boolVal");
+            if (missingFields != null) {
+                throw new SafeIllegalArgumentException(
+                        "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
+            }
+        }
+
+        private static List<String> addFieldIfMissing(List<String> prev, boolean initialized, String fieldName) {
+            List<String> missingFields = prev;
+            if (!initialized) {
+                if (missingFields == null) {
+                    missingFields = new ArrayList<>(3);
+                }
+                missingFields.add(fieldName);
+            }
+            return missingFields;
+        }
+
+        @CheckReturnValue
+        public PrimitiveExample build() {
+            checkNotBuilt();
+            this._buildInvoked = true;
+            validatePrimitiveFieldsHaveBeenInitialized();
+            return new PrimitiveExample(
+                    stringVal, intVal, longVal, doubleVal, boolVal, ridVal, uuidVal, datetimeVal, binaryVal);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/SafetyExample.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/SafetyExample.java
@@ -1,0 +1,176 @@
+package errors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.errorprone.annotations.CheckReturnValue;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.Unsafe;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@Unsafe
+@JsonDeserialize(builder = SafetyExample.Builder.class)
+@Generated("com.palantir.conjure.java.types.BeanGenerator")
+public final class SafetyExample {
+    private final String safeString;
+
+    private final double unsafeDouble;
+
+    private int memoizedHashCode;
+
+    private SafetyExample(String safeString, double unsafeDouble) {
+        validateFields(safeString);
+        this.safeString = safeString;
+        this.unsafeDouble = unsafeDouble;
+    }
+
+    @JsonProperty("safeString")
+    @Safe
+    public String getSafeString() {
+        return this.safeString;
+    }
+
+    @JsonProperty("unsafeDouble")
+    @Unsafe
+    public double getUnsafeDouble() {
+        return this.unsafeDouble;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof SafetyExample && equalTo((SafetyExample) other));
+    }
+
+    private boolean equalTo(SafetyExample other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.safeString.equals(other.safeString)
+                && Double.doubleToLongBits(this.unsafeDouble) == Double.doubleToLongBits(other.unsafeDouble);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = memoizedHashCode;
+        if (result == 0) {
+            int hash = 1;
+            hash = 31 * hash + this.safeString.hashCode();
+            hash = 31 * hash + Double.hashCode(this.unsafeDouble);
+            result = hash;
+            memoizedHashCode = result;
+        }
+        return result;
+    }
+
+    @Override
+    @Unsafe
+    public String toString() {
+        return "SafetyExample{safeString: " + safeString + ", unsafeDouble: " + unsafeDouble + '}';
+    }
+
+    public static SafetyExample of(@Safe String safeString, @Unsafe double unsafeDouble) {
+        return builder().safeString(safeString).unsafeDouble(unsafeDouble).build();
+    }
+
+    private static void validateFields(String safeString) {
+        List<String> missingFields = null;
+        missingFields = addFieldIfMissing(missingFields, safeString, "safeString");
+        if (missingFields != null) {
+            throw new SafeIllegalArgumentException(
+                    "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
+        }
+    }
+
+    private static List<String> addFieldIfMissing(List<String> prev, Object fieldValue, String fieldName) {
+        List<String> missingFields = prev;
+        if (fieldValue == null) {
+            if (missingFields == null) {
+                missingFields = new ArrayList<>(1);
+            }
+            missingFields.add(fieldName);
+        }
+        return missingFields;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder {
+        boolean _buildInvoked;
+
+        private @Safe String safeString;
+
+        private @Unsafe double unsafeDouble;
+
+        private boolean _unsafeDoubleInitialized = false;
+
+        private Builder() {}
+
+        public Builder from(SafetyExample other) {
+            checkNotBuilt();
+            safeString(other.getSafeString());
+            unsafeDouble(other.getUnsafeDouble());
+            return this;
+        }
+
+        @JsonSetter("safeString")
+        public Builder safeString(@Nonnull @Safe String safeString) {
+            checkNotBuilt();
+            this.safeString = Preconditions.checkNotNull(safeString, "safeString cannot be null");
+            return this;
+        }
+
+        @JsonSetter("unsafeDouble")
+        public Builder unsafeDouble(@Unsafe double unsafeDouble) {
+            checkNotBuilt();
+            this.unsafeDouble = unsafeDouble;
+            this._unsafeDoubleInitialized = true;
+            return this;
+        }
+
+        private void validatePrimitiveFieldsHaveBeenInitialized() {
+            List<String> missingFields = null;
+            missingFields = addFieldIfMissing(missingFields, _unsafeDoubleInitialized, "unsafeDouble");
+            if (missingFields != null) {
+                throw new SafeIllegalArgumentException(
+                        "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
+            }
+        }
+
+        private static List<String> addFieldIfMissing(List<String> prev, boolean initialized, String fieldName) {
+            List<String> missingFields = prev;
+            if (!initialized) {
+                if (missingFields == null) {
+                    missingFields = new ArrayList<>(1);
+                }
+                missingFields.add(fieldName);
+            }
+            return missingFields;
+        }
+
+        @CheckReturnValue
+        public SafetyExample build() {
+            checkNotBuilt();
+            this._buildInvoked = true;
+            validatePrimitiveFieldsHaveBeenInitialized();
+            return new SafetyExample(safeString, unsafeDouble);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/StringAliasEx.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/StringAliasEx.java
@@ -1,0 +1,58 @@
+package errors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@Safe
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class StringAliasEx implements Comparable<StringAliasEx> {
+    private final @Safe String value;
+
+    private StringAliasEx(@Nonnull @Safe String value) {
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
+    }
+
+    @JsonValue
+    public @Safe String get() {
+        return value;
+    }
+
+    @Override
+    @Safe
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof StringAliasEx && equalTo((StringAliasEx) other));
+    }
+
+    private boolean equalTo(StringAliasEx other) {
+        return this.value.equals(other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.value.hashCode();
+    }
+
+    @Override
+    public int compareTo(StringAliasEx other) {
+        return value.compareTo(other.get());
+    }
+
+    public static StringAliasEx valueOf(@Safe String value) {
+        return of(value);
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static StringAliasEx of(@Nonnull @Safe String value) {
+        return new StringAliasEx(value);
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/UnionExample.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/UnionExample.java
@@ -1,0 +1,579 @@
+package errors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.types.UnionGenerator")
+public final class UnionExample {
+    private final Base value;
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    private UnionExample(Base value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    private Base getValue() {
+        return value;
+    }
+
+    public static UnionExample stringVariant(String value) {
+        return new UnionExample(new StringVariantWrapper(value));
+    }
+
+    public static UnionExample intVariant(int value) {
+        return new UnionExample(new IntVariantWrapper(value));
+    }
+
+    public static UnionExample objectVariant(ObjectReference value) {
+        return new UnionExample(new ObjectVariantWrapper(value));
+    }
+
+    public static UnionExample collectionVariant(List<String> value) {
+        return new UnionExample(new CollectionVariantWrapper(value));
+    }
+
+    public static UnionExample optionalVariant(Optional<String> value) {
+        return new UnionExample(new OptionalVariantWrapper(value));
+    }
+
+    public static UnionExample unknown(@Safe String type, Object value) {
+        switch (Preconditions.checkNotNull(type, "Type is required")) {
+            case "stringVariant":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: stringVariant");
+            case "intVariant":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: intVariant");
+            case "objectVariant":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: objectVariant");
+            case "collectionVariant":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: collectionVariant");
+            case "optionalVariant":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: optionalVariant");
+            default:
+                return new UnionExample(new UnknownWrapper(type, Collections.singletonMap(type, value)));
+        }
+    }
+
+    public <T> T accept(Visitor<T> visitor) {
+        return value.accept(visitor);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof UnionExample && equalTo((UnionExample) other));
+    }
+
+    private boolean equalTo(UnionExample other) {
+        return this.value.equals(other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.value.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "UnionExample{value: " + value + '}';
+    }
+
+    public interface Visitor<T> {
+        T visitStringVariant(String value);
+
+        T visitIntVariant(int value);
+
+        T visitObjectVariant(ObjectReference value);
+
+        T visitCollectionVariant(List<String> value);
+
+        T visitOptionalVariant(Optional<String> value);
+
+        T visitUnknown(@Safe String unknownType);
+
+        static <T> CollectionVariantStageVisitorBuilder<T> builder() {
+            return new VisitorBuilder<T>();
+        }
+    }
+
+    private static final class VisitorBuilder<T>
+            implements CollectionVariantStageVisitorBuilder<T>,
+                    IntVariantStageVisitorBuilder<T>,
+                    ObjectVariantStageVisitorBuilder<T>,
+                    OptionalVariantStageVisitorBuilder<T>,
+                    StringVariantStageVisitorBuilder<T>,
+                    UnknownStageVisitorBuilder<T>,
+                    Completed_StageVisitorBuilder<T> {
+        private Function<List<String>, T> collectionVariantVisitor;
+
+        private IntFunction<T> intVariantVisitor;
+
+        private Function<ObjectReference, T> objectVariantVisitor;
+
+        private Function<Optional<String>, T> optionalVariantVisitor;
+
+        private Function<String, T> stringVariantVisitor;
+
+        private Function<String, T> unknownVisitor;
+
+        @Override
+        public IntVariantStageVisitorBuilder<T> collectionVariant(
+                @Nonnull Function<List<String>, T> collectionVariantVisitor) {
+            Preconditions.checkNotNull(collectionVariantVisitor, "collectionVariantVisitor cannot be null");
+            this.collectionVariantVisitor = collectionVariantVisitor;
+            return this;
+        }
+
+        @Override
+        public ObjectVariantStageVisitorBuilder<T> intVariant(@Nonnull IntFunction<T> intVariantVisitor) {
+            Preconditions.checkNotNull(intVariantVisitor, "intVariantVisitor cannot be null");
+            this.intVariantVisitor = intVariantVisitor;
+            return this;
+        }
+
+        @Override
+        public OptionalVariantStageVisitorBuilder<T> objectVariant(
+                @Nonnull Function<ObjectReference, T> objectVariantVisitor) {
+            Preconditions.checkNotNull(objectVariantVisitor, "objectVariantVisitor cannot be null");
+            this.objectVariantVisitor = objectVariantVisitor;
+            return this;
+        }
+
+        @Override
+        public StringVariantStageVisitorBuilder<T> optionalVariant(
+                @Nonnull Function<Optional<String>, T> optionalVariantVisitor) {
+            Preconditions.checkNotNull(optionalVariantVisitor, "optionalVariantVisitor cannot be null");
+            this.optionalVariantVisitor = optionalVariantVisitor;
+            return this;
+        }
+
+        @Override
+        public UnknownStageVisitorBuilder<T> stringVariant(@Nonnull Function<String, T> stringVariantVisitor) {
+            Preconditions.checkNotNull(stringVariantVisitor, "stringVariantVisitor cannot be null");
+            this.stringVariantVisitor = stringVariantVisitor;
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor) {
+            Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
+            this.unknownVisitor = unknownVisitor;
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
+            this.unknownVisitor = unknownType -> {
+                throw new SafeIllegalArgumentException(
+                        "Unknown variant of the 'UnionExample' union", SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
+        public Visitor<T> build() {
+            final Function<List<String>, T> collectionVariantVisitor = this.collectionVariantVisitor;
+            final IntFunction<T> intVariantVisitor = this.intVariantVisitor;
+            final Function<ObjectReference, T> objectVariantVisitor = this.objectVariantVisitor;
+            final Function<Optional<String>, T> optionalVariantVisitor = this.optionalVariantVisitor;
+            final Function<String, T> stringVariantVisitor = this.stringVariantVisitor;
+            final Function<String, T> unknownVisitor = this.unknownVisitor;
+            return new Visitor<T>() {
+                @Override
+                public T visitCollectionVariant(List<String> value) {
+                    return collectionVariantVisitor.apply(value);
+                }
+
+                @Override
+                public T visitIntVariant(int value) {
+                    return intVariantVisitor.apply(value);
+                }
+
+                @Override
+                public T visitObjectVariant(ObjectReference value) {
+                    return objectVariantVisitor.apply(value);
+                }
+
+                @Override
+                public T visitOptionalVariant(Optional<String> value) {
+                    return optionalVariantVisitor.apply(value);
+                }
+
+                @Override
+                public T visitStringVariant(String value) {
+                    return stringVariantVisitor.apply(value);
+                }
+
+                @Override
+                public T visitUnknown(String value) {
+                    return unknownVisitor.apply(value);
+                }
+            };
+        }
+    }
+
+    public interface CollectionVariantStageVisitorBuilder<T> {
+        IntVariantStageVisitorBuilder<T> collectionVariant(@Nonnull Function<List<String>, T> collectionVariantVisitor);
+    }
+
+    public interface IntVariantStageVisitorBuilder<T> {
+        ObjectVariantStageVisitorBuilder<T> intVariant(@Nonnull IntFunction<T> intVariantVisitor);
+    }
+
+    public interface ObjectVariantStageVisitorBuilder<T> {
+        OptionalVariantStageVisitorBuilder<T> objectVariant(@Nonnull Function<ObjectReference, T> objectVariantVisitor);
+    }
+
+    public interface OptionalVariantStageVisitorBuilder<T> {
+        StringVariantStageVisitorBuilder<T> optionalVariant(
+                @Nonnull Function<Optional<String>, T> optionalVariantVisitor);
+    }
+
+    public interface StringVariantStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> stringVariant(@Nonnull Function<String, T> stringVariantVisitor);
+    }
+
+    public interface UnknownStageVisitorBuilder<T> {
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
+    }
+
+    public interface Completed_StageVisitorBuilder<T> {
+        Visitor<T> build();
+    }
+
+    @JsonTypeInfo(
+            use = JsonTypeInfo.Id.NAME,
+            include = JsonTypeInfo.As.EXISTING_PROPERTY,
+            property = "type",
+            visible = true,
+            defaultImpl = UnknownWrapper.class)
+    @JsonSubTypes({
+        @JsonSubTypes.Type(StringVariantWrapper.class),
+        @JsonSubTypes.Type(IntVariantWrapper.class),
+        @JsonSubTypes.Type(ObjectVariantWrapper.class),
+        @JsonSubTypes.Type(CollectionVariantWrapper.class),
+        @JsonSubTypes.Type(OptionalVariantWrapper.class)
+    })
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private interface Base {
+        <T> T accept(Visitor<T> visitor);
+    }
+
+    @JsonTypeName("stringVariant")
+    private static final class StringVariantWrapper implements Base {
+        private final String value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private StringVariantWrapper(@JsonSetter("stringVariant") @Nonnull String value) {
+            Preconditions.checkNotNull(value, "stringVariant cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(value = "type", index = 0)
+        private String getType() {
+            return "stringVariant";
+        }
+
+        @JsonProperty("stringVariant")
+        private String getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitStringVariant(value);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof StringVariantWrapper && equalTo((StringVariantWrapper) other));
+        }
+
+        private boolean equalTo(StringVariantWrapper other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.value.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "StringVariantWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("intVariant")
+    private static final class IntVariantWrapper implements Base {
+        private final int value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private IntVariantWrapper(@JsonSetter("intVariant") @Nonnull int value) {
+            Preconditions.checkNotNull(value, "intVariant cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(value = "type", index = 0)
+        private String getType() {
+            return "intVariant";
+        }
+
+        @JsonProperty("intVariant")
+        private int getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitIntVariant(value);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof IntVariantWrapper && equalTo((IntVariantWrapper) other));
+        }
+
+        private boolean equalTo(IntVariantWrapper other) {
+            return this.value == other.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return this.value;
+        }
+
+        @Override
+        public String toString() {
+            return "IntVariantWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("objectVariant")
+    private static final class ObjectVariantWrapper implements Base {
+        private final ObjectReference value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private ObjectVariantWrapper(@JsonSetter("objectVariant") @Nonnull ObjectReference value) {
+            Preconditions.checkNotNull(value, "objectVariant cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(value = "type", index = 0)
+        private String getType() {
+            return "objectVariant";
+        }
+
+        @JsonProperty("objectVariant")
+        private ObjectReference getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitObjectVariant(value);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof ObjectVariantWrapper && equalTo((ObjectVariantWrapper) other));
+        }
+
+        private boolean equalTo(ObjectVariantWrapper other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.value.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "ObjectVariantWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("collectionVariant")
+    private static final class CollectionVariantWrapper implements Base {
+        private final List<String> value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private CollectionVariantWrapper(
+                @JsonSetter(value = "collectionVariant", nulls = Nulls.AS_EMPTY) @Nonnull List<String> value) {
+            Preconditions.checkNotNull(value, "collectionVariant cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(value = "type", index = 0)
+        private String getType() {
+            return "collectionVariant";
+        }
+
+        @JsonProperty("collectionVariant")
+        private List<String> getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitCollectionVariant(value);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other
+                    || (other instanceof CollectionVariantWrapper && equalTo((CollectionVariantWrapper) other));
+        }
+
+        private boolean equalTo(CollectionVariantWrapper other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.value.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "CollectionVariantWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("optionalVariant")
+    private static final class OptionalVariantWrapper implements Base {
+        private final Optional<String> value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private OptionalVariantWrapper(
+                @JsonSetter(value = "optionalVariant", nulls = Nulls.AS_EMPTY) @Nonnull Optional<String> value) {
+            Preconditions.checkNotNull(value, "optionalVariant cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(value = "type", index = 0)
+        private String getType() {
+            return "optionalVariant";
+        }
+
+        @JsonProperty("optionalVariant")
+        private Optional<String> getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitOptionalVariant(value);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other
+                    || (other instanceof OptionalVariantWrapper && equalTo((OptionalVariantWrapper) other));
+        }
+
+        private boolean equalTo(OptionalVariantWrapper other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.value.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "OptionalVariantWrapper{value: " + value + '}';
+        }
+    }
+
+    private static final class UnknownWrapper implements Base {
+        private final String type;
+
+        private final Map<String, Object> value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private UnknownWrapper(@JsonProperty("type") String type) {
+            this(type, new HashMap<String, Object>());
+        }
+
+        private UnknownWrapper(@Nonnull String type, @Nonnull Map<String, Object> value) {
+            Preconditions.checkNotNull(type, "type cannot be null");
+            Preconditions.checkNotNull(value, "value cannot be null");
+            this.type = type;
+            this.value = value;
+        }
+
+        @JsonProperty
+        private String getType() {
+            return type;
+        }
+
+        @JsonAnyGetter
+        private Map<String, Object> getValue() {
+            return value;
+        }
+
+        @JsonAnySetter
+        private void put(String key, Object val) {
+            value.put(key, val);
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitUnknown(type);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof UnknownWrapper && equalTo((UnknownWrapper) other));
+        }
+
+        private boolean equalTo(UnknownWrapper other) {
+            return this.type.equals(other.type) && this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 1;
+            hash = 31 * hash + this.type.hashCode();
+            hash = 31 * hash + this.value.hashCode();
+            return hash;
+        }
+
+        @Override
+        public String toString() {
+            return "UnknownWrapper{type: " + type + ", value: " + value + '}';
+        }
+    }
+}

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/parameterized/TestCases.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/parameterized/TestCases.java
@@ -159,7 +159,7 @@ public final class TestCases {
                             .excludeEmptyOptionals(true)
                             .jetbrainsContractAnnotations(true)
                             .build())
-                    .generatorTypes(GeneratorType.ERROR)
+                    .generatorTypes(List.of(GeneratorType.ERROR, GeneratorType.OBJECT))
                     .build())
             .add(ParameterizedTestCase.builder()
                     .name("service-vanilla")

--- a/conjure-java-core/src/test/resources/example-errors.yml
+++ b/conjure-java-core/src/test/resources/example-errors.yml
@@ -1,6 +1,91 @@
 types:
+  imports:
+    ExternalLong:
+      base-type: string
+      external:
+        java: java.lang.Long
   definitions:
     default-package: com.palantir.product
+    objects:
+      PrimitiveExample:
+        fields:
+          stringVal: string
+          intVal: integer
+          longVal: safelong
+          doubleVal: double
+          boolVal: boolean
+          ridVal: rid
+          uuidVal: uuid
+          datetimeVal: datetime
+          binaryVal: binary
+          # skipping bearertoken: it's DO_NOT_LOG so it cannot be used anyway.
+      CollectionExample:
+        fields:
+          stringList: list<string>
+          stringSet: set<string>
+          stringMap: map<string, string>
+      NestedCollectionExample:
+        fields:
+          nestedList: list<list<string>>
+          nestedMap: map<string, map<string, string>>
+          mixedCollection: map<string, list<ObjectReference>>
+      OptionalExample:
+        fields:
+          optionalString: optional<string>
+          optionalObject: optional<ObjectReference>
+          optionalCollection: optional<list<string>>
+      ObjectReference:
+        fields:
+          name: string
+          value: integer
+      UnionExample:
+        union:
+          stringVariant: string
+          intVariant: integer
+          objectVariant: ObjectReference
+          collectionVariant: list<string>
+          optionalVariant: optional<string>
+      StringAliasEx:
+        alias: string
+        safety: safe
+      OptionalAlias:
+        alias: optional<string>
+        safety: safe
+      CollectionAlias:
+        alias: list<string>
+      NestedAlias:
+        alias: StringAliasEx
+      ExternalExample:
+        fields:
+          externalLong: ExternalLong
+          optionalExternal: optional<ExternalLong>
+      AnyExample:
+        fields:
+          anyValue: any
+          anyMap: map<string, any>
+      # We do not expect anything to differ in ser/de because of the safety. But let's be comprehensive.
+      SafetyExample:
+        fields:
+          safeString:
+            type: string
+            safety: safe
+          unsafeDouble:
+            type: double
+            safety: unsafe
+      EmptyObject:
+        fields: { }
+      EmptyUnion:
+        union: { }
+      ComplexExample:
+        fields:
+          metadata: map<StringAliasEx, optional<list<ObjectReference>>>
+          status: EnumExample
+          variants: list<UnionExample>
+          external: optional<ExternalLong>
+      EnumExample:
+        values:
+          - A
+          - B
     errors:
       InvalidTypeDefinition:
         namespace: Conjure
@@ -26,7 +111,7 @@ types:
         namespace: ConjureJava
         docs: Failed to compile Conjure definition to Java code.
         code: INTERNAL
-      DifferentPackage:
+      DifferentPackageError:
         package: com.palantir.another
         namespace: Conjure
         docs: Different package.
@@ -45,3 +130,24 @@ types:
         unsafe-args:
           cause: string
           shouldThrow: boolean
+      ErrorWithComplexArgs:
+        namespace: Conjure
+        code: INTERNAL
+        safe-args:
+          primitiveExample: PrimitiveExample
+          collectionExample: CollectionExample
+          nestedCollectionExample: NestedCollectionExample
+          optionalExample: OptionalExample
+          objectReference: ObjectReference
+          unionExample: UnionExample
+          enumExample: EnumExample
+          stringAlias: StringAliasEx
+          optionalAlias: OptionalAlias
+          collectionAlias: CollectionAlias
+          nestedAlias: NestedAlias
+          externalExample: ExternalExample
+          anyExample: AnyExample
+          emptyObject: EmptyObject
+          complexExample: ComplexExample
+        unsafe-args:
+          safetyExample: SafetyExample


### PR DESCRIPTION
## Before this PR
In #2608, I test the ser/de of various error parameter types. Several thousand lines of generated code is required for the Conjure objects I'm checking in. I'd like to checkin these definitions and generated files in a separate (this) PR to make reviewing #2608 easier.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add example error with several parameter types
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

