### PR TITLE
Support deserialization of double aliases from strings

### DIFF
--- a/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/AliasAsMapKeyExample.java
@@ -30,6 +30,8 @@ public final class AliasAsMapKeyExample {
 
     private final Map<IntegerAliasExample, ManyFieldExample> integers;
 
+    private final Map<DoubleAliasExample, ManyFieldExample> doubles;
+
     private final Map<SafeLongAliasExample, ManyFieldExample> safelongs;
 
     private final Map<DateTimeAliasExample, ManyFieldExample> datetimes;
@@ -43,14 +45,16 @@ public final class AliasAsMapKeyExample {
             Map<RidAliasExample, ManyFieldExample> rids,
             Map<BearerTokenAliasExample, ManyFieldExample> bearertokens,
             Map<IntegerAliasExample, ManyFieldExample> integers,
+            Map<DoubleAliasExample, ManyFieldExample> doubles,
             Map<SafeLongAliasExample, ManyFieldExample> safelongs,
             Map<DateTimeAliasExample, ManyFieldExample> datetimes,
             Map<UuidAliasExample, ManyFieldExample> uuids) {
-        validateFields(strings, rids, bearertokens, integers, safelongs, datetimes, uuids);
+        validateFields(strings, rids, bearertokens, integers, doubles, safelongs, datetimes, uuids);
         this.strings = Collections.unmodifiableMap(strings);
         this.rids = Collections.unmodifiableMap(rids);
         this.bearertokens = Collections.unmodifiableMap(bearertokens);
         this.integers = Collections.unmodifiableMap(integers);
+        this.doubles = Collections.unmodifiableMap(doubles);
         this.safelongs = Collections.unmodifiableMap(safelongs);
         this.datetimes = Collections.unmodifiableMap(datetimes);
         this.uuids = Collections.unmodifiableMap(uuids);
@@ -74,6 +78,11 @@ public final class AliasAsMapKeyExample {
     @JsonProperty("integers")
     public Map<IntegerAliasExample, ManyFieldExample> getIntegers() {
         return this.integers;
+    }
+
+    @JsonProperty("doubles")
+    public Map<DoubleAliasExample, ManyFieldExample> getDoubles() {
+        return this.doubles;
     }
 
     @JsonProperty("safelongs")
@@ -106,6 +115,7 @@ public final class AliasAsMapKeyExample {
                 && this.rids.equals(other.rids)
                 && this.bearertokens.equals(other.bearertokens)
                 && this.integers.equals(other.integers)
+                && this.doubles.equals(other.doubles)
                 && this.safelongs.equals(other.safelongs)
                 && this.datetimes.equals(other.datetimes)
                 && this.uuids.equals(other.uuids);
@@ -120,6 +130,7 @@ public final class AliasAsMapKeyExample {
             hash = 31 * hash + this.rids.hashCode();
             hash = 31 * hash + this.bearertokens.hashCode();
             hash = 31 * hash + this.integers.hashCode();
+            hash = 31 * hash + this.doubles.hashCode();
             hash = 31 * hash + this.safelongs.hashCode();
             hash = 31 * hash + this.datetimes.hashCode();
             hash = 31 * hash + this.uuids.hashCode();
@@ -133,8 +144,8 @@ public final class AliasAsMapKeyExample {
     @DoNotLog
     public String toString() {
         return "AliasAsMapKeyExample{strings: " + strings + ", rids: " + rids + ", bearertokens: " + bearertokens
-                + ", integers: " + integers + ", safelongs: " + safelongs + ", datetimes: " + datetimes + ", uuids: "
-                + uuids + '}';
+                + ", integers: " + integers + ", doubles: " + doubles + ", safelongs: " + safelongs + ", datetimes: "
+                + datetimes + ", uuids: " + uuids + '}';
     }
 
     private static void validateFields(
@@ -142,6 +153,7 @@ public final class AliasAsMapKeyExample {
             Map<RidAliasExample, ManyFieldExample> rids,
             Map<BearerTokenAliasExample, ManyFieldExample> bearertokens,
             Map<IntegerAliasExample, ManyFieldExample> integers,
+            Map<DoubleAliasExample, ManyFieldExample> doubles,
             Map<SafeLongAliasExample, ManyFieldExample> safelongs,
             Map<DateTimeAliasExample, ManyFieldExample> datetimes,
             Map<UuidAliasExample, ManyFieldExample> uuids) {
@@ -150,6 +162,7 @@ public final class AliasAsMapKeyExample {
         missingFields = addFieldIfMissing(missingFields, rids, "rids");
         missingFields = addFieldIfMissing(missingFields, bearertokens, "bearertokens");
         missingFields = addFieldIfMissing(missingFields, integers, "integers");
+        missingFields = addFieldIfMissing(missingFields, doubles, "doubles");
         missingFields = addFieldIfMissing(missingFields, safelongs, "safelongs");
         missingFields = addFieldIfMissing(missingFields, datetimes, "datetimes");
         missingFields = addFieldIfMissing(missingFields, uuids, "uuids");
@@ -163,7 +176,7 @@ public final class AliasAsMapKeyExample {
         List<String> missingFields = prev;
         if (fieldValue == null) {
             if (missingFields == null) {
-                missingFields = new ArrayList<>(7);
+                missingFields = new ArrayList<>(8);
             }
             missingFields.add(fieldName);
         }
@@ -186,6 +199,8 @@ public final class AliasAsMapKeyExample {
 
         private Map<IntegerAliasExample, ManyFieldExample> integers = new LinkedHashMap<>();
 
+        private Map<DoubleAliasExample, ManyFieldExample> doubles = new LinkedHashMap<>();
+
         private Map<SafeLongAliasExample, ManyFieldExample> safelongs = new LinkedHashMap<>();
 
         private Map<DateTimeAliasExample, ManyFieldExample> datetimes = new LinkedHashMap<>();
@@ -200,6 +215,7 @@ public final class AliasAsMapKeyExample {
             rids(other.getRids());
             bearertokens(other.getBearertokens());
             integers(other.getIntegers());
+            doubles(other.getDoubles());
             safelongs(other.getSafelongs());
             datetimes(other.getDatetimes());
             uuids(other.getUuids());
@@ -283,6 +299,25 @@ public final class AliasAsMapKeyExample {
             return this;
         }
 
+        @JsonSetter(value = "doubles", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
+        public Builder doubles(@Nonnull Map<DoubleAliasExample, ManyFieldExample> doubles) {
+            checkNotBuilt();
+            this.doubles = new LinkedHashMap<>(Preconditions.checkNotNull(doubles, "doubles cannot be null"));
+            return this;
+        }
+
+        public Builder putAllDoubles(@Nonnull Map<DoubleAliasExample, ManyFieldExample> doubles) {
+            checkNotBuilt();
+            this.doubles.putAll(Preconditions.checkNotNull(doubles, "doubles cannot be null"));
+            return this;
+        }
+
+        public Builder doubles(DoubleAliasExample key, ManyFieldExample value) {
+            checkNotBuilt();
+            this.doubles.put(key, value);
+            return this;
+        }
+
         @JsonSetter(value = "safelongs", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder safelongs(@Nonnull Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
             checkNotBuilt();
@@ -344,7 +379,8 @@ public final class AliasAsMapKeyExample {
         public AliasAsMapKeyExample build() {
             checkNotBuilt();
             this._buildInvoked = true;
-            return new AliasAsMapKeyExample(strings, rids, bearertokens, integers, safelongs, datetimes, uuids);
+            return new AliasAsMapKeyExample(
+                    strings, rids, bearertokens, integers, doubles, safelongs, datetimes, uuids);
         }
 
         private void checkNotBuilt() {

--- a/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/AliasAsMapKeyExample.java
@@ -32,6 +32,8 @@ public final class AliasAsMapKeyExample {
 
     private final Map<DoubleAliasExample, ManyFieldExample> doubles;
 
+    private final Map<Double, ManyFieldExample> rawDoubles;
+
     private final Map<SafeLongAliasExample, ManyFieldExample> safelongs;
 
     private final Map<DateTimeAliasExample, ManyFieldExample> datetimes;
@@ -46,15 +48,17 @@ public final class AliasAsMapKeyExample {
             Map<BearerTokenAliasExample, ManyFieldExample> bearertokens,
             Map<IntegerAliasExample, ManyFieldExample> integers,
             Map<DoubleAliasExample, ManyFieldExample> doubles,
+            Map<Double, ManyFieldExample> rawDoubles,
             Map<SafeLongAliasExample, ManyFieldExample> safelongs,
             Map<DateTimeAliasExample, ManyFieldExample> datetimes,
             Map<UuidAliasExample, ManyFieldExample> uuids) {
-        validateFields(strings, rids, bearertokens, integers, doubles, safelongs, datetimes, uuids);
+        validateFields(strings, rids, bearertokens, integers, doubles, rawDoubles, safelongs, datetimes, uuids);
         this.strings = Collections.unmodifiableMap(strings);
         this.rids = Collections.unmodifiableMap(rids);
         this.bearertokens = Collections.unmodifiableMap(bearertokens);
         this.integers = Collections.unmodifiableMap(integers);
         this.doubles = Collections.unmodifiableMap(doubles);
+        this.rawDoubles = Collections.unmodifiableMap(rawDoubles);
         this.safelongs = Collections.unmodifiableMap(safelongs);
         this.datetimes = Collections.unmodifiableMap(datetimes);
         this.uuids = Collections.unmodifiableMap(uuids);
@@ -83,6 +87,11 @@ public final class AliasAsMapKeyExample {
     @JsonProperty("doubles")
     public Map<DoubleAliasExample, ManyFieldExample> getDoubles() {
         return this.doubles;
+    }
+
+    @JsonProperty("rawDoubles")
+    public Map<Double, ManyFieldExample> getRawDoubles() {
+        return this.rawDoubles;
     }
 
     @JsonProperty("safelongs")
@@ -116,6 +125,7 @@ public final class AliasAsMapKeyExample {
                 && this.bearertokens.equals(other.bearertokens)
                 && this.integers.equals(other.integers)
                 && this.doubles.equals(other.doubles)
+                && this.rawDoubles.equals(other.rawDoubles)
                 && this.safelongs.equals(other.safelongs)
                 && this.datetimes.equals(other.datetimes)
                 && this.uuids.equals(other.uuids);
@@ -131,6 +141,7 @@ public final class AliasAsMapKeyExample {
             hash = 31 * hash + this.bearertokens.hashCode();
             hash = 31 * hash + this.integers.hashCode();
             hash = 31 * hash + this.doubles.hashCode();
+            hash = 31 * hash + this.rawDoubles.hashCode();
             hash = 31 * hash + this.safelongs.hashCode();
             hash = 31 * hash + this.datetimes.hashCode();
             hash = 31 * hash + this.uuids.hashCode();
@@ -144,8 +155,8 @@ public final class AliasAsMapKeyExample {
     @DoNotLog
     public String toString() {
         return "AliasAsMapKeyExample{strings: " + strings + ", rids: " + rids + ", bearertokens: " + bearertokens
-                + ", integers: " + integers + ", doubles: " + doubles + ", safelongs: " + safelongs + ", datetimes: "
-                + datetimes + ", uuids: " + uuids + '}';
+                + ", integers: " + integers + ", doubles: " + doubles + ", rawDoubles: " + rawDoubles + ", safelongs: "
+                + safelongs + ", datetimes: " + datetimes + ", uuids: " + uuids + '}';
     }
 
     private static void validateFields(
@@ -154,6 +165,7 @@ public final class AliasAsMapKeyExample {
             Map<BearerTokenAliasExample, ManyFieldExample> bearertokens,
             Map<IntegerAliasExample, ManyFieldExample> integers,
             Map<DoubleAliasExample, ManyFieldExample> doubles,
+            Map<Double, ManyFieldExample> rawDoubles,
             Map<SafeLongAliasExample, ManyFieldExample> safelongs,
             Map<DateTimeAliasExample, ManyFieldExample> datetimes,
             Map<UuidAliasExample, ManyFieldExample> uuids) {
@@ -163,6 +175,7 @@ public final class AliasAsMapKeyExample {
         missingFields = addFieldIfMissing(missingFields, bearertokens, "bearertokens");
         missingFields = addFieldIfMissing(missingFields, integers, "integers");
         missingFields = addFieldIfMissing(missingFields, doubles, "doubles");
+        missingFields = addFieldIfMissing(missingFields, rawDoubles, "rawDoubles");
         missingFields = addFieldIfMissing(missingFields, safelongs, "safelongs");
         missingFields = addFieldIfMissing(missingFields, datetimes, "datetimes");
         missingFields = addFieldIfMissing(missingFields, uuids, "uuids");
@@ -176,7 +189,7 @@ public final class AliasAsMapKeyExample {
         List<String> missingFields = prev;
         if (fieldValue == null) {
             if (missingFields == null) {
-                missingFields = new ArrayList<>(8);
+                missingFields = new ArrayList<>(9);
             }
             missingFields.add(fieldName);
         }
@@ -201,6 +214,8 @@ public final class AliasAsMapKeyExample {
 
         private Map<DoubleAliasExample, ManyFieldExample> doubles = new LinkedHashMap<>();
 
+        private Map<Double, ManyFieldExample> rawDoubles = new LinkedHashMap<>();
+
         private Map<SafeLongAliasExample, ManyFieldExample> safelongs = new LinkedHashMap<>();
 
         private Map<DateTimeAliasExample, ManyFieldExample> datetimes = new LinkedHashMap<>();
@@ -216,6 +231,7 @@ public final class AliasAsMapKeyExample {
             bearertokens(other.getBearertokens());
             integers(other.getIntegers());
             doubles(other.getDoubles());
+            rawDoubles(other.getRawDoubles());
             safelongs(other.getSafelongs());
             datetimes(other.getDatetimes());
             uuids(other.getUuids());
@@ -318,6 +334,25 @@ public final class AliasAsMapKeyExample {
             return this;
         }
 
+        @JsonSetter(value = "rawDoubles", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
+        public Builder rawDoubles(@Nonnull Map<Double, ManyFieldExample> rawDoubles) {
+            checkNotBuilt();
+            this.rawDoubles = new LinkedHashMap<>(Preconditions.checkNotNull(rawDoubles, "rawDoubles cannot be null"));
+            return this;
+        }
+
+        public Builder putAllRawDoubles(@Nonnull Map<Double, ManyFieldExample> rawDoubles) {
+            checkNotBuilt();
+            this.rawDoubles.putAll(Preconditions.checkNotNull(rawDoubles, "rawDoubles cannot be null"));
+            return this;
+        }
+
+        public Builder rawDoubles(double key, ManyFieldExample value) {
+            checkNotBuilt();
+            this.rawDoubles.put(key, value);
+            return this;
+        }
+
         @JsonSetter(value = "safelongs", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder safelongs(@Nonnull Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
             checkNotBuilt();
@@ -380,7 +415,7 @@ public final class AliasAsMapKeyExample {
             checkNotBuilt();
             this._buildInvoked = true;
             return new AliasAsMapKeyExample(
-                    strings, rids, bearertokens, integers, doubles, safelongs, datetimes, uuids);
+                    strings, rids, bearertokens, integers, doubles, rawDoubles, safelongs, datetimes, uuids);
         }
 
         private void checkNotBuilt() {

--- a/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/DoubleAliasExample.java
@@ -77,7 +77,16 @@ public final class DoubleAliasExample implements Comparable<DoubleAliasExample> 
             case "-Infinity":
                 return DoubleAliasExample.of(Double.NEGATIVE_INFINITY);
             default:
-                throw new IllegalArgumentException("Cannot deserialize string into double: " + value);
+                try {
+                    double doubleValue = Double.parseDouble(value);
+                    if (Double.toString(doubleValue).equals(value)) {
+                        return DoubleAliasExample.of(doubleValue);
+                    } else {
+                        throw new IllegalArgumentException("Cannot deserialize string into double: " + value);
+                    }
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("Cannot deserialize string into double: " + value);
+                }
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/SafeDoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/SafeDoubleAliasExample.java
@@ -80,7 +80,16 @@ public final class SafeDoubleAliasExample implements Comparable<SafeDoubleAliasE
             case "-Infinity":
                 return SafeDoubleAliasExample.of(Double.NEGATIVE_INFINITY);
             default:
-                throw new IllegalArgumentException("Cannot deserialize string into double: " + value);
+                try {
+                    double doubleValue = Double.parseDouble(value);
+                    if (Double.toString(doubleValue).equals(value)) {
+                        return SafeDoubleAliasExample.of(doubleValue);
+                    } else {
+                        throw new IllegalArgumentException("Cannot deserialize string into double: " + value);
+                    }
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("Cannot deserialize string into double: " + value);
+                }
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/template/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/template/com/palantir/product/AliasAsMapKeyExample.java
@@ -30,6 +30,8 @@ public final class AliasAsMapKeyExample {
 
     private final Map<IntegerAliasExample, ManyFieldExample> integers;
 
+    private final Map<DoubleAliasExample, ManyFieldExample> doubles;
+
     private final Map<SafeLongAliasExample, ManyFieldExample> safelongs;
 
     private final Map<DateTimeAliasExample, ManyFieldExample> datetimes;
@@ -43,14 +45,16 @@ public final class AliasAsMapKeyExample {
             Map<RidAliasExample, ManyFieldExample> rids,
             Map<BearerTokenAliasExample, ManyFieldExample> bearertokens,
             Map<IntegerAliasExample, ManyFieldExample> integers,
+            Map<DoubleAliasExample, ManyFieldExample> doubles,
             Map<SafeLongAliasExample, ManyFieldExample> safelongs,
             Map<DateTimeAliasExample, ManyFieldExample> datetimes,
             Map<UuidAliasExample, ManyFieldExample> uuids) {
-        validateFields(strings, rids, bearertokens, integers, safelongs, datetimes, uuids);
+        validateFields(strings, rids, bearertokens, integers, doubles, safelongs, datetimes, uuids);
         this.strings = Collections.unmodifiableMap(strings);
         this.rids = Collections.unmodifiableMap(rids);
         this.bearertokens = Collections.unmodifiableMap(bearertokens);
         this.integers = Collections.unmodifiableMap(integers);
+        this.doubles = Collections.unmodifiableMap(doubles);
         this.safelongs = Collections.unmodifiableMap(safelongs);
         this.datetimes = Collections.unmodifiableMap(datetimes);
         this.uuids = Collections.unmodifiableMap(uuids);
@@ -74,6 +78,11 @@ public final class AliasAsMapKeyExample {
     @JsonProperty("integers")
     public Map<IntegerAliasExample, ManyFieldExample> getIntegers() {
         return this.integers;
+    }
+
+    @JsonProperty("doubles")
+    public Map<DoubleAliasExample, ManyFieldExample> getDoubles() {
+        return this.doubles;
     }
 
     @JsonProperty("safelongs")
@@ -106,6 +115,7 @@ public final class AliasAsMapKeyExample {
                 && this.rids.equals(other.rids)
                 && this.bearertokens.equals(other.bearertokens)
                 && this.integers.equals(other.integers)
+                && this.doubles.equals(other.doubles)
                 && this.safelongs.equals(other.safelongs)
                 && this.datetimes.equals(other.datetimes)
                 && this.uuids.equals(other.uuids);
@@ -120,6 +130,7 @@ public final class AliasAsMapKeyExample {
             hash = 31 * hash + this.rids.hashCode();
             hash = 31 * hash + this.bearertokens.hashCode();
             hash = 31 * hash + this.integers.hashCode();
+            hash = 31 * hash + this.doubles.hashCode();
             hash = 31 * hash + this.safelongs.hashCode();
             hash = 31 * hash + this.datetimes.hashCode();
             hash = 31 * hash + this.uuids.hashCode();
@@ -133,8 +144,8 @@ public final class AliasAsMapKeyExample {
     @DoNotLog
     public String toString() {
         return "AliasAsMapKeyExample{strings: " + strings + ", rids: " + rids + ", bearertokens: " + bearertokens
-                + ", integers: " + integers + ", safelongs: " + safelongs + ", datetimes: " + datetimes + ", uuids: "
-                + uuids + '}';
+                + ", integers: " + integers + ", doubles: " + doubles + ", safelongs: " + safelongs + ", datetimes: "
+                + datetimes + ", uuids: " + uuids + '}';
     }
 
     private static void validateFields(
@@ -142,6 +153,7 @@ public final class AliasAsMapKeyExample {
             Map<RidAliasExample, ManyFieldExample> rids,
             Map<BearerTokenAliasExample, ManyFieldExample> bearertokens,
             Map<IntegerAliasExample, ManyFieldExample> integers,
+            Map<DoubleAliasExample, ManyFieldExample> doubles,
             Map<SafeLongAliasExample, ManyFieldExample> safelongs,
             Map<DateTimeAliasExample, ManyFieldExample> datetimes,
             Map<UuidAliasExample, ManyFieldExample> uuids) {
@@ -150,6 +162,7 @@ public final class AliasAsMapKeyExample {
         missingFields = addFieldIfMissing(missingFields, rids, "rids");
         missingFields = addFieldIfMissing(missingFields, bearertokens, "bearertokens");
         missingFields = addFieldIfMissing(missingFields, integers, "integers");
+        missingFields = addFieldIfMissing(missingFields, doubles, "doubles");
         missingFields = addFieldIfMissing(missingFields, safelongs, "safelongs");
         missingFields = addFieldIfMissing(missingFields, datetimes, "datetimes");
         missingFields = addFieldIfMissing(missingFields, uuids, "uuids");
@@ -163,7 +176,7 @@ public final class AliasAsMapKeyExample {
         List<String> missingFields = prev;
         if (fieldValue == null) {
             if (missingFields == null) {
-                missingFields = new ArrayList<>(7);
+                missingFields = new ArrayList<>(8);
             }
             missingFields.add(fieldName);
         }
@@ -186,6 +199,8 @@ public final class AliasAsMapKeyExample {
 
         private Map<IntegerAliasExample, ManyFieldExample> integers = new LinkedHashMap<>();
 
+        private Map<DoubleAliasExample, ManyFieldExample> doubles = new LinkedHashMap<>();
+
         private Map<SafeLongAliasExample, ManyFieldExample> safelongs = new LinkedHashMap<>();
 
         private Map<DateTimeAliasExample, ManyFieldExample> datetimes = new LinkedHashMap<>();
@@ -200,6 +215,7 @@ public final class AliasAsMapKeyExample {
             rids(other.getRids());
             bearertokens(other.getBearertokens());
             integers(other.getIntegers());
+            doubles(other.getDoubles());
             safelongs(other.getSafelongs());
             datetimes(other.getDatetimes());
             uuids(other.getUuids());
@@ -283,6 +299,25 @@ public final class AliasAsMapKeyExample {
             return this;
         }
 
+        @JsonSetter(value = "doubles", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
+        public Builder doubles(@Nonnull Map<DoubleAliasExample, ManyFieldExample> doubles) {
+            checkNotBuilt();
+            this.doubles = new LinkedHashMap<>(Preconditions.checkNotNull(doubles, "doubles cannot be null"));
+            return this;
+        }
+
+        public Builder putAllDoubles(@Nonnull Map<DoubleAliasExample, ManyFieldExample> doubles) {
+            checkNotBuilt();
+            this.doubles.putAll(Preconditions.checkNotNull(doubles, "doubles cannot be null"));
+            return this;
+        }
+
+        public Builder doubles(DoubleAliasExample key, ManyFieldExample value) {
+            checkNotBuilt();
+            this.doubles.put(key, value);
+            return this;
+        }
+
         @JsonSetter(value = "safelongs", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder safelongs(@Nonnull Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
             checkNotBuilt();
@@ -344,7 +379,8 @@ public final class AliasAsMapKeyExample {
         public AliasAsMapKeyExample build() {
             checkNotBuilt();
             this._buildInvoked = true;
-            return new AliasAsMapKeyExample(strings, rids, bearertokens, integers, safelongs, datetimes, uuids);
+            return new AliasAsMapKeyExample(
+                    strings, rids, bearertokens, integers, doubles, safelongs, datetimes, uuids);
         }
 
         private void checkNotBuilt() {

--- a/conjure-java-core/src/integrationInput/java/template/com/palantir/product/AliasAsMapKeyExample.java
+++ b/conjure-java-core/src/integrationInput/java/template/com/palantir/product/AliasAsMapKeyExample.java
@@ -32,6 +32,8 @@ public final class AliasAsMapKeyExample {
 
     private final Map<DoubleAliasExample, ManyFieldExample> doubles;
 
+    private final Map<Double, ManyFieldExample> rawDoubles;
+
     private final Map<SafeLongAliasExample, ManyFieldExample> safelongs;
 
     private final Map<DateTimeAliasExample, ManyFieldExample> datetimes;
@@ -46,15 +48,17 @@ public final class AliasAsMapKeyExample {
             Map<BearerTokenAliasExample, ManyFieldExample> bearertokens,
             Map<IntegerAliasExample, ManyFieldExample> integers,
             Map<DoubleAliasExample, ManyFieldExample> doubles,
+            Map<Double, ManyFieldExample> rawDoubles,
             Map<SafeLongAliasExample, ManyFieldExample> safelongs,
             Map<DateTimeAliasExample, ManyFieldExample> datetimes,
             Map<UuidAliasExample, ManyFieldExample> uuids) {
-        validateFields(strings, rids, bearertokens, integers, doubles, safelongs, datetimes, uuids);
+        validateFields(strings, rids, bearertokens, integers, doubles, rawDoubles, safelongs, datetimes, uuids);
         this.strings = Collections.unmodifiableMap(strings);
         this.rids = Collections.unmodifiableMap(rids);
         this.bearertokens = Collections.unmodifiableMap(bearertokens);
         this.integers = Collections.unmodifiableMap(integers);
         this.doubles = Collections.unmodifiableMap(doubles);
+        this.rawDoubles = Collections.unmodifiableMap(rawDoubles);
         this.safelongs = Collections.unmodifiableMap(safelongs);
         this.datetimes = Collections.unmodifiableMap(datetimes);
         this.uuids = Collections.unmodifiableMap(uuids);
@@ -83,6 +87,11 @@ public final class AliasAsMapKeyExample {
     @JsonProperty("doubles")
     public Map<DoubleAliasExample, ManyFieldExample> getDoubles() {
         return this.doubles;
+    }
+
+    @JsonProperty("rawDoubles")
+    public Map<Double, ManyFieldExample> getRawDoubles() {
+        return this.rawDoubles;
     }
 
     @JsonProperty("safelongs")
@@ -116,6 +125,7 @@ public final class AliasAsMapKeyExample {
                 && this.bearertokens.equals(other.bearertokens)
                 && this.integers.equals(other.integers)
                 && this.doubles.equals(other.doubles)
+                && this.rawDoubles.equals(other.rawDoubles)
                 && this.safelongs.equals(other.safelongs)
                 && this.datetimes.equals(other.datetimes)
                 && this.uuids.equals(other.uuids);
@@ -131,6 +141,7 @@ public final class AliasAsMapKeyExample {
             hash = 31 * hash + this.bearertokens.hashCode();
             hash = 31 * hash + this.integers.hashCode();
             hash = 31 * hash + this.doubles.hashCode();
+            hash = 31 * hash + this.rawDoubles.hashCode();
             hash = 31 * hash + this.safelongs.hashCode();
             hash = 31 * hash + this.datetimes.hashCode();
             hash = 31 * hash + this.uuids.hashCode();
@@ -144,8 +155,8 @@ public final class AliasAsMapKeyExample {
     @DoNotLog
     public String toString() {
         return "AliasAsMapKeyExample{strings: " + strings + ", rids: " + rids + ", bearertokens: " + bearertokens
-                + ", integers: " + integers + ", doubles: " + doubles + ", safelongs: " + safelongs + ", datetimes: "
-                + datetimes + ", uuids: " + uuids + '}';
+                + ", integers: " + integers + ", doubles: " + doubles + ", rawDoubles: " + rawDoubles + ", safelongs: "
+                + safelongs + ", datetimes: " + datetimes + ", uuids: " + uuids + '}';
     }
 
     private static void validateFields(
@@ -154,6 +165,7 @@ public final class AliasAsMapKeyExample {
             Map<BearerTokenAliasExample, ManyFieldExample> bearertokens,
             Map<IntegerAliasExample, ManyFieldExample> integers,
             Map<DoubleAliasExample, ManyFieldExample> doubles,
+            Map<Double, ManyFieldExample> rawDoubles,
             Map<SafeLongAliasExample, ManyFieldExample> safelongs,
             Map<DateTimeAliasExample, ManyFieldExample> datetimes,
             Map<UuidAliasExample, ManyFieldExample> uuids) {
@@ -163,6 +175,7 @@ public final class AliasAsMapKeyExample {
         missingFields = addFieldIfMissing(missingFields, bearertokens, "bearertokens");
         missingFields = addFieldIfMissing(missingFields, integers, "integers");
         missingFields = addFieldIfMissing(missingFields, doubles, "doubles");
+        missingFields = addFieldIfMissing(missingFields, rawDoubles, "rawDoubles");
         missingFields = addFieldIfMissing(missingFields, safelongs, "safelongs");
         missingFields = addFieldIfMissing(missingFields, datetimes, "datetimes");
         missingFields = addFieldIfMissing(missingFields, uuids, "uuids");
@@ -176,7 +189,7 @@ public final class AliasAsMapKeyExample {
         List<String> missingFields = prev;
         if (fieldValue == null) {
             if (missingFields == null) {
-                missingFields = new ArrayList<>(8);
+                missingFields = new ArrayList<>(9);
             }
             missingFields.add(fieldName);
         }
@@ -201,6 +214,8 @@ public final class AliasAsMapKeyExample {
 
         private Map<DoubleAliasExample, ManyFieldExample> doubles = new LinkedHashMap<>();
 
+        private Map<Double, ManyFieldExample> rawDoubles = new LinkedHashMap<>();
+
         private Map<SafeLongAliasExample, ManyFieldExample> safelongs = new LinkedHashMap<>();
 
         private Map<DateTimeAliasExample, ManyFieldExample> datetimes = new LinkedHashMap<>();
@@ -216,6 +231,7 @@ public final class AliasAsMapKeyExample {
             bearertokens(other.getBearertokens());
             integers(other.getIntegers());
             doubles(other.getDoubles());
+            rawDoubles(other.getRawDoubles());
             safelongs(other.getSafelongs());
             datetimes(other.getDatetimes());
             uuids(other.getUuids());
@@ -318,6 +334,25 @@ public final class AliasAsMapKeyExample {
             return this;
         }
 
+        @JsonSetter(value = "rawDoubles", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
+        public Builder rawDoubles(@Nonnull Map<Double, ManyFieldExample> rawDoubles) {
+            checkNotBuilt();
+            this.rawDoubles = new LinkedHashMap<>(Preconditions.checkNotNull(rawDoubles, "rawDoubles cannot be null"));
+            return this;
+        }
+
+        public Builder putAllRawDoubles(@Nonnull Map<Double, ManyFieldExample> rawDoubles) {
+            checkNotBuilt();
+            this.rawDoubles.putAll(Preconditions.checkNotNull(rawDoubles, "rawDoubles cannot be null"));
+            return this;
+        }
+
+        public Builder rawDoubles(double key, ManyFieldExample value) {
+            checkNotBuilt();
+            this.rawDoubles.put(key, value);
+            return this;
+        }
+
         @JsonSetter(value = "safelongs", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
         public Builder safelongs(@Nonnull Map<SafeLongAliasExample, ManyFieldExample> safelongs) {
             checkNotBuilt();
@@ -380,7 +415,7 @@ public final class AliasAsMapKeyExample {
             checkNotBuilt();
             this._buildInvoked = true;
             return new AliasAsMapKeyExample(
-                    strings, rids, bearertokens, integers, doubles, safelongs, datetimes, uuids);
+                    strings, rids, bearertokens, integers, doubles, rawDoubles, safelongs, datetimes, uuids);
         }
 
         private void checkNotBuilt() {

--- a/conjure-java-core/src/integrationInput/java/template/com/palantir/product/DoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/template/com/palantir/product/DoubleAliasExample.java
@@ -77,7 +77,16 @@ public final class DoubleAliasExample implements Comparable<DoubleAliasExample> 
             case "-Infinity":
                 return DoubleAliasExample.of(Double.NEGATIVE_INFINITY);
             default:
-                throw new IllegalArgumentException("Cannot deserialize string into double: " + value);
+                try {
+                    double doubleValue = Double.parseDouble(value);
+                    if (Double.toString(doubleValue).equals(value)) {
+                        return DoubleAliasExample.of(doubleValue);
+                    } else {
+                        throw new IllegalArgumentException("Cannot deserialize string into double: " + value);
+                    }
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("Cannot deserialize string into double: " + value);
+                }
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/template/com/palantir/product/SafeDoubleAliasExample.java
+++ b/conjure-java-core/src/integrationInput/java/template/com/palantir/product/SafeDoubleAliasExample.java
@@ -80,7 +80,16 @@ public final class SafeDoubleAliasExample implements Comparable<SafeDoubleAliasE
             case "-Infinity":
                 return SafeDoubleAliasExample.of(Double.NEGATIVE_INFINITY);
             default:
-                throw new IllegalArgumentException("Cannot deserialize string into double: " + value);
+                try {
+                    double doubleValue = Double.parseDouble(value);
+                    if (Double.toString(doubleValue).equals(value)) {
+                        return SafeDoubleAliasExample.of(doubleValue);
+                    } else {
+                        throw new IllegalArgumentException("Cannot deserialize string into double: " + value);
+                    }
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("Cannot deserialize string into double: " + value);
+                }
         }
     }
 }

--- a/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/AliasedDouble.java
+++ b/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/AliasedDouble.java
@@ -77,7 +77,16 @@ public final class AliasedDouble implements Comparable<AliasedDouble> {
             case "-Infinity":
                 return AliasedDouble.of(Double.NEGATIVE_INFINITY);
             default:
-                throw new IllegalArgumentException("Cannot deserialize string into double: " + value);
+                try {
+                    double doubleValue = Double.parseDouble(value);
+                    if (Double.toString(doubleValue).equals(value)) {
+                        return AliasedDouble.of(doubleValue);
+                    } else {
+                        throw new IllegalArgumentException("Cannot deserialize string into double: " + value);
+                    }
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("Cannot deserialize string into double: " + value);
+                }
         }
     }
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -208,9 +208,20 @@ public final class AliasGenerator {
                     .unindent()
                     .add("default:\n")
                     .indent()
+                    .beginControlFlow("try")
+                    .addStatement("double doubleValue = $T.parseDouble(value)", Double.class)
+                    .beginControlFlow("if ($T.toString(doubleValue).equals(value))", Double.class)
+                    .addStatement("return $T.of(doubleValue)", thisClass)
+                    .nextControlFlow("else")
                     .addStatement(
                             "throw new $T(\"Cannot deserialize string into double: \" + value)",
                             IllegalArgumentException.class)
+                    .endControlFlow()
+                    .nextControlFlow("catch ($T e)", NumberFormatException.class)
+                    .addStatement(
+                            "throw new $T(\"Cannot deserialize string into double: \" + value)",
+                            IllegalArgumentException.class)
+                    .endControlFlow()
                     .unindent()
                     .endControlFlow()
                     .build();

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -567,6 +567,7 @@ public final class WireFormatTests {
                     "bearertokens":{},
                     "integers":{},
                     "doubles":{"%s": {"string":"hello","integer":1,"doubleValue":%s,"items":[],"set":[],"map":{},"alias":"hello"}},
+                    "rawDoubles":{"%s": {"string":"hello","integer":1,"doubleValue":%s,"items":[],"set":[],"map":{},"alias":"hello"}},
                     "safelongs":{},
                     "datetimes":{},
                     "uuids":{}
@@ -576,10 +577,16 @@ public final class WireFormatTests {
                 Set.of(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)
                                 .contains(doubleKey)
                         ? "\"" + doubleKey + "\""
+                        : doubleKey,
+                doubleKey,
+                Set.of(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)
+                                .contains(doubleKey)
+                        ? "\"" + doubleKey + "\""
                         : doubleKey);
         String expected = expectedPretty.strip().replaceAll("\n", "").replaceAll(" ", "");
         AliasAsMapKeyExample example = AliasAsMapKeyExample.builder()
                 .doubles(ImmutableMap.of(DoubleAliasExample.of(doubleKey), value))
+                .rawDoubles(doubleKey, value)
                 .build();
         assertThat(mapper.writeValueAsString(example)).isEqualTo(expected);
         assertThat(mapper.readValue(expected, AliasAsMapKeyExample.class)).isEqualTo(example);

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.types;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import allexamples.com.palantir.product.AliasAsMapKeyExample;
 import allexamples.com.palantir.product.BinaryAliasExample;
 import allexamples.com.palantir.product.BinaryExample;
 import allexamples.com.palantir.product.DateTimeExample;
@@ -31,6 +32,7 @@ import allexamples.com.palantir.product.ExternalStringAliasExample;
 import allexamples.com.palantir.product.IntegerAliasExample;
 import allexamples.com.palantir.product.ListAlias;
 import allexamples.com.palantir.product.ListExample;
+import allexamples.com.palantir.product.ManyFieldExample;
 import allexamples.com.palantir.product.MapAliasExample;
 import allexamples.com.palantir.product.MapExample;
 import allexamples.com.palantir.product.OptionalAlias;
@@ -531,13 +533,51 @@ public final class WireFormatTests {
 
     @Test
     public void double_alias_should_serialize_with_decimal_point() throws Exception {
+        assertThat(String.valueOf(10e2)).isEqualTo("1000.0");
         assertThat(mapper.writeValueAsString(DoubleAliasExample.of(100L))).isEqualTo("100.0");
+    }
+
+    @Test
+    public void double_alias_should_serialize_with_e() throws Exception {
+        assertThat(mapper.writeValueAsString(DoubleAliasExample.of(100e2))).isEqualTo("100.0e2");
     }
 
     @Test
     public void double_alias_should_deserialize_without_decimal_point() throws Exception {
         // frontends can send numbers like this!
         assertThat(mapper.readValue("100", DoubleAliasExample.class)).isEqualTo(DoubleAliasExample.of(100L));
+    }
+
+    @Test
+    public void double_alias_map_key_should_serialize_as_string() throws Exception {
+        ManyFieldExample value = ManyFieldExample.builder()
+                .integer(1)
+                .doubleValue(1.0)
+                .string("hello")
+                .alias(StringAliasExample.of("hello"))
+                .build();
+
+        String expectedPretty =
+                // language=JSON
+                """
+                {
+                    "strings":{},
+                    "rids":{},
+                    "bearertokens":{},
+                    "integers":{},
+                    "doubles":{"1.0": {"string":"hello","integer":1,"doubleValue":1.0,"items":[],"set":[],"map":{},"alias":"hello"}},
+                    "safelongs":{},
+                    "datetimes":{},
+                    "uuids":{}
+                    }
+                """;
+        String expected = expectedPretty.strip().replaceAll("\n", "").replaceAll(" ", "");
+        AliasAsMapKeyExample example = AliasAsMapKeyExample.builder()
+                // .integers(ImmutableMap.of(IntegerAliasExample.of(1), value))
+                .doubles(ImmutableMap.of(DoubleAliasExample.of(1.0), value))
+                .build();
+        assertThat(mapper.writeValueAsString(example)).isEqualTo(expected);
+        assertThat(mapper.readValue(expected, AliasAsMapKeyExample.class)).isEqualTo(example);
     }
 
     @Test

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -87,6 +87,8 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @Execution(ExecutionMode.CONCURRENT)
 public final class WireFormatTests {
@@ -533,13 +535,12 @@ public final class WireFormatTests {
 
     @Test
     public void double_alias_should_serialize_with_decimal_point() throws Exception {
-        assertThat(String.valueOf(10e2)).isEqualTo("1000.0");
         assertThat(mapper.writeValueAsString(DoubleAliasExample.of(100L))).isEqualTo("100.0");
     }
 
     @Test
     public void double_alias_should_serialize_with_e() throws Exception {
-        assertThat(mapper.writeValueAsString(DoubleAliasExample.of(100e2))).isEqualTo("100.0e2");
+        assertThat(mapper.writeValueAsString(DoubleAliasExample.of(100e20))).isEqualTo("1.0E22");
     }
 
     @Test
@@ -548,33 +549,37 @@ public final class WireFormatTests {
         assertThat(mapper.readValue("100", DoubleAliasExample.class)).isEqualTo(DoubleAliasExample.of(100L));
     }
 
-    @Test
-    public void double_alias_map_key_should_serialize_as_string() throws Exception {
+    @ParameterizedTest
+    @ValueSource(doubles = {1, Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, -0.0, 1e20})
+    public void double_alias_map_key_should_serialize_as_string(Double doubleKey) throws Exception {
         ManyFieldExample value = ManyFieldExample.builder()
                 .integer(1)
-                .doubleValue(1.0)
+                .doubleValue(doubleKey)
                 .string("hello")
                 .alias(StringAliasExample.of("hello"))
                 .build();
 
-        String expectedPretty =
-                // language=JSON
+        String expectedPretty = String.format(
                 """
                 {
                     "strings":{},
                     "rids":{},
                     "bearertokens":{},
                     "integers":{},
-                    "doubles":{"1.0": {"string":"hello","integer":1,"doubleValue":1.0,"items":[],"set":[],"map":{},"alias":"hello"}},
+                    "doubles":{"%s": {"string":"hello","integer":1,"doubleValue":%s,"items":[],"set":[],"map":{},"alias":"hello"}},
                     "safelongs":{},
                     "datetimes":{},
                     "uuids":{}
                     }
-                """;
+                """,
+                doubleKey,
+                Set.of(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)
+                                .contains(doubleKey)
+                        ? "\"" + doubleKey + "\""
+                        : doubleKey);
         String expected = expectedPretty.strip().replaceAll("\n", "").replaceAll(" ", "");
         AliasAsMapKeyExample example = AliasAsMapKeyExample.builder()
-                // .integers(ImmutableMap.of(IntegerAliasExample.of(1), value))
-                .doubles(ImmutableMap.of(DoubleAliasExample.of(1.0), value))
+                .doubles(ImmutableMap.of(DoubleAliasExample.of(doubleKey), value))
                 .build();
         assertThat(mapper.writeValueAsString(example)).isEqualTo(expected);
         assertThat(mapper.readValue(expected, AliasAsMapKeyExample.class)).isEqualTo(example);

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -559,6 +559,11 @@ public final class WireFormatTests {
                 .alias(StringAliasExample.of("hello"))
                 .build();
 
+        String doubleValue = Set.of(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)
+                        .contains(doubleKey)
+                ? "\"" + doubleKey + "\""
+                : doubleKey.toString();
+
         String expectedPretty = String.format(
                 """
                 {
@@ -573,16 +578,7 @@ public final class WireFormatTests {
                     "uuids":{}
                     }
                 """,
-                doubleKey,
-                Set.of(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)
-                                .contains(doubleKey)
-                        ? "\"" + doubleKey + "\""
-                        : doubleKey,
-                doubleKey,
-                Set.of(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)
-                                .contains(doubleKey)
-                        ? "\"" + doubleKey + "\""
-                        : doubleKey);
+                doubleKey, doubleValue, doubleKey, doubleValue);
         String expected = expectedPretty.strip().replaceAll("\n", "").replaceAll(" ", "");
         AliasAsMapKeyExample example = AliasAsMapKeyExample.builder()
                 .doubles(ImmutableMap.of(DoubleAliasExample.of(doubleKey), value))

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -261,7 +261,7 @@ types:
           rids: map<RidAliasExample, ManyFieldExample>
           bearertokens: map<BearerTokenAliasExample, ManyFieldExample>
           integers: map<IntegerAliasExample, ManyFieldExample>
-          # doubles: map<DoubleAliasExample, ManyFieldExample> # typescript freaks out with the 'NaN'
+          doubles: map<DoubleAliasExample, ManyFieldExample> # typescript freaks out with the 'NaN'
           safelongs: map<SafeLongAliasExample, ManyFieldExample>
           datetimes: map<DateTimeAliasExample, ManyFieldExample>
           uuids: map<UuidAliasExample, ManyFieldExample>

--- a/conjure-java-core/src/test/resources/example-types.yml
+++ b/conjure-java-core/src/test/resources/example-types.yml
@@ -262,6 +262,7 @@ types:
           bearertokens: map<BearerTokenAliasExample, ManyFieldExample>
           integers: map<IntegerAliasExample, ManyFieldExample>
           doubles: map<DoubleAliasExample, ManyFieldExample> # typescript freaks out with the 'NaN'
+          rawDoubles: map<double, ManyFieldExample>
           safelongs: map<SafeLongAliasExample, ManyFieldExample>
           datetimes: map<DateTimeAliasExample, ManyFieldExample>
           uuids: map<UuidAliasExample, ManyFieldExample>


### PR DESCRIPTION
## Before this PR
Aliases of doubles are valid keys in maps. Keys in maps are serialized as strings. Aliases of doubles can only be deserialized from `NaN`, `Infinity`, and `-Infinity`. We should support deserialization of other valid double values.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Support deserialization of double aliases from strings
==COMMIT_MSG==

## Possible downsides?

