### PR TITLE
Support optional auth parameters in conjure-undertow-annotations

### DIFF
--- a/conjure-undertow-annotations/readme.md
+++ b/conjure-undertow-annotations/readme.md
@@ -77,8 +77,7 @@ public interface MyService {
 }
 ```
 
-When using an HTTP authentication header in the form of `Bearer [token]`, the token can be automatically injected when
-using an [`AuthHeader`](https://github.com/palantir/auth-tokens/blob/develop/auth-tokens/src/main/java/com/palantir/tokens/auth/AuthHeader.java) parameter:
+To access a bearer token provided using the HTTP `Authorization` header in the form of `Bearer [token]`, you can use an unannotated [`AuthHeader`](https://github.com/palantir/auth-tokens/blob/develop/auth-tokens/src/main/java/com/palantir/tokens/auth/AuthHeader.java) or `Optional<AuthHeader>` parameter, which will be deserialized using the [`AuthorizationExtractor`](../conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/AuthorizationExtractor.java):
 
 ```java
 public interface MyService {
@@ -88,14 +87,30 @@ public interface MyService {
 }
 ```
 
-Similarly, you can access a bearer token from a cookie when using the `@Handle.Cookie` annotation together with the
-[`BearerToken`](https://github.com/palantir/auth-tokens/blob/develop/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java) type which also sets the respective auth state:
+```java
+public interface MyService {
+
+    @Handle(method = HttpMethod.GET, path = "/path")
+    void myEndpoint(Optional<AuthHeader> authHeader);
+}
+```
+
+Similarly, to access a bearer token provided using a cookie, you can use the `@Handle.Cookie` annotation on a 
+[`BearerToken`](https://github.com/palantir/auth-tokens/blob/develop/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java) or `Optional<BearerToken>` parameter, which will be deserialized using the [`AuthorizationExtractor`](../conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/AuthorizationExtractor.java):
 
 ```java
 public interface MyService {
 
     @Handle(method = HttpMethod.GET, path = "/path")
     void myEndpoint(@Handle.Cookie("AUTH_TOKEN") BearerToken token);
+}
+```
+
+```java
+public interface MyService {
+
+    @Handle(method = HttpMethod.GET, path = "/path")
+    void myEndpoint(@Handle.Cookie("AUTH_TOKEN") Optional<BearerToken> token);
 }
 ```
 

--- a/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/BearerTokenCookieDeserializer.java
+++ b/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/BearerTokenCookieDeserializer.java
@@ -23,6 +23,7 @@ import com.palantir.tokens.auth.BearerToken;
 import io.undertow.server.HttpServerExchange;
 import java.io.IOException;
 
+@Deprecated
 public final class BearerTokenCookieDeserializer implements Deserializer<BearerToken> {
 
     private final UndertowRuntime runtime;

--- a/conjure-undertow-processor-example/src/main/java/com/palantir/conjure/java/undertow/example/ExampleService.java
+++ b/conjure-undertow-processor-example/src/main/java/com/palantir/conjure/java/undertow/example/ExampleService.java
@@ -86,7 +86,10 @@ public interface ExampleService {
             @Handle.Header(value = "Foo", decoder = StringCollectionParameterDecoder.class) String headerValue);
 
     @Handle(method = HttpMethod.GET, path = "/authHeader")
-    String authenticated(AuthHeader auth);
+    String authHeader(AuthHeader authHeader);
+
+    @Handle(method = HttpMethod.GET, path = "/optionalAuthHeader")
+    String optionalAuthHeader(Optional<AuthHeader> authHeader);
 
     @Handle(method = HttpMethod.GET, path = "/exchange")
     void exchange(HttpServerExchange exchange);
@@ -101,7 +104,10 @@ public interface ExampleService {
     String optionalCookie(@Cookie(value = "MY_COOKIE") Optional<String> cookieValue);
 
     @Handle(method = HttpMethod.GET, path = "/authCookie")
-    BearerToken authCookie(@Cookie(value = "AUTH_TOKEN") BearerToken token);
+    String authCookie(@Cookie(value = "AUTH_TOKEN") BearerToken token);
+
+    @Handle(method = HttpMethod.GET, path = "/optionalAuthCookie")
+    String optionalAuthCookie(@Cookie(value = "AUTH_TOKEN") Optional<BearerToken> token);
 
     @Handle(method = HttpMethod.GET, path = "/optionalBigIntegerCookie")
     String optionalBigIntegerCookie(@Cookie(value = "BIG_INTEGER") Optional<BigInteger> cookieValue);

--- a/conjure-undertow-processor-example/src/test/java/com/palantir/conjure/java/undertow/example/ExampleResource.java
+++ b/conjure-undertow-processor-example/src/test/java/com/palantir/conjure/java/undertow/example/ExampleResource.java
@@ -106,10 +106,13 @@ final class ExampleResource implements ExampleService {
     }
 
     @Override
-    public String authenticated(AuthHeader auth) {
-        return Preconditions.checkNotNull(auth, "AuthHeader is required")
-                .getBearerToken()
-                .toString();
+    public String authHeader(AuthHeader authHeader) {
+        return Preconditions.checkNotNull(authHeader, "AuthHeader is required").toString();
+    }
+
+    @Override
+    public String optionalAuthHeader(Optional<AuthHeader> authHeader) {
+        return authHeader.map(AuthHeader::toString).orElse("empty");
     }
 
     @Override
@@ -133,8 +136,13 @@ final class ExampleResource implements ExampleService {
     }
 
     @Override
-    public BearerToken authCookie(BearerToken token) {
-        return Preconditions.checkNotNull(token, "Token parameter is required");
+    public String authCookie(BearerToken token) {
+        return Preconditions.checkNotNull(token, "Token parameter is required").toString();
+    }
+
+    @Override
+    public String optionalAuthCookie(Optional<BearerToken> token) {
+        return token.map(BearerToken::toString).orElse("empty");
     }
 
     @Override

--- a/conjure-undertow-processor-example/src/test/java/com/palantir/conjure/java/undertow/example/ExampleServiceTest.java
+++ b/conjure-undertow-processor-example/src/test/java/com/palantir/conjure/java/undertow/example/ExampleServiceTest.java
@@ -260,10 +260,43 @@ class ExampleServiceTest {
             HttpURLConnection connection =
                     (HttpURLConnection) new URL("http://localhost:" + port + "/authHeader").openConnection();
             connection.setRequestProperty(HttpHeaders.AUTHORIZATION, authHeader.toString());
-            byte[] expected = ("\"" + authHeader.getBearerToken().toString() + "\"").getBytes(StandardCharsets.UTF_8);
+            byte[] expected = ("\"" + authHeader + "\"").getBytes(StandardCharsets.UTF_8);
             assertThat(connection.getResponseCode()).isEqualTo(200);
             assertThat(connection.getContentType()).startsWith("application/json");
             assertThat(connection.getInputStream()).hasBinaryContent(expected);
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    void testOptionalAuthHeader() throws IOException {
+        Undertow server = TestHelper.started(ExampleServiceEndpoints.of(new ExampleResource()));
+        try {
+            int port = TestHelper.getPort(server);
+
+            // Header value is present
+            AuthHeader authHeader =
+                    AuthHeader.of(BearerToken.valueOf(UUID.randomUUID().toString()));
+            HttpURLConnection connection =
+                    (HttpURLConnection) new URL("http://localhost:" + port + "/optionalAuthHeader").openConnection();
+            connection.setRequestProperty(HttpHeaders.AUTHORIZATION, authHeader.toString());
+            byte[] expected = ("\"" + authHeader + "\"").getBytes(StandardCharsets.UTF_8);
+            assertThat(connection.getResponseCode()).isEqualTo(200);
+            assertThat(connection.getContentType()).startsWith("application/json");
+            try (InputStream responseStream = connection.getInputStream()) {
+                assertThat(responseStream).hasBinaryContent(expected);
+            }
+
+            // Header value is empty
+            connection =
+                    (HttpURLConnection) new URL("http://localhost:" + port + "/optionalAuthHeader").openConnection();
+            byte[] emptyResponse = "\"empty\"".getBytes(StandardCharsets.UTF_8);
+            assertThat(connection.getResponseCode()).isEqualTo(200);
+            assertThat(connection.getContentType()).startsWith("application/json");
+            try (InputStream responseStream = connection.getInputStream()) {
+                assertThat(responseStream).hasBinaryContent(emptyResponse);
+            }
         } finally {
             server.stop();
         }
@@ -360,6 +393,37 @@ class ExampleServiceTest {
             assertThat(connection.getResponseCode()).isEqualTo(200);
             assertThat(connection.getContentType()).startsWith("application/json");
             assertThat(connection.getInputStream()).hasBinaryContent(expected);
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    void testOptionalAuthCookieParam() throws Exception {
+        Undertow server = TestHelper.started(ExampleServiceEndpoints.of(new ExampleResource()));
+        try {
+            int port = TestHelper.getPort(server);
+
+            // Cookie value is present
+            HttpURLConnection connection =
+                    (HttpURLConnection) new URL("http://localhost:" + port + "/optionalAuthCookie").openConnection();
+            connection.setRequestProperty(HttpHeaders.COOKIE, "AUTH_TOKEN=my-token");
+            byte[] expected = "\"my-token\"".getBytes(StandardCharsets.UTF_8);
+            assertThat(connection.getResponseCode()).isEqualTo(200);
+            assertThat(connection.getContentType()).startsWith("application/json");
+            try (InputStream responseStream = connection.getInputStream()) {
+                assertThat(responseStream).hasBinaryContent(expected);
+            }
+
+            // Cookie value is present
+            connection =
+                    (HttpURLConnection) new URL("http://localhost:" + port + "/optionalAuthCookie").openConnection();
+            byte[] emptyResponse = "\"empty\"".getBytes(StandardCharsets.UTF_8);
+            assertThat(connection.getResponseCode()).isEqualTo(200);
+            assertThat(connection.getContentType()).startsWith("application/json");
+            try (InputStream responseStream = connection.getInputStream()) {
+                assertThat(responseStream).hasBinaryContent(emptyResponse);
+            }
         } finally {
             server.stop();
         }

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessor.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessor.java
@@ -162,7 +162,6 @@ public final class ConjureUndertowAnnotationProcessor extends AbstractProcessor 
                     "Failed validation");
             return maybeEndpoints.stream().map(Optional::get).collect(Collectors.toList());
         });
-
         ClassName serviceInterface = (ClassName) TypeName.get(annotatedType.asType());
 
         ServiceDefinition serviceDefinition = ImmutableServiceDefinition.builder()

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/EndpointDefinitions.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/EndpointDefinitions.java
@@ -21,6 +21,7 @@ import com.google.common.base.Predicates;
 import com.palantir.conjure.java.undertow.annotations.Handle;
 import com.palantir.conjure.java.undertow.annotations.HttpMethod;
 import com.palantir.conjure.java.undertow.processor.ErrorContext;
+import com.palantir.conjure.java.undertow.processor.data.ParameterTypeVisitors.IsAuthVisitor;
 import com.palantir.logsafe.SafeArg;
 import io.undertow.util.PathTemplate;
 import java.util.ArrayList;
@@ -58,6 +59,7 @@ public final class EndpointDefinitions {
         this.returnTypesResolver = new ReturnTypesResolver(context);
     }
 
+    @SuppressWarnings("CyclomaticComplexity")
     public Optional<EndpointDefinition> tryParseEndpointDefinition(
             DeclaredType annotatedType, ExecutableElement element) {
         AnnotationReflector requestAnnotationReflector = MoreElements.getAnnotationMirror(element, Handle.class)
@@ -130,6 +132,13 @@ public final class EndpointDefinitions {
         if (!actualPathParams.equals(expectedPathParams)) {
             errorContext.reportError("Path template parameters do not match method path parameters", element);
             return Optional.empty();
+        }
+
+        long numAuthParameters = argumentDefinitions.stream()
+                .filter(argument -> argument.paramType().match(IsAuthVisitor.INSTANCE))
+                .count();
+        if (numAuthParameters > 1) {
+            errorContext.reportError("Methods cannot have multiple auth parameters", element);
         }
 
         return Optional.of(ImmutableEndpointDefinition.builder()

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParamTypesResolver.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParamTypesResolver.java
@@ -143,6 +143,9 @@ public final class ParamTypesResolver {
             if (context.isSameTypes(parameterType, AuthHeader.class)) {
                 return Optional.of(ParameterTypes.authHeader(
                         variableElement.getSimpleName().toString()));
+            } else if (context.isOptionalSameTypes(parameterType, AuthHeader.class)) {
+                return Optional.of(ParameterTypes.optionalAuthHeader(
+                        variableElement.getSimpleName().toString()));
             } else if (context.isSameTypes(parameterType, HttpServerExchange.class)) {
                 return Optional.of(ParameterTypes.exchange());
             } else if (context.isSameTypes(parameterType, RequestContext.class)) {
@@ -278,19 +281,31 @@ public final class ParamTypesResolver {
             AnnotationReflector annotationReflector,
             SafeLoggingAnnotation safeLoggable) {
         String javaParameterName = variableElement.getSimpleName().toString();
-        String deserializerName = InstanceVariables.joinCamelCase(javaParameterName, "Deserializer");
         if (context.isSameTypes(variableElement.asType(), BearerToken.class)) {
             if (!safeLoggable.equals(SafeLoggingAnnotation.UNKNOWN)) {
                 context.reportError(
-                        "BearerToken parameter cannot be annotated with safe logging annotations",
+                        "Parameter type cannot be annotated with safe logging annotations",
                         variableElement,
                         SafeArg.of("type", variableElement.asType()));
                 return Optional.empty();
             }
-            // TODO(fwindheuser): Add some validation no more than one BearerToken cookie param is used.
-            return Optional.of(ParameterTypes.authCookie(
-                    javaParameterName, annotationReflector.getAnnotationValue(String.class), deserializerName));
+
+            return Optional.of(
+                    ParameterTypes.authCookie(javaParameterName, annotationReflector.getAnnotationValue(String.class)));
+        } else if (context.isOptionalSameTypes(variableElement.asType(), BearerToken.class)) {
+            if (!safeLoggable.equals(SafeLoggingAnnotation.UNKNOWN)) {
+                context.reportError(
+                        "Parameter type cannot be annotated with safe logging annotations",
+                        variableElement,
+                        SafeArg.of("type", variableElement.asType()));
+                return Optional.empty();
+            }
+
+            return Optional.of(ParameterTypes.optionalAuthCookie(
+                    javaParameterName, annotationReflector.getAnnotationValue(String.class)));
         }
+
+        String deserializerName = InstanceVariables.joinCamelCase(javaParameterName, "Deserializer");
 
         return Optional.of(ParameterTypes.cookie(
                 javaParameterName,

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParameterType.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParameterType.java
@@ -69,9 +69,13 @@ public interface ParameterType {
                 CodeBlock deserializerFactory,
                 SafeLoggingAnnotation safeLoggable);
 
-        R authCookie(String variableName, String cookieName, String deserializerFieldName);
+        R authCookie(String variableName, String cookieName);
+
+        R optionalAuthCookie(String variableName, String cookieName);
 
         R authHeader(String variableName);
+
+        R optionalAuthHeader(String variableName);
 
         R exchange();
 

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParameterTypeVisitors.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ParameterTypeVisitors.java
@@ -22,6 +22,107 @@ import com.palantir.javapoet.CodeBlock;
 
 public final class ParameterTypeVisitors {
 
+    public enum IsAuthVisitor implements Cases<Boolean> {
+        INSTANCE;
+
+        @Override
+        public Boolean body(
+                String _variableName,
+                CodeBlock _deserializerFactory,
+                String _deserializerFieldName,
+                SafeLoggingAnnotation _safeLoggable) {
+            return false;
+        }
+
+        @Override
+        public Boolean header(
+                String _variableName,
+                String _headerName,
+                String _deserializerFieldName,
+                CodeBlock _deserializerFactory,
+                SafeLoggingAnnotation _safeLoggable) {
+            return false;
+        }
+
+        @Override
+        public Boolean path(
+                String _paramName,
+                String _deserializerFieldName,
+                CodeBlock _deserializerFactory,
+                SafeLoggingAnnotation _safeLoggable) {
+            return false;
+        }
+
+        @Override
+        public Boolean pathMulti(
+                String _paramName,
+                String _deserializerFieldName,
+                CodeBlock _deserializerFactory,
+                SafeLoggingAnnotation _safeLoggable) {
+            return false;
+        }
+
+        @Override
+        public Boolean query(
+                String _variableName,
+                String _paramName,
+                String _deserializerFieldName,
+                CodeBlock _deserializerFactory,
+                SafeLoggingAnnotation _safeLoggable) {
+            return false;
+        }
+
+        @Override
+        public Boolean form(
+                String _variableName,
+                String _paramName,
+                String _deserializerFieldName,
+                CodeBlock _deserializerFactory,
+                SafeLoggingAnnotation _safeLoggable) {
+            return false;
+        }
+
+        @Override
+        public Boolean cookie(
+                String _variableName,
+                String _cookieName,
+                String _deserializerFieldName,
+                CodeBlock _deserializerFactory,
+                SafeLoggingAnnotation _safeLoggable) {
+            return false;
+        }
+
+        @Override
+        public Boolean authCookie(String _variableName, String _cookieName) {
+            return true;
+        }
+
+        @Override
+        public Boolean optionalAuthCookie(String _variableName, String _cookieName) {
+            return true;
+        }
+
+        @Override
+        public Boolean authHeader(String _variableName) {
+            return true;
+        }
+
+        @Override
+        public Boolean optionalAuthHeader(String _variableName) {
+            return true;
+        }
+
+        @Override
+        public Boolean exchange() {
+            return false;
+        }
+
+        @Override
+        public Boolean context() {
+            return false;
+        }
+    }
+
     public enum UsesRequestContextVisitor implements Cases<Boolean> {
         INSTANCE;
 
@@ -93,12 +194,22 @@ public final class ParameterTypeVisitors {
         }
 
         @Override
-        public Boolean authCookie(String _variableName, String _cookieName, String _deserializerFieldName) {
+        public Boolean authCookie(String _variableName, String _cookieName) {
+            return false;
+        }
+
+        @Override
+        public Boolean optionalAuthCookie(String _variableName, String _cookieName) {
             return false;
         }
 
         @Override
         public Boolean authHeader(String _variableName) {
+            return false;
+        }
+
+        @Override
+        public Boolean optionalAuthHeader(String _variableName) {
             return false;
         }
 

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ResolverContext.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/data/ResolverContext.java
@@ -49,6 +49,15 @@ public final class ResolverContext implements ErrorContext {
         return types.isSameType(typeMirror, getTypeMirror(clazz));
     }
 
+    public boolean isOptionalSameTypes(TypeMirror typeMirror, Class<?> clazz) {
+        TypeMirror innerType = getGenericInnerType(Optional.class, typeMirror).orElse(null);
+        if (innerType == null) {
+            return false;
+        }
+
+        return isSameTypes(innerType, clazz);
+    }
+
     public boolean isAssignable(TypeMirror typeMirror, Class<?> clazz) {
         return types.isAssignable(typeMirror, getTypeMirror(clazz));
     }

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.SetMultimap;
-import com.palantir.conjure.java.undertow.annotations.BearerTokenCookieDeserializer;
 import com.palantir.conjure.java.undertow.annotations.CookieDeserializer;
 import com.palantir.conjure.java.undertow.annotations.FormParamDeserializer;
 import com.palantir.conjure.java.undertow.annotations.HeaderParamDeserializer;
@@ -62,8 +61,10 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.tokens.auth.AuthHeader;
+import com.palantir.tokens.auth.BearerToken;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
 import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import io.undertow.util.StatusCodes;
@@ -388,30 +389,34 @@ public final class ConjureUndertowEndpointsGenerator {
             }
 
             @Override
-            public Void authCookie(String variableName, String cookieName, String deserializerFieldName) {
-                TypeName paramType = def.argType().match(ArgTypeTypeName.INSTANCE);
-                additionalFields.add(ImmutableAdditionalField.builder()
-                        .field(FieldSpec.builder(
-                                        ParameterizedTypeName.get(ClassName.get(Deserializer.class), paramType.box()),
-                                        deserializerFieldName,
-                                        Modifier.PRIVATE,
-                                        Modifier.FINAL)
-                                .build())
-                        .constructorInitializer(CodeBlock.builder()
-                                .addStatement(
-                                        "this.$N = new $T(runtime, $S)",
-                                        deserializerFieldName,
-                                        BearerTokenCookieDeserializer.class,
-                                        cookieName)
-                                .build())
-                        .build());
-                handlerBuilder.addStatement("$T $N = $L", paramType, variableName, invokeDeserializer(def));
+            public Void authCookie(String variableName, String _cookieName) {
+                handlerBuilder.addStatement("$T $N = $L", BearerToken.class, variableName, invokeDeserializer(def));
+                return null;
+            }
+
+            @Override
+            public Void optionalAuthCookie(String variableName, String _cookieName) {
+                handlerBuilder.addStatement(
+                        "$T $N = $L",
+                        ParameterizedTypeName.get(Optional.class, BearerToken.class),
+                        variableName,
+                        invokeDeserializer(def));
                 return null;
             }
 
             @Override
             public Void authHeader(String variableName) {
                 handlerBuilder.addStatement("$T $N = $L", AuthHeader.class, variableName, invokeDeserializer(def));
+                return null;
+            }
+
+            @Override
+            public Void optionalAuthHeader(String variableName) {
+                handlerBuilder.addStatement(
+                        "$T $N = $L",
+                        ParameterizedTypeName.get(Optional.class, AuthHeader.class),
+                        variableName,
+                        invokeDeserializer(def));
                 return null;
             }
 
@@ -629,13 +634,35 @@ public final class ConjureUndertowEndpointsGenerator {
             }
 
             @Override
-            public CodeBlock authCookie(String _variableName, String _cookieName, String deserializerFieldName) {
-                return CodeBlock.of("this.$N.deserialize($N)", deserializerFieldName, EXCHANGE_NAME);
+            public CodeBlock authCookie(String _variableName, String cookieName) {
+                return CodeBlock.of("this.$N.auth().cookie($N, $S)", RUNTIME_NAME, EXCHANGE_NAME, cookieName);
+            }
+
+            @Override
+            public CodeBlock optionalAuthCookie(String _variableName, String cookieName) {
+                return CodeBlock.of(
+                        "$2N.getRequestCookies().containsKey($3S) "
+                                + "? Optional.of(this.$1N.auth().cookie($2N, $3S)) "
+                                + ": Optional.empty()",
+                        RUNTIME_NAME,
+                        EXCHANGE_NAME,
+                        cookieName);
             }
 
             @Override
             public CodeBlock authHeader(String _variableName) {
                 return CodeBlock.of("this.$N.auth().header($N)", RUNTIME_NAME, EXCHANGE_NAME);
+            }
+
+            @Override
+            public CodeBlock optionalAuthHeader(String _variableName) {
+                return CodeBlock.of(
+                        "$2N.getRequestHeaders().contains($3T.AUTHORIZATION) "
+                                + "? Optional.of(this.$1N.auth().header($2N)) "
+                                + ": Optional.empty()",
+                        RUNTIME_NAME,
+                        EXCHANGE_NAME,
+                        Headers.class);
             }
 
             @Override
@@ -721,13 +748,22 @@ public final class ConjureUndertowEndpointsGenerator {
                     }
 
                     @Override
-                    public CodeBlock authCookie(
-                            String variableName, String _cookieName, String _deserializerFieldName) {
+                    public CodeBlock authCookie(String variableName, String _cookieName) {
+                        return CodeBlock.of(variableName);
+                    }
+
+                    @Override
+                    public CodeBlock optionalAuthCookie(String variableName, String _cookieName) {
                         return CodeBlock.of(variableName);
                     }
 
                     @Override
                     public CodeBlock authHeader(String variableName) {
+                        return CodeBlock.of(variableName);
+                    }
+
+                    @Override
+                    public CodeBlock optionalAuthHeader(String variableName) {
                         return CodeBlock.of(variableName);
                     }
 

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/ConjureUndertowAnnotationProcessorTest.java
@@ -34,6 +34,9 @@ import com.palantir.conjure.java.undertow.processor.sample.ExtendsNested;
 import com.palantir.conjure.java.undertow.processor.sample.ExtendsSimpleInterface;
 import com.palantir.conjure.java.undertow.processor.sample.GenericImpl;
 import com.palantir.conjure.java.undertow.processor.sample.MismatchedPathParam;
+import com.palantir.conjure.java.undertow.processor.sample.MultipleAuthCookieParam;
+import com.palantir.conjure.java.undertow.processor.sample.MultipleAuthHeaderCookieParam;
+import com.palantir.conjure.java.undertow.processor.sample.MultipleAuthHeaderParam;
 import com.palantir.conjure.java.undertow.processor.sample.MultipleBodyInterface;
 import com.palantir.conjure.java.undertow.processor.sample.NameClashContextParam;
 import com.palantir.conjure.java.undertow.processor.sample.NameClashExchangeParam;
@@ -167,7 +170,7 @@ public class ConjureUndertowAnnotationProcessorTest {
     @Test
     public void testSafeLoggingAuthCookie() {
         assertThat(compileTestClass(TEST_CLASSES_BASE_DIR, SafeLoggableAuthCookieParam.class))
-                .hadErrorContaining("BearerToken parameter cannot be annotated with safe logging annotations");
+                .hadErrorContaining("Parameter type cannot be annotated with safe logging annotations");
     }
 
     @Test
@@ -259,6 +262,24 @@ public class ConjureUndertowAnnotationProcessorTest {
     public void unmatchedPathTemplateParam() {
         assertThat(compileTestClass(TEST_CLASSES_BASE_DIR, UnmatchedPathTemplateParam.class))
                 .hadErrorContaining("Path template parameters do not match method path parameters");
+    }
+
+    @Test
+    public void multipleAuthHeaderParam() {
+        assertThat(compileTestClass(TEST_CLASSES_BASE_DIR, MultipleAuthHeaderParam.class))
+                .hadErrorContaining("Methods cannot have multiple auth parameters");
+    }
+
+    @Test
+    public void multipleAuthCookieParam() {
+        assertThat(compileTestClass(TEST_CLASSES_BASE_DIR, MultipleAuthCookieParam.class))
+                .hadErrorContaining("Methods cannot have multiple auth parameters");
+    }
+
+    @Test
+    public void multipleAuthHeaderCookieParam() {
+        assertThat(compileTestClass(TEST_CLASSES_BASE_DIR, MultipleAuthHeaderCookieParam.class))
+                .hadErrorContaining("Methods cannot have multiple auth parameters");
     }
 
     @Test

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/MultipleAuthCookieParam.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/MultipleAuthCookieParam.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.palantir.conjure.java.undertow.annotations.Handle;
+import com.palantir.conjure.java.undertow.annotations.Handle.Cookie;
+import com.palantir.conjure.java.undertow.annotations.HttpMethod;
+import com.palantir.tokens.auth.BearerToken;
+import java.util.Optional;
+
+public interface MultipleAuthCookieParam {
+
+    @Handle(method = HttpMethod.GET, path = "/")
+    void multipleAuthHeaderParam(
+            @Cookie(value = "TOKEN") BearerToken token,
+            @Cookie(value = "OTHER_TOKEN") Optional<BearerToken> otherToken);
+}

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/MultipleAuthHeaderCookieParam.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/MultipleAuthHeaderCookieParam.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.palantir.conjure.java.undertow.annotations.Handle;
+import com.palantir.conjure.java.undertow.annotations.Handle.Cookie;
+import com.palantir.conjure.java.undertow.annotations.HttpMethod;
+import com.palantir.tokens.auth.AuthHeader;
+import com.palantir.tokens.auth.BearerToken;
+
+public interface MultipleAuthHeaderCookieParam {
+
+    @Handle(method = HttpMethod.GET, path = "/")
+    void multipleAuthHeaderParam(AuthHeader authHeader, @Cookie(value = "TOKEN") BearerToken token);
+}

--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/MultipleAuthHeaderParam.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/MultipleAuthHeaderParam.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.processor.sample;
+
+import com.palantir.conjure.java.undertow.annotations.Handle;
+import com.palantir.conjure.java.undertow.annotations.HttpMethod;
+import com.palantir.tokens.auth.AuthHeader;
+import java.util.Optional;
+
+public interface MultipleAuthHeaderParam {
+
+    @Handle(method = HttpMethod.GET, path = "/")
+    void multipleAuthHeaderParam(AuthHeader authHeader, Optional<AuthHeader> otherAuthHeader);
+}

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/CookieParamsEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/CookieParamsEndpoints.java.generated
@@ -1,7 +1,6 @@
 package com.palantir.conjure.java.undertow.processor.sample;
 
 import com.google.common.collect.ImmutableList;
-import com.palantir.conjure.java.undertow.annotations.BearerTokenCookieDeserializer;
 import com.palantir.conjure.java.undertow.annotations.CookieDeserializer;
 import com.palantir.conjure.java.undertow.annotations.DefaultSerDe;
 import com.palantir.conjure.java.undertow.annotations.ParamDecoders;
@@ -56,8 +55,6 @@ public final class CookieParamsEndpoints implements UndertowService {
 
         private final Deserializer<String> decoderCookieDeserializer;
 
-        private final Deserializer<BearerToken> tokenDeserializer;
-
         private final Serializer<String> cookieParamsSerializer;
 
         CookieParamsEndpoint(UndertowRuntime runtime, CookieParams delegate) {
@@ -71,7 +68,6 @@ public final class CookieParamsEndpoints implements UndertowService {
                     "optionalIntCookie", ParamDecoders.optionalIntegerParamDecoder(runtime.plainSerDe()));
             this.decoderCookieDeserializer =
                     new CookieDeserializer<>("decoderCookie", CookieParams.StringParamDecoder.INSTANCE);
-            this.tokenDeserializer = new BearerTokenCookieDeserializer(runtime, "AUTH_TOKEN");
             this.cookieParamsSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
         }
 
@@ -81,7 +77,7 @@ public final class CookieParamsEndpoints implements UndertowService {
             Optional<String> optionalStringCookie = this.optionalStringCookieDeserializer.deserialize(exchange);
             OptionalInt optionalIntCookie = this.optionalIntCookieDeserializer.deserialize(exchange);
             String decoderCookie = this.decoderCookieDeserializer.deserialize(exchange);
-            BearerToken token = this.tokenDeserializer.deserialize(exchange);
+            BearerToken token = this.runtime.auth().cookie(exchange, "AUTH_TOKEN");
             write(
                     this.delegate.cookieParams(
                             stringCookie, optionalStringCookie, optionalIntCookie, decoderCookie, token),


### PR DESCRIPTION
There are some legitimate cases where endpoints do not require authentication, but will use credentials if they are provided. For example, a logout endpoint.

Currently, the `Authorization` header parameters of these endpoints must be declared using `@Header` and are interpreted as normal header parameters instead of an authorization parameter. This means that we won't use `AuthorizationExtractor` to deserialize them and thus don't populate the MDC with the metadata from the provided credential.

This PR updates conjure-undertow-annotations to support `Optional<AuthHeader>` and `@Cookie Optional<BearerToken>` parameters and treat them as auth parameters.