### PR TITLE
Fix sealed union deserialization for camel case fields

### DIFF
--- a/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/UnionExample.java
+++ b/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/UnionExample.java
@@ -33,11 +33,11 @@ import javax.annotation.processing.Generated;
         visible = true,
         defaultImpl = UnionExample.Unknown.class)
 @JsonSubTypes({
-    @JsonSubTypes.Type(value = UnionExample.StringVariant.class, name = "stringvariant"),
-    @JsonSubTypes.Type(value = UnionExample.IntVariant.class, name = "intvariant"),
-    @JsonSubTypes.Type(value = UnionExample.ObjectVariant.class, name = "objectvariant"),
-    @JsonSubTypes.Type(value = UnionExample.CollectionVariant.class, name = "collectionvariant"),
-    @JsonSubTypes.Type(value = UnionExample.OptionalVariant.class, name = "optionalvariant")
+    @JsonSubTypes.Type(value = UnionExample.StringVariant.class, name = "stringVariant"),
+    @JsonSubTypes.Type(value = UnionExample.IntVariant.class, name = "intVariant"),
+    @JsonSubTypes.Type(value = UnionExample.ObjectVariant.class, name = "objectVariant"),
+    @JsonSubTypes.Type(value = UnionExample.CollectionVariant.class, name = "collectionVariant"),
+    @JsonSubTypes.Type(value = UnionExample.OptionalVariant.class, name = "optionalVariant")
 })
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract sealed class UnionExample

--- a/conjure-java-core/src/integrationInput/java/sealedunions/com/palantir/product/CamelCaseUnion.java
+++ b/conjure-java-core/src/integrationInput/java/sealedunions/com/palantir/product/CamelCaseUnion.java
@@ -1,0 +1,249 @@
+package sealedunions.com.palantir.product;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+@Generated("com.palantir.conjure.java.types.UnionGenerator")
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        property = "type",
+        visible = true,
+        defaultImpl = CamelCaseUnion.Unknown.class)
+@JsonSubTypes(@JsonSubTypes.Type(value = CamelCaseUnion.CamelCasedField.class, name = "camelcasedfield"))
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract sealed class CamelCaseUnion permits CamelCaseUnion.CamelCasedField, CamelCaseUnion.Unknown {
+    public static CamelCaseUnion camelCasedField(String value) {
+        return new CamelCasedField(value);
+    }
+
+    public static CamelCaseUnion unknown(@Safe String type, Object value) {
+        switch (Preconditions.checkNotNull(type, "Type is required")) {
+            case "camelCasedField":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: camelCasedField");
+            default:
+                return new Unknown(type, Collections.singletonMap(type, value));
+        }
+    }
+
+    public Known throwOnUnknown() {
+        if (this instanceof Unknown) {
+            throw new SafeIllegalArgumentException(
+                    "Unknown variant of the 'CamelCaseUnion' union",
+                    SafeArg.of("unknownType", ((Unknown) this).type()));
+        } else {
+            return (Known) this;
+        }
+    }
+
+    public abstract <T> T accept(Visitor<T> visitor);
+
+    public sealed interface Known permits CamelCasedField {}
+
+    @JsonTypeName("camelCasedField")
+    public static final class CamelCasedField extends CamelCaseUnion implements Known {
+        private final String value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private CamelCasedField(@JsonSetter("camelCasedField") @Nonnull String value) {
+            Preconditions.checkNotNull(value, "camelCasedField cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(index = 0)
+        private String type() {
+            return "camelCasedField";
+        }
+
+        @JsonProperty("camelCasedField")
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitCamelCasedField(value);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof CamelCasedField && equalTo((CamelCasedField) other));
+        }
+
+        private boolean equalTo(CamelCasedField other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.value.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "CamelCaseUnion.CamelCasedField{value: " + value + '}';
+        }
+    }
+
+    public static final class Unknown extends CamelCaseUnion {
+        private final String type;
+
+        private final Map<String, Object> value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private Unknown(@JsonProperty("type") String type) {
+            this(type, new HashMap<String, Object>());
+        }
+
+        private Unknown(@Nonnull String type, @Nonnull Map<String, Object> value) {
+            Preconditions.checkNotNull(type, "type cannot be null");
+            Preconditions.checkNotNull(value, "value cannot be null");
+            this.type = type;
+            this.value = value;
+        }
+
+        @JsonProperty
+        public String type() {
+            return type;
+        }
+
+        @JsonAnyGetter
+        public Map<String, Object> value() {
+            return value;
+        }
+
+        @JsonAnySetter
+        private void put(String key, Object val) {
+            value.put(key, val);
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitUnknown(type, value.get(type));
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof Unknown && equalTo((Unknown) other));
+        }
+
+        private boolean equalTo(Unknown other) {
+            return this.type.equals(other.type) && this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 1;
+            hash = 31 * hash + this.type.hashCode();
+            hash = 31 * hash + this.value.hashCode();
+            return hash;
+        }
+
+        @Override
+        public String toString() {
+            return "CamelCaseUnion.Unknown{type: " + type + ", value: " + value + '}';
+        }
+    }
+
+    public interface Visitor<T> {
+        T visitCamelCasedField(String value);
+
+        T visitUnknown(@Safe String unknownType, Object unknownValue);
+
+        static <T> CamelCasedFieldStageVisitorBuilder<T> builder() {
+            return new VisitorBuilder<T>();
+        }
+    }
+
+    private static final class VisitorBuilder<T>
+            implements CamelCasedFieldStageVisitorBuilder<T>,
+                    UnknownStageVisitorBuilder<T>,
+                    Completed_StageVisitorBuilder<T> {
+        private Function<String, T> camelCasedFieldVisitor;
+
+        private BiFunction<@Safe String, Object, T> unknownVisitor;
+
+        @Override
+        public UnknownStageVisitorBuilder<T> camelCasedField(@Nonnull Function<String, T> camelCasedFieldVisitor) {
+            Preconditions.checkNotNull(camelCasedFieldVisitor, "camelCasedFieldVisitor cannot be null");
+            this.camelCasedFieldVisitor = camelCasedFieldVisitor;
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull BiFunction<@Safe String, Object, T> unknownVisitor) {
+            Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
+            this.unknownVisitor = unknownVisitor;
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<@Safe String, T> unknownVisitor) {
+            Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
+            this.unknownVisitor = (unknownType, _unknownValue) -> unknownVisitor.apply(unknownType);
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
+            this.unknownVisitor = (unknownType, _unknownValue) -> {
+                throw new SafeIllegalArgumentException(
+                        "Unknown variant of the 'CamelCaseUnion' union", SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
+        public Visitor<T> build() {
+            final Function<String, T> camelCasedFieldVisitor = this.camelCasedFieldVisitor;
+            final BiFunction<@Safe String, Object, T> unknownVisitor = this.unknownVisitor;
+            return new Visitor<T>() {
+                @Override
+                public T visitCamelCasedField(String value) {
+                    return camelCasedFieldVisitor.apply(value);
+                }
+
+                @Override
+                public T visitUnknown(String unknownType, Object unknownValue) {
+                    return unknownVisitor.apply(unknownType, unknownValue);
+                }
+            };
+        }
+    }
+
+    public interface CamelCasedFieldStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> camelCasedField(@Nonnull Function<String, T> camelCasedFieldVisitor);
+    }
+
+    public interface UnknownStageVisitorBuilder<T> {
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull BiFunction<@Safe String, Object, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<@Safe String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
+    }
+
+    public interface Completed_StageVisitorBuilder<T> {
+        Visitor<T> build();
+    }
+}

--- a/conjure-java-core/src/integrationInput/java/sealedunions/com/palantir/product/CamelCaseUnion.java
+++ b/conjure-java-core/src/integrationInput/java/sealedunions/com/palantir/product/CamelCaseUnion.java
@@ -29,7 +29,7 @@ import javax.annotation.processing.Generated;
         property = "type",
         visible = true,
         defaultImpl = CamelCaseUnion.Unknown.class)
-@JsonSubTypes(@JsonSubTypes.Type(value = CamelCaseUnion.CamelCasedField.class, name = "camelcasedfield"))
+@JsonSubTypes(@JsonSubTypes.Type(value = CamelCaseUnion.CamelCasedField.class, name = "camelCasedField"))
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract sealed class CamelCaseUnion permits CamelCaseUnion.CamelCasedField, CamelCaseUnion.Unknown {
     public static CamelCaseUnion camelCasedField(String value) {

--- a/conjure-java-core/src/integrationInput/java/sealedunions/com/palantir/product/UnionReservedNames.java
+++ b/conjure-java-core/src/integrationInput/java/sealedunions/com/palantir/product/UnionReservedNames.java
@@ -44,7 +44,7 @@ import javax.annotation.processing.Generated;
     @JsonSubTypes.Type(value = UnionReservedNames.Final.class, name = "final"),
     @JsonSubTypes.Type(value = UnionReservedNames.Throws.class, name = "throws"),
     @JsonSubTypes.Type(value = UnionReservedNames.Static.class, name = "static"),
-    @JsonSubTypes.Type(value = UnionReservedNames.UnionReservedNames_.class, name = "unionreservednames")
+    @JsonSubTypes.Type(value = UnionReservedNames.UnionReservedNames_.class, name = "unionReservedNames")
 })
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract sealed class UnionReservedNames

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -231,8 +231,7 @@ public final class UnionGenerator {
                                 "name",
                                 "$S",
                                 // "unknown" is valid here since UnknownVariant is only used as a default
-                                StringUtils.lowerCase(
-                                        memberTypeDef.getFieldName().get())) // non-capitalized
+                                memberTypeDef.getFieldName().get())
                         .build())
                 .toList();
         AnnotationSpec.Builder annotationBuilder = AnnotationSpec.builder(JsonSubTypes.class);

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -85,6 +85,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import sealedunions.com.palantir.product.CamelCaseUnion;
 import sealedunions.com.palantir.product.SimpleUnion;
 import sealedunions.com.palantir.product.UnionReservedNames;
 
@@ -920,6 +921,20 @@ public final class WireFormatTests {
     void testSealedInterfaceUnionType_deserialize_javaReserved() throws JsonProcessingException {
         assertThat(mapper.readValue("{\"type\":\"void\",\"void\":\"test\"}", UnionReservedNames.class))
                 .isEqualTo(UnionReservedNames.void_("test"));
+    }
+
+    @Test
+    void testSealedInterfaceUnionType_serialize_CamelCase() throws JsonProcessingException {
+        CamelCaseUnion simpleUnion = CamelCaseUnion.camelCasedField("test");
+        assertThat(mapper.writeValueAsString(simpleUnion))
+                .isEqualTo("{\"type\":\"camelCasedField\",\"camelCasedField\":\"test\"}");
+    }
+
+    @Test
+    void testSealedInterfaceUnionType_deserialize_CamelCase() throws JsonProcessingException {
+        assertThat(mapper.readValue(
+                        "{\"type\":\"camelCasedField\",\"camelCasedField\":\"test\"}", CamelCaseUnion.class))
+                .isEqualTo(CamelCaseUnion.camelCasedField("test"));
     }
 
     private static final class TestVisitor implements UnionTypeExample.Visitor<Integer> {

--- a/conjure-java-core/src/test/resources/example-unions.yml
+++ b/conjure-java-core/src/test/resources/example-unions.yml
@@ -26,3 +26,6 @@ types:
           unionReservedNames: string
       EmptyUnion:
         union: {}
+      CamelCaseUnion:
+        union:
+          camelCasedField: string


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
We were converting field names to fully lowercase for the subtypes annotation - which prevented Jackson from matching on the correct sub type at deserialization time.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Generated `@JsonSubTypes.Type` annotation has correct camel casing for field names instead of lowercase. This allows sealed unions to deserialize correctly.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

