### PR TITLE
stop using deprecated method in ObjectMapper

### DIFF
--- a/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
+++ b/conjure-java/src/main/java/com/palantir/conjure/java/cli/ConjureJavaCli.java
@@ -68,7 +68,7 @@ public final class ConjureJavaCli implements Runnable {
     public static final class GenerateCommand implements Runnable {
         private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
                 .registerModule(new Jdk8Module())
-                .setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
+                .setDefaultPropertyInclusion(JsonInclude.Include.NON_ABSENT);
 
         @CommandLine.Parameters(paramLabel = "<input>", description = "Path to the input IR file", index = "0")
         private String input;


### PR DESCRIPTION


## Before this PR
In Jackson 2.20.0, `ObjectMapper#setSerializationInclusion` is marked deprecated (although the source change claims it has been deprecated since 2.9).

## After this PR
To prepare to adopt 2.20, replace `ObjectMapper#setSerializationInclusion` with `ObjectMapper#setDefaultPropertyInclusion`.

==COMMIT_MSG==
stop using deprecated method in ObjectMapper
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

