### PR TITLE
Generate sealed interfaces to match against endpoint associated errors

### DIFF
--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/another/EndpointSpecificErrors.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/another/EndpointSpecificErrors.java
@@ -1,0 +1,63 @@
+package endpointerrors.com.palantir.another;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.palantir.conjure.java.api.errors.AbstractSerializableError;
+import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.RemoteException;
+import com.palantir.conjure.java.api.errors.SerializableError;
+import com.palantir.conjure.java.api.errors.SerializableErrorProvider;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.types.ErrorGenerator")
+public final class EndpointSpecificErrors {
+    /** An error in a different package. */
+    public static final ErrorType DIFFERENT_PACKAGE =
+            ErrorType.create(ErrorType.Code.INTERNAL, "EndpointSpecific:DifferentPackage");
+
+    private EndpointSpecificErrors() {}
+
+    /** Returns true if the {@link RemoteException} is named EndpointSpecific:DifferentPackage */
+    public static boolean isDifferentPackage(RemoteException remoteException) {
+        Preconditions.checkNotNull(remoteException, "remote exception must not be null");
+        return DIFFERENT_PACKAGE.name().equals(remoteException.getError().errorName());
+    }
+
+    public static record DifferentPackageParameters() {}
+
+    public static final class DifferentPackageSerializableError
+            extends AbstractSerializableError<DifferentPackageParameters> {
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        DifferentPackageSerializableError(
+                @JsonProperty("errorCode") @Safe String errorCode,
+                @JsonProperty("errorName") @Safe String errorName,
+                @JsonProperty("errorInstanceId") @Safe String errorInstanceId,
+                @JsonProperty("parameters") DifferentPackageParameters parameters) {
+            super(errorCode, errorName, errorInstanceId, parameters);
+        }
+
+        public SerializableError toSerializableError() {
+            return SerializableError.builder()
+                    .errorCode(errorCode())
+                    .errorName(errorName())
+                    .errorInstanceId(errorInstanceId())
+                    .build();
+        }
+    }
+
+    public static final class DifferentPackageException extends RemoteException
+            implements SerializableErrorProvider<DifferentPackageParameters> {
+        private DifferentPackageSerializableError error;
+
+        public DifferentPackageException(DifferentPackageSerializableError error, int status) {
+            super(error.toSerializableError(), status);
+            this.error = error;
+        }
+
+        public DifferentPackageSerializableError error() {
+            return error;
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/another/EndpointSpecificServerErrors.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/another/EndpointSpecificServerErrors.java
@@ -1,0 +1,37 @@
+package endpointerrors.com.palantir.another;
+
+import com.palantir.conjure.java.api.errors.EndpointServiceException;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+import org.jetbrains.annotations.Contract;
+
+@Generated("com.palantir.conjure.java.types.EndpointErrorGenerator")
+public final class EndpointSpecificServerErrors {
+    private EndpointSpecificServerErrors() {}
+
+    public static DifferentPackage differentPackage() {
+        return new DifferentPackage(null);
+    }
+
+    public static DifferentPackage differentPackage(@Nullable Throwable cause) {
+        return new DifferentPackage(cause);
+    }
+
+    /**
+     * Throws a {@link DifferentPackage} when {@code shouldThrow} is true.
+     *
+     * @param shouldThrow Cause the method to throw when true
+     */
+    @Contract("true -> fail")
+    public static void throwIfDifferentPackage(boolean shouldThrow) {
+        if (shouldThrow) {
+            throw differentPackage();
+        }
+    }
+
+    public static final class DifferentPackage extends EndpointServiceException {
+        private DifferentPackage(@Nullable Throwable cause) {
+            super(EndpointSpecificErrors.DIFFERENT_PACKAGE, cause);
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ComplicatedObject.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ComplicatedObject.java
@@ -1,0 +1,172 @@
+package endpointerrors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.errorprone.annotations.CheckReturnValue;
+import com.palantir.conjure.java.lib.internal.ConjureCollections;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@JsonDeserialize(builder = ComplicatedObject.Builder.class)
+@Generated("com.palantir.conjure.java.types.BeanGenerator")
+public final class ComplicatedObject {
+    private final List<String> fieldOne;
+
+    private final Optional<StringAlias> fieldTwo;
+
+    private int memoizedHashCode;
+
+    private ComplicatedObject(List<String> fieldOne, Optional<StringAlias> fieldTwo) {
+        validateFields(fieldOne, fieldTwo);
+        this.fieldOne = ConjureCollections.unmodifiableList(fieldOne);
+        this.fieldTwo = fieldTwo;
+    }
+
+    @JsonProperty("fieldOne")
+    public List<String> getFieldOne() {
+        return this.fieldOne;
+    }
+
+    @JsonProperty("fieldTwo")
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    public Optional<StringAlias> getFieldTwo() {
+        return this.fieldTwo;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof ComplicatedObject && equalTo((ComplicatedObject) other));
+    }
+
+    private boolean equalTo(ComplicatedObject other) {
+        if (this.memoizedHashCode != 0
+                && other.memoizedHashCode != 0
+                && this.memoizedHashCode != other.memoizedHashCode) {
+            return false;
+        }
+        return this.fieldOne.equals(other.fieldOne) && this.fieldTwo.equals(other.fieldTwo);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = memoizedHashCode;
+        if (result == 0) {
+            int hash = 1;
+            hash = 31 * hash + this.fieldOne.hashCode();
+            hash = 31 * hash + this.fieldTwo.hashCode();
+            result = hash;
+            memoizedHashCode = result;
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ComplicatedObject{fieldOne: " + fieldOne + ", fieldTwo: " + fieldTwo + '}';
+    }
+
+    public static ComplicatedObject of(List<String> fieldOne, StringAlias fieldTwo) {
+        return builder().fieldOne(fieldOne).fieldTwo(Optional.of(fieldTwo)).build();
+    }
+
+    private static void validateFields(List<String> fieldOne, Optional<StringAlias> fieldTwo) {
+        List<String> missingFields = null;
+        missingFields = addFieldIfMissing(missingFields, fieldOne, "fieldOne");
+        missingFields = addFieldIfMissing(missingFields, fieldTwo, "fieldTwo");
+        if (missingFields != null) {
+            throw new SafeIllegalArgumentException(
+                    "Some required fields have not been set", SafeArg.of("missingFields", missingFields));
+        }
+    }
+
+    private static List<String> addFieldIfMissing(List<String> prev, Object fieldValue, String fieldName) {
+        List<String> missingFields = prev;
+        if (fieldValue == null) {
+            if (missingFields == null) {
+                missingFields = new ArrayList<>(2);
+            }
+            missingFields.add(fieldName);
+        }
+        return missingFields;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Generated("com.palantir.conjure.java.types.BeanBuilderGenerator")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder {
+        boolean _buildInvoked;
+
+        private List<String> fieldOne = ConjureCollections.newNonNullList();
+
+        private Optional<StringAlias> fieldTwo = Optional.empty();
+
+        private Builder() {}
+
+        public Builder from(ComplicatedObject other) {
+            checkNotBuilt();
+            fieldOne(other.getFieldOne());
+            fieldTwo(other.getFieldTwo());
+            return this;
+        }
+
+        @JsonSetter(value = "fieldOne", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
+        public Builder fieldOne(@Nonnull Iterable<String> fieldOne) {
+            checkNotBuilt();
+            this.fieldOne =
+                    ConjureCollections.newNonNullList(Preconditions.checkNotNull(fieldOne, "fieldOne cannot be null"));
+            return this;
+        }
+
+        public Builder addAllFieldOne(@Nonnull Iterable<String> fieldOne) {
+            checkNotBuilt();
+            ConjureCollections.addAllAndCheckNonNull(
+                    this.fieldOne, Preconditions.checkNotNull(fieldOne, "fieldOne cannot be null"));
+            return this;
+        }
+
+        public Builder fieldOne(String fieldOne) {
+            checkNotBuilt();
+            Preconditions.checkNotNull(fieldOne, "fieldOne cannot be null");
+            this.fieldOne.add(fieldOne);
+            return this;
+        }
+
+        @JsonSetter(value = "fieldTwo", nulls = Nulls.SKIP)
+        public Builder fieldTwo(@Nonnull Optional<StringAlias> fieldTwo) {
+            checkNotBuilt();
+            this.fieldTwo = Preconditions.checkNotNull(fieldTwo, "fieldTwo cannot be null");
+            return this;
+        }
+
+        public Builder fieldTwo(@Nonnull StringAlias fieldTwo) {
+            checkNotBuilt();
+            this.fieldTwo = Optional.of(Preconditions.checkNotNull(fieldTwo, "fieldTwo cannot be null"));
+            return this;
+        }
+
+        @CheckReturnValue
+        public ComplicatedObject build() {
+            checkNotBuilt();
+            this._buildInvoked = true;
+            return new ComplicatedObject(fieldOne, fieldTwo);
+        }
+
+        private void checkNotBuilt() {
+            Preconditions.checkState(!_buildInvoked, "Build has already been called");
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ConjureErrors.java
@@ -29,7 +29,8 @@ public final class ConjureErrors {
     }
 
     public static record ConflictingCauseSafeArgErrParameters(
-            @JsonProperty("cause") @Safe String cause, @JsonProperty("shouldThrow") @Safe boolean shouldThrow) {}
+            @JsonProperty("cause") @Safe String cause,
+            @JsonProperty("shouldThrow") @Safe boolean shouldThrow) {}
 
     public static final class ConflictingCauseSafeArgErrSerializableError
             extends AbstractSerializableError<ConflictingCauseSafeArgErrParameters> {

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ConjureErrors.java
@@ -1,0 +1,69 @@
+package endpointerrors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.palantir.conjure.java.api.errors.AbstractSerializableError;
+import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.RemoteException;
+import com.palantir.conjure.java.api.errors.SerializableError;
+import com.palantir.conjure.java.api.errors.SerializableErrorProvider;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.types.ErrorGenerator")
+public final class ConjureErrors {
+    /** Cause argument conflicts with reserved Throwable cause parameter. */
+    public static final ErrorType CONFLICTING_CAUSE_SAFE_ARG_ERR =
+            ErrorType.create(ErrorType.Code.INTERNAL, "Conjure:ConflictingCauseSafeArgErr");
+
+    private ConjureErrors() {}
+
+    /** Returns true if the {@link RemoteException} is named Conjure:ConflictingCauseSafeArgErr */
+    public static boolean isConflictingCauseSafeArgErr(RemoteException remoteException) {
+        Preconditions.checkNotNull(remoteException, "remote exception must not be null");
+        return CONFLICTING_CAUSE_SAFE_ARG_ERR
+                .name()
+                .equals(remoteException.getError().errorName());
+    }
+
+    public static record ConflictingCauseSafeArgErrParameters(
+            @JsonProperty("cause") @Safe String cause, @JsonProperty("shouldThrow") @Safe boolean shouldThrow) {}
+
+    public static final class ConflictingCauseSafeArgErrSerializableError
+            extends AbstractSerializableError<ConflictingCauseSafeArgErrParameters> {
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        ConflictingCauseSafeArgErrSerializableError(
+                @JsonProperty("errorCode") @Safe String errorCode,
+                @JsonProperty("errorName") @Safe String errorName,
+                @JsonProperty("errorInstanceId") @Safe String errorInstanceId,
+                @JsonProperty("parameters") ConflictingCauseSafeArgErrParameters parameters) {
+            super(errorCode, errorName, errorInstanceId, parameters);
+        }
+
+        public SerializableError toSerializableError() {
+            return SerializableError.builder()
+                    .putParameters("cause", Objects.toString(parameters().cause()))
+                    .putParameters("shouldThrow", Objects.toString(parameters().shouldThrow()))
+                    .errorCode(errorCode())
+                    .errorName(errorName())
+                    .errorInstanceId(errorInstanceId())
+                    .build();
+        }
+    }
+
+    public static final class ConflictingCauseSafeArgErrException extends RemoteException
+            implements SerializableErrorProvider<ConflictingCauseSafeArgErrParameters> {
+        private ConflictingCauseSafeArgErrSerializableError error;
+
+        public ConflictingCauseSafeArgErrException(ConflictingCauseSafeArgErrSerializableError error, int status) {
+            super(error.toSerializableError(), status);
+            this.error = error;
+        }
+
+        public ConflictingCauseSafeArgErrSerializableError error() {
+            return error;
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ConjureServerErrors.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ConjureServerErrors.java
@@ -1,0 +1,48 @@
+package endpointerrors.com.palantir.product;
+
+import com.palantir.conjure.java.api.errors.EndpointServiceException;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+import org.jetbrains.annotations.Contract;
+
+@Generated("com.palantir.conjure.java.types.EndpointErrorGenerator")
+public final class ConjureServerErrors {
+    private ConjureServerErrors() {}
+
+    public static ConflictingCauseSafeArgErr conflictingCauseSafeArgErr(
+            @Safe String cause_, @Safe boolean shouldThrow_) {
+        return new ConflictingCauseSafeArgErr(cause_, shouldThrow_, null);
+    }
+
+    public static ConflictingCauseSafeArgErr conflictingCauseSafeArgErr(
+            @Safe String cause_, @Safe boolean shouldThrow_, @Nullable Throwable cause) {
+        return new ConflictingCauseSafeArgErr(cause_, shouldThrow_, cause);
+    }
+
+    /**
+     * Throws a {@link ConflictingCauseSafeArgErr} when {@code shouldThrow} is true.
+     *
+     * @param shouldThrow Cause the method to throw when true
+     * @param cause_
+     * @param shouldThrow_
+     */
+    @Contract("true, _, _ -> fail")
+    public static void throwIfConflictingCauseSafeArgErr(
+            boolean shouldThrow, @Safe String cause_, @Safe boolean shouldThrow_) {
+        if (shouldThrow) {
+            throw conflictingCauseSafeArgErr(cause_, shouldThrow_);
+        }
+    }
+
+    public static final class ConflictingCauseSafeArgErr extends EndpointServiceException {
+        private ConflictingCauseSafeArgErr(@Safe String cause_, @Safe boolean shouldThrow_, @Nullable Throwable cause) {
+            super(
+                    ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG_ERR,
+                    cause,
+                    SafeArg.of("cause", cause_),
+                    SafeArg.of("shouldThrow", shouldThrow_));
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/DialogueErrorEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/DialogueErrorEndpoints.java
@@ -1,0 +1,198 @@
+package endpointerrors.com.palantir.product;
+
+import com.google.common.collect.ListMultimap;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.HttpMethod;
+import com.palantir.dialogue.PathTemplate;
+import com.palantir.dialogue.UrlBuilder;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Optional;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.services.dialogue.DialogueEndpointsGenerator")
+enum DialogueErrorEndpoints implements Endpoint {
+    testBasicError {
+        private final PathTemplate pathTemplate =
+                PathTemplate.builder().fixed("errors").fixed("basic").build();
+
+        @Override
+        public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+            pathTemplate.fill(params, url);
+        }
+
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.POST;
+        }
+
+        @Override
+        public String serviceName() {
+            return "ErrorService";
+        }
+
+        @Override
+        public String endpointName() {
+            return "testBasicError";
+        }
+
+        @Override
+        public String version() {
+            return VERSION;
+        }
+    },
+
+    testImportedError {
+        private final PathTemplate pathTemplate =
+                PathTemplate.builder().fixed("errors").fixed("imported").build();
+
+        @Override
+        public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+            pathTemplate.fill(params, url);
+        }
+
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.POST;
+        }
+
+        @Override
+        public String serviceName() {
+            return "ErrorService";
+        }
+
+        @Override
+        public String endpointName() {
+            return "testImportedError";
+        }
+
+        @Override
+        public String version() {
+            return VERSION;
+        }
+    },
+
+    testMultipleErrorsAndPackages {
+        private final PathTemplate pathTemplate =
+                PathTemplate.builder().fixed("errors").fixed("multiple").build();
+
+        @Override
+        public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+            pathTemplate.fill(params, url);
+        }
+
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.POST;
+        }
+
+        @Override
+        public String serviceName() {
+            return "ErrorService";
+        }
+
+        @Override
+        public String endpointName() {
+            return "testMultipleErrorsAndPackages";
+        }
+
+        @Override
+        public String version() {
+            return VERSION;
+        }
+    },
+
+    testEmptyBody {
+        private final PathTemplate pathTemplate =
+                PathTemplate.builder().fixed("errors").fixed("empty").build();
+
+        @Override
+        public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+            pathTemplate.fill(params, url);
+        }
+
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.POST;
+        }
+
+        @Override
+        public String serviceName() {
+            return "ErrorService";
+        }
+
+        @Override
+        public String endpointName() {
+            return "testEmptyBody";
+        }
+
+        @Override
+        public String version() {
+            return VERSION;
+        }
+    },
+
+    testBinary {
+        private final PathTemplate pathTemplate =
+                PathTemplate.builder().fixed("errors").fixed("binary").build();
+
+        @Override
+        public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+            pathTemplate.fill(params, url);
+        }
+
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.POST;
+        }
+
+        @Override
+        public String serviceName() {
+            return "ErrorService";
+        }
+
+        @Override
+        public String endpointName() {
+            return "testBinary";
+        }
+
+        @Override
+        public String version() {
+            return VERSION;
+        }
+    },
+
+    testOptionalBinary {
+        private final PathTemplate pathTemplate =
+                PathTemplate.builder().fixed("errors").fixed("optional-binary").build();
+
+        @Override
+        public void renderPath(ListMultimap<String, String> params, UrlBuilder url) {
+            pathTemplate.fill(params, url);
+        }
+
+        @Override
+        public HttpMethod httpMethod() {
+            return HttpMethod.POST;
+        }
+
+        @Override
+        public String serviceName() {
+            return "ErrorService";
+        }
+
+        @Override
+        public String endpointName() {
+            return "testOptionalBinary";
+        }
+
+        @Override
+        public String version() {
+            return VERSION;
+        }
+    };
+
+    private static final String VERSION = Optional.ofNullable(
+                    DialogueErrorEndpoints.class.getPackage().getImplementationVersion())
+            .orElse("0.0.0");
+}

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/EndpointSpecificErrors.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/EndpointSpecificErrors.java
@@ -28,7 +28,8 @@ public final class EndpointSpecificErrors {
     }
 
     public static record EndpointErrorParameters(
-            @JsonProperty("typeName") @Safe String typeName, @JsonProperty("typeDef") @Unsafe Object typeDef) {}
+            @JsonProperty("typeName") @Safe String typeName,
+            @JsonProperty("typeDef") @Unsafe Object typeDef) {}
 
     public static final class EndpointErrorSerializableError
             extends AbstractSerializableError<EndpointErrorParameters> {

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/EndpointSpecificErrors.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/EndpointSpecificErrors.java
@@ -1,0 +1,68 @@
+package endpointerrors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.palantir.conjure.java.api.errors.AbstractSerializableError;
+import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.RemoteException;
+import com.palantir.conjure.java.api.errors.SerializableError;
+import com.palantir.conjure.java.api.errors.SerializableErrorProvider;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.Unsafe;
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.types.ErrorGenerator")
+public final class EndpointSpecificErrors {
+    /** Docs for an endpoint error. */
+    public static final ErrorType ENDPOINT_ERROR =
+            ErrorType.create(ErrorType.Code.INVALID_ARGUMENT, "EndpointSpecific:EndpointError");
+
+    private EndpointSpecificErrors() {}
+
+    /** Returns true if the {@link RemoteException} is named EndpointSpecific:EndpointError */
+    public static boolean isEndpointError(RemoteException remoteException) {
+        Preconditions.checkNotNull(remoteException, "remote exception must not be null");
+        return ENDPOINT_ERROR.name().equals(remoteException.getError().errorName());
+    }
+
+    public static record EndpointErrorParameters(
+            @JsonProperty("typeName") @Safe String typeName, @JsonProperty("typeDef") @Unsafe Object typeDef) {}
+
+    public static final class EndpointErrorSerializableError
+            extends AbstractSerializableError<EndpointErrorParameters> {
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        EndpointErrorSerializableError(
+                @JsonProperty("errorCode") @Safe String errorCode,
+                @JsonProperty("errorName") @Safe String errorName,
+                @JsonProperty("errorInstanceId") @Safe String errorInstanceId,
+                @JsonProperty("parameters") EndpointErrorParameters parameters) {
+            super(errorCode, errorName, errorInstanceId, parameters);
+        }
+
+        public SerializableError toSerializableError() {
+            return SerializableError.builder()
+                    .putParameters("typeName", Objects.toString(parameters().typeName()))
+                    .putParameters("typeDef", Objects.toString(parameters().typeDef()))
+                    .errorCode(errorCode())
+                    .errorName(errorName())
+                    .errorInstanceId(errorInstanceId())
+                    .build();
+        }
+    }
+
+    public static final class EndpointErrorException extends RemoteException
+            implements SerializableErrorProvider<EndpointErrorParameters> {
+        private EndpointErrorSerializableError error;
+
+        public EndpointErrorException(EndpointErrorSerializableError error, int status) {
+            super(error.toSerializableError(), status);
+            this.error = error;
+        }
+
+        public EndpointErrorSerializableError error() {
+            return error;
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/EndpointSpecificServerErrors.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/EndpointSpecificServerErrors.java
@@ -1,0 +1,48 @@
+package endpointerrors.com.palantir.product;
+
+import com.palantir.conjure.java.api.errors.EndpointServiceException;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.Unsafe;
+import com.palantir.logsafe.UnsafeArg;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+import org.jetbrains.annotations.Contract;
+
+@Generated("com.palantir.conjure.java.types.EndpointErrorGenerator")
+public final class EndpointSpecificServerErrors {
+    private EndpointSpecificServerErrors() {}
+
+    public static EndpointError endpointError(@Safe String typeName, @Unsafe Object typeDef) {
+        return new EndpointError(typeName, typeDef, null);
+    }
+
+    public static EndpointError endpointError(
+            @Safe String typeName, @Unsafe Object typeDef, @Nullable Throwable cause) {
+        return new EndpointError(typeName, typeDef, cause);
+    }
+
+    /**
+     * Throws a {@link EndpointError} when {@code shouldThrow} is true.
+     *
+     * @param shouldThrow Cause the method to throw when true
+     * @param typeName
+     * @param typeDef
+     */
+    @Contract("true, _, _ -> fail")
+    public static void throwIfEndpointError(boolean shouldThrow, @Safe String typeName, @Unsafe Object typeDef) {
+        if (shouldThrow) {
+            throw endpointError(typeName, typeDef);
+        }
+    }
+
+    public static final class EndpointError extends EndpointServiceException {
+        private EndpointError(@Safe String typeName, @Unsafe Object typeDef, @Nullable Throwable cause) {
+            super(
+                    EndpointSpecificErrors.ENDPOINT_ERROR,
+                    cause,
+                    SafeArg.of("typeName", typeName),
+                    UnsafeArg.of("typeDef", typeDef));
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/EndpointSpecificTwoErrors.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/EndpointSpecificTwoErrors.java
@@ -1,0 +1,63 @@
+package endpointerrors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.palantir.conjure.java.api.errors.AbstractSerializableError;
+import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.RemoteException;
+import com.palantir.conjure.java.api.errors.SerializableError;
+import com.palantir.conjure.java.api.errors.SerializableErrorProvider;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.types.ErrorGenerator")
+public final class EndpointSpecificTwoErrors {
+    /** An error in a different namespace. */
+    public static final ErrorType DIFFERENT_NAMESPACE =
+            ErrorType.create(ErrorType.Code.INTERNAL, "EndpointSpecificTwo:DifferentNamespace");
+
+    private EndpointSpecificTwoErrors() {}
+
+    /** Returns true if the {@link RemoteException} is named EndpointSpecificTwo:DifferentNamespace */
+    public static boolean isDifferentNamespace(RemoteException remoteException) {
+        Preconditions.checkNotNull(remoteException, "remote exception must not be null");
+        return DIFFERENT_NAMESPACE.name().equals(remoteException.getError().errorName());
+    }
+
+    public static record DifferentNamespaceParameters() {}
+
+    public static final class DifferentNamespaceSerializableError
+            extends AbstractSerializableError<DifferentNamespaceParameters> {
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        DifferentNamespaceSerializableError(
+                @JsonProperty("errorCode") @Safe String errorCode,
+                @JsonProperty("errorName") @Safe String errorName,
+                @JsonProperty("errorInstanceId") @Safe String errorInstanceId,
+                @JsonProperty("parameters") DifferentNamespaceParameters parameters) {
+            super(errorCode, errorName, errorInstanceId, parameters);
+        }
+
+        public SerializableError toSerializableError() {
+            return SerializableError.builder()
+                    .errorCode(errorCode())
+                    .errorName(errorName())
+                    .errorInstanceId(errorInstanceId())
+                    .build();
+        }
+    }
+
+    public static final class DifferentNamespaceException extends RemoteException
+            implements SerializableErrorProvider<DifferentNamespaceParameters> {
+        private DifferentNamespaceSerializableError error;
+
+        public DifferentNamespaceException(DifferentNamespaceSerializableError error, int status) {
+            super(error.toSerializableError(), status);
+            this.error = error;
+        }
+
+        public DifferentNamespaceSerializableError error() {
+            return error;
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/EndpointSpecificTwoServerErrors.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/EndpointSpecificTwoServerErrors.java
@@ -1,0 +1,37 @@
+package endpointerrors.com.palantir.product;
+
+import com.palantir.conjure.java.api.errors.EndpointServiceException;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+import org.jetbrains.annotations.Contract;
+
+@Generated("com.palantir.conjure.java.types.EndpointErrorGenerator")
+public final class EndpointSpecificTwoServerErrors {
+    private EndpointSpecificTwoServerErrors() {}
+
+    public static DifferentNamespace differentNamespace() {
+        return new DifferentNamespace(null);
+    }
+
+    public static DifferentNamespace differentNamespace(@Nullable Throwable cause) {
+        return new DifferentNamespace(cause);
+    }
+
+    /**
+     * Throws a {@link DifferentNamespace} when {@code shouldThrow} is true.
+     *
+     * @param shouldThrow Cause the method to throw when true
+     */
+    @Contract("true -> fail")
+    public static void throwIfDifferentNamespace(boolean shouldThrow) {
+        if (shouldThrow) {
+            throw differentNamespace();
+        }
+    }
+
+    public static final class DifferentNamespace extends EndpointServiceException {
+        private DifferentNamespace(@Nullable Throwable cause) {
+            super(EndpointSpecificTwoErrors.DIFFERENT_NAMESPACE, cause);
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceAsync.java
@@ -16,7 +16,6 @@ import com.palantir.dialogue.PlainSerDe;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Serializer;
 import com.palantir.dialogue.TypeMarker;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.tokens.auth.AuthHeader;
 import java.io.InputStream;
 import java.lang.Boolean;
@@ -274,7 +273,7 @@ public interface ErrorServiceAsync {
             } else if (e instanceof ConjureErrors.ConflictingCauseSafeArgErrException ex) {
                 return new ConflictingCauseSafeArgErr(ex);
             } else {
-                throw new SafeIllegalArgumentException("Not an error associated with testBasicError", e);
+                return new Unknown(e);
             }
         }
 
@@ -282,6 +281,8 @@ public interface ErrorServiceAsync {
 
         final record ConflictingCauseSafeArgErr(ConjureErrors.ConflictingCauseSafeArgErrException e)
                 implements TestBasicErrorErrors {}
+
+        final record Unknown(RemoteException e) implements TestBasicErrorErrors {}
     }
 
     sealed interface TestImportedErrorErrors {
@@ -289,12 +290,14 @@ public interface ErrorServiceAsync {
             if (e instanceof EndpointSpecificErrors.EndpointErrorException ex) {
                 return new EndpointError(ex);
             } else {
-                throw new SafeIllegalArgumentException("Not an error associated with testImportedError", e);
+                return new Unknown(e);
             }
         }
 
         final record EndpointError(EndpointSpecificErrors.EndpointErrorException e)
                 implements TestImportedErrorErrors {}
+
+        final record Unknown(RemoteException e) implements TestImportedErrorErrors {}
     }
 
     sealed interface TestMultipleErrorsAndPackagesErrors {
@@ -312,7 +315,7 @@ public interface ErrorServiceAsync {
             } else if (e instanceof TestErrors.ComplicatedParametersException ex) {
                 return new ComplicatedParameters(ex);
             } else {
-                throw new SafeIllegalArgumentException("Not an error associated with testMultipleErrorsAndPackages", e);
+                return new Unknown(e);
             }
         }
 
@@ -330,6 +333,8 @@ public interface ErrorServiceAsync {
 
         final record ComplicatedParameters(TestErrors.ComplicatedParametersException e)
                 implements TestMultipleErrorsAndPackagesErrors {}
+
+        final record Unknown(RemoteException e) implements TestMultipleErrorsAndPackagesErrors {}
     }
 
     sealed interface TestEmptyBodyErrors {
@@ -337,11 +342,13 @@ public interface ErrorServiceAsync {
             if (e instanceof TestErrors.InvalidArgumentException ex) {
                 return new InvalidArgument(ex);
             } else {
-                throw new SafeIllegalArgumentException("Not an error associated with testEmptyBody", e);
+                return new Unknown(e);
             }
         }
 
         final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestEmptyBodyErrors {}
+
+        final record Unknown(RemoteException e) implements TestEmptyBodyErrors {}
     }
 
     sealed interface TestBinaryErrors {
@@ -349,11 +356,13 @@ public interface ErrorServiceAsync {
             if (e instanceof TestErrors.InvalidArgumentException ex) {
                 return new InvalidArgument(ex);
             } else {
-                throw new SafeIllegalArgumentException("Not an error associated with testBinary", e);
+                return new Unknown(e);
             }
         }
 
         final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestBinaryErrors {}
+
+        final record Unknown(RemoteException e) implements TestBinaryErrors {}
     }
 
     sealed interface TestOptionalBinaryErrors {
@@ -361,10 +370,12 @@ public interface ErrorServiceAsync {
             if (e instanceof TestErrors.InvalidArgumentException ex) {
                 return new InvalidArgument(ex);
             } else {
-                throw new SafeIllegalArgumentException("Not an error associated with testOptionalBinary", e);
+                return new Unknown(e);
             }
         }
 
         final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestOptionalBinaryErrors {}
+
+        final record Unknown(RemoteException e) implements TestOptionalBinaryErrors {}
     }
 }

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceAsync.java
@@ -266,11 +266,11 @@ public interface ErrorServiceAsync {
         }
     }
 
-    sealed interface TestBasicErrorErrors
-            permits TestBasicErrorErrors.InvalidArgument,
-                    TestBasicErrorErrors.ConflictingCauseSafeArgErr,
-                    TestBasicErrorErrors.Unknown {
-        static TestBasicErrorErrors from(RemoteException e) {
+    sealed interface TestBasicErrorError
+            permits TestBasicErrorError.InvalidArgument,
+                    TestBasicErrorError.ConflictingCauseSafeArgErr,
+                    TestBasicErrorError.Unknown {
+        static TestBasicErrorError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);
             } else if (ConjureErrors.isConflictingCauseSafeArgErr(e)) {
@@ -280,17 +280,17 @@ public interface ErrorServiceAsync {
             }
         }
 
-        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestBasicErrorErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestBasicErrorError {}
 
         record ConflictingCauseSafeArgErr(ConjureErrors.ConflictingCauseSafeArgErrException exception)
-                implements TestBasicErrorErrors {}
+                implements TestBasicErrorError {}
 
-        record Unknown(RemoteException exception) implements TestBasicErrorErrors {}
+        record Unknown(RemoteException exception) implements TestBasicErrorError {}
     }
 
-    sealed interface TestImportedErrorErrors
-            permits TestImportedErrorErrors.EndpointError, TestImportedErrorErrors.Unknown {
-        static TestImportedErrorErrors from(RemoteException e) {
+    sealed interface TestImportedErrorError
+            permits TestImportedErrorError.EndpointError, TestImportedErrorError.Unknown {
+        static TestImportedErrorError from(RemoteException e) {
             if (EndpointSpecificErrors.isEndpointError(e)) {
                 return new EndpointError((EndpointSpecificErrors.EndpointErrorException) e);
             } else {
@@ -299,19 +299,19 @@ public interface ErrorServiceAsync {
         }
 
         record EndpointError(EndpointSpecificErrors.EndpointErrorException exception)
-                implements TestImportedErrorErrors {}
+                implements TestImportedErrorError {}
 
-        record Unknown(RemoteException exception) implements TestImportedErrorErrors {}
+        record Unknown(RemoteException exception) implements TestImportedErrorError {}
     }
 
-    sealed interface TestMultipleErrorsAndPackagesErrors
-            permits TestMultipleErrorsAndPackagesErrors.InvalidArgument,
-                    TestMultipleErrorsAndPackagesErrors.NotFound,
-                    TestMultipleErrorsAndPackagesErrors.DifferentNamespace,
-                    TestMultipleErrorsAndPackagesErrors.DifferentPackage,
-                    TestMultipleErrorsAndPackagesErrors.ComplicatedParameters,
-                    TestMultipleErrorsAndPackagesErrors.Unknown {
-        static TestMultipleErrorsAndPackagesErrors from(RemoteException e) {
+    sealed interface TestMultipleErrorsAndPackagesError
+            permits TestMultipleErrorsAndPackagesError.InvalidArgument,
+                    TestMultipleErrorsAndPackagesError.NotFound,
+                    TestMultipleErrorsAndPackagesError.DifferentNamespace,
+                    TestMultipleErrorsAndPackagesError.DifferentPackage,
+                    TestMultipleErrorsAndPackagesError.ComplicatedParameters,
+                    TestMultipleErrorsAndPackagesError.Unknown {
+        static TestMultipleErrorsAndPackagesError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);
             } else if (TestErrors.isNotFound(e)) {
@@ -329,25 +329,25 @@ public interface ErrorServiceAsync {
         }
 
         record InvalidArgument(TestErrors.InvalidArgumentException exception)
-                implements TestMultipleErrorsAndPackagesErrors {}
+                implements TestMultipleErrorsAndPackagesError {}
 
-        record NotFound(TestErrors.NotFoundException exception) implements TestMultipleErrorsAndPackagesErrors {}
+        record NotFound(TestErrors.NotFoundException exception) implements TestMultipleErrorsAndPackagesError {}
 
         record DifferentNamespace(EndpointSpecificTwoErrors.DifferentNamespaceException exception)
-                implements TestMultipleErrorsAndPackagesErrors {}
+                implements TestMultipleErrorsAndPackagesError {}
 
         record DifferentPackage(
                 endpointerrors.com.palantir.another.EndpointSpecificErrors.DifferentPackageException exception)
-                implements TestMultipleErrorsAndPackagesErrors {}
+                implements TestMultipleErrorsAndPackagesError {}
 
         record ComplicatedParameters(TestErrors.ComplicatedParametersException exception)
-                implements TestMultipleErrorsAndPackagesErrors {}
+                implements TestMultipleErrorsAndPackagesError {}
 
-        record Unknown(RemoteException exception) implements TestMultipleErrorsAndPackagesErrors {}
+        record Unknown(RemoteException exception) implements TestMultipleErrorsAndPackagesError {}
     }
 
-    sealed interface TestEmptyBodyErrors permits TestEmptyBodyErrors.InvalidArgument, TestEmptyBodyErrors.Unknown {
-        static TestEmptyBodyErrors from(RemoteException e) {
+    sealed interface TestEmptyBodyError permits TestEmptyBodyError.InvalidArgument, TestEmptyBodyError.Unknown {
+        static TestEmptyBodyError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);
             } else {
@@ -355,13 +355,13 @@ public interface ErrorServiceAsync {
             }
         }
 
-        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestEmptyBodyErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestEmptyBodyError {}
 
-        record Unknown(RemoteException exception) implements TestEmptyBodyErrors {}
+        record Unknown(RemoteException exception) implements TestEmptyBodyError {}
     }
 
-    sealed interface TestBinaryErrors permits TestBinaryErrors.InvalidArgument, TestBinaryErrors.Unknown {
-        static TestBinaryErrors from(RemoteException e) {
+    sealed interface TestBinaryError permits TestBinaryError.InvalidArgument, TestBinaryError.Unknown {
+        static TestBinaryError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);
             } else {
@@ -369,14 +369,14 @@ public interface ErrorServiceAsync {
             }
         }
 
-        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestBinaryErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestBinaryError {}
 
-        record Unknown(RemoteException exception) implements TestBinaryErrors {}
+        record Unknown(RemoteException exception) implements TestBinaryError {}
     }
 
-    sealed interface TestOptionalBinaryErrors
-            permits TestOptionalBinaryErrors.InvalidArgument, TestOptionalBinaryErrors.Unknown {
-        static TestOptionalBinaryErrors from(RemoteException e) {
+    sealed interface TestOptionalBinaryError
+            permits TestOptionalBinaryError.InvalidArgument, TestOptionalBinaryError.Unknown {
+        static TestOptionalBinaryError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);
             } else {
@@ -384,8 +384,8 @@ public interface ErrorServiceAsync {
             }
         }
 
-        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestOptionalBinaryErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestOptionalBinaryError {}
 
-        record Unknown(RemoteException exception) implements TestOptionalBinaryErrors {}
+        record Unknown(RemoteException exception) implements TestOptionalBinaryError {}
     }
 }

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceAsync.java
@@ -1,0 +1,370 @@
+package endpointerrors.com.palantir.product;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.conjure.java.api.errors.RemoteException;
+import com.palantir.conjure.java.lib.internal.ClientEndpoint;
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.ConjureRuntime;
+import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.EndpointChannelFactory;
+import com.palantir.dialogue.ExceptionDeserializerArgs;
+import com.palantir.dialogue.PlainSerDe;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Serializer;
+import com.palantir.dialogue.TypeMarker;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.tokens.auth.AuthHeader;
+import java.io.InputStream;
+import java.lang.Boolean;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.Void;
+import java.util.Optional;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(ErrorServiceAsync.Factory.class)
+public interface ErrorServiceAsync {
+    /** @apiNote {@code POST /errors/basic} */
+    @ClientEndpoint(method = "POST", path = "/errors/basic")
+    ListenableFuture<String> testBasicError(AuthHeader authHeader, boolean shouldThrowError);
+
+    /** @apiNote {@code POST /errors/imported} */
+    @ClientEndpoint(method = "POST", path = "/errors/imported")
+    ListenableFuture<String> testImportedError(AuthHeader authHeader, boolean shouldThrowError);
+
+    /** @apiNote {@code POST /errors/multiple} */
+    @ClientEndpoint(method = "POST", path = "/errors/multiple")
+    ListenableFuture<String> testMultipleErrorsAndPackages(AuthHeader authHeader, Optional<String> errorToThrow);
+
+    /** @apiNote {@code POST /errors/empty} */
+    @ClientEndpoint(method = "POST", path = "/errors/empty")
+    ListenableFuture<Void> testEmptyBody(AuthHeader authHeader, boolean shouldThrowError);
+
+    /** @apiNote {@code POST /errors/binary} */
+    @ClientEndpoint(method = "POST", path = "/errors/binary")
+    ListenableFuture<InputStream> testBinary(AuthHeader authHeader, boolean shouldThrowError);
+
+    /** @apiNote {@code POST /errors/optional-binary} */
+    @ClientEndpoint(method = "POST", path = "/errors/optional-binary")
+    ListenableFuture<Optional<InputStream>> testOptionalBinary(AuthHeader authHeader, OptionalBinaryResponseMode mode);
+
+    /** Creates an asynchronous/non-blocking client for a ErrorService service. */
+    static ErrorServiceAsync of(EndpointChannelFactory _endpointChannelFactory, ConjureRuntime _runtime) {
+        return new ErrorServiceAsync() {
+            private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
+
+            private final Serializer<Boolean> testBasicErrorSerializer =
+                    _runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
+
+            private final EndpointChannel testBasicErrorChannel =
+                    _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testBasicError);
+
+            private final Deserializer<String> testBasicErrorDeserializer =
+                    _runtime.bodySerDe().deserializer(createExceptionDeserializerArgs(new TypeMarker<String>() {}));
+
+            private final Serializer<Boolean> testImportedErrorSerializer =
+                    _runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
+
+            private final EndpointChannel testImportedErrorChannel =
+                    _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testImportedError);
+
+            private final Deserializer<String> testImportedErrorDeserializer =
+                    _runtime.bodySerDe().deserializer(createExceptionDeserializerArgs(new TypeMarker<String>() {}));
+
+            private final Serializer<Optional<String>> testMultipleErrorsAndPackagesSerializer =
+                    _runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {});
+
+            private final EndpointChannel testMultipleErrorsAndPackagesChannel =
+                    _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testMultipleErrorsAndPackages);
+
+            private final Deserializer<String> testMultipleErrorsAndPackagesDeserializer =
+                    _runtime.bodySerDe().deserializer(createExceptionDeserializerArgs(new TypeMarker<String>() {}));
+
+            private final Serializer<Boolean> testEmptyBodySerializer =
+                    _runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
+
+            private final EndpointChannel testEmptyBodyChannel =
+                    _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testEmptyBody);
+
+            private final Deserializer<Void> testEmptyBodyDeserializer = _runtime.bodySerDe()
+                    .emptyBodyDeserializer(createExceptionDeserializerArgs(new TypeMarker<Void>() {}));
+
+            private final Serializer<Boolean> testBinarySerializer =
+                    _runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
+
+            private final EndpointChannel testBinaryChannel =
+                    _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testBinary);
+
+            private final Deserializer<InputStream> testBinaryDeserializer = _runtime.bodySerDe()
+                    .inputStreamDeserializer(createExceptionDeserializerArgs(new TypeMarker<InputStream>() {}));
+
+            private final Serializer<OptionalBinaryResponseMode> testOptionalBinarySerializer =
+                    _runtime.bodySerDe().serializer(new TypeMarker<OptionalBinaryResponseMode>() {});
+
+            private final EndpointChannel testOptionalBinaryChannel =
+                    _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testOptionalBinary);
+
+            private final Deserializer<Optional<InputStream>> testOptionalBinaryDeserializer = _runtime.bodySerDe()
+                    .optionalInputStreamDeserializer(
+                            createExceptionDeserializerArgs(new TypeMarker<Optional<InputStream>>() {}));
+
+            private <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
+                return ExceptionDeserializerArgs.<T>builder()
+                        .returnType(returnType)
+                        .exception(
+                                endpointerrors.com.palantir.another.EndpointSpecificErrors.DIFFERENT_PACKAGE.name(),
+                                new TypeMarker<
+                                        endpointerrors.com.palantir.another.EndpointSpecificErrors
+                                                .DifferentPackageSerializableError>() {},
+                                new TypeMarker<
+                                        endpointerrors.com.palantir.another.EndpointSpecificErrors
+                                                .DifferentPackageException>() {})
+                        .exception(
+                                TestErrors.COMPLICATED_PARAMETERS.name(),
+                                new TypeMarker<TestErrors.ComplicatedParametersSerializableError>() {},
+                                new TypeMarker<TestErrors.ComplicatedParametersException>() {})
+                        .exception(
+                                ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG_ERR.name(),
+                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgErrSerializableError>() {},
+                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgErrException>() {})
+                        .exception(
+                                EndpointSpecificTwoErrors.DIFFERENT_NAMESPACE.name(),
+                                new TypeMarker<EndpointSpecificTwoErrors.DifferentNamespaceSerializableError>() {},
+                                new TypeMarker<EndpointSpecificTwoErrors.DifferentNamespaceException>() {})
+                        .exception(
+                                EndpointSpecificErrors.ENDPOINT_ERROR.name(),
+                                new TypeMarker<EndpointSpecificErrors.EndpointErrorSerializableError>() {},
+                                new TypeMarker<EndpointSpecificErrors.EndpointErrorException>() {})
+                        .exception(
+                                TestErrors.INVALID_ARGUMENT.name(),
+                                new TypeMarker<TestErrors.InvalidArgumentSerializableError>() {},
+                                new TypeMarker<TestErrors.InvalidArgumentException>() {})
+                        .exception(
+                                TestErrors.NOT_FOUND.name(),
+                                new TypeMarker<TestErrors.NotFoundSerializableError>() {},
+                                new TypeMarker<TestErrors.NotFoundException>() {})
+                        .build();
+            }
+
+            @Override
+            public ListenableFuture<String> testBasicError(AuthHeader authHeader, boolean shouldThrowError) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.body(testBasicErrorSerializer.serialize(shouldThrowError));
+                if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
+                    _request.putHeaderParams(
+                            "Accept-Conjure-Error-Parameter-Format",
+                            _runtime.bodySerDe().errorParameterFormat().get().toString());
+                }
+                return _runtime.clients().call(testBasicErrorChannel, _request.build(), testBasicErrorDeserializer);
+            }
+
+            @Override
+            public ListenableFuture<String> testImportedError(AuthHeader authHeader, boolean shouldThrowError) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.body(testImportedErrorSerializer.serialize(shouldThrowError));
+                if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
+                    _request.putHeaderParams(
+                            "Accept-Conjure-Error-Parameter-Format",
+                            _runtime.bodySerDe().errorParameterFormat().get().toString());
+                }
+                return _runtime.clients()
+                        .call(testImportedErrorChannel, _request.build(), testImportedErrorDeserializer);
+            }
+
+            @Override
+            public ListenableFuture<String> testMultipleErrorsAndPackages(
+                    AuthHeader authHeader, Optional<String> errorToThrow) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.body(testMultipleErrorsAndPackagesSerializer.serialize(errorToThrow));
+                if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
+                    _request.putHeaderParams(
+                            "Accept-Conjure-Error-Parameter-Format",
+                            _runtime.bodySerDe().errorParameterFormat().get().toString());
+                }
+                return _runtime.clients()
+                        .call(
+                                testMultipleErrorsAndPackagesChannel,
+                                _request.build(),
+                                testMultipleErrorsAndPackagesDeserializer);
+            }
+
+            @Override
+            public ListenableFuture<Void> testEmptyBody(AuthHeader authHeader, boolean shouldThrowError) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.body(testEmptyBodySerializer.serialize(shouldThrowError));
+                if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
+                    _request.putHeaderParams(
+                            "Accept-Conjure-Error-Parameter-Format",
+                            _runtime.bodySerDe().errorParameterFormat().get().toString());
+                }
+                return _runtime.clients().call(testEmptyBodyChannel, _request.build(), testEmptyBodyDeserializer);
+            }
+
+            @Override
+            public ListenableFuture<InputStream> testBinary(AuthHeader authHeader, boolean shouldThrowError) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.body(testBinarySerializer.serialize(shouldThrowError));
+                if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
+                    _request.putHeaderParams(
+                            "Accept-Conjure-Error-Parameter-Format",
+                            _runtime.bodySerDe().errorParameterFormat().get().toString());
+                }
+                return _runtime.clients().call(testBinaryChannel, _request.build(), testBinaryDeserializer);
+            }
+
+            @Override
+            public ListenableFuture<Optional<InputStream>> testOptionalBinary(
+                    AuthHeader authHeader, OptionalBinaryResponseMode mode) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.body(testOptionalBinarySerializer.serialize(mode));
+                if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
+                    _request.putHeaderParams(
+                            "Accept-Conjure-Error-Parameter-Format",
+                            _runtime.bodySerDe().errorParameterFormat().get().toString());
+                }
+                return _runtime.clients()
+                        .call(testOptionalBinaryChannel, _request.build(), testOptionalBinaryDeserializer);
+            }
+
+            @Override
+            public String toString() {
+                return "ErrorServiceAsync{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime=" + _runtime
+                        + '}';
+            }
+        };
+    }
+
+    /** Creates an asynchronous/non-blocking client for a ErrorService service. */
+    static ErrorServiceAsync of(Channel _channel, ConjureRuntime _runtime) {
+        if (_channel instanceof EndpointChannelFactory) {
+            return of((EndpointChannelFactory) _channel, _runtime);
+        }
+        return of(
+                new EndpointChannelFactory() {
+                    @Override
+                    public EndpointChannel endpoint(Endpoint endpoint) {
+                        return _runtime.clients().bind(_channel, endpoint);
+                    }
+                },
+                _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<ErrorServiceAsync> {
+        @Override
+        public ErrorServiceAsync create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return ErrorServiceAsync.of(endpointChannelFactory, runtime);
+        }
+    }
+
+    sealed interface TestBasicErrorErrors {
+        static TestBasicErrorErrors from(RemoteException e) {
+            if (e instanceof TestErrors.InvalidArgumentException ex) {
+                return new InvalidArgument(ex);
+            } else if (e instanceof ConjureErrors.ConflictingCauseSafeArgErrException ex) {
+                return new ConflictingCauseSafeArgErr(ex);
+            } else {
+                throw new SafeIllegalArgumentException("Not an error associated with testBasicError", e);
+            }
+        }
+
+        final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestBasicErrorErrors {}
+
+        final record ConflictingCauseSafeArgErr(ConjureErrors.ConflictingCauseSafeArgErrException e)
+                implements TestBasicErrorErrors {}
+    }
+
+    sealed interface TestImportedErrorErrors {
+        static TestImportedErrorErrors from(RemoteException e) {
+            if (e instanceof EndpointSpecificErrors.EndpointErrorException ex) {
+                return new EndpointError(ex);
+            } else {
+                throw new SafeIllegalArgumentException("Not an error associated with testImportedError", e);
+            }
+        }
+
+        final record EndpointError(EndpointSpecificErrors.EndpointErrorException e)
+                implements TestImportedErrorErrors {}
+    }
+
+    sealed interface TestMultipleErrorsAndPackagesErrors {
+        static TestMultipleErrorsAndPackagesErrors from(RemoteException e) {
+            if (e instanceof TestErrors.InvalidArgumentException ex) {
+                return new InvalidArgument(ex);
+            } else if (e instanceof TestErrors.NotFoundException ex) {
+                return new NotFound(ex);
+            } else if (e instanceof EndpointSpecificTwoErrors.DifferentNamespaceException ex) {
+                return new DifferentNamespace(ex);
+            } else if (e
+                    instanceof
+                    endpointerrors.com.palantir.another.EndpointSpecificErrors.DifferentPackageException ex) {
+                return new DifferentPackage(ex);
+            } else if (e instanceof TestErrors.ComplicatedParametersException ex) {
+                return new ComplicatedParameters(ex);
+            } else {
+                throw new SafeIllegalArgumentException("Not an error associated with testMultipleErrorsAndPackages", e);
+            }
+        }
+
+        final record InvalidArgument(TestErrors.InvalidArgumentException e)
+                implements TestMultipleErrorsAndPackagesErrors {}
+
+        final record NotFound(TestErrors.NotFoundException e) implements TestMultipleErrorsAndPackagesErrors {}
+
+        final record DifferentNamespace(EndpointSpecificTwoErrors.DifferentNamespaceException e)
+                implements TestMultipleErrorsAndPackagesErrors {}
+
+        final record DifferentPackage(
+                endpointerrors.com.palantir.another.EndpointSpecificErrors.DifferentPackageException e)
+                implements TestMultipleErrorsAndPackagesErrors {}
+
+        final record ComplicatedParameters(TestErrors.ComplicatedParametersException e)
+                implements TestMultipleErrorsAndPackagesErrors {}
+    }
+
+    sealed interface TestEmptyBodyErrors {
+        static TestEmptyBodyErrors from(RemoteException e) {
+            if (e instanceof TestErrors.InvalidArgumentException ex) {
+                return new InvalidArgument(ex);
+            } else {
+                throw new SafeIllegalArgumentException("Not an error associated with testEmptyBody", e);
+            }
+        }
+
+        final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestEmptyBodyErrors {}
+    }
+
+    sealed interface TestBinaryErrors {
+        static TestBinaryErrors from(RemoteException e) {
+            if (e instanceof TestErrors.InvalidArgumentException ex) {
+                return new InvalidArgument(ex);
+            } else {
+                throw new SafeIllegalArgumentException("Not an error associated with testBinary", e);
+            }
+        }
+
+        final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestBinaryErrors {}
+    }
+
+    sealed interface TestOptionalBinaryErrors {
+        static TestOptionalBinaryErrors from(RemoteException e) {
+            if (e instanceof TestErrors.InvalidArgumentException ex) {
+                return new InvalidArgument(ex);
+            } else {
+                throw new SafeIllegalArgumentException("Not an error associated with testOptionalBinary", e);
+            }
+        }
+
+        final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestOptionalBinaryErrors {}
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceAsync.java
@@ -266,113 +266,126 @@ public interface ErrorServiceAsync {
         }
     }
 
-    sealed interface TestBasicErrorErrors {
+    sealed interface TestBasicErrorErrors
+            permits TestBasicErrorErrors.InvalidArgument,
+                    TestBasicErrorErrors.ConflictingCauseSafeArgErr,
+                    TestBasicErrorErrors.Unknown {
         static TestBasicErrorErrors from(RemoteException e) {
-            if (e instanceof TestErrors.InvalidArgumentException ex) {
-                return new InvalidArgument(ex);
-            } else if (e instanceof ConjureErrors.ConflictingCauseSafeArgErrException ex) {
-                return new ConflictingCauseSafeArgErr(ex);
+            if (TestErrors.isInvalidArgument(e)) {
+                return new InvalidArgument((TestErrors.InvalidArgumentException) e);
+            } else if (ConjureErrors.isConflictingCauseSafeArgErr(e)) {
+                return new ConflictingCauseSafeArgErr((ConjureErrors.ConflictingCauseSafeArgErrException) e);
             } else {
                 return new Unknown(e);
             }
         }
 
-        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestBasicErrorErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestBasicErrorErrors {}
 
-        record ConflictingCauseSafeArgErr(ConjureErrors.ConflictingCauseSafeArgErrException e)
+        record ConflictingCauseSafeArgErr(ConjureErrors.ConflictingCauseSafeArgErrException exception)
                 implements TestBasicErrorErrors {}
 
-        record Unknown(RemoteException e) implements TestBasicErrorErrors {}
+        record Unknown(RemoteException exception) implements TestBasicErrorErrors {}
     }
 
-    sealed interface TestImportedErrorErrors {
+    sealed interface TestImportedErrorErrors
+            permits TestImportedErrorErrors.EndpointError, TestImportedErrorErrors.Unknown {
         static TestImportedErrorErrors from(RemoteException e) {
-            if (e instanceof EndpointSpecificErrors.EndpointErrorException ex) {
-                return new EndpointError(ex);
+            if (EndpointSpecificErrors.isEndpointError(e)) {
+                return new EndpointError((EndpointSpecificErrors.EndpointErrorException) e);
             } else {
                 return new Unknown(e);
             }
         }
 
-        record EndpointError(EndpointSpecificErrors.EndpointErrorException e) implements TestImportedErrorErrors {}
+        record EndpointError(EndpointSpecificErrors.EndpointErrorException exception)
+                implements TestImportedErrorErrors {}
 
-        record Unknown(RemoteException e) implements TestImportedErrorErrors {}
+        record Unknown(RemoteException exception) implements TestImportedErrorErrors {}
     }
 
-    sealed interface TestMultipleErrorsAndPackagesErrors {
+    sealed interface TestMultipleErrorsAndPackagesErrors
+            permits TestMultipleErrorsAndPackagesErrors.InvalidArgument,
+                    TestMultipleErrorsAndPackagesErrors.NotFound,
+                    TestMultipleErrorsAndPackagesErrors.DifferentNamespace,
+                    TestMultipleErrorsAndPackagesErrors.DifferentPackage,
+                    TestMultipleErrorsAndPackagesErrors.ComplicatedParameters,
+                    TestMultipleErrorsAndPackagesErrors.Unknown {
         static TestMultipleErrorsAndPackagesErrors from(RemoteException e) {
-            if (e instanceof TestErrors.InvalidArgumentException ex) {
-                return new InvalidArgument(ex);
-            } else if (e instanceof TestErrors.NotFoundException ex) {
-                return new NotFound(ex);
-            } else if (e instanceof EndpointSpecificTwoErrors.DifferentNamespaceException ex) {
-                return new DifferentNamespace(ex);
-            } else if (e
-                    instanceof
-                    endpointerrors.com.palantir.another.EndpointSpecificErrors.DifferentPackageException ex) {
-                return new DifferentPackage(ex);
-            } else if (e instanceof TestErrors.ComplicatedParametersException ex) {
-                return new ComplicatedParameters(ex);
+            if (TestErrors.isInvalidArgument(e)) {
+                return new InvalidArgument((TestErrors.InvalidArgumentException) e);
+            } else if (TestErrors.isNotFound(e)) {
+                return new NotFound((TestErrors.NotFoundException) e);
+            } else if (EndpointSpecificTwoErrors.isDifferentNamespace(e)) {
+                return new DifferentNamespace((EndpointSpecificTwoErrors.DifferentNamespaceException) e);
+            } else if (endpointerrors.com.palantir.another.EndpointSpecificErrors.isDifferentPackage(e)) {
+                return new DifferentPackage(
+                        (endpointerrors.com.palantir.another.EndpointSpecificErrors.DifferentPackageException) e);
+            } else if (TestErrors.isComplicatedParameters(e)) {
+                return new ComplicatedParameters((TestErrors.ComplicatedParametersException) e);
             } else {
                 return new Unknown(e);
             }
         }
 
-        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestMultipleErrorsAndPackagesErrors {}
-
-        record NotFound(TestErrors.NotFoundException e) implements TestMultipleErrorsAndPackagesErrors {}
-
-        record DifferentNamespace(EndpointSpecificTwoErrors.DifferentNamespaceException e)
+        record InvalidArgument(TestErrors.InvalidArgumentException exception)
                 implements TestMultipleErrorsAndPackagesErrors {}
 
-        record DifferentPackage(endpointerrors.com.palantir.another.EndpointSpecificErrors.DifferentPackageException e)
+        record NotFound(TestErrors.NotFoundException exception) implements TestMultipleErrorsAndPackagesErrors {}
+
+        record DifferentNamespace(EndpointSpecificTwoErrors.DifferentNamespaceException exception)
                 implements TestMultipleErrorsAndPackagesErrors {}
 
-        record ComplicatedParameters(TestErrors.ComplicatedParametersException e)
+        record DifferentPackage(
+                endpointerrors.com.palantir.another.EndpointSpecificErrors.DifferentPackageException exception)
                 implements TestMultipleErrorsAndPackagesErrors {}
 
-        record Unknown(RemoteException e) implements TestMultipleErrorsAndPackagesErrors {}
+        record ComplicatedParameters(TestErrors.ComplicatedParametersException exception)
+                implements TestMultipleErrorsAndPackagesErrors {}
+
+        record Unknown(RemoteException exception) implements TestMultipleErrorsAndPackagesErrors {}
     }
 
-    sealed interface TestEmptyBodyErrors {
+    sealed interface TestEmptyBodyErrors permits TestEmptyBodyErrors.InvalidArgument, TestEmptyBodyErrors.Unknown {
         static TestEmptyBodyErrors from(RemoteException e) {
-            if (e instanceof TestErrors.InvalidArgumentException ex) {
-                return new InvalidArgument(ex);
+            if (TestErrors.isInvalidArgument(e)) {
+                return new InvalidArgument((TestErrors.InvalidArgumentException) e);
             } else {
                 return new Unknown(e);
             }
         }
 
-        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestEmptyBodyErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestEmptyBodyErrors {}
 
-        record Unknown(RemoteException e) implements TestEmptyBodyErrors {}
+        record Unknown(RemoteException exception) implements TestEmptyBodyErrors {}
     }
 
-    sealed interface TestBinaryErrors {
+    sealed interface TestBinaryErrors permits TestBinaryErrors.InvalidArgument, TestBinaryErrors.Unknown {
         static TestBinaryErrors from(RemoteException e) {
-            if (e instanceof TestErrors.InvalidArgumentException ex) {
-                return new InvalidArgument(ex);
+            if (TestErrors.isInvalidArgument(e)) {
+                return new InvalidArgument((TestErrors.InvalidArgumentException) e);
             } else {
                 return new Unknown(e);
             }
         }
 
-        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestBinaryErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestBinaryErrors {}
 
-        record Unknown(RemoteException e) implements TestBinaryErrors {}
+        record Unknown(RemoteException exception) implements TestBinaryErrors {}
     }
 
-    sealed interface TestOptionalBinaryErrors {
+    sealed interface TestOptionalBinaryErrors
+            permits TestOptionalBinaryErrors.InvalidArgument, TestOptionalBinaryErrors.Unknown {
         static TestOptionalBinaryErrors from(RemoteException e) {
-            if (e instanceof TestErrors.InvalidArgumentException ex) {
-                return new InvalidArgument(ex);
+            if (TestErrors.isInvalidArgument(e)) {
+                return new InvalidArgument((TestErrors.InvalidArgumentException) e);
             } else {
                 return new Unknown(e);
             }
         }
 
-        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestOptionalBinaryErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestOptionalBinaryErrors {}
 
-        record Unknown(RemoteException e) implements TestOptionalBinaryErrors {}
+        record Unknown(RemoteException exception) implements TestOptionalBinaryErrors {}
     }
 }

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceAsync.java
@@ -277,12 +277,12 @@ public interface ErrorServiceAsync {
             }
         }
 
-        final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestBasicErrorErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestBasicErrorErrors {}
 
-        final record ConflictingCauseSafeArgErr(ConjureErrors.ConflictingCauseSafeArgErrException e)
+        record ConflictingCauseSafeArgErr(ConjureErrors.ConflictingCauseSafeArgErrException e)
                 implements TestBasicErrorErrors {}
 
-        final record Unknown(RemoteException e) implements TestBasicErrorErrors {}
+        record Unknown(RemoteException e) implements TestBasicErrorErrors {}
     }
 
     sealed interface TestImportedErrorErrors {
@@ -294,10 +294,9 @@ public interface ErrorServiceAsync {
             }
         }
 
-        final record EndpointError(EndpointSpecificErrors.EndpointErrorException e)
-                implements TestImportedErrorErrors {}
+        record EndpointError(EndpointSpecificErrors.EndpointErrorException e) implements TestImportedErrorErrors {}
 
-        final record Unknown(RemoteException e) implements TestImportedErrorErrors {}
+        record Unknown(RemoteException e) implements TestImportedErrorErrors {}
     }
 
     sealed interface TestMultipleErrorsAndPackagesErrors {
@@ -319,22 +318,20 @@ public interface ErrorServiceAsync {
             }
         }
 
-        final record InvalidArgument(TestErrors.InvalidArgumentException e)
+        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestMultipleErrorsAndPackagesErrors {}
+
+        record NotFound(TestErrors.NotFoundException e) implements TestMultipleErrorsAndPackagesErrors {}
+
+        record DifferentNamespace(EndpointSpecificTwoErrors.DifferentNamespaceException e)
                 implements TestMultipleErrorsAndPackagesErrors {}
 
-        final record NotFound(TestErrors.NotFoundException e) implements TestMultipleErrorsAndPackagesErrors {}
-
-        final record DifferentNamespace(EndpointSpecificTwoErrors.DifferentNamespaceException e)
+        record DifferentPackage(endpointerrors.com.palantir.another.EndpointSpecificErrors.DifferentPackageException e)
                 implements TestMultipleErrorsAndPackagesErrors {}
 
-        final record DifferentPackage(
-                endpointerrors.com.palantir.another.EndpointSpecificErrors.DifferentPackageException e)
+        record ComplicatedParameters(TestErrors.ComplicatedParametersException e)
                 implements TestMultipleErrorsAndPackagesErrors {}
 
-        final record ComplicatedParameters(TestErrors.ComplicatedParametersException e)
-                implements TestMultipleErrorsAndPackagesErrors {}
-
-        final record Unknown(RemoteException e) implements TestMultipleErrorsAndPackagesErrors {}
+        record Unknown(RemoteException e) implements TestMultipleErrorsAndPackagesErrors {}
     }
 
     sealed interface TestEmptyBodyErrors {
@@ -346,9 +343,9 @@ public interface ErrorServiceAsync {
             }
         }
 
-        final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestEmptyBodyErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestEmptyBodyErrors {}
 
-        final record Unknown(RemoteException e) implements TestEmptyBodyErrors {}
+        record Unknown(RemoteException e) implements TestEmptyBodyErrors {}
     }
 
     sealed interface TestBinaryErrors {
@@ -360,9 +357,9 @@ public interface ErrorServiceAsync {
             }
         }
 
-        final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestBinaryErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestBinaryErrors {}
 
-        final record Unknown(RemoteException e) implements TestBinaryErrors {}
+        record Unknown(RemoteException e) implements TestBinaryErrors {}
     }
 
     sealed interface TestOptionalBinaryErrors {
@@ -374,8 +371,8 @@ public interface ErrorServiceAsync {
             }
         }
 
-        final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestOptionalBinaryErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestOptionalBinaryErrors {}
 
-        final record Unknown(RemoteException e) implements TestOptionalBinaryErrors {}
+        record Unknown(RemoteException e) implements TestOptionalBinaryErrors {}
     }
 }

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceBlocking.java
@@ -16,7 +16,6 @@ import com.palantir.dialogue.PlainSerDe;
 import com.palantir.dialogue.Request;
 import com.palantir.dialogue.Serializer;
 import com.palantir.dialogue.TypeMarker;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.tokens.auth.AuthHeader;
 import java.io.InputStream;
 import java.lang.Boolean;
@@ -274,7 +273,7 @@ public interface ErrorServiceBlocking {
             } else if (e instanceof ConjureErrors.ConflictingCauseSafeArgErrException ex) {
                 return new ConflictingCauseSafeArgErr(ex);
             } else {
-                throw new SafeIllegalArgumentException("Not an error associated with testBasicError", e);
+                return new Unknown(e);
             }
         }
 
@@ -282,6 +281,8 @@ public interface ErrorServiceBlocking {
 
         final record ConflictingCauseSafeArgErr(ConjureErrors.ConflictingCauseSafeArgErrException e)
                 implements TestBasicErrorErrors {}
+
+        final record Unknown(RemoteException e) implements TestBasicErrorErrors {}
     }
 
     sealed interface TestImportedErrorErrors {
@@ -289,12 +290,14 @@ public interface ErrorServiceBlocking {
             if (e instanceof EndpointSpecificErrors.EndpointErrorException ex) {
                 return new EndpointError(ex);
             } else {
-                throw new SafeIllegalArgumentException("Not an error associated with testImportedError", e);
+                return new Unknown(e);
             }
         }
 
         final record EndpointError(EndpointSpecificErrors.EndpointErrorException e)
                 implements TestImportedErrorErrors {}
+
+        final record Unknown(RemoteException e) implements TestImportedErrorErrors {}
     }
 
     sealed interface TestMultipleErrorsAndPackagesErrors {
@@ -312,7 +315,7 @@ public interface ErrorServiceBlocking {
             } else if (e instanceof TestErrors.ComplicatedParametersException ex) {
                 return new ComplicatedParameters(ex);
             } else {
-                throw new SafeIllegalArgumentException("Not an error associated with testMultipleErrorsAndPackages", e);
+                return new Unknown(e);
             }
         }
 
@@ -330,6 +333,8 @@ public interface ErrorServiceBlocking {
 
         final record ComplicatedParameters(TestErrors.ComplicatedParametersException e)
                 implements TestMultipleErrorsAndPackagesErrors {}
+
+        final record Unknown(RemoteException e) implements TestMultipleErrorsAndPackagesErrors {}
     }
 
     sealed interface TestEmptyBodyErrors {
@@ -337,11 +342,13 @@ public interface ErrorServiceBlocking {
             if (e instanceof TestErrors.InvalidArgumentException ex) {
                 return new InvalidArgument(ex);
             } else {
-                throw new SafeIllegalArgumentException("Not an error associated with testEmptyBody", e);
+                return new Unknown(e);
             }
         }
 
         final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestEmptyBodyErrors {}
+
+        final record Unknown(RemoteException e) implements TestEmptyBodyErrors {}
     }
 
     sealed interface TestBinaryErrors {
@@ -349,11 +356,13 @@ public interface ErrorServiceBlocking {
             if (e instanceof TestErrors.InvalidArgumentException ex) {
                 return new InvalidArgument(ex);
             } else {
-                throw new SafeIllegalArgumentException("Not an error associated with testBinary", e);
+                return new Unknown(e);
             }
         }
 
         final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestBinaryErrors {}
+
+        final record Unknown(RemoteException e) implements TestBinaryErrors {}
     }
 
     sealed interface TestOptionalBinaryErrors {
@@ -361,10 +370,12 @@ public interface ErrorServiceBlocking {
             if (e instanceof TestErrors.InvalidArgumentException ex) {
                 return new InvalidArgument(ex);
             } else {
-                throw new SafeIllegalArgumentException("Not an error associated with testOptionalBinary", e);
+                return new Unknown(e);
             }
         }
 
         final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestOptionalBinaryErrors {}
+
+        final record Unknown(RemoteException e) implements TestOptionalBinaryErrors {}
     }
 }

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceBlocking.java
@@ -277,12 +277,12 @@ public interface ErrorServiceBlocking {
             }
         }
 
-        final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestBasicErrorErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestBasicErrorErrors {}
 
-        final record ConflictingCauseSafeArgErr(ConjureErrors.ConflictingCauseSafeArgErrException e)
+        record ConflictingCauseSafeArgErr(ConjureErrors.ConflictingCauseSafeArgErrException e)
                 implements TestBasicErrorErrors {}
 
-        final record Unknown(RemoteException e) implements TestBasicErrorErrors {}
+        record Unknown(RemoteException e) implements TestBasicErrorErrors {}
     }
 
     sealed interface TestImportedErrorErrors {
@@ -294,10 +294,9 @@ public interface ErrorServiceBlocking {
             }
         }
 
-        final record EndpointError(EndpointSpecificErrors.EndpointErrorException e)
-                implements TestImportedErrorErrors {}
+        record EndpointError(EndpointSpecificErrors.EndpointErrorException e) implements TestImportedErrorErrors {}
 
-        final record Unknown(RemoteException e) implements TestImportedErrorErrors {}
+        record Unknown(RemoteException e) implements TestImportedErrorErrors {}
     }
 
     sealed interface TestMultipleErrorsAndPackagesErrors {
@@ -319,22 +318,20 @@ public interface ErrorServiceBlocking {
             }
         }
 
-        final record InvalidArgument(TestErrors.InvalidArgumentException e)
+        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestMultipleErrorsAndPackagesErrors {}
+
+        record NotFound(TestErrors.NotFoundException e) implements TestMultipleErrorsAndPackagesErrors {}
+
+        record DifferentNamespace(EndpointSpecificTwoErrors.DifferentNamespaceException e)
                 implements TestMultipleErrorsAndPackagesErrors {}
 
-        final record NotFound(TestErrors.NotFoundException e) implements TestMultipleErrorsAndPackagesErrors {}
-
-        final record DifferentNamespace(EndpointSpecificTwoErrors.DifferentNamespaceException e)
+        record DifferentPackage(endpointerrors.com.palantir.another.EndpointSpecificErrors.DifferentPackageException e)
                 implements TestMultipleErrorsAndPackagesErrors {}
 
-        final record DifferentPackage(
-                endpointerrors.com.palantir.another.EndpointSpecificErrors.DifferentPackageException e)
+        record ComplicatedParameters(TestErrors.ComplicatedParametersException e)
                 implements TestMultipleErrorsAndPackagesErrors {}
 
-        final record ComplicatedParameters(TestErrors.ComplicatedParametersException e)
-                implements TestMultipleErrorsAndPackagesErrors {}
-
-        final record Unknown(RemoteException e) implements TestMultipleErrorsAndPackagesErrors {}
+        record Unknown(RemoteException e) implements TestMultipleErrorsAndPackagesErrors {}
     }
 
     sealed interface TestEmptyBodyErrors {
@@ -346,9 +343,9 @@ public interface ErrorServiceBlocking {
             }
         }
 
-        final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestEmptyBodyErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestEmptyBodyErrors {}
 
-        final record Unknown(RemoteException e) implements TestEmptyBodyErrors {}
+        record Unknown(RemoteException e) implements TestEmptyBodyErrors {}
     }
 
     sealed interface TestBinaryErrors {
@@ -360,9 +357,9 @@ public interface ErrorServiceBlocking {
             }
         }
 
-        final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestBinaryErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestBinaryErrors {}
 
-        final record Unknown(RemoteException e) implements TestBinaryErrors {}
+        record Unknown(RemoteException e) implements TestBinaryErrors {}
     }
 
     sealed interface TestOptionalBinaryErrors {
@@ -374,8 +371,8 @@ public interface ErrorServiceBlocking {
             }
         }
 
-        final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestOptionalBinaryErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestOptionalBinaryErrors {}
 
-        final record Unknown(RemoteException e) implements TestOptionalBinaryErrors {}
+        record Unknown(RemoteException e) implements TestOptionalBinaryErrors {}
     }
 }

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceBlocking.java
@@ -266,11 +266,11 @@ public interface ErrorServiceBlocking {
         }
     }
 
-    sealed interface TestBasicErrorErrors
-            permits TestBasicErrorErrors.InvalidArgument,
-                    TestBasicErrorErrors.ConflictingCauseSafeArgErr,
-                    TestBasicErrorErrors.Unknown {
-        static TestBasicErrorErrors from(RemoteException e) {
+    sealed interface TestBasicErrorError
+            permits TestBasicErrorError.InvalidArgument,
+                    TestBasicErrorError.ConflictingCauseSafeArgErr,
+                    TestBasicErrorError.Unknown {
+        static TestBasicErrorError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);
             } else if (ConjureErrors.isConflictingCauseSafeArgErr(e)) {
@@ -280,17 +280,17 @@ public interface ErrorServiceBlocking {
             }
         }
 
-        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestBasicErrorErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestBasicErrorError {}
 
         record ConflictingCauseSafeArgErr(ConjureErrors.ConflictingCauseSafeArgErrException exception)
-                implements TestBasicErrorErrors {}
+                implements TestBasicErrorError {}
 
-        record Unknown(RemoteException exception) implements TestBasicErrorErrors {}
+        record Unknown(RemoteException exception) implements TestBasicErrorError {}
     }
 
-    sealed interface TestImportedErrorErrors
-            permits TestImportedErrorErrors.EndpointError, TestImportedErrorErrors.Unknown {
-        static TestImportedErrorErrors from(RemoteException e) {
+    sealed interface TestImportedErrorError
+            permits TestImportedErrorError.EndpointError, TestImportedErrorError.Unknown {
+        static TestImportedErrorError from(RemoteException e) {
             if (EndpointSpecificErrors.isEndpointError(e)) {
                 return new EndpointError((EndpointSpecificErrors.EndpointErrorException) e);
             } else {
@@ -299,19 +299,19 @@ public interface ErrorServiceBlocking {
         }
 
         record EndpointError(EndpointSpecificErrors.EndpointErrorException exception)
-                implements TestImportedErrorErrors {}
+                implements TestImportedErrorError {}
 
-        record Unknown(RemoteException exception) implements TestImportedErrorErrors {}
+        record Unknown(RemoteException exception) implements TestImportedErrorError {}
     }
 
-    sealed interface TestMultipleErrorsAndPackagesErrors
-            permits TestMultipleErrorsAndPackagesErrors.InvalidArgument,
-                    TestMultipleErrorsAndPackagesErrors.NotFound,
-                    TestMultipleErrorsAndPackagesErrors.DifferentNamespace,
-                    TestMultipleErrorsAndPackagesErrors.DifferentPackage,
-                    TestMultipleErrorsAndPackagesErrors.ComplicatedParameters,
-                    TestMultipleErrorsAndPackagesErrors.Unknown {
-        static TestMultipleErrorsAndPackagesErrors from(RemoteException e) {
+    sealed interface TestMultipleErrorsAndPackagesError
+            permits TestMultipleErrorsAndPackagesError.InvalidArgument,
+                    TestMultipleErrorsAndPackagesError.NotFound,
+                    TestMultipleErrorsAndPackagesError.DifferentNamespace,
+                    TestMultipleErrorsAndPackagesError.DifferentPackage,
+                    TestMultipleErrorsAndPackagesError.ComplicatedParameters,
+                    TestMultipleErrorsAndPackagesError.Unknown {
+        static TestMultipleErrorsAndPackagesError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);
             } else if (TestErrors.isNotFound(e)) {
@@ -329,25 +329,25 @@ public interface ErrorServiceBlocking {
         }
 
         record InvalidArgument(TestErrors.InvalidArgumentException exception)
-                implements TestMultipleErrorsAndPackagesErrors {}
+                implements TestMultipleErrorsAndPackagesError {}
 
-        record NotFound(TestErrors.NotFoundException exception) implements TestMultipleErrorsAndPackagesErrors {}
+        record NotFound(TestErrors.NotFoundException exception) implements TestMultipleErrorsAndPackagesError {}
 
         record DifferentNamespace(EndpointSpecificTwoErrors.DifferentNamespaceException exception)
-                implements TestMultipleErrorsAndPackagesErrors {}
+                implements TestMultipleErrorsAndPackagesError {}
 
         record DifferentPackage(
                 endpointerrors.com.palantir.another.EndpointSpecificErrors.DifferentPackageException exception)
-                implements TestMultipleErrorsAndPackagesErrors {}
+                implements TestMultipleErrorsAndPackagesError {}
 
         record ComplicatedParameters(TestErrors.ComplicatedParametersException exception)
-                implements TestMultipleErrorsAndPackagesErrors {}
+                implements TestMultipleErrorsAndPackagesError {}
 
-        record Unknown(RemoteException exception) implements TestMultipleErrorsAndPackagesErrors {}
+        record Unknown(RemoteException exception) implements TestMultipleErrorsAndPackagesError {}
     }
 
-    sealed interface TestEmptyBodyErrors permits TestEmptyBodyErrors.InvalidArgument, TestEmptyBodyErrors.Unknown {
-        static TestEmptyBodyErrors from(RemoteException e) {
+    sealed interface TestEmptyBodyError permits TestEmptyBodyError.InvalidArgument, TestEmptyBodyError.Unknown {
+        static TestEmptyBodyError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);
             } else {
@@ -355,13 +355,13 @@ public interface ErrorServiceBlocking {
             }
         }
 
-        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestEmptyBodyErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestEmptyBodyError {}
 
-        record Unknown(RemoteException exception) implements TestEmptyBodyErrors {}
+        record Unknown(RemoteException exception) implements TestEmptyBodyError {}
     }
 
-    sealed interface TestBinaryErrors permits TestBinaryErrors.InvalidArgument, TestBinaryErrors.Unknown {
-        static TestBinaryErrors from(RemoteException e) {
+    sealed interface TestBinaryError permits TestBinaryError.InvalidArgument, TestBinaryError.Unknown {
+        static TestBinaryError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);
             } else {
@@ -369,14 +369,14 @@ public interface ErrorServiceBlocking {
             }
         }
 
-        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestBinaryErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestBinaryError {}
 
-        record Unknown(RemoteException exception) implements TestBinaryErrors {}
+        record Unknown(RemoteException exception) implements TestBinaryError {}
     }
 
-    sealed interface TestOptionalBinaryErrors
-            permits TestOptionalBinaryErrors.InvalidArgument, TestOptionalBinaryErrors.Unknown {
-        static TestOptionalBinaryErrors from(RemoteException e) {
+    sealed interface TestOptionalBinaryError
+            permits TestOptionalBinaryError.InvalidArgument, TestOptionalBinaryError.Unknown {
+        static TestOptionalBinaryError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);
             } else {
@@ -384,8 +384,8 @@ public interface ErrorServiceBlocking {
             }
         }
 
-        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestOptionalBinaryErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestOptionalBinaryError {}
 
-        record Unknown(RemoteException exception) implements TestOptionalBinaryErrors {}
+        record Unknown(RemoteException exception) implements TestOptionalBinaryError {}
     }
 }

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceBlocking.java
@@ -266,113 +266,126 @@ public interface ErrorServiceBlocking {
         }
     }
 
-    sealed interface TestBasicErrorErrors {
+    sealed interface TestBasicErrorErrors
+            permits TestBasicErrorErrors.InvalidArgument,
+                    TestBasicErrorErrors.ConflictingCauseSafeArgErr,
+                    TestBasicErrorErrors.Unknown {
         static TestBasicErrorErrors from(RemoteException e) {
-            if (e instanceof TestErrors.InvalidArgumentException ex) {
-                return new InvalidArgument(ex);
-            } else if (e instanceof ConjureErrors.ConflictingCauseSafeArgErrException ex) {
-                return new ConflictingCauseSafeArgErr(ex);
+            if (TestErrors.isInvalidArgument(e)) {
+                return new InvalidArgument((TestErrors.InvalidArgumentException) e);
+            } else if (ConjureErrors.isConflictingCauseSafeArgErr(e)) {
+                return new ConflictingCauseSafeArgErr((ConjureErrors.ConflictingCauseSafeArgErrException) e);
             } else {
                 return new Unknown(e);
             }
         }
 
-        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestBasicErrorErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestBasicErrorErrors {}
 
-        record ConflictingCauseSafeArgErr(ConjureErrors.ConflictingCauseSafeArgErrException e)
+        record ConflictingCauseSafeArgErr(ConjureErrors.ConflictingCauseSafeArgErrException exception)
                 implements TestBasicErrorErrors {}
 
-        record Unknown(RemoteException e) implements TestBasicErrorErrors {}
+        record Unknown(RemoteException exception) implements TestBasicErrorErrors {}
     }
 
-    sealed interface TestImportedErrorErrors {
+    sealed interface TestImportedErrorErrors
+            permits TestImportedErrorErrors.EndpointError, TestImportedErrorErrors.Unknown {
         static TestImportedErrorErrors from(RemoteException e) {
-            if (e instanceof EndpointSpecificErrors.EndpointErrorException ex) {
-                return new EndpointError(ex);
+            if (EndpointSpecificErrors.isEndpointError(e)) {
+                return new EndpointError((EndpointSpecificErrors.EndpointErrorException) e);
             } else {
                 return new Unknown(e);
             }
         }
 
-        record EndpointError(EndpointSpecificErrors.EndpointErrorException e) implements TestImportedErrorErrors {}
+        record EndpointError(EndpointSpecificErrors.EndpointErrorException exception)
+                implements TestImportedErrorErrors {}
 
-        record Unknown(RemoteException e) implements TestImportedErrorErrors {}
+        record Unknown(RemoteException exception) implements TestImportedErrorErrors {}
     }
 
-    sealed interface TestMultipleErrorsAndPackagesErrors {
+    sealed interface TestMultipleErrorsAndPackagesErrors
+            permits TestMultipleErrorsAndPackagesErrors.InvalidArgument,
+                    TestMultipleErrorsAndPackagesErrors.NotFound,
+                    TestMultipleErrorsAndPackagesErrors.DifferentNamespace,
+                    TestMultipleErrorsAndPackagesErrors.DifferentPackage,
+                    TestMultipleErrorsAndPackagesErrors.ComplicatedParameters,
+                    TestMultipleErrorsAndPackagesErrors.Unknown {
         static TestMultipleErrorsAndPackagesErrors from(RemoteException e) {
-            if (e instanceof TestErrors.InvalidArgumentException ex) {
-                return new InvalidArgument(ex);
-            } else if (e instanceof TestErrors.NotFoundException ex) {
-                return new NotFound(ex);
-            } else if (e instanceof EndpointSpecificTwoErrors.DifferentNamespaceException ex) {
-                return new DifferentNamespace(ex);
-            } else if (e
-                    instanceof
-                    endpointerrors.com.palantir.another.EndpointSpecificErrors.DifferentPackageException ex) {
-                return new DifferentPackage(ex);
-            } else if (e instanceof TestErrors.ComplicatedParametersException ex) {
-                return new ComplicatedParameters(ex);
+            if (TestErrors.isInvalidArgument(e)) {
+                return new InvalidArgument((TestErrors.InvalidArgumentException) e);
+            } else if (TestErrors.isNotFound(e)) {
+                return new NotFound((TestErrors.NotFoundException) e);
+            } else if (EndpointSpecificTwoErrors.isDifferentNamespace(e)) {
+                return new DifferentNamespace((EndpointSpecificTwoErrors.DifferentNamespaceException) e);
+            } else if (endpointerrors.com.palantir.another.EndpointSpecificErrors.isDifferentPackage(e)) {
+                return new DifferentPackage(
+                        (endpointerrors.com.palantir.another.EndpointSpecificErrors.DifferentPackageException) e);
+            } else if (TestErrors.isComplicatedParameters(e)) {
+                return new ComplicatedParameters((TestErrors.ComplicatedParametersException) e);
             } else {
                 return new Unknown(e);
             }
         }
 
-        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestMultipleErrorsAndPackagesErrors {}
-
-        record NotFound(TestErrors.NotFoundException e) implements TestMultipleErrorsAndPackagesErrors {}
-
-        record DifferentNamespace(EndpointSpecificTwoErrors.DifferentNamespaceException e)
+        record InvalidArgument(TestErrors.InvalidArgumentException exception)
                 implements TestMultipleErrorsAndPackagesErrors {}
 
-        record DifferentPackage(endpointerrors.com.palantir.another.EndpointSpecificErrors.DifferentPackageException e)
+        record NotFound(TestErrors.NotFoundException exception) implements TestMultipleErrorsAndPackagesErrors {}
+
+        record DifferentNamespace(EndpointSpecificTwoErrors.DifferentNamespaceException exception)
                 implements TestMultipleErrorsAndPackagesErrors {}
 
-        record ComplicatedParameters(TestErrors.ComplicatedParametersException e)
+        record DifferentPackage(
+                endpointerrors.com.palantir.another.EndpointSpecificErrors.DifferentPackageException exception)
                 implements TestMultipleErrorsAndPackagesErrors {}
 
-        record Unknown(RemoteException e) implements TestMultipleErrorsAndPackagesErrors {}
+        record ComplicatedParameters(TestErrors.ComplicatedParametersException exception)
+                implements TestMultipleErrorsAndPackagesErrors {}
+
+        record Unknown(RemoteException exception) implements TestMultipleErrorsAndPackagesErrors {}
     }
 
-    sealed interface TestEmptyBodyErrors {
+    sealed interface TestEmptyBodyErrors permits TestEmptyBodyErrors.InvalidArgument, TestEmptyBodyErrors.Unknown {
         static TestEmptyBodyErrors from(RemoteException e) {
-            if (e instanceof TestErrors.InvalidArgumentException ex) {
-                return new InvalidArgument(ex);
+            if (TestErrors.isInvalidArgument(e)) {
+                return new InvalidArgument((TestErrors.InvalidArgumentException) e);
             } else {
                 return new Unknown(e);
             }
         }
 
-        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestEmptyBodyErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestEmptyBodyErrors {}
 
-        record Unknown(RemoteException e) implements TestEmptyBodyErrors {}
+        record Unknown(RemoteException exception) implements TestEmptyBodyErrors {}
     }
 
-    sealed interface TestBinaryErrors {
+    sealed interface TestBinaryErrors permits TestBinaryErrors.InvalidArgument, TestBinaryErrors.Unknown {
         static TestBinaryErrors from(RemoteException e) {
-            if (e instanceof TestErrors.InvalidArgumentException ex) {
-                return new InvalidArgument(ex);
+            if (TestErrors.isInvalidArgument(e)) {
+                return new InvalidArgument((TestErrors.InvalidArgumentException) e);
             } else {
                 return new Unknown(e);
             }
         }
 
-        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestBinaryErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestBinaryErrors {}
 
-        record Unknown(RemoteException e) implements TestBinaryErrors {}
+        record Unknown(RemoteException exception) implements TestBinaryErrors {}
     }
 
-    sealed interface TestOptionalBinaryErrors {
+    sealed interface TestOptionalBinaryErrors
+            permits TestOptionalBinaryErrors.InvalidArgument, TestOptionalBinaryErrors.Unknown {
         static TestOptionalBinaryErrors from(RemoteException e) {
-            if (e instanceof TestErrors.InvalidArgumentException ex) {
-                return new InvalidArgument(ex);
+            if (TestErrors.isInvalidArgument(e)) {
+                return new InvalidArgument((TestErrors.InvalidArgumentException) e);
             } else {
                 return new Unknown(e);
             }
         }
 
-        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestOptionalBinaryErrors {}
+        record InvalidArgument(TestErrors.InvalidArgumentException exception) implements TestOptionalBinaryErrors {}
 
-        record Unknown(RemoteException e) implements TestOptionalBinaryErrors {}
+        record Unknown(RemoteException exception) implements TestOptionalBinaryErrors {}
     }
 }

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceBlocking.java
@@ -1,0 +1,370 @@
+package endpointerrors.com.palantir.product;
+
+import com.google.errorprone.annotations.MustBeClosed;
+import com.palantir.conjure.java.api.errors.RemoteException;
+import com.palantir.conjure.java.lib.internal.ClientEndpoint;
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.ConjureRuntime;
+import com.palantir.dialogue.Deserializer;
+import com.palantir.dialogue.DialogueService;
+import com.palantir.dialogue.DialogueServiceFactory;
+import com.palantir.dialogue.Endpoint;
+import com.palantir.dialogue.EndpointChannel;
+import com.palantir.dialogue.EndpointChannelFactory;
+import com.palantir.dialogue.ExceptionDeserializerArgs;
+import com.palantir.dialogue.PlainSerDe;
+import com.palantir.dialogue.Request;
+import com.palantir.dialogue.Serializer;
+import com.palantir.dialogue.TypeMarker;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.tokens.auth.AuthHeader;
+import java.io.InputStream;
+import java.lang.Boolean;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.Void;
+import java.util.Optional;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.services.dialogue.DialogueInterfaceGenerator")
+@DialogueService(ErrorServiceBlocking.Factory.class)
+public interface ErrorServiceBlocking {
+    /** @apiNote {@code POST /errors/basic} */
+    @ClientEndpoint(method = "POST", path = "/errors/basic")
+    String testBasicError(AuthHeader authHeader, boolean shouldThrowError);
+
+    /** @apiNote {@code POST /errors/imported} */
+    @ClientEndpoint(method = "POST", path = "/errors/imported")
+    String testImportedError(AuthHeader authHeader, boolean shouldThrowError);
+
+    /** @apiNote {@code POST /errors/multiple} */
+    @ClientEndpoint(method = "POST", path = "/errors/multiple")
+    String testMultipleErrorsAndPackages(AuthHeader authHeader, Optional<String> errorToThrow);
+
+    /** @apiNote {@code POST /errors/empty} */
+    @ClientEndpoint(method = "POST", path = "/errors/empty")
+    void testEmptyBody(AuthHeader authHeader, boolean shouldThrowError);
+
+    /** @apiNote {@code POST /errors/binary} */
+    @ClientEndpoint(method = "POST", path = "/errors/binary")
+    @MustBeClosed
+    InputStream testBinary(AuthHeader authHeader, boolean shouldThrowError);
+
+    /** @apiNote {@code POST /errors/optional-binary} */
+    @ClientEndpoint(method = "POST", path = "/errors/optional-binary")
+    Optional<InputStream> testOptionalBinary(AuthHeader authHeader, OptionalBinaryResponseMode mode);
+
+    /** Creates a synchronous/blocking client for a ErrorService service. */
+    static ErrorServiceBlocking of(EndpointChannelFactory _endpointChannelFactory, ConjureRuntime _runtime) {
+        return new ErrorServiceBlocking() {
+            private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
+
+            private final Serializer<Boolean> testBasicErrorSerializer =
+                    _runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
+
+            private final EndpointChannel testBasicErrorChannel =
+                    _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testBasicError);
+
+            private final Deserializer<String> testBasicErrorDeserializer =
+                    _runtime.bodySerDe().deserializer(createExceptionDeserializerArgs(new TypeMarker<String>() {}));
+
+            private final Serializer<Boolean> testImportedErrorSerializer =
+                    _runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
+
+            private final EndpointChannel testImportedErrorChannel =
+                    _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testImportedError);
+
+            private final Deserializer<String> testImportedErrorDeserializer =
+                    _runtime.bodySerDe().deserializer(createExceptionDeserializerArgs(new TypeMarker<String>() {}));
+
+            private final Serializer<Optional<String>> testMultipleErrorsAndPackagesSerializer =
+                    _runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {});
+
+            private final EndpointChannel testMultipleErrorsAndPackagesChannel =
+                    _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testMultipleErrorsAndPackages);
+
+            private final Deserializer<String> testMultipleErrorsAndPackagesDeserializer =
+                    _runtime.bodySerDe().deserializer(createExceptionDeserializerArgs(new TypeMarker<String>() {}));
+
+            private final Serializer<Boolean> testEmptyBodySerializer =
+                    _runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
+
+            private final EndpointChannel testEmptyBodyChannel =
+                    _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testEmptyBody);
+
+            private final Deserializer<Void> testEmptyBodyDeserializer = _runtime.bodySerDe()
+                    .emptyBodyDeserializer(createExceptionDeserializerArgs(new TypeMarker<Void>() {}));
+
+            private final Serializer<Boolean> testBinarySerializer =
+                    _runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
+
+            private final EndpointChannel testBinaryChannel =
+                    _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testBinary);
+
+            private final Deserializer<InputStream> testBinaryDeserializer = _runtime.bodySerDe()
+                    .inputStreamDeserializer(createExceptionDeserializerArgs(new TypeMarker<InputStream>() {}));
+
+            private final Serializer<OptionalBinaryResponseMode> testOptionalBinarySerializer =
+                    _runtime.bodySerDe().serializer(new TypeMarker<OptionalBinaryResponseMode>() {});
+
+            private final EndpointChannel testOptionalBinaryChannel =
+                    _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testOptionalBinary);
+
+            private final Deserializer<Optional<InputStream>> testOptionalBinaryDeserializer = _runtime.bodySerDe()
+                    .optionalInputStreamDeserializer(
+                            createExceptionDeserializerArgs(new TypeMarker<Optional<InputStream>>() {}));
+
+            private <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
+                return ExceptionDeserializerArgs.<T>builder()
+                        .returnType(returnType)
+                        .exception(
+                                endpointerrors.com.palantir.another.EndpointSpecificErrors.DIFFERENT_PACKAGE.name(),
+                                new TypeMarker<
+                                        endpointerrors.com.palantir.another.EndpointSpecificErrors
+                                                .DifferentPackageSerializableError>() {},
+                                new TypeMarker<
+                                        endpointerrors.com.palantir.another.EndpointSpecificErrors
+                                                .DifferentPackageException>() {})
+                        .exception(
+                                TestErrors.COMPLICATED_PARAMETERS.name(),
+                                new TypeMarker<TestErrors.ComplicatedParametersSerializableError>() {},
+                                new TypeMarker<TestErrors.ComplicatedParametersException>() {})
+                        .exception(
+                                ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG_ERR.name(),
+                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgErrSerializableError>() {},
+                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgErrException>() {})
+                        .exception(
+                                EndpointSpecificTwoErrors.DIFFERENT_NAMESPACE.name(),
+                                new TypeMarker<EndpointSpecificTwoErrors.DifferentNamespaceSerializableError>() {},
+                                new TypeMarker<EndpointSpecificTwoErrors.DifferentNamespaceException>() {})
+                        .exception(
+                                EndpointSpecificErrors.ENDPOINT_ERROR.name(),
+                                new TypeMarker<EndpointSpecificErrors.EndpointErrorSerializableError>() {},
+                                new TypeMarker<EndpointSpecificErrors.EndpointErrorException>() {})
+                        .exception(
+                                TestErrors.INVALID_ARGUMENT.name(),
+                                new TypeMarker<TestErrors.InvalidArgumentSerializableError>() {},
+                                new TypeMarker<TestErrors.InvalidArgumentException>() {})
+                        .exception(
+                                TestErrors.NOT_FOUND.name(),
+                                new TypeMarker<TestErrors.NotFoundSerializableError>() {},
+                                new TypeMarker<TestErrors.NotFoundException>() {})
+                        .build();
+            }
+
+            @Override
+            public String testBasicError(AuthHeader authHeader, boolean shouldThrowError) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.body(testBasicErrorSerializer.serialize(shouldThrowError));
+                if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
+                    _request.putHeaderParams(
+                            "Accept-Conjure-Error-Parameter-Format",
+                            _runtime.bodySerDe().errorParameterFormat().get().toString());
+                }
+                return _runtime.clients()
+                        .callBlocking(testBasicErrorChannel, _request.build(), testBasicErrorDeserializer);
+            }
+
+            @Override
+            public String testImportedError(AuthHeader authHeader, boolean shouldThrowError) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.body(testImportedErrorSerializer.serialize(shouldThrowError));
+                if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
+                    _request.putHeaderParams(
+                            "Accept-Conjure-Error-Parameter-Format",
+                            _runtime.bodySerDe().errorParameterFormat().get().toString());
+                }
+                return _runtime.clients()
+                        .callBlocking(testImportedErrorChannel, _request.build(), testImportedErrorDeserializer);
+            }
+
+            @Override
+            public String testMultipleErrorsAndPackages(AuthHeader authHeader, Optional<String> errorToThrow) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.body(testMultipleErrorsAndPackagesSerializer.serialize(errorToThrow));
+                if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
+                    _request.putHeaderParams(
+                            "Accept-Conjure-Error-Parameter-Format",
+                            _runtime.bodySerDe().errorParameterFormat().get().toString());
+                }
+                return _runtime.clients()
+                        .callBlocking(
+                                testMultipleErrorsAndPackagesChannel,
+                                _request.build(),
+                                testMultipleErrorsAndPackagesDeserializer);
+            }
+
+            @Override
+            public void testEmptyBody(AuthHeader authHeader, boolean shouldThrowError) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.body(testEmptyBodySerializer.serialize(shouldThrowError));
+                if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
+                    _request.putHeaderParams(
+                            "Accept-Conjure-Error-Parameter-Format",
+                            _runtime.bodySerDe().errorParameterFormat().get().toString());
+                }
+                _runtime.clients().callBlocking(testEmptyBodyChannel, _request.build(), testEmptyBodyDeserializer);
+            }
+
+            @Override
+            public InputStream testBinary(AuthHeader authHeader, boolean shouldThrowError) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.body(testBinarySerializer.serialize(shouldThrowError));
+                if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
+                    _request.putHeaderParams(
+                            "Accept-Conjure-Error-Parameter-Format",
+                            _runtime.bodySerDe().errorParameterFormat().get().toString());
+                }
+                return _runtime.clients().callBlocking(testBinaryChannel, _request.build(), testBinaryDeserializer);
+            }
+
+            @Override
+            public Optional<InputStream> testOptionalBinary(AuthHeader authHeader, OptionalBinaryResponseMode mode) {
+                Request.Builder _request = Request.builder();
+                _request.putHeaderParams("Authorization", authHeader.toString());
+                _request.body(testOptionalBinarySerializer.serialize(mode));
+                if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
+                    _request.putHeaderParams(
+                            "Accept-Conjure-Error-Parameter-Format",
+                            _runtime.bodySerDe().errorParameterFormat().get().toString());
+                }
+                return _runtime.clients()
+                        .callBlocking(testOptionalBinaryChannel, _request.build(), testOptionalBinaryDeserializer);
+            }
+
+            @Override
+            public String toString() {
+                return "ErrorServiceBlocking{_endpointChannelFactory=" + _endpointChannelFactory + ", runtime="
+                        + _runtime + '}';
+            }
+        };
+    }
+
+    /** Creates an asynchronous/non-blocking client for a ErrorService service. */
+    static ErrorServiceBlocking of(Channel _channel, ConjureRuntime _runtime) {
+        if (_channel instanceof EndpointChannelFactory) {
+            return of((EndpointChannelFactory) _channel, _runtime);
+        }
+        return of(
+                new EndpointChannelFactory() {
+                    @Override
+                    public EndpointChannel endpoint(Endpoint endpoint) {
+                        return _runtime.clients().bind(_channel, endpoint);
+                    }
+                },
+                _runtime);
+    }
+
+    final class Factory implements DialogueServiceFactory<ErrorServiceBlocking> {
+        @Override
+        public ErrorServiceBlocking create(EndpointChannelFactory endpointChannelFactory, ConjureRuntime runtime) {
+            return ErrorServiceBlocking.of(endpointChannelFactory, runtime);
+        }
+    }
+
+    sealed interface TestBasicErrorErrors {
+        static TestBasicErrorErrors from(RemoteException e) {
+            if (e instanceof TestErrors.InvalidArgumentException ex) {
+                return new InvalidArgument(ex);
+            } else if (e instanceof ConjureErrors.ConflictingCauseSafeArgErrException ex) {
+                return new ConflictingCauseSafeArgErr(ex);
+            } else {
+                throw new SafeIllegalArgumentException("Not an error associated with testBasicError", e);
+            }
+        }
+
+        final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestBasicErrorErrors {}
+
+        final record ConflictingCauseSafeArgErr(ConjureErrors.ConflictingCauseSafeArgErrException e)
+                implements TestBasicErrorErrors {}
+    }
+
+    sealed interface TestImportedErrorErrors {
+        static TestImportedErrorErrors from(RemoteException e) {
+            if (e instanceof EndpointSpecificErrors.EndpointErrorException ex) {
+                return new EndpointError(ex);
+            } else {
+                throw new SafeIllegalArgumentException("Not an error associated with testImportedError", e);
+            }
+        }
+
+        final record EndpointError(EndpointSpecificErrors.EndpointErrorException e)
+                implements TestImportedErrorErrors {}
+    }
+
+    sealed interface TestMultipleErrorsAndPackagesErrors {
+        static TestMultipleErrorsAndPackagesErrors from(RemoteException e) {
+            if (e instanceof TestErrors.InvalidArgumentException ex) {
+                return new InvalidArgument(ex);
+            } else if (e instanceof TestErrors.NotFoundException ex) {
+                return new NotFound(ex);
+            } else if (e instanceof EndpointSpecificTwoErrors.DifferentNamespaceException ex) {
+                return new DifferentNamespace(ex);
+            } else if (e
+                    instanceof
+                    endpointerrors.com.palantir.another.EndpointSpecificErrors.DifferentPackageException ex) {
+                return new DifferentPackage(ex);
+            } else if (e instanceof TestErrors.ComplicatedParametersException ex) {
+                return new ComplicatedParameters(ex);
+            } else {
+                throw new SafeIllegalArgumentException("Not an error associated with testMultipleErrorsAndPackages", e);
+            }
+        }
+
+        final record InvalidArgument(TestErrors.InvalidArgumentException e)
+                implements TestMultipleErrorsAndPackagesErrors {}
+
+        final record NotFound(TestErrors.NotFoundException e) implements TestMultipleErrorsAndPackagesErrors {}
+
+        final record DifferentNamespace(EndpointSpecificTwoErrors.DifferentNamespaceException e)
+                implements TestMultipleErrorsAndPackagesErrors {}
+
+        final record DifferentPackage(
+                endpointerrors.com.palantir.another.EndpointSpecificErrors.DifferentPackageException e)
+                implements TestMultipleErrorsAndPackagesErrors {}
+
+        final record ComplicatedParameters(TestErrors.ComplicatedParametersException e)
+                implements TestMultipleErrorsAndPackagesErrors {}
+    }
+
+    sealed interface TestEmptyBodyErrors {
+        static TestEmptyBodyErrors from(RemoteException e) {
+            if (e instanceof TestErrors.InvalidArgumentException ex) {
+                return new InvalidArgument(ex);
+            } else {
+                throw new SafeIllegalArgumentException("Not an error associated with testEmptyBody", e);
+            }
+        }
+
+        final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestEmptyBodyErrors {}
+    }
+
+    sealed interface TestBinaryErrors {
+        static TestBinaryErrors from(RemoteException e) {
+            if (e instanceof TestErrors.InvalidArgumentException ex) {
+                return new InvalidArgument(ex);
+            } else {
+                throw new SafeIllegalArgumentException("Not an error associated with testBinary", e);
+            }
+        }
+
+        final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestBinaryErrors {}
+    }
+
+    sealed interface TestOptionalBinaryErrors {
+        static TestOptionalBinaryErrors from(RemoteException e) {
+            if (e instanceof TestErrors.InvalidArgumentException ex) {
+                return new InvalidArgument(ex);
+            } else {
+                throw new SafeIllegalArgumentException("Not an error associated with testOptionalBinary", e);
+            }
+        }
+
+        final record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestOptionalBinaryErrors {}
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceEndpoints.java
@@ -1,0 +1,345 @@
+package endpointerrors.com.palantir.product;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
+import com.palantir.conjure.java.undertow.lib.Deserializer;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.Serializer;
+import com.palantir.conjure.java.undertow.lib.TypeMarker;
+import com.palantir.conjure.java.undertow.lib.UndertowRuntime;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import com.palantir.tokens.auth.AuthHeader;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+import io.undertow.util.Methods;
+import io.undertow.util.StatusCodes;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.services.UndertowServiceHandlerGenerator")
+public final class ErrorServiceEndpoints implements UndertowService {
+    private final UndertowErrorService delegate;
+
+    private ErrorServiceEndpoints(UndertowErrorService delegate) {
+        this.delegate = delegate;
+    }
+
+    public static UndertowService of(UndertowErrorService delegate) {
+        return new ErrorServiceEndpoints(delegate);
+    }
+
+    @Override
+    public List<Endpoint> endpoints(UndertowRuntime runtime) {
+        return ImmutableList.of(
+                new TestBasicErrorEndpoint(runtime, delegate),
+                new TestImportedErrorEndpoint(runtime, delegate),
+                new TestMultipleErrorsAndPackagesEndpoint(runtime, delegate),
+                new TestEmptyBodyEndpoint(runtime, delegate),
+                new TestBinaryEndpoint(runtime, delegate),
+                new TestOptionalBinaryEndpoint(runtime, delegate));
+    }
+
+    private static final class TestBasicErrorEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final UndertowErrorService delegate;
+
+        private final Deserializer<Boolean> deserializer;
+
+        private final Serializer<String> serializer;
+
+        TestBasicErrorEndpoint(UndertowRuntime runtime, UndertowErrorService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange)
+                throws IOException, TestServerErrors.InvalidArgument, ConjureServerErrors.ConflictingCauseSafeArgErr {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            Boolean shouldThrowError = deserializer.deserialize(exchange);
+            String result = delegate.testBasicError(authHeader, shouldThrowError);
+            serializer.serialize(result, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/errors/basic";
+        }
+
+        @Override
+        public String serviceName() {
+            return "ErrorService";
+        }
+
+        @Override
+        public String name() {
+            return "testBasicError";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class TestImportedErrorEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final UndertowErrorService delegate;
+
+        private final Deserializer<Boolean> deserializer;
+
+        private final Serializer<String> serializer;
+
+        TestImportedErrorEndpoint(UndertowRuntime runtime, UndertowErrorService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange)
+                throws IOException, EndpointSpecificServerErrors.EndpointError {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            Boolean shouldThrowError = deserializer.deserialize(exchange);
+            String result = delegate.testImportedError(authHeader, shouldThrowError);
+            serializer.serialize(result, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/errors/imported";
+        }
+
+        @Override
+        public String serviceName() {
+            return "ErrorService";
+        }
+
+        @Override
+        public String name() {
+            return "testImportedError";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class TestMultipleErrorsAndPackagesEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final UndertowErrorService delegate;
+
+        private final Deserializer<Optional<String>> deserializer;
+
+        private final Serializer<String> serializer;
+
+        TestMultipleErrorsAndPackagesEndpoint(UndertowRuntime runtime, UndertowErrorService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange)
+                throws IOException, TestServerErrors.InvalidArgument, TestServerErrors.NotFound,
+                        EndpointSpecificTwoServerErrors.DifferentNamespace,
+                        endpointerrors.com.palantir.another.EndpointSpecificServerErrors.DifferentPackage,
+                        TestServerErrors.ComplicatedParameters {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            Optional<String> errorToThrow = deserializer.deserialize(exchange);
+            String result = delegate.testMultipleErrorsAndPackages(authHeader, errorToThrow);
+            serializer.serialize(result, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/errors/multiple";
+        }
+
+        @Override
+        public String serviceName() {
+            return "ErrorService";
+        }
+
+        @Override
+        public String name() {
+            return "testMultipleErrorsAndPackages";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class TestEmptyBodyEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final UndertowErrorService delegate;
+
+        private final Deserializer<Boolean> deserializer;
+
+        TestEmptyBodyEndpoint(UndertowRuntime runtime, UndertowErrorService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {}, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException, TestServerErrors.InvalidArgument {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            Boolean shouldThrowError = deserializer.deserialize(exchange);
+            delegate.testEmptyBody(authHeader, shouldThrowError);
+            exchange.setStatusCode(StatusCodes.NO_CONTENT);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/errors/empty";
+        }
+
+        @Override
+        public String serviceName() {
+            return "ErrorService";
+        }
+
+        @Override
+        public String name() {
+            return "testEmptyBody";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class TestBinaryEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final UndertowErrorService delegate;
+
+        private final Deserializer<Boolean> deserializer;
+
+        TestBinaryEndpoint(UndertowRuntime runtime, UndertowErrorService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {}, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException, TestServerErrors.InvalidArgument {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            Boolean shouldThrowError = deserializer.deserialize(exchange);
+            BinaryResponseBody result = delegate.testBinary(authHeader, shouldThrowError);
+            runtime.bodySerDe().serialize(result, exchange);
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/errors/binary";
+        }
+
+        @Override
+        public String serviceName() {
+            return "ErrorService";
+        }
+
+        @Override
+        public String name() {
+            return "testBinary";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+
+    private static final class TestOptionalBinaryEndpoint implements HttpHandler, Endpoint {
+        private final UndertowRuntime runtime;
+
+        private final UndertowErrorService delegate;
+
+        private final Deserializer<OptionalBinaryResponseMode> deserializer;
+
+        TestOptionalBinaryEndpoint(UndertowRuntime runtime, UndertowErrorService delegate) {
+            this.runtime = runtime;
+            this.delegate = delegate;
+            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<OptionalBinaryResponseMode>() {}, this);
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws IOException, TestServerErrors.InvalidArgument {
+            AuthHeader authHeader = runtime.auth().header(exchange);
+            OptionalBinaryResponseMode mode = deserializer.deserialize(exchange);
+            Optional<BinaryResponseBody> result = delegate.testOptionalBinary(authHeader, mode);
+            if (result.isPresent()) {
+                runtime.bodySerDe().serialize(result.get(), exchange);
+            } else {
+                exchange.setStatusCode(StatusCodes.NO_CONTENT);
+            }
+        }
+
+        @Override
+        public HttpString method() {
+            return Methods.POST;
+        }
+
+        @Override
+        public String template() {
+            return "/errors/optional-binary";
+        }
+
+        @Override
+        public String serviceName() {
+            return "ErrorService";
+        }
+
+        @Override
+        public String name() {
+            return "testOptionalBinary";
+        }
+
+        @Override
+        public HttpHandler handler() {
+            return this;
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/OptionalBinaryResponseMode.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/OptionalBinaryResponseMode.java
@@ -1,0 +1,239 @@
+package endpointerrors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.errorprone.annotations.Immutable;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+/**
+ * This class is used instead of a native enum to support unknown values. Rather than throw an exception, the
+ * {@link OptionalBinaryResponseMode#valueOf} method defaults to a new instantiation of
+ * {@link OptionalBinaryResponseMode} where {@link OptionalBinaryResponseMode#get} will return
+ * {@link OptionalBinaryResponseMode.Value#UNKNOWN}.
+ *
+ * <p>For example, {@code OptionalBinaryResponseMode.valueOf("corrupted value").get()} will return
+ * {@link OptionalBinaryResponseMode.Value#UNKNOWN}, but {@link OptionalBinaryResponseMode#toString} will return
+ * "corrupted value".
+ *
+ * <p>There is no method to access all instantiations of this class, since they cannot be known at compile time.
+ */
+@Generated("com.palantir.conjure.java.types.EnumGenerator")
+@Safe
+@Immutable
+public final class OptionalBinaryResponseMode {
+    public static final OptionalBinaryResponseMode PRESENT = new OptionalBinaryResponseMode(Value.PRESENT, "PRESENT");
+
+    public static final OptionalBinaryResponseMode ABSENT = new OptionalBinaryResponseMode(Value.ABSENT, "ABSENT");
+
+    public static final OptionalBinaryResponseMode ERROR = new OptionalBinaryResponseMode(Value.ERROR, "ERROR");
+
+    private static final List<OptionalBinaryResponseMode> values =
+            Collections.unmodifiableList(Arrays.asList(PRESENT, ABSENT, ERROR));
+
+    private final Value value;
+
+    private final String string;
+
+    private OptionalBinaryResponseMode(Value value, String string) {
+        this.value = value;
+        this.string = string;
+    }
+
+    public Value get() {
+        return this.value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return this.string;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return (this == other)
+                || (this.value == Value.UNKNOWN
+                        && other instanceof OptionalBinaryResponseMode
+                        && this.string.equals(((OptionalBinaryResponseMode) other).string));
+    }
+
+    @Override
+    public int hashCode() {
+        return this.string.hashCode();
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static OptionalBinaryResponseMode valueOf(@Nonnull @Safe String value) {
+        Preconditions.checkNotNull(value, "value cannot be null");
+        String upperCasedValue = value.toUpperCase(Locale.ROOT);
+        switch (upperCasedValue) {
+            case "PRESENT":
+                return PRESENT;
+            case "ABSENT":
+                return ABSENT;
+            case "ERROR":
+                return ERROR;
+            default:
+                return new OptionalBinaryResponseMode(Value.UNKNOWN, upperCasedValue);
+        }
+    }
+
+    public <T> T accept(Visitor<T> visitor) {
+        switch (value) {
+            case PRESENT:
+                return visitor.visitPresent();
+            case ABSENT:
+                return visitor.visitAbsent();
+            case ERROR:
+                return visitor.visitError();
+            default:
+                return visitor.visitUnknown(string);
+        }
+    }
+
+    public static List<OptionalBinaryResponseMode> values() {
+        return values;
+    }
+
+    @Generated("com.palantir.conjure.java.types.EnumGenerator")
+    public enum Value {
+        PRESENT,
+
+        ABSENT,
+
+        ERROR,
+
+        UNKNOWN
+    }
+
+    @Generated("com.palantir.conjure.java.types.EnumGenerator")
+    public interface Visitor<T> {
+        T visitPresent();
+
+        T visitAbsent();
+
+        T visitError();
+
+        T visitUnknown(String unknownValue);
+
+        static <T> PresentStageVisitorBuilder<T> builder() {
+            return new VisitorBuilder<T>();
+        }
+    }
+
+    private static final class VisitorBuilder<T>
+            implements PresentStageVisitorBuilder<T>,
+                    AbsentStageVisitorBuilder<T>,
+                    ErrorStageVisitorBuilder<T>,
+                    UnknownStageVisitorBuilder<T>,
+                    Completed_StageVisitorBuilder<T> {
+        private Supplier<T> presentVisitor;
+
+        private Supplier<T> absentVisitor;
+
+        private Supplier<T> errorVisitor;
+
+        private Function<@Safe String, T> unknownVisitor;
+
+        @Override
+        public AbsentStageVisitorBuilder<T> visitPresent(@Nonnull Supplier<T> presentVisitor) {
+            Preconditions.checkNotNull(presentVisitor, "presentVisitor cannot be null");
+            this.presentVisitor = presentVisitor;
+            return this;
+        }
+
+        @Override
+        public ErrorStageVisitorBuilder<T> visitAbsent(@Nonnull Supplier<T> absentVisitor) {
+            Preconditions.checkNotNull(absentVisitor, "absentVisitor cannot be null");
+            this.absentVisitor = absentVisitor;
+            return this;
+        }
+
+        @Override
+        public UnknownStageVisitorBuilder<T> visitError(@Nonnull Supplier<T> errorVisitor) {
+            Preconditions.checkNotNull(errorVisitor, "errorVisitor cannot be null");
+            this.errorVisitor = errorVisitor;
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor) {
+            Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
+            this.unknownVisitor = unknownType -> unknownVisitor.apply(unknownType);
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
+            this.unknownVisitor = unknownType -> {
+                throw new SafeIllegalArgumentException(
+                        "Unknown variant of the 'OptionalBinaryResponseMode' union",
+                        SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
+        public Visitor<T> build() {
+            final Supplier<T> presentVisitor = this.presentVisitor;
+            final Supplier<T> absentVisitor = this.absentVisitor;
+            final Supplier<T> errorVisitor = this.errorVisitor;
+            final Function<@Safe String, T> unknownVisitor = this.unknownVisitor;
+            return new Visitor<T>() {
+                @Override
+                public T visitPresent() {
+                    return presentVisitor.get();
+                }
+
+                @Override
+                public T visitAbsent() {
+                    return absentVisitor.get();
+                }
+
+                @Override
+                public T visitError() {
+                    return errorVisitor.get();
+                }
+
+                @Override
+                public T visitUnknown(String unknownType) {
+                    return unknownVisitor.apply(unknownType);
+                }
+            };
+        }
+    }
+
+    public interface PresentStageVisitorBuilder<T> {
+        AbsentStageVisitorBuilder<T> visitPresent(@Nonnull Supplier<T> presentVisitor);
+    }
+
+    public interface AbsentStageVisitorBuilder<T> {
+        ErrorStageVisitorBuilder<T> visitAbsent(@Nonnull Supplier<T> absentVisitor);
+    }
+
+    public interface ErrorStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> visitError(@Nonnull Supplier<T> errorVisitor);
+    }
+
+    public interface UnknownStageVisitorBuilder<T> {
+        Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
+    }
+
+    public interface Completed_StageVisitorBuilder<T> {
+        Visitor<T> build();
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/StringAlias.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/StringAlias.java
@@ -1,0 +1,55 @@
+package endpointerrors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Preconditions;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.types.AliasGenerator")
+public final class StringAlias implements Comparable<StringAlias> {
+    private final String value;
+
+    private StringAlias(@Nonnull String value) {
+        this.value = Preconditions.checkNotNull(value, "value cannot be null");
+    }
+
+    @JsonValue
+    public String get() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return this == other || (other instanceof StringAlias && equalTo((StringAlias) other));
+    }
+
+    private boolean equalTo(StringAlias other) {
+        return this.value.equals(other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.value.hashCode();
+    }
+
+    @Override
+    public int compareTo(StringAlias other) {
+        return value.compareTo(other.get());
+    }
+
+    public static StringAlias valueOf(String value) {
+        return of(value);
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static StringAlias of(@Nonnull String value) {
+        return new StringAlias(value);
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/TestErrors.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/TestErrors.java
@@ -48,9 +48,11 @@ public final class TestErrors {
             @JsonProperty("complicatedObjectMap") @Safe Map<Integer, ComplicatedObject> complicatedObjectMap) {}
 
     public static record InvalidArgumentParameters(
-            @JsonProperty("field") @Safe String field, @JsonProperty("value") @Unsafe String value) {}
+            @JsonProperty("field") @Safe String field,
+            @JsonProperty("value") @Unsafe String value) {}
 
-    public static record NotFoundParameters(@JsonProperty("resource") @Safe String resource) {}
+    public static record NotFoundParameters(
+            @JsonProperty("resource") @Safe String resource) {}
 
     public static final class ComplicatedParametersSerializableError
             extends AbstractSerializableError<ComplicatedParametersParameters> {

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/TestErrors.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/TestErrors.java
@@ -1,0 +1,161 @@
+package endpointerrors.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.palantir.conjure.java.api.errors.AbstractSerializableError;
+import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.RemoteException;
+import com.palantir.conjure.java.api.errors.SerializableError;
+import com.palantir.conjure.java.api.errors.SerializableErrorProvider;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.Unsafe;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.types.ErrorGenerator")
+public final class TestErrors {
+    public static final ErrorType COMPLICATED_PARAMETERS =
+            ErrorType.create(ErrorType.Code.INTERNAL, "Test:ComplicatedParameters");
+
+    public static final ErrorType INVALID_ARGUMENT =
+            ErrorType.create(ErrorType.Code.INVALID_ARGUMENT, "Test:InvalidArgument");
+
+    public static final ErrorType NOT_FOUND = ErrorType.create(ErrorType.Code.NOT_FOUND, "Test:NotFound");
+
+    private TestErrors() {}
+
+    /** Returns true if the {@link RemoteException} is named Test:ComplicatedParameters */
+    public static boolean isComplicatedParameters(RemoteException remoteException) {
+        Preconditions.checkNotNull(remoteException, "remote exception must not be null");
+        return COMPLICATED_PARAMETERS.name().equals(remoteException.getError().errorName());
+    }
+
+    /** Returns true if the {@link RemoteException} is named Test:InvalidArgument */
+    public static boolean isInvalidArgument(RemoteException remoteException) {
+        Preconditions.checkNotNull(remoteException, "remote exception must not be null");
+        return INVALID_ARGUMENT.name().equals(remoteException.getError().errorName());
+    }
+
+    /** Returns true if the {@link RemoteException} is named Test:NotFound */
+    public static boolean isNotFound(RemoteException remoteException) {
+        Preconditions.checkNotNull(remoteException, "remote exception must not be null");
+        return NOT_FOUND.name().equals(remoteException.getError().errorName());
+    }
+
+    public static record ComplicatedParametersParameters(
+            @JsonProperty("complicatedObjectMap") @Safe Map<Integer, ComplicatedObject> complicatedObjectMap) {}
+
+    public static record InvalidArgumentParameters(
+            @JsonProperty("field") @Safe String field, @JsonProperty("value") @Unsafe String value) {}
+
+    public static record NotFoundParameters(@JsonProperty("resource") @Safe String resource) {}
+
+    public static final class ComplicatedParametersSerializableError
+            extends AbstractSerializableError<ComplicatedParametersParameters> {
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        ComplicatedParametersSerializableError(
+                @JsonProperty("errorCode") @Safe String errorCode,
+                @JsonProperty("errorName") @Safe String errorName,
+                @JsonProperty("errorInstanceId") @Safe String errorInstanceId,
+                @JsonProperty("parameters") ComplicatedParametersParameters parameters) {
+            super(errorCode, errorName, errorInstanceId, parameters);
+        }
+
+        public SerializableError toSerializableError() {
+            return SerializableError.builder()
+                    .putParameters(
+                            "complicatedObjectMap",
+                            Objects.toString(parameters().complicatedObjectMap()))
+                    .errorCode(errorCode())
+                    .errorName(errorName())
+                    .errorInstanceId(errorInstanceId())
+                    .build();
+        }
+    }
+
+    public static final class InvalidArgumentSerializableError
+            extends AbstractSerializableError<InvalidArgumentParameters> {
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        InvalidArgumentSerializableError(
+                @JsonProperty("errorCode") @Safe String errorCode,
+                @JsonProperty("errorName") @Safe String errorName,
+                @JsonProperty("errorInstanceId") @Safe String errorInstanceId,
+                @JsonProperty("parameters") InvalidArgumentParameters parameters) {
+            super(errorCode, errorName, errorInstanceId, parameters);
+        }
+
+        public SerializableError toSerializableError() {
+            return SerializableError.builder()
+                    .putParameters("field", Objects.toString(parameters().field()))
+                    .putParameters("value", Objects.toString(parameters().value()))
+                    .errorCode(errorCode())
+                    .errorName(errorName())
+                    .errorInstanceId(errorInstanceId())
+                    .build();
+        }
+    }
+
+    public static final class NotFoundSerializableError extends AbstractSerializableError<NotFoundParameters> {
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        NotFoundSerializableError(
+                @JsonProperty("errorCode") @Safe String errorCode,
+                @JsonProperty("errorName") @Safe String errorName,
+                @JsonProperty("errorInstanceId") @Safe String errorInstanceId,
+                @JsonProperty("parameters") NotFoundParameters parameters) {
+            super(errorCode, errorName, errorInstanceId, parameters);
+        }
+
+        public SerializableError toSerializableError() {
+            return SerializableError.builder()
+                    .putParameters("resource", Objects.toString(parameters().resource()))
+                    .errorCode(errorCode())
+                    .errorName(errorName())
+                    .errorInstanceId(errorInstanceId())
+                    .build();
+        }
+    }
+
+    public static final class ComplicatedParametersException extends RemoteException
+            implements SerializableErrorProvider<ComplicatedParametersParameters> {
+        private ComplicatedParametersSerializableError error;
+
+        public ComplicatedParametersException(ComplicatedParametersSerializableError error, int status) {
+            super(error.toSerializableError(), status);
+            this.error = error;
+        }
+
+        public ComplicatedParametersSerializableError error() {
+            return error;
+        }
+    }
+
+    public static final class InvalidArgumentException extends RemoteException
+            implements SerializableErrorProvider<InvalidArgumentParameters> {
+        private InvalidArgumentSerializableError error;
+
+        public InvalidArgumentException(InvalidArgumentSerializableError error, int status) {
+            super(error.toSerializableError(), status);
+            this.error = error;
+        }
+
+        public InvalidArgumentSerializableError error() {
+            return error;
+        }
+    }
+
+    public static final class NotFoundException extends RemoteException
+            implements SerializableErrorProvider<NotFoundParameters> {
+        private NotFoundSerializableError error;
+
+        public NotFoundException(NotFoundSerializableError error, int status) {
+            super(error.toSerializableError(), status);
+            this.error = error;
+        }
+
+        public NotFoundSerializableError error() {
+            return error;
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/TestServerErrors.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/TestServerErrors.java
@@ -1,0 +1,102 @@
+package endpointerrors.com.palantir.product;
+
+import com.palantir.conjure.java.api.errors.EndpointServiceException;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.Unsafe;
+import com.palantir.logsafe.UnsafeArg;
+import java.util.Map;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+import org.jetbrains.annotations.Contract;
+
+@Generated("com.palantir.conjure.java.types.EndpointErrorGenerator")
+public final class TestServerErrors {
+    private TestServerErrors() {}
+
+    public static ComplicatedParameters complicatedParameters(
+            @Safe Map<Integer, ComplicatedObject> complicatedObjectMap) {
+        return new ComplicatedParameters(complicatedObjectMap, null);
+    }
+
+    public static ComplicatedParameters complicatedParameters(
+            @Safe Map<Integer, ComplicatedObject> complicatedObjectMap, @Nullable Throwable cause) {
+        return new ComplicatedParameters(complicatedObjectMap, cause);
+    }
+
+    public static InvalidArgument invalidArgument(@Safe String field, @Unsafe String value) {
+        return new InvalidArgument(field, value, null);
+    }
+
+    public static InvalidArgument invalidArgument(@Safe String field, @Unsafe String value, @Nullable Throwable cause) {
+        return new InvalidArgument(field, value, cause);
+    }
+
+    public static NotFound notFound(@Safe String resource) {
+        return new NotFound(resource, null);
+    }
+
+    public static NotFound notFound(@Safe String resource, @Nullable Throwable cause) {
+        return new NotFound(resource, cause);
+    }
+
+    /**
+     * Throws a {@link ComplicatedParameters} when {@code shouldThrow} is true.
+     *
+     * @param shouldThrow Cause the method to throw when true
+     * @param complicatedObjectMap
+     */
+    @Contract("true, _ -> fail")
+    public static void throwIfComplicatedParameters(
+            boolean shouldThrow, @Safe Map<Integer, ComplicatedObject> complicatedObjectMap) {
+        if (shouldThrow) {
+            throw complicatedParameters(complicatedObjectMap);
+        }
+    }
+
+    /**
+     * Throws a {@link InvalidArgument} when {@code shouldThrow} is true.
+     *
+     * @param shouldThrow Cause the method to throw when true
+     * @param field
+     * @param value
+     */
+    @Contract("true, _, _ -> fail")
+    public static void throwIfInvalidArgument(boolean shouldThrow, @Safe String field, @Unsafe String value) {
+        if (shouldThrow) {
+            throw invalidArgument(field, value);
+        }
+    }
+
+    /**
+     * Throws a {@link NotFound} when {@code shouldThrow} is true.
+     *
+     * @param shouldThrow Cause the method to throw when true
+     * @param resource
+     */
+    @Contract("true, _ -> fail")
+    public static void throwIfNotFound(boolean shouldThrow, @Safe String resource) {
+        if (shouldThrow) {
+            throw notFound(resource);
+        }
+    }
+
+    public static final class ComplicatedParameters extends EndpointServiceException {
+        private ComplicatedParameters(
+                @Safe Map<Integer, ComplicatedObject> complicatedObjectMap, @Nullable Throwable cause) {
+            super(TestErrors.COMPLICATED_PARAMETERS, cause, SafeArg.of("complicatedObjectMap", complicatedObjectMap));
+        }
+    }
+
+    public static final class InvalidArgument extends EndpointServiceException {
+        private InvalidArgument(@Safe String field, @Unsafe String value, @Nullable Throwable cause) {
+            super(TestErrors.INVALID_ARGUMENT, cause, SafeArg.of("field", field), UnsafeArg.of("value", value));
+        }
+    }
+
+    public static final class NotFound extends EndpointServiceException {
+        private NotFound(@Safe String resource, @Nullable Throwable cause) {
+            super(TestErrors.NOT_FOUND, cause, SafeArg.of("resource", resource));
+        }
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/UndertowErrorService.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/UndertowErrorService.java
@@ -1,0 +1,58 @@
+package endpointerrors.com.palantir.product;
+
+import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
+import com.palantir.tokens.auth.AuthHeader;
+import java.util.Optional;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.services.UndertowServiceInterfaceGenerator")
+public interface UndertowErrorService {
+    /**
+     * @apiNote {@code POST /errors/basic}
+     * @throws TestServerErrors.InvalidArgument
+     * @throws ConjureServerErrors.ConflictingCauseSafeArgErr
+     */
+    String testBasicError(AuthHeader authHeader, boolean shouldThrowError)
+            throws TestServerErrors.InvalidArgument, ConjureServerErrors.ConflictingCauseSafeArgErr;
+
+    /**
+     * @apiNote {@code POST /errors/imported}
+     * @throws EndpointSpecificServerErrors.EndpointError
+     */
+    String testImportedError(AuthHeader authHeader, boolean shouldThrowError)
+            throws EndpointSpecificServerErrors.EndpointError;
+
+    /**
+     * @apiNote {@code POST /errors/multiple}
+     * @throws TestServerErrors.InvalidArgument
+     * @throws TestServerErrors.NotFound Something was not found.
+     * @throws EndpointSpecificTwoServerErrors.DifferentNamespace
+     * @throws endpointerrors.com.palantir.another.EndpointSpecificServerErrors.DifferentPackage
+     * @throws TestServerErrors.ComplicatedParameters
+     */
+    String testMultipleErrorsAndPackages(AuthHeader authHeader, Optional<String> errorToThrow)
+            throws TestServerErrors.InvalidArgument, TestServerErrors.NotFound,
+                    EndpointSpecificTwoServerErrors.DifferentNamespace,
+                    endpointerrors.com.palantir.another.EndpointSpecificServerErrors.DifferentPackage,
+                    TestServerErrors.ComplicatedParameters;
+
+    /**
+     * @apiNote {@code POST /errors/empty}
+     * @throws TestServerErrors.InvalidArgument
+     */
+    void testEmptyBody(AuthHeader authHeader, boolean shouldThrowError) throws TestServerErrors.InvalidArgument;
+
+    /**
+     * @apiNote {@code POST /errors/binary}
+     * @throws TestServerErrors.InvalidArgument
+     */
+    BinaryResponseBody testBinary(AuthHeader authHeader, boolean shouldThrowError)
+            throws TestServerErrors.InvalidArgument;
+
+    /**
+     * @apiNote {@code POST /errors/optional-binary}
+     * @throws TestServerErrors.InvalidArgument
+     */
+    Optional<BinaryResponseBody> testOptionalBinary(AuthHeader authHeader, OptionalBinaryResponseMode mode)
+            throws TestServerErrors.InvalidArgument;
+}

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteServiceBlocking.java
@@ -1,7 +1,6 @@
 package exceptionthrowingdialogueinterfaces.com.palantir.product;
 
 import com.google.errorprone.annotations.MustBeClosed;
-import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.conjure.java.lib.internal.ClientEndpoint;
 import com.palantir.dialogue.Channel;
@@ -20,9 +19,14 @@ import com.palantir.dialogue.TypeMarker;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
-import exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors.InvalidTypeDefinitionException;
-import exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureJavaErrors.JavaCompilationFailedException;
 import java.io.InputStream;
+import java.lang.Boolean;
+import java.lang.Double;
+import java.lang.Integer;
+import java.lang.Long;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.Void;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -489,7 +493,6 @@ public interface EteServiceBlocking {
 
             @Override
             public String string(AuthHeader authHeader) {
-
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
@@ -996,24 +999,6 @@ public interface EteServiceBlocking {
                         + '}';
             }
         };
-    }
-
-    public sealed interface StringErrors {
-        public record JavaCompilationFailed(JavaCompilationFailedException e) implements StringErrors {}
-
-        public record InvalidTypeDefinition(InvalidTypeDefinitionException e) implements StringErrors {}
-
-        public record Unknown(RemoteException e) implements StringErrors {}
-
-        public static StringErrors of(RemoteException e) {
-            if (e instanceof JavaCompilationFailedException ex) {
-                return new JavaCompilationFailed(ex);
-            } else if (e instanceof InvalidTypeDefinitionException ex) {
-                return new InvalidTypeDefinition(ex);
-            } else {
-                return new Unknown(e);
-            }
-        }
     }
 
     /** Creates an asynchronous/non-blocking client for a EteService service. */

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteServiceBlocking.java
@@ -1,6 +1,7 @@
 package exceptionthrowingdialogueinterfaces.com.palantir.product;
 
 import com.google.errorprone.annotations.MustBeClosed;
+import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.conjure.java.lib.internal.ClientEndpoint;
 import com.palantir.dialogue.Channel;
@@ -19,14 +20,9 @@ import com.palantir.dialogue.TypeMarker;
 import com.palantir.ri.ResourceIdentifier;
 import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
+import exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors.InvalidTypeDefinitionException;
+import exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureJavaErrors.JavaCompilationFailedException;
 import java.io.InputStream;
-import java.lang.Boolean;
-import java.lang.Double;
-import java.lang.Integer;
-import java.lang.Long;
-import java.lang.Override;
-import java.lang.String;
-import java.lang.Void;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -493,6 +489,7 @@ public interface EteServiceBlocking {
 
             @Override
             public String string(AuthHeader authHeader) {
+
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
@@ -999,6 +996,24 @@ public interface EteServiceBlocking {
                         + '}';
             }
         };
+    }
+
+    public sealed interface StringErrors {
+        public record JavaCompilationFailed(JavaCompilationFailedException e) implements StringErrors {}
+
+        public record InvalidTypeDefinition(InvalidTypeDefinitionException e) implements StringErrors {}
+
+        public record Unknown(RemoteException e) implements StringErrors {}
+
+        public static StringErrors of(RemoteException e) {
+            if (e instanceof JavaCompilationFailedException ex) {
+                return new JavaCompilationFailed(ex);
+            } else if (e instanceof InvalidTypeDefinitionException ex) {
+                return new InvalidTypeDefinition(ex);
+            } else {
+                return new Unknown(e);
+            }
+        }
     }
 
     /** Creates an asynchronous/non-blocking client for a EteService service. */

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
@@ -240,9 +240,7 @@ public final class DialogueInterfaceGenerator {
                 first = false;
                 codeBlock.beginControlFlow(
                         "if ($T.$N(e))", errorTypesClass, ErrorGenerationUtils.errorInstanceCheckMethodName(errorName));
-                // codeBlock.beginControlFlow("if (e instanceof $T ex)", exceptionClassName);
             } else {
-                // codeBlock.nextControlFlow("else if (e instanceof $T ex)", exceptionClassName);
                 codeBlock.nextControlFlow(
                         "else if ($T.$N(e))",
                         errorTypesClass,

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
@@ -205,21 +205,18 @@ public final class DialogueInterfaceGenerator {
 
     private Optional<TypeSpec> endpointErrorUtilityType(
             EndpointDefinition endpointDef, String packageName, ClassName className) {
-        ClassName utiltyClassName = ClassName.get(
-                packageName,
-                className.simpleName(),
-                CaseFormat.LOWER_CAMEL.to(
-                                CaseFormat.UPPER_CAMEL,
-                                endpointDef.getEndpointName().get()) + "Errors");
+        ClassName utilityClassName = className.nestedClass(CaseFormat.LOWER_CAMEL.to(
+                        CaseFormat.UPPER_CAMEL, endpointDef.getEndpointName().get())
+                + "Errors");
         if (endpointDef.getErrors().isEmpty()) {
             return Optional.empty();
         }
-        TypeSpec.Builder builder = TypeSpec.interfaceBuilder(utiltyClassName)
+        TypeSpec.Builder builder = TypeSpec.interfaceBuilder(utilityClassName)
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.SEALED);
         MethodSpec.Builder fromBuilder = MethodSpec.methodBuilder("from")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .addParameter(RemoteException.class, "e")
-                .returns(utiltyClassName);
+                .returns(utilityClassName);
 
         boolean first = true;
         CodeBlock.Builder codeBlock = CodeBlock.builder();
@@ -230,24 +227,34 @@ public final class DialogueInterfaceGenerator {
                     Packages.getPrefixedPackage(errorPackage, options.packagePrefix()),
                     ErrorGenerationUtils.errorTypesClassName(error.getError().getNamespace()),
                     ErrorGenerationUtils.errorExceptionClassName(errorName));
-            TypeSpec errorRecord = createRecordForEndpointErrorUtility(errorName, exceptionClassName, utiltyClassName);
-            // Not strictly required. Seems a bit cleaner to not have it.
-            // builder.addPermittedSubclass(ClassName.get(errorPackage, errorName));
+            TypeSpec errorRecord = createRecordForEndpointErrorUtility(errorName, exceptionClassName, utilityClassName);
+            builder.addPermittedSubclass(utilityClassName.nestedClass(errorName));
             builder.addType(errorRecord);
+
+            ClassName errorTypesClass = ClassName.get(
+                    Packages.getPrefixedPackage(error.getError().getPackage(), options.packagePrefix()),
+                    ErrorGenerationUtils.errorTypesClassName(error.getError().getNamespace()));
 
             // Add to the `from` method
             if (first) {
                 first = false;
-                codeBlock.beginControlFlow("if (e instanceof $T ex)", exceptionClassName);
+                codeBlock.beginControlFlow(
+                        "if ($T.$N(e))", errorTypesClass, ErrorGenerationUtils.errorInstanceCheckMethodName(errorName));
+                // codeBlock.beginControlFlow("if (e instanceof $T ex)", exceptionClassName);
             } else {
-                codeBlock.nextControlFlow("else if (e instanceof $T ex)", exceptionClassName);
+                // codeBlock.nextControlFlow("else if (e instanceof $T ex)", exceptionClassName);
+                codeBlock.nextControlFlow(
+                        "else if ($T.$N(e))",
+                        errorTypesClass,
+                        ErrorGenerationUtils.errorInstanceCheckMethodName(errorName));
             }
-            codeBlock.addStatement("return new $L(ex)", errorName);
+            codeBlock.addStatement("return new $N(($T) e)", errorName, exceptionClassName);
         }
         // Add the unknown case
         TypeSpec unknownRecord =
-                createRecordForEndpointErrorUtility("Unknown", ClassName.get(RemoteException.class), utiltyClassName);
+                createRecordForEndpointErrorUtility("Unknown", ClassName.get(RemoteException.class), utilityClassName);
         builder.addType(unknownRecord);
+        builder.addPermittedSubclass(utilityClassName.nestedClass("Unknown"));
         codeBlock.nextControlFlow("else").addStatement("return new $L(e)", unknownRecord.name());
         codeBlock.endControlFlow();
         fromBuilder.addCode(codeBlock.build());
@@ -259,7 +266,8 @@ public final class DialogueInterfaceGenerator {
             String recordName, ClassName errorClassName, ClassName utiltyClassName) {
         return TypeSpec.recordBuilder(recordName)
                 .recordConstructor(MethodSpec.constructorBuilder()
-                        .addParameter(ParameterSpec.builder(errorClassName, "e").build())
+                        .addParameter(ParameterSpec.builder(errorClassName, "exception")
+                                .build())
                         .build())
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .addSuperinterface(utiltyClassName)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
@@ -16,18 +16,20 @@
 
 package com.palantir.conjure.java.services.dialogue;
 
-import static java.util.stream.Collectors.toList;
-
+import com.google.common.base.CaseFormat;
 import com.google.errorprone.annotations.MustBeClosed;
 import com.palantir.conjure.java.ConjureAnnotations;
 import com.palantir.conjure.java.Options;
+import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.services.IsUndertowAsyncMarkerVisitor;
 import com.palantir.conjure.java.services.ServiceGenerators;
 import com.palantir.conjure.java.services.ServiceGenerators.EndpointErrorsJavaDoc;
 import com.palantir.conjure.java.services.ServiceGenerators.EndpointJavaDocGenerationOptions;
 import com.palantir.conjure.java.services.ServiceGenerators.RequestLineJavaDoc;
+import com.palantir.conjure.java.util.ErrorGenerationUtils;
 import com.palantir.conjure.java.util.Packages;
 import com.palantir.conjure.spec.EndpointDefinition;
+import com.palantir.conjure.spec.EndpointError;
 import com.palantir.conjure.spec.ServiceDefinition;
 import com.palantir.conjure.visitor.TypeVisitor;
 import com.palantir.dialogue.Channel;
@@ -42,12 +44,15 @@ import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.CodeBlock;
 import com.palantir.javapoet.JavaFile;
 import com.palantir.javapoet.MethodSpec;
+import com.palantir.javapoet.ParameterSpec;
 import com.palantir.javapoet.ParameterizedTypeName;
 import com.palantir.javapoet.TypeName;
 import com.palantir.javapoet.TypeSpec;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.InputStream;
+import java.util.Optional;
 import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
 
@@ -100,9 +105,14 @@ public final class DialogueInterfaceGenerator {
 
         def.getDocs().ifPresent(docs -> serviceBuilder.addJavadoc("$L", StringUtils.appendIfMissing(docs.get(), "\n")));
 
-        serviceBuilder.addMethods(def.getEndpoints().stream()
-                .map(endpoint -> apiMethod(endpoint, serviceCallType))
-                .collect(toList()));
+        for (EndpointDefinition endpoint : def.getEndpoints()) {
+            serviceBuilder.addMethod(apiMethod(endpoint, serviceCallType));
+            endpointErrorUtilityType(
+                            endpoint,
+                            Packages.getPrefixedPackage(def.getServiceName().getPackage(), options.packagePrefix()),
+                            className)
+                    .ifPresent(serviceBuilder::addType);
+        }
 
         MethodSpec staticFactoryMethod = methodGenerator.generate(def);
         serviceBuilder.addMethod(staticFactoryMethod);
@@ -190,5 +200,67 @@ public final class DialogueInterfaceGenerator {
         }
 
         return methodBuilder.build();
+    }
+
+    private Optional<TypeSpec> endpointErrorUtilityType(
+            EndpointDefinition endpointDef, String packageName, ClassName className) {
+        ClassName utiltyClassName = ClassName.get(
+                packageName,
+                className.simpleName(),
+                CaseFormat.LOWER_CAMEL.to(
+                                CaseFormat.UPPER_CAMEL,
+                                endpointDef.getEndpointName().get()) + "Errors");
+        if (endpointDef.getErrors().isEmpty()) {
+            return Optional.empty();
+        }
+        TypeSpec.Builder builder = TypeSpec.interfaceBuilder(utiltyClassName)
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.SEALED);
+        MethodSpec.Builder fromBuilder = MethodSpec.methodBuilder("from")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .addParameter(RemoteException.class, "e")
+                .returns(utiltyClassName);
+
+        boolean first = true;
+        CodeBlock.Builder codeBlock = CodeBlock.builder();
+        for (EndpointError error : endpointDef.getErrors()) {
+            String errorName = error.getError().getName();
+            String errorPackage = error.getError().getPackage();
+            ClassName exceptionClassName = ClassName.get(
+                    Packages.getPrefixedPackage(errorPackage, options.packagePrefix()),
+                    ErrorGenerationUtils.errorTypesClassName(error.getError().getNamespace()),
+                    ErrorGenerationUtils.errorExceptionClassName(errorName));
+            // exceptionClassNames.add(exceptionClassName);
+            // Construct the record
+            TypeSpec errorRecord = TypeSpec.recordBuilder(errorName)
+                    .recordConstructor(MethodSpec.constructorBuilder()
+                            .addParameter(ParameterSpec.builder(exceptionClassName, "e")
+                                    .build())
+                            .build())
+                    .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                    .addSuperinterface(utiltyClassName)
+                    .build();
+            // Not strictly required. Seems a bit cleaner to not have it.
+            // builder.addPermittedSubclass(ClassName.get(errorPackage, errorName));
+            builder.addType(errorRecord);
+
+            // Add to the `from` method
+            if (first) {
+                first = false;
+                codeBlock.beginControlFlow("if (e instanceof $T ex)", exceptionClassName);
+            } else {
+                codeBlock.nextControlFlow("else if (e instanceof $T ex)", exceptionClassName);
+            }
+            codeBlock.addStatement("return new $L(ex)", errorName);
+        }
+        codeBlock
+                .nextControlFlow("else")
+                .addStatement(
+                        "throw new $T(\"Not an error associated with $L\", e)",
+                        SafeIllegalArgumentException.class,
+                        endpointDef.getEndpointName().get());
+        codeBlock.endControlFlow();
+        fromBuilder.addCode(codeBlock.build());
+        builder.addMethod(fromBuilder.build());
+        return Optional.of(builder.build());
     }
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
@@ -50,7 +50,6 @@ import com.palantir.javapoet.TypeName;
 import com.palantir.javapoet.TypeSpec;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.InputStream;
 import java.util.Optional;
 import javax.lang.model.element.Modifier;
@@ -107,11 +106,13 @@ public final class DialogueInterfaceGenerator {
 
         for (EndpointDefinition endpoint : def.getEndpoints()) {
             serviceBuilder.addMethod(apiMethod(endpoint, serviceCallType));
-            endpointErrorUtilityType(
-                            endpoint,
-                            Packages.getPrefixedPackage(def.getServiceName().getPackage(), options.packagePrefix()),
-                            className)
-                    .ifPresent(serviceBuilder::addType);
+            if (options.generateErrorParameterFormatRespectingDialogueInterfaces()) {
+                endpointErrorUtilityType(
+                                endpoint,
+                                Packages.getPrefixedPackage(def.getServiceName().getPackage(), options.packagePrefix()),
+                                className)
+                        .ifPresent(serviceBuilder::addType);
+            }
         }
 
         MethodSpec staticFactoryMethod = methodGenerator.generate(def);
@@ -229,16 +230,7 @@ public final class DialogueInterfaceGenerator {
                     Packages.getPrefixedPackage(errorPackage, options.packagePrefix()),
                     ErrorGenerationUtils.errorTypesClassName(error.getError().getNamespace()),
                     ErrorGenerationUtils.errorExceptionClassName(errorName));
-            // exceptionClassNames.add(exceptionClassName);
-            // Construct the record
-            TypeSpec errorRecord = TypeSpec.recordBuilder(errorName)
-                    .recordConstructor(MethodSpec.constructorBuilder()
-                            .addParameter(ParameterSpec.builder(exceptionClassName, "e")
-                                    .build())
-                            .build())
-                    .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-                    .addSuperinterface(utiltyClassName)
-                    .build();
+            TypeSpec errorRecord = createRecordForEndpointErrorUtility(errorName, exceptionClassName, utiltyClassName);
             // Not strictly required. Seems a bit cleaner to not have it.
             // builder.addPermittedSubclass(ClassName.get(errorPackage, errorName));
             builder.addType(errorRecord);
@@ -252,15 +244,25 @@ public final class DialogueInterfaceGenerator {
             }
             codeBlock.addStatement("return new $L(ex)", errorName);
         }
-        codeBlock
-                .nextControlFlow("else")
-                .addStatement(
-                        "throw new $T(\"Not an error associated with $L\", e)",
-                        SafeIllegalArgumentException.class,
-                        endpointDef.getEndpointName().get());
+        // Add the unknown case
+        TypeSpec unknownRecord =
+                createRecordForEndpointErrorUtility("Unknown", ClassName.get(RemoteException.class), utiltyClassName);
+        builder.addType(unknownRecord);
+        codeBlock.nextControlFlow("else").addStatement("return new $L(e)", unknownRecord.name());
         codeBlock.endControlFlow();
         fromBuilder.addCode(codeBlock.build());
         builder.addMethod(fromBuilder.build());
         return Optional.of(builder.build());
+    }
+
+    private static TypeSpec createRecordForEndpointErrorUtility(
+            String recordName, ClassName errorClassName, ClassName utiltyClassName) {
+        return TypeSpec.recordBuilder(recordName)
+                .recordConstructor(MethodSpec.constructorBuilder()
+                        .addParameter(ParameterSpec.builder(errorClassName, "e").build())
+                        .build())
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                .addSuperinterface(utiltyClassName)
+                .build();
     }
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
@@ -261,7 +261,7 @@ public final class DialogueInterfaceGenerator {
                 .recordConstructor(MethodSpec.constructorBuilder()
                         .addParameter(ParameterSpec.builder(errorClassName, "e").build())
                         .build())
-                .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .addSuperinterface(utiltyClassName)
                 .build();
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
@@ -207,7 +207,7 @@ public final class DialogueInterfaceGenerator {
             EndpointDefinition endpointDef, String packageName, ClassName className) {
         ClassName utilityClassName = className.nestedClass(CaseFormat.LOWER_CAMEL.to(
                         CaseFormat.UPPER_CAMEL, endpointDef.getEndpointName().get())
-                + "Errors");
+                + "Error");
         if (endpointDef.getErrors().isEmpty()) {
             return Optional.empty();
         }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ErrorGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ErrorGenerator.java
@@ -144,7 +144,8 @@ public final class ErrorGenerator implements Generator {
                 .map(entry -> {
                     String typeName = CaseFormat.UPPER_CAMEL.to(
                             CaseFormat.UPPER_UNDERSCORE, entry.getErrorName().getName());
-                    String methodName = "is" + entry.getErrorName().getName();
+                    String methodName = ErrorGenerationUtils.errorInstanceCheckMethodName(
+                            entry.getErrorName().getName());
 
                     return MethodSpec.methodBuilder(methodName)
                             .addModifiers(Modifier.PUBLIC, Modifier.STATIC)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/ErrorGenerationUtils.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/ErrorGenerationUtils.java
@@ -63,6 +63,10 @@ public final class ErrorGenerationUtils {
         return namespace.get() + "Errors";
     }
 
+    public static String errorInstanceCheckMethodName(String errorName) {
+        return "is" + errorName;
+    }
+
     public static String serializableErrorClassName(String errorName) {
         return errorName + "SerializableError";
     }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -46,7 +46,6 @@ import dialogue.com.palantir.product.NestedStringAliasExample;
 import dialogue.com.palantir.product.SimpleEnum;
 import dialogue.com.palantir.product.SimpleUnion;
 import dialogue.com.palantir.product.StringAliasExample;
-import endpointerrors.com.palantir.product.ErrorServiceBlocking;
 import exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors.ErrorWithComplexArgsException;
 import io.undertow.Handlers;
 import io.undertow.Undertow;
@@ -97,7 +96,6 @@ public final class UndertowServiceEteTest extends TestBase {
     private final EteServiceAsync asyncClient;
     private final EteBinaryServiceBlocking binaryClient;
     private final exceptionthrowingdialogueinterfaces.com.palantir.product.EteServiceBlocking exceptionThrowingClient;
-    private final endpointerrors.com.palantir.product.ErrorServiceBlocking errorsClient;
 
     private static int port;
 
@@ -108,7 +106,6 @@ public final class UndertowServiceEteTest extends TestBase {
         this.exceptionThrowingClient = DialogueClients.create(
                 exceptionthrowingdialogueinterfaces.com.palantir.product.EteServiceBlocking.class,
                 clientConfiguration(port));
-        this.errorsClient = DialogueClients.create(ErrorServiceBlocking.class, clientConfiguration(port));
     }
 
     @BeforeAll

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -46,6 +46,7 @@ import dialogue.com.palantir.product.NestedStringAliasExample;
 import dialogue.com.palantir.product.SimpleEnum;
 import dialogue.com.palantir.product.SimpleUnion;
 import dialogue.com.palantir.product.StringAliasExample;
+import endpointerrors.com.palantir.product.ErrorServiceBlocking;
 import exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors.ErrorWithComplexArgsException;
 import io.undertow.Handlers;
 import io.undertow.Undertow;
@@ -93,20 +94,21 @@ public final class UndertowServiceEteTest extends TestBase {
     private static Undertow server;
 
     private final EteServiceBlocking client;
-    private final exceptionthrowingdialogueinterfaces.com.palantir.product.EteServiceBlocking exceptionThrowingClient;
     private final EteServiceAsync asyncClient;
-
     private final EteBinaryServiceBlocking binaryClient;
+    private final exceptionthrowingdialogueinterfaces.com.palantir.product.EteServiceBlocking exceptionThrowingClient;
+    private final endpointerrors.com.palantir.product.ErrorServiceBlocking errorsClient;
 
     private static int port;
 
     public UndertowServiceEteTest() {
         this.client = DialogueClients.create(EteServiceBlocking.class, clientConfiguration(port));
+        this.asyncClient = DialogueClients.create(EteServiceAsync.class, clientConfiguration(port));
+        this.binaryClient = DialogueClients.create(EteBinaryServiceBlocking.class, clientConfiguration(port));
         this.exceptionThrowingClient = DialogueClients.create(
                 exceptionthrowingdialogueinterfaces.com.palantir.product.EteServiceBlocking.class,
                 clientConfiguration(port));
-        this.asyncClient = DialogueClients.create(EteServiceAsync.class, clientConfiguration(port));
-        this.binaryClient = DialogueClients.create(EteBinaryServiceBlocking.class, clientConfiguration(port));
+        this.errorsClient = DialogueClients.create(ErrorServiceBlocking.class, clientConfiguration(port));
     }
 
     @BeforeAll

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/endpointerrors/ErrorResource.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/endpointerrors/ErrorResource.java
@@ -1,0 +1,97 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.endpointerrors;
+
+import com.palantir.conjure.java.undertow.lib.BinaryResponseBody;
+import com.palantir.tokens.auth.AuthHeader;
+import endpointerrors.com.palantir.product.ComplicatedObject;
+import endpointerrors.com.palantir.product.EndpointSpecificServerErrors;
+import endpointerrors.com.palantir.product.EndpointSpecificTwoServerErrors;
+import endpointerrors.com.palantir.product.OptionalBinaryResponseMode;
+import endpointerrors.com.palantir.product.StringAlias;
+import endpointerrors.com.palantir.product.TestServerErrors;
+import endpointerrors.com.palantir.product.UndertowErrorService;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+interface ErrorResource {
+    final class Impl implements UndertowErrorService {
+        public static final String SUCCESS = "success!";
+
+        @Override
+        public String testBasicError(AuthHeader _authHeader, boolean shouldThrowError) {
+            if (shouldThrowError) {
+                throw TestServerErrors.invalidArgument("field", "value");
+            }
+            return SUCCESS;
+        }
+
+        @Override
+        public String testImportedError(AuthHeader authHeader, boolean shouldThrowError) {
+            if (shouldThrowError) {
+                throw EndpointSpecificServerErrors.endpointError("typeName", "typeDef");
+            }
+            return SUCCESS;
+        }
+
+        @Override
+        public String testMultipleErrorsAndPackages(AuthHeader authHeader, Optional<String> errorToThrow) {
+            if (errorToThrow.isPresent()) {
+                String error = errorToThrow.get();
+                switch (error) {
+                    case "invalidArgument" -> throw TestServerErrors.invalidArgument("field", "value");
+                    case "notFound" -> throw TestServerErrors.notFound("resource");
+                    case "differentNamespace" -> throw EndpointSpecificTwoServerErrors.differentNamespace();
+                    case "differentPackage" ->
+                        throw endpointerrors.com.palantir.another.EndpointSpecificServerErrors.differentPackage();
+                    case "complicatedParameters" ->
+                        throw TestServerErrors.complicatedParameters(
+                                Map.of(1, ComplicatedObject.of(List.of("string"), StringAlias.of("alias"))));
+                    default -> throw new IllegalArgumentException("Unknown error: " + error);
+                }
+            }
+            return SUCCESS;
+        }
+
+        @Override
+        public void testEmptyBody(AuthHeader authHeader, boolean shouldThrowError) {
+            if (shouldThrowError) {
+                throw TestServerErrors.invalidArgument("field", "value");
+            }
+        }
+
+        @Override
+        public BinaryResponseBody testBinary(AuthHeader authHeader, boolean shouldThrowError) {
+            if (shouldThrowError) {
+                throw TestServerErrors.invalidArgument("field", "value");
+            }
+            return output -> output.write(SUCCESS.getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public Optional<BinaryResponseBody> testOptionalBinary(AuthHeader authHeader, OptionalBinaryResponseMode mode) {
+            if (mode.equals(OptionalBinaryResponseMode.ERROR)) {
+                throw TestServerErrors.invalidArgument("field", "value");
+            } else if (mode.equals(OptionalBinaryResponseMode.PRESENT)) {
+                return Optional.of(output -> output.write(SUCCESS.getBytes(StandardCharsets.UTF_8)));
+            }
+            return Optional.empty();
+        }
+    }
+}

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/endpointerrors/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/endpointerrors/UndertowServiceEteTest.java
@@ -83,8 +83,10 @@ public final class UndertowServiceEteTest extends TestBase {
         } catch (RemoteException e) {
             TestBasicErrorErrors error = ErrorServiceBlocking.TestBasicErrorErrors.from(e);
             assertThat(error).isInstanceOfSatisfying(TestBasicErrorErrors.InvalidArgument.class, invalidArgument -> {
-                assertThat(invalidArgument.e().error().parameters().field()).isEqualTo("field");
-                assertThat(invalidArgument.e().error().parameters().value()).isEqualTo("value");
+                assertThat(invalidArgument.exception().error().parameters().field())
+                        .isEqualTo("field");
+                assertThat(invalidArgument.exception().error().parameters().value())
+                        .isEqualTo("value");
             });
         }
     }

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/endpointerrors/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/endpointerrors/UndertowServiceEteTest.java
@@ -26,7 +26,7 @@ import com.palantir.conjure.java.undertow.runtime.ConjureHandler;
 import com.palantir.dialogue.clients.DialogueClients;
 import com.palantir.tokens.auth.AuthHeader;
 import endpointerrors.com.palantir.product.ErrorServiceBlocking;
-import endpointerrors.com.palantir.product.ErrorServiceBlocking.TestBasicErrorErrors;
+import endpointerrors.com.palantir.product.ErrorServiceBlocking.TestBasicErrorError;
 import endpointerrors.com.palantir.product.ErrorServiceEndpoints;
 import io.undertow.Handlers;
 import io.undertow.Undertow;
@@ -81,8 +81,8 @@ public final class UndertowServiceEteTest extends TestBase {
         try {
             errorServiceClient.testMultipleErrorsAndPackages(AUTH_HEADER, Optional.of("invalidArgument"));
         } catch (RemoteException e) {
-            TestBasicErrorErrors error = ErrorServiceBlocking.TestBasicErrorErrors.from(e);
-            assertThat(error).isInstanceOfSatisfying(TestBasicErrorErrors.InvalidArgument.class, invalidArgument -> {
+            TestBasicErrorError error = ErrorServiceBlocking.TestBasicErrorError.from(e);
+            assertThat(error).isInstanceOfSatisfying(TestBasicErrorError.InvalidArgument.class, invalidArgument -> {
                 assertThat(invalidArgument.exception().error().parameters().field())
                         .isEqualTo("field");
                 assertThat(invalidArgument.exception().error().parameters().value())

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/endpointerrors/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/endpointerrors/UndertowServiceEteTest.java
@@ -1,0 +1,91 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.endpointerrors;
+
+import static com.palantir.conjure.java.EteTestServer.clientConfiguration;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.google.common.collect.Iterables;
+import com.palantir.conjure.java.TestBase;
+import com.palantir.conjure.java.api.errors.RemoteException;
+import com.palantir.conjure.java.undertow.runtime.ConjureHandler;
+import com.palantir.dialogue.clients.DialogueClients;
+import com.palantir.tokens.auth.AuthHeader;
+import endpointerrors.com.palantir.product.ErrorServiceBlocking;
+import endpointerrors.com.palantir.product.ErrorServiceBlocking.TestBasicErrorErrors;
+import endpointerrors.com.palantir.product.ErrorServiceEndpoints;
+import io.undertow.Handlers;
+import io.undertow.Undertow;
+import io.undertow.UndertowOptions;
+import io.undertow.server.HttpHandler;
+import java.net.InetSocketAddress;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+public final class UndertowServiceEteTest extends TestBase {
+    private static final AuthHeader AUTH_HEADER = AuthHeader.valueOf("authHeader");
+    private static Undertow server;
+    private static int port;
+    private final ErrorServiceBlocking errorServiceClient;
+
+    public UndertowServiceEteTest() {
+        this.errorServiceClient = DialogueClients.create(ErrorServiceBlocking.class, clientConfiguration(port));
+    }
+
+    @BeforeAll
+    public static void before() {
+
+        HttpHandler handler = ConjureHandler.builder()
+                .services(ErrorServiceEndpoints.of(new ErrorResource.Impl()))
+                .build();
+
+        server = Undertow.builder()
+                .setServerOption(UndertowOptions.DECODE_URL, false)
+                .addHttpListener(0, "0.0.0.0")
+                .setHandler(Handlers.path().addPrefixPath("/test-example/api", handler))
+                .build();
+        server.start();
+        port = ((InetSocketAddress)
+                        Iterables.getOnlyElement(server.getListenerInfo()).getAddress())
+                .getPort();
+    }
+
+    @AfterAll
+    public static void after() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void test_endpoint_error_utility() {
+        try {
+            errorServiceClient.testMultipleErrorsAndPackages(AUTH_HEADER, Optional.of("invalidArgument"));
+        } catch (RemoteException e) {
+            TestBasicErrorErrors error = ErrorServiceBlocking.TestBasicErrorErrors.from(e);
+            assertThat(error).isInstanceOfSatisfying(TestBasicErrorErrors.InvalidArgument.class, invalidArgument -> {
+                assertThat(invalidArgument.e().error().parameters().field()).isEqualTo("field");
+                assertThat(invalidArgument.e().error().parameters().value()).isEqualTo("value");
+            });
+        }
+    }
+}

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/parameterized/TestCases.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/parameterized/TestCases.java
@@ -300,6 +300,24 @@ public final class TestCases {
                             GeneratorType.ENDPOINT_ERROR))
                     .build())
             .add(ParameterizedTestCase.builder()
+                    .name("endpoint-errors")
+                    .docs("Generate service objects for endpoint associated errors.")
+                    .files(Path.of("example-endpoint-errors.yml"))
+                    .options(Options.builder()
+                            .undertowServicePrefix(true)
+                            .nonNullCollections(true)
+                            .excludeEmptyOptionals(true)
+                            .jetbrainsContractAnnotations(true)
+                            .dangerousDoNotUseEnableEndpointAssociatedErrors(true)
+                            .generateErrorParameterFormatRespectingDialogueInterfaces(true)
+                            .build())
+                    .generatorTypes(List.of(
+                            GeneratorType.OBJECT,
+                            GeneratorType.ERROR,
+                            GeneratorType.ENDPOINT_ERROR,
+                            GeneratorType.DIALOGUE))
+                    .build())
+            .add(ParameterizedTestCase.builder()
                     .name("async-request")
                     .docs("Generate undertow and jersey objects to test processing async requests.")
                     .files(Path.of("async-request-processing-test.yml"))

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/parameterized/TestCases.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/parameterized/TestCases.java
@@ -300,24 +300,6 @@ public final class TestCases {
                             GeneratorType.ENDPOINT_ERROR))
                     .build())
             .add(ParameterizedTestCase.builder()
-                    .name("endpoint-errors")
-                    .docs("Generate service objects for endpoint associated errors.")
-                    .files(Path.of("example-endpoint-errors.yml"))
-                    .options(Options.builder()
-                            .undertowServicePrefix(true)
-                            .nonNullCollections(true)
-                            .excludeEmptyOptionals(true)
-                            .jetbrainsContractAnnotations(true)
-                            .dangerousDoNotUseEnableEndpointAssociatedErrors(true)
-                            .generateErrorParameterFormatRespectingDialogueInterfaces(true)
-                            .build())
-                    .generatorTypes(List.of(
-                            GeneratorType.OBJECT,
-                            GeneratorType.ERROR,
-                            GeneratorType.ENDPOINT_ERROR,
-                            GeneratorType.DIALOGUE))
-                    .build())
-            .add(ParameterizedTestCase.builder()
                     .name("async-request")
                     .docs("Generate undertow and jersey objects to test processing async requests.")
                     .files(Path.of("async-request-processing-test.yml"))
@@ -377,6 +359,25 @@ public final class TestCases {
                             .sealedUnionVisitors(true)
                             .build())
                     .generatorTypes(GeneratorType.OBJECT)
+                    .build())
+            .add(ParameterizedTestCase.builder()
+                    .name("endpoint-errors")
+                    .docs("Generate service objects for endpoint associated errors.")
+                    .files(Path.of("example-endpoint-errors.yml"))
+                    .options(Options.builder()
+                            .undertowServicePrefix(true)
+                            .nonNullCollections(true)
+                            .excludeEmptyOptionals(true)
+                            .jetbrainsContractAnnotations(true)
+                            .dangerousDoNotUseEnableEndpointAssociatedErrors(true)
+                            .generateErrorParameterFormatRespectingDialogueInterfaces(true)
+                            .build())
+                    .generatorTypes(List.of(
+                            GeneratorType.OBJECT,
+                            GeneratorType.ERROR,
+                            GeneratorType.ENDPOINT_ERROR,
+                            GeneratorType.DIALOGUE,
+                            GeneratorType.UNDERTOW))
                     .build())
             .build();
 


### PR DESCRIPTION
## Before this PR
In #2401 we added support for defining endpoint associated errors. This allowed Conjure service owners to define the errors that clients should expect to handle. This work was extended in #2435 where Dialogue client interfaces were generated to return sealed interfaces permitting records that corresponded to each endpoint error, and a "success" type, acting as a "result" type.

Initially the stance was that endpoint errors defined by services *need* to be handled by clients: using result types (or checked exceptions) would nudge callers of a client's endpoint to handle all of the potential errors a service has associated with the endpoint. (This could be worked around by utility methods that extract specific "success" types out of the provided result type but that would be an intentional choice made by clients.) In practice, this is a restrictive stance that hurts adoption: client code does not always need to handle the errors that endpoints have associated but if they would like to, they should have a way to know what errors should be handled.

Another reason to not change the return type of all endpoints in all Dialogue client interfaces is that it could lead to ABI breaks.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
For each endpoint that has associated errors in its definition, there will be a new sealed interface generated that allows devs to convert a generic `RemoteException` into one of the error-specific exceptions. The sealed interface allows devs on Java 21+ to use exhaustive pattern matching switch statements providing compile-time guarantees that they have handled all possible endpoint associated errors.

For example, consider this endpoint definition:

```yaml
ErrorService:
  name: Error Service
  package: com.palantir.product
  default-auth: header
  base-path: /errors
  endpoints:
    testBasicError:
      http: POST /basic
      args:
        shouldThrowError: boolean
      returns: string
      errors:
        - InvalidArgument
        - ConflictingCauseSafeArgErr
```

The following Dialogue client interface will be generated:

```java
public interface ErrorServiceBlocking {
    /** @apiNote {@code POST /errors/basic} */
    @ClientEndpoint(method = "POST", path = "/errors/basic")
    String testBasicError(AuthHeader authHeader, boolean shouldThrowError);
    
    // <various other methods not relevant to this feature>
    
    sealed interface TestBasicErrorErrors {
        static TestBasicErrorErrors from(RemoteException e) {
            if (e instanceof TestErrors.InvalidArgumentException ex) {
                return new InvalidArgument(ex);
            } else if (e instanceof ConjureErrors.ConflictingCauseSafeArgErrException ex) {
                return new ConflictingCauseSafeArgErr(ex);
            } else {
                return new Unknown(e);
            }
        }

        record InvalidArgument(TestErrors.InvalidArgumentException e) implements TestBasicErrorErrors {}

        record ConflictingCauseSafeArgErr(ConjureErrors.ConflictingCauseSafeArgErrException e)
                implements TestBasicErrorErrors {}

        record Unknown(RemoteException e) implements TestBasicErrorErrors {}
    }
}
```

This allows clients to catch `RemoteException`s thrown by the call to `testBasicError` and convert it into a `TestBasicErrorErrors` object.

==COMMIT_MSG==
Generate sealed interfaces to match against endpoint associated errors
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

