### PR TITLE
Optimize bulk operations on primitive lists

### DIFF
--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureCollections.java
@@ -83,6 +83,13 @@ public final class ConjureCollections {
 
     @SuppressWarnings("unchecked")
     public static <T> void addAllAndCheckNonNull(Collection<T> addTo, Iterable<? extends T> elementsToAdd) {
+        if (elementsToAdd instanceof ConjureIntegerList
+                || elementsToAdd instanceof ConjureDoubleList
+                || elementsToAdd instanceof ConjureSafeLongList) {
+            // Primitive lists will never have null elements.
+            addAll(addTo, elementsToAdd);
+            return;
+        }
         Preconditions.checkNotNull(elementsToAdd, "elementsToAdd cannot be null");
         // If we know the number of elements we are adding and the addTo Collection is an ArrayList, we can eagerly
         // resize it to only do one grow() of the array.

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureDoubleList.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureDoubleList.java
@@ -57,6 +57,11 @@ final class ConjureDoubleList extends AbstractList<Double> implements RandomAcce
 
     @Override
     public boolean addAll(int index, Collection<? extends Double> collection) {
+        if (collection instanceof ConjureDoubleList primitives) {
+            return index == size() - 1
+                    ? delegate.addAll(primitives.delegate)
+                    : delegate.addAllAtIndex(index, primitives.delegate);
+        }
         double[] target = new double[collection.size()];
         Iterate.forEachWithIndex(collection, (each, parameter) -> target[parameter] = each.doubleValue());
         return delegate.addAllAtIndex(index, target);

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureDoubleList.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureDoubleList.java
@@ -58,9 +58,7 @@ final class ConjureDoubleList extends AbstractList<Double> implements RandomAcce
     @Override
     public boolean addAll(int index, Collection<? extends Double> collection) {
         if (collection instanceof ConjureDoubleList primitives) {
-            return index == size() - 1
-                    ? delegate.addAll(primitives.delegate)
-                    : delegate.addAllAtIndex(index, primitives.delegate);
+            return delegate.addAllAtIndex(index, primitives.delegate);
         }
         double[] target = new double[collection.size()];
         Iterate.forEachWithIndex(collection, (each, parameter) -> target[parameter] = each.doubleValue());

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureIntegerList.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureIntegerList.java
@@ -58,9 +58,7 @@ final class ConjureIntegerList extends AbstractList<Integer> implements RandomAc
     @Override
     public boolean addAll(int index, Collection<? extends Integer> collection) {
         if (collection instanceof ConjureIntegerList primitives) {
-            return index == size() - 1
-                    ? delegate.addAll(primitives.delegate)
-                    : delegate.addAllAtIndex(index, primitives.delegate);
+            return delegate.addAllAtIndex(index, primitives.delegate);
         }
         int[] target = new int[collection.size()];
         Iterate.forEachWithIndex(collection, (each, parameter) -> target[parameter] = each.intValue());

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureIntegerList.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureIntegerList.java
@@ -57,6 +57,11 @@ final class ConjureIntegerList extends AbstractList<Integer> implements RandomAc
 
     @Override
     public boolean addAll(int index, Collection<? extends Integer> collection) {
+        if (collection instanceof ConjureIntegerList primitives) {
+            return index == size() - 1
+                    ? delegate.addAll(primitives.delegate)
+                    : delegate.addAllAtIndex(index, primitives.delegate);
+        }
         int[] target = new int[collection.size()];
         Iterate.forEachWithIndex(collection, (each, parameter) -> target[parameter] = each.intValue());
         return delegate.addAllAtIndex(index, target);

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureSafeLongList.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureSafeLongList.java
@@ -53,9 +53,7 @@ final class ConjureSafeLongList extends AbstractList<SafeLong> implements Random
     @Override
     public boolean addAll(int index, Collection<? extends SafeLong> collection) {
         if (collection instanceof ConjureSafeLongList primitives) {
-            return index == size() - 1
-                    ? delegate.addAll(primitives.delegate)
-                    : delegate.addAllAtIndex(index, primitives.delegate);
+            return delegate.addAllAtIndex(index, primitives.delegate);
         }
         long[] target = new long[collection.size()];
         Iterate.forEachWithIndex(collection, (each, parameter) -> target[parameter] = each.longValue());

--- a/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureSafeLongList.java
+++ b/conjure-lib/src/main/java/com/palantir/conjure/java/lib/internal/ConjureSafeLongList.java
@@ -52,6 +52,11 @@ final class ConjureSafeLongList extends AbstractList<SafeLong> implements Random
 
     @Override
     public boolean addAll(int index, Collection<? extends SafeLong> collection) {
+        if (collection instanceof ConjureSafeLongList primitives) {
+            return index == size() - 1
+                    ? delegate.addAll(primitives.delegate)
+                    : delegate.addAllAtIndex(index, primitives.delegate);
+        }
         long[] target = new long[collection.size()];
         Iterate.forEachWithIndex(collection, (each, parameter) -> target[parameter] = each.longValue());
         return delegate.addAllAtIndex(index, target);


### PR DESCRIPTION
## Before this PR
Lots of boxing and slow iteration when operating on primitive lists.

## After this PR
==COMMIT_MSG==
Optimize bulk operations on primitive lists

- addAllAndCheckNonNull skips null checks for primitive lists
- inserting a primitive list in the middle of a primitive list creates intermediate int[] using arraycopy
==COMMIT_MSG==

## Possible downsides?
