### PR TITLE
Optimize CLI dist performance by adding JVM exports

### DIFF
--- a/conjure-java/build.gradle
+++ b/conjure-java/build.gradle
@@ -18,6 +18,16 @@ apply plugin: 'com.palantir.external-publish-application-dist'
 
 mainClassName = 'com.palantir.conjure.java.cli.ConjureJavaCli'
 
+application {
+    applicationDefaultJvmArgs.addAll([
+            '--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED',
+            '--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED',
+            '--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED',
+            '--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED',
+            '--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED'
+    ])
+}
+
 dependencies {
     implementation project(':conjure-java-core')
     implementation 'com.fasterxml.jackson.core:jackson-annotations'


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Addressing #2325. 

After transitioning from Java 8 to newer versions, the JPMS restricted access to certain compiler APIs that Conjure-Java relies on for efficient formatting. When running conjure-java through gradle environments, these restrictions were bypassed due to the `--add-exports` arguments specified in our [gradle.properties](https://github.com/palantir/conjure-java/blob/develop/gradle.properties#L4C1-L5C1), allowing the use of the efficient [DirectFormatterFacade](https://github.com/palantir/goethe/blob/develop/goethe/src/main/java/com/palantir/goethe/DirectFormatterFacade.java). However, when running the standalone CLI tool, it fell back to the slower [BootstrappingFormatterFacade](https://github.com/palantir/goethe/blob/develop/goethe/src/main/java/com/palantir/goethe/BootstrappingFormatterFacade.java), which launches a separate process for each formatting operation - we noted the slowness [here](https://github.com/palantir/goethe/blob/develop/goethe/src/main/java/com/palantir/goethe/FormatterFacadeFactory.java#L31-L33), but for some reason this message doesn't make its way to my stderr.

Testing locally on a sample input conjure IR, my execution time drops from ~53s to ~4s. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds JVM exports for the `jdk.compiler` by default to conjure-java's CLI distribution. 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

