### PR TITLE
Add test utility for error-specific `RemoteException` and `SerializableError`

### DIFF
--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/another/EndpointSpecificErrors.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/another/EndpointSpecificErrors.java
@@ -60,4 +60,22 @@ public final class EndpointSpecificErrors {
             return error;
         }
     }
+
+    /**
+     * This utility class is provided to make creating error-specific exceptions easier for tests. It should not be used
+     * outside of tests!
+     */
+    public static final class DifferentPackageTestUtility {
+        public static DifferentPackageSerializableError createSerializableError(
+                String errorInstanceId, DifferentPackageParameters parameters) {
+            return new DifferentPackageSerializableError(
+                    DIFFERENT_PACKAGE.code().name(), DIFFERENT_PACKAGE.name(), errorInstanceId, parameters);
+        }
+
+        public static DifferentPackageException createException(
+                String errorInstanceId, DifferentPackageParameters parameters) {
+            return new DifferentPackageException(
+                    createSerializableError(errorInstanceId, parameters), DIFFERENT_PACKAGE.httpErrorCode());
+        }
+    }
 }

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ConjureErrors.java
@@ -67,4 +67,26 @@ public final class ConjureErrors {
             return error;
         }
     }
+
+    /**
+     * This utility class is provided to make creating error-specific exceptions easier for tests. It should not be used
+     * outside of tests!
+     */
+    public static final class ConflictingCauseSafeArgErrTestUtility {
+        public static ConflictingCauseSafeArgErrSerializableError createSerializableError(
+                String errorInstanceId, ConflictingCauseSafeArgErrParameters parameters) {
+            return new ConflictingCauseSafeArgErrSerializableError(
+                    CONFLICTING_CAUSE_SAFE_ARG_ERR.code().name(),
+                    CONFLICTING_CAUSE_SAFE_ARG_ERR.name(),
+                    errorInstanceId,
+                    parameters);
+        }
+
+        public static ConflictingCauseSafeArgErrException createException(
+                String errorInstanceId, ConflictingCauseSafeArgErrParameters parameters) {
+            return new ConflictingCauseSafeArgErrException(
+                    createSerializableError(errorInstanceId, parameters),
+                    CONFLICTING_CAUSE_SAFE_ARG_ERR.httpErrorCode());
+        }
+    }
 }

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/EndpointSpecificErrors.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/EndpointSpecificErrors.java
@@ -66,4 +66,22 @@ public final class EndpointSpecificErrors {
             return error;
         }
     }
+
+    /**
+     * This utility class is provided to make creating error-specific exceptions easier for tests. It should not be used
+     * outside of tests!
+     */
+    public static final class EndpointErrorTestUtility {
+        public static EndpointErrorSerializableError createSerializableError(
+                String errorInstanceId, EndpointErrorParameters parameters) {
+            return new EndpointErrorSerializableError(
+                    ENDPOINT_ERROR.code().name(), ENDPOINT_ERROR.name(), errorInstanceId, parameters);
+        }
+
+        public static EndpointErrorException createException(
+                String errorInstanceId, EndpointErrorParameters parameters) {
+            return new EndpointErrorException(
+                    createSerializableError(errorInstanceId, parameters), ENDPOINT_ERROR.httpErrorCode());
+        }
+    }
 }

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/EndpointSpecificTwoErrors.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/EndpointSpecificTwoErrors.java
@@ -60,4 +60,22 @@ public final class EndpointSpecificTwoErrors {
             return error;
         }
     }
+
+    /**
+     * This utility class is provided to make creating error-specific exceptions easier for tests. It should not be used
+     * outside of tests!
+     */
+    public static final class DifferentNamespaceTestUtility {
+        public static DifferentNamespaceSerializableError createSerializableError(
+                String errorInstanceId, DifferentNamespaceParameters parameters) {
+            return new DifferentNamespaceSerializableError(
+                    DIFFERENT_NAMESPACE.code().name(), DIFFERENT_NAMESPACE.name(), errorInstanceId, parameters);
+        }
+
+        public static DifferentNamespaceException createException(
+                String errorInstanceId, DifferentNamespaceParameters parameters) {
+            return new DifferentNamespaceException(
+                    createSerializableError(errorInstanceId, parameters), DIFFERENT_NAMESPACE.httpErrorCode());
+        }
+    }
 }

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/TestErrors.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/TestErrors.java
@@ -160,4 +160,57 @@ public final class TestErrors {
             return error;
         }
     }
+
+    /**
+     * This utility class is provided to make creating error-specific exceptions easier for tests. It should not be used
+     * outside of tests!
+     */
+    public static final class ComplicatedParametersTestUtility {
+        public static ComplicatedParametersSerializableError createSerializableError(
+                String errorInstanceId, ComplicatedParametersParameters parameters) {
+            return new ComplicatedParametersSerializableError(
+                    COMPLICATED_PARAMETERS.code().name(), COMPLICATED_PARAMETERS.name(), errorInstanceId, parameters);
+        }
+
+        public static ComplicatedParametersException createException(
+                String errorInstanceId, ComplicatedParametersParameters parameters) {
+            return new ComplicatedParametersException(
+                    createSerializableError(errorInstanceId, parameters), COMPLICATED_PARAMETERS.httpErrorCode());
+        }
+    }
+
+    /**
+     * This utility class is provided to make creating error-specific exceptions easier for tests. It should not be used
+     * outside of tests!
+     */
+    public static final class InvalidArgumentTestUtility {
+        public static InvalidArgumentSerializableError createSerializableError(
+                String errorInstanceId, InvalidArgumentParameters parameters) {
+            return new InvalidArgumentSerializableError(
+                    INVALID_ARGUMENT.code().name(), INVALID_ARGUMENT.name(), errorInstanceId, parameters);
+        }
+
+        public static InvalidArgumentException createException(
+                String errorInstanceId, InvalidArgumentParameters parameters) {
+            return new InvalidArgumentException(
+                    createSerializableError(errorInstanceId, parameters), INVALID_ARGUMENT.httpErrorCode());
+        }
+    }
+
+    /**
+     * This utility class is provided to make creating error-specific exceptions easier for tests. It should not be used
+     * outside of tests!
+     */
+    public static final class NotFoundTestUtility {
+        public static NotFoundSerializableError createSerializableError(
+                String errorInstanceId, NotFoundParameters parameters) {
+            return new NotFoundSerializableError(
+                    NOT_FOUND.code().name(), NOT_FOUND.name(), errorInstanceId, parameters);
+        }
+
+        public static NotFoundException createException(String errorInstanceId, NotFoundParameters parameters) {
+            return new NotFoundException(
+                    createSerializableError(errorInstanceId, parameters), NOT_FOUND.httpErrorCode());
+        }
+    }
 }

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/another/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/another/ConjureErrors.java
@@ -81,4 +81,22 @@ public final class ConjureErrors {
             return error;
         }
     }
+
+    /**
+     * This utility class is provided to make creating error-specific exceptions easier for tests. It should not be used
+     * outside of tests!
+     */
+    public static final class DifferentPackageErrorTestUtility {
+        public static DifferentPackageErrorSerializableError createSerializableError(
+                String errorInstanceId, DifferentPackageErrorParameters parameters) {
+            return new DifferentPackageErrorSerializableError(
+                    DIFFERENT_PACKAGE_ERROR.code().name(), DIFFERENT_PACKAGE_ERROR.name(), errorInstanceId, parameters);
+        }
+
+        public static DifferentPackageErrorException createException(
+                String errorInstanceId, DifferentPackageErrorParameters parameters) {
+            return new DifferentPackageErrorException(
+                    createSerializableError(errorInstanceId, parameters), DIFFERENT_PACKAGE_ERROR.httpErrorCode());
+        }
+    }
 }

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/ConjureErrors.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/ConjureErrors.java
@@ -573,4 +573,103 @@ public final class ConjureErrors {
             return error;
         }
     }
+
+    /**
+     * This utility class is provided to make creating error-specific exceptions easier for tests. It should not be used
+     * outside of tests!
+     */
+    public static final class ConflictingCauseSafeArgTestUtility {
+        public static ConflictingCauseSafeArgSerializableError createSerializableError(
+                String errorInstanceId, ConflictingCauseSafeArgParameters parameters) {
+            return new ConflictingCauseSafeArgSerializableError(
+                    CONFLICTING_CAUSE_SAFE_ARG.code().name(),
+                    CONFLICTING_CAUSE_SAFE_ARG.name(),
+                    errorInstanceId,
+                    parameters);
+        }
+
+        public static ConflictingCauseSafeArgException createException(
+                String errorInstanceId, ConflictingCauseSafeArgParameters parameters) {
+            return new ConflictingCauseSafeArgException(
+                    createSerializableError(errorInstanceId, parameters), CONFLICTING_CAUSE_SAFE_ARG.httpErrorCode());
+        }
+    }
+
+    /**
+     * This utility class is provided to make creating error-specific exceptions easier for tests. It should not be used
+     * outside of tests!
+     */
+    public static final class ConflictingCauseUnsafeArgTestUtility {
+        public static ConflictingCauseUnsafeArgSerializableError createSerializableError(
+                String errorInstanceId, ConflictingCauseUnsafeArgParameters parameters) {
+            return new ConflictingCauseUnsafeArgSerializableError(
+                    CONFLICTING_CAUSE_UNSAFE_ARG.code().name(),
+                    CONFLICTING_CAUSE_UNSAFE_ARG.name(),
+                    errorInstanceId,
+                    parameters);
+        }
+
+        public static ConflictingCauseUnsafeArgException createException(
+                String errorInstanceId, ConflictingCauseUnsafeArgParameters parameters) {
+            return new ConflictingCauseUnsafeArgException(
+                    createSerializableError(errorInstanceId, parameters), CONFLICTING_CAUSE_UNSAFE_ARG.httpErrorCode());
+        }
+    }
+
+    /**
+     * This utility class is provided to make creating error-specific exceptions easier for tests. It should not be used
+     * outside of tests!
+     */
+    public static final class ErrorWithComplexArgsTestUtility {
+        public static ErrorWithComplexArgsSerializableError createSerializableError(
+                String errorInstanceId, ErrorWithComplexArgsParameters parameters) {
+            return new ErrorWithComplexArgsSerializableError(
+                    ERROR_WITH_COMPLEX_ARGS.code().name(), ERROR_WITH_COMPLEX_ARGS.name(), errorInstanceId, parameters);
+        }
+
+        public static ErrorWithComplexArgsException createException(
+                String errorInstanceId, ErrorWithComplexArgsParameters parameters) {
+            return new ErrorWithComplexArgsException(
+                    createSerializableError(errorInstanceId, parameters), ERROR_WITH_COMPLEX_ARGS.httpErrorCode());
+        }
+    }
+
+    /**
+     * This utility class is provided to make creating error-specific exceptions easier for tests. It should not be used
+     * outside of tests!
+     */
+    public static final class InvalidServiceDefinitionTestUtility {
+        public static InvalidServiceDefinitionSerializableError createSerializableError(
+                String errorInstanceId, InvalidServiceDefinitionParameters parameters) {
+            return new InvalidServiceDefinitionSerializableError(
+                    INVALID_SERVICE_DEFINITION.code().name(),
+                    INVALID_SERVICE_DEFINITION.name(),
+                    errorInstanceId,
+                    parameters);
+        }
+
+        public static InvalidServiceDefinitionException createException(
+                String errorInstanceId, InvalidServiceDefinitionParameters parameters) {
+            return new InvalidServiceDefinitionException(
+                    createSerializableError(errorInstanceId, parameters), INVALID_SERVICE_DEFINITION.httpErrorCode());
+        }
+    }
+
+    /**
+     * This utility class is provided to make creating error-specific exceptions easier for tests. It should not be used
+     * outside of tests!
+     */
+    public static final class InvalidTypeDefinitionTestUtility {
+        public static InvalidTypeDefinitionSerializableError createSerializableError(
+                String errorInstanceId, InvalidTypeDefinitionParameters parameters) {
+            return new InvalidTypeDefinitionSerializableError(
+                    INVALID_TYPE_DEFINITION.code().name(), INVALID_TYPE_DEFINITION.name(), errorInstanceId, parameters);
+        }
+
+        public static InvalidTypeDefinitionException createException(
+                String errorInstanceId, InvalidTypeDefinitionParameters parameters) {
+            return new InvalidTypeDefinitionException(
+                    createSerializableError(errorInstanceId, parameters), INVALID_TYPE_DEFINITION.httpErrorCode());
+        }
+    }
 }

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/ConjureJavaErrors.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/ConjureJavaErrors.java
@@ -81,4 +81,22 @@ public final class ConjureJavaErrors {
             return error;
         }
     }
+
+    /**
+     * This utility class is provided to make creating error-specific exceptions easier for tests. It should not be used
+     * outside of tests!
+     */
+    public static final class JavaCompilationFailedTestUtility {
+        public static JavaCompilationFailedSerializableError createSerializableError(
+                String errorInstanceId, JavaCompilationFailedParameters parameters) {
+            return new JavaCompilationFailedSerializableError(
+                    JAVA_COMPILATION_FAILED.code().name(), JAVA_COMPILATION_FAILED.name(), errorInstanceId, parameters);
+        }
+
+        public static JavaCompilationFailedException createException(
+                String errorInstanceId, JavaCompilationFailedParameters parameters) {
+            return new JavaCompilationFailedException(
+                    createSerializableError(errorInstanceId, parameters), JAVA_COMPILATION_FAILED.httpErrorCode());
+        }
+    }
 }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ErrorGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ErrorGenerator.java
@@ -179,7 +179,8 @@ public final class ErrorGenerator implements Generator {
             typeBuilder
                     .addTypes(generateErrorParameterRecords(errorTypeDefinitions, typeMapper))
                     .addTypes(generateSerializableErrors(errorTypeDefinitions))
-                    .addTypes(generateRemoteExceptionTypes(errorsClassName, errorTypeDefinitions));
+                    .addTypes(generateRemoteExceptionTypes(errorsClassName, errorTypeDefinitions))
+                    .addTypes(generateErrorTestUtilities(errorsClassName, errorTypeDefinitions));
         }
 
         return JavaFile.builder(conjurePackage, typeBuilder.build())
@@ -320,6 +321,70 @@ public final class ErrorGenerator implements Generator {
                     typeMapper, fieldDef, false));
         }
         return parametersRecordBuilder.recordConstructor(ctorBuilder.build()).build();
+    }
+
+    private static List<TypeSpec> generateErrorTestUtilities(
+            ClassName errorsClassName, List<ErrorDefinition> errorDefinitions) {
+        return errorDefinitions.stream()
+                .map(def -> ErrorGenerator.generateErrorTestUtility(errorsClassName, def))
+                .toList();
+    }
+
+    private static TypeSpec generateErrorTestUtility(ClassName errorsClassName, ErrorDefinition errorDefinition) {
+        String testUtilityClassName = errorDefinition.getErrorName().getName() + "TestUtility";
+        ClassName serializableErrorClass =
+                errorsClassName.nestedClass(errorDefinition.getErrorName().getName() + "SerializableError");
+        ClassName exceptionErrorClass =
+                errorsClassName.nestedClass(errorDefinition.getErrorName().getName() + "Exception");
+        String errorTypeName = CaseFormat.UPPER_CAMEL.to(
+                CaseFormat.UPPER_UNDERSCORE, errorDefinition.getErrorName().getName());
+        MethodSpec createSerializableError = MethodSpec.methodBuilder("createSerializableError")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .returns(serializableErrorClass)
+                .addParameter(
+                        ParameterSpec.builder(String.class, "errorInstanceId").build())
+                .addParameter(ParameterSpec.builder(
+                                errorsClassName.nestedClass(
+                                        ErrorGenerationUtils.errorParametersClassName(errorDefinition)),
+                                "parameters")
+                        .build())
+                .addCode(CodeBlock.builder()
+                        .addStatement(
+                                "return new $T($L.code().name(), $L.name(), $L, $L)",
+                                serializableErrorClass,
+                                errorTypeName,
+                                errorTypeName,
+                                "errorInstanceId",
+                                "parameters")
+                        .build())
+                .build();
+        MethodSpec createException = MethodSpec.methodBuilder("createException")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .returns(exceptionErrorClass)
+                .addParameter(
+                        ParameterSpec.builder(String.class, "errorInstanceId").build())
+                .addParameter(ParameterSpec.builder(
+                                errorsClassName.nestedClass(
+                                        ErrorGenerationUtils.errorParametersClassName(errorDefinition)),
+                                "parameters")
+                        .build())
+                .addCode(CodeBlock.builder()
+                        .addStatement(
+                                "return new $T(createSerializableError($L, $L), $L.httpErrorCode())",
+                                exceptionErrorClass,
+                                "errorInstanceId",
+                                "parameters",
+                                errorTypeName)
+                        .build())
+                .build();
+        return TypeSpec.classBuilder(testUtilityClassName)
+                .addJavadoc(
+                        "This utility class is provided to make creating error-specific exceptions easier for tests."
+                                + " It should not be used outside of tests!")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                .addMethod(createSerializableError)
+                .addMethod(createException)
+                .build();
     }
 
     private static MethodSpec generateExceptionFactory(


### PR DESCRIPTION
## Before this PR
Previously devs would mock interactions with Dialogue clients that threw a `RemoteException` by creating a Mockito mock returning a constructed `RemoteException`. Now, clients throw subclasses of `RemoteException`. It is not possible to construct these error-specific `RemoteException`s because the error's `SerializableError` constructor (a required parameter when constructing the `RemoteException` subclass) is package private. I'd like this to remain package-private: devs should not be constructing these errors in their production code. Still, there should be an easy way for folks to construct these error-specific `RemoteException`s for use in unit tests.

## After this PR
For each error, generate a test utility class that is able to construct error specific `RemoteException`s and `SerializableError`s.

==COMMIT_MSG==
Add test utility for error-specific `RemoteException` and `SerializableError`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
I would like folks to only use this in tests. I've named the class `TestUtility` and provided a JavaDoc telling folks to only use this in tests. Still, it's possible for folks to construct and throw these Conjure-generated exceptions in their code if they really wanted to.
