### PR TITLE
Remove unnecessary permits clauses

### DIFF
--- a/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/EmptyUnion.java
+++ b/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/EmptyUnion.java
@@ -28,7 +28,7 @@ import javax.annotation.processing.Generated;
         defaultImpl = EmptyUnion.Unknown.class)
 @JsonSubTypes({})
 @JsonIgnoreProperties(ignoreUnknown = true)
-public abstract sealed class EmptyUnion permits EmptyUnion.Unknown {
+public abstract sealed class EmptyUnion {
     public static EmptyUnion unknown(@Safe String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
             default:

--- a/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/SimpleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/SimpleUnion.java
@@ -30,7 +30,7 @@ import javax.annotation.processing.Generated;
         defaultImpl = SimpleUnion.Unknown.class)
 @JsonSubTypes(@JsonSubTypes.Type(value = SimpleUnion.Value.class, name = "value"))
 @JsonIgnoreProperties(ignoreUnknown = true)
-public abstract sealed class SimpleUnion permits SimpleUnion.Value, SimpleUnion.Unknown {
+public abstract sealed class SimpleUnion {
     public static SimpleUnion value(@Safe String value) {
         return new Value(value);
     }
@@ -56,7 +56,7 @@ public abstract sealed class SimpleUnion permits SimpleUnion.Value, SimpleUnion.
 
     public abstract <T> T accept(Visitor<T> visitor);
 
-    public sealed interface Known permits Value {}
+    public sealed interface Known {}
 
     @JsonTypeName("value")
     public static final class Value extends SimpleUnion implements Known {

--- a/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/UnionExample.java
+++ b/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/UnionExample.java
@@ -40,13 +40,7 @@ import javax.annotation.processing.Generated;
     @JsonSubTypes.Type(value = UnionExample.OptionalVariant.class, name = "optionalVariant")
 })
 @JsonIgnoreProperties(ignoreUnknown = true)
-public abstract sealed class UnionExample
-        permits UnionExample.StringVariant,
-                UnionExample.IntVariant,
-                UnionExample.ObjectVariant,
-                UnionExample.CollectionVariant,
-                UnionExample.OptionalVariant,
-                UnionExample.Unknown {
+public abstract sealed class UnionExample {
     public static UnionExample stringVariant(String value) {
         return new StringVariant(value);
     }
@@ -100,8 +94,7 @@ public abstract sealed class UnionExample
 
     public abstract <T> T accept(Visitor<T> visitor);
 
-    public sealed interface Known
-            permits StringVariant, IntVariant, ObjectVariant, CollectionVariant, OptionalVariant {}
+    public sealed interface Known {}
 
     @JsonTypeName("stringVariant")
     public static final class StringVariant extends UnionExample implements Known {

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceAsync.java
@@ -266,10 +266,7 @@ public interface ErrorServiceAsync {
         }
     }
 
-    sealed interface TestBasicErrorError
-            permits TestBasicErrorError.InvalidArgument,
-                    TestBasicErrorError.ConflictingCauseSafeArgErr,
-                    TestBasicErrorError.Unknown {
+    sealed interface TestBasicErrorError {
         static TestBasicErrorError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);
@@ -288,8 +285,7 @@ public interface ErrorServiceAsync {
         record Unknown(RemoteException exception) implements TestBasicErrorError {}
     }
 
-    sealed interface TestImportedErrorError
-            permits TestImportedErrorError.EndpointError, TestImportedErrorError.Unknown {
+    sealed interface TestImportedErrorError {
         static TestImportedErrorError from(RemoteException e) {
             if (EndpointSpecificErrors.isEndpointError(e)) {
                 return new EndpointError((EndpointSpecificErrors.EndpointErrorException) e);
@@ -304,13 +300,7 @@ public interface ErrorServiceAsync {
         record Unknown(RemoteException exception) implements TestImportedErrorError {}
     }
 
-    sealed interface TestMultipleErrorsAndPackagesError
-            permits TestMultipleErrorsAndPackagesError.InvalidArgument,
-                    TestMultipleErrorsAndPackagesError.NotFound,
-                    TestMultipleErrorsAndPackagesError.DifferentNamespace,
-                    TestMultipleErrorsAndPackagesError.DifferentPackage,
-                    TestMultipleErrorsAndPackagesError.ComplicatedParameters,
-                    TestMultipleErrorsAndPackagesError.Unknown {
+    sealed interface TestMultipleErrorsAndPackagesError {
         static TestMultipleErrorsAndPackagesError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);
@@ -346,7 +336,7 @@ public interface ErrorServiceAsync {
         record Unknown(RemoteException exception) implements TestMultipleErrorsAndPackagesError {}
     }
 
-    sealed interface TestEmptyBodyError permits TestEmptyBodyError.InvalidArgument, TestEmptyBodyError.Unknown {
+    sealed interface TestEmptyBodyError {
         static TestEmptyBodyError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);
@@ -360,7 +350,7 @@ public interface ErrorServiceAsync {
         record Unknown(RemoteException exception) implements TestEmptyBodyError {}
     }
 
-    sealed interface TestBinaryError permits TestBinaryError.InvalidArgument, TestBinaryError.Unknown {
+    sealed interface TestBinaryError {
         static TestBinaryError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);
@@ -374,8 +364,7 @@ public interface ErrorServiceAsync {
         record Unknown(RemoteException exception) implements TestBinaryError {}
     }
 
-    sealed interface TestOptionalBinaryError
-            permits TestOptionalBinaryError.InvalidArgument, TestOptionalBinaryError.Unknown {
+    sealed interface TestOptionalBinaryError {
         static TestOptionalBinaryError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceBlocking.java
@@ -266,10 +266,7 @@ public interface ErrorServiceBlocking {
         }
     }
 
-    sealed interface TestBasicErrorError
-            permits TestBasicErrorError.InvalidArgument,
-                    TestBasicErrorError.ConflictingCauseSafeArgErr,
-                    TestBasicErrorError.Unknown {
+    sealed interface TestBasicErrorError {
         static TestBasicErrorError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);
@@ -288,8 +285,7 @@ public interface ErrorServiceBlocking {
         record Unknown(RemoteException exception) implements TestBasicErrorError {}
     }
 
-    sealed interface TestImportedErrorError
-            permits TestImportedErrorError.EndpointError, TestImportedErrorError.Unknown {
+    sealed interface TestImportedErrorError {
         static TestImportedErrorError from(RemoteException e) {
             if (EndpointSpecificErrors.isEndpointError(e)) {
                 return new EndpointError((EndpointSpecificErrors.EndpointErrorException) e);
@@ -304,13 +300,7 @@ public interface ErrorServiceBlocking {
         record Unknown(RemoteException exception) implements TestImportedErrorError {}
     }
 
-    sealed interface TestMultipleErrorsAndPackagesError
-            permits TestMultipleErrorsAndPackagesError.InvalidArgument,
-                    TestMultipleErrorsAndPackagesError.NotFound,
-                    TestMultipleErrorsAndPackagesError.DifferentNamespace,
-                    TestMultipleErrorsAndPackagesError.DifferentPackage,
-                    TestMultipleErrorsAndPackagesError.ComplicatedParameters,
-                    TestMultipleErrorsAndPackagesError.Unknown {
+    sealed interface TestMultipleErrorsAndPackagesError {
         static TestMultipleErrorsAndPackagesError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);
@@ -346,7 +336,7 @@ public interface ErrorServiceBlocking {
         record Unknown(RemoteException exception) implements TestMultipleErrorsAndPackagesError {}
     }
 
-    sealed interface TestEmptyBodyError permits TestEmptyBodyError.InvalidArgument, TestEmptyBodyError.Unknown {
+    sealed interface TestEmptyBodyError {
         static TestEmptyBodyError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);
@@ -360,7 +350,7 @@ public interface ErrorServiceBlocking {
         record Unknown(RemoteException exception) implements TestEmptyBodyError {}
     }
 
-    sealed interface TestBinaryError permits TestBinaryError.InvalidArgument, TestBinaryError.Unknown {
+    sealed interface TestBinaryError {
         static TestBinaryError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);
@@ -374,8 +364,7 @@ public interface ErrorServiceBlocking {
         record Unknown(RemoteException exception) implements TestBinaryError {}
     }
 
-    sealed interface TestOptionalBinaryError
-            permits TestOptionalBinaryError.InvalidArgument, TestOptionalBinaryError.Unknown {
+    sealed interface TestOptionalBinaryError {
         static TestOptionalBinaryError from(RemoteException e) {
             if (TestErrors.isInvalidArgument(e)) {
                 return new InvalidArgument((TestErrors.InvalidArgumentException) e);

--- a/conjure-java-core/src/integrationInput/java/sealedunions/com/palantir/product/CamelCaseUnion.java
+++ b/conjure-java-core/src/integrationInput/java/sealedunions/com/palantir/product/CamelCaseUnion.java
@@ -31,7 +31,7 @@ import javax.annotation.processing.Generated;
         defaultImpl = CamelCaseUnion.Unknown.class)
 @JsonSubTypes(@JsonSubTypes.Type(value = CamelCaseUnion.CamelCasedField.class, name = "camelCasedField"))
 @JsonIgnoreProperties(ignoreUnknown = true)
-public abstract sealed class CamelCaseUnion permits CamelCaseUnion.CamelCasedField, CamelCaseUnion.Unknown {
+public abstract sealed class CamelCaseUnion {
     public static CamelCaseUnion camelCasedField(String value) {
         return new CamelCasedField(value);
     }
@@ -58,7 +58,7 @@ public abstract sealed class CamelCaseUnion permits CamelCaseUnion.CamelCasedFie
 
     public abstract <T> T accept(Visitor<T> visitor);
 
-    public sealed interface Known permits CamelCasedField {}
+    public sealed interface Known {}
 
     @JsonTypeName("camelCasedField")
     public static final class CamelCasedField extends CamelCaseUnion implements Known {

--- a/conjure-java-core/src/integrationInput/java/sealedunions/com/palantir/product/EmptyUnion.java
+++ b/conjure-java-core/src/integrationInput/java/sealedunions/com/palantir/product/EmptyUnion.java
@@ -29,7 +29,7 @@ import javax.annotation.processing.Generated;
         defaultImpl = EmptyUnion.Unknown.class)
 @JsonSubTypes({})
 @JsonIgnoreProperties(ignoreUnknown = true)
-public abstract sealed class EmptyUnion permits EmptyUnion.Unknown {
+public abstract sealed class EmptyUnion {
     public static EmptyUnion unknown(@Safe String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
             default:

--- a/conjure-java-core/src/integrationInput/java/sealedunions/com/palantir/product/SimpleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/sealedunions/com/palantir/product/SimpleUnion.java
@@ -37,8 +37,7 @@ import javax.annotation.processing.Generated;
     @JsonSubTypes.Type(value = SimpleUnion.Baz.class, name = "baz")
 })
 @JsonIgnoreProperties(ignoreUnknown = true)
-public abstract sealed class SimpleUnion
-        permits SimpleUnion.Foo, SimpleUnion.Bar, SimpleUnion.Baz, SimpleUnion.Unknown {
+public abstract sealed class SimpleUnion {
     public static SimpleUnion foo(String value) {
         return new Foo(value);
     }
@@ -78,7 +77,7 @@ public abstract sealed class SimpleUnion
 
     public abstract <T> T accept(Visitor<T> visitor);
 
-    public sealed interface Known permits Foo, Bar, Baz {}
+    public sealed interface Known {}
 
     @JsonTypeName("foo")
     public static final class Foo extends SimpleUnion implements Known {

--- a/conjure-java-core/src/integrationInput/java/sealedunions/com/palantir/product/UnionReservedNames.java
+++ b/conjure-java-core/src/integrationInput/java/sealedunions/com/palantir/product/UnionReservedNames.java
@@ -47,23 +47,7 @@ import javax.annotation.processing.Generated;
     @JsonSubTypes.Type(value = UnionReservedNames.UnionReservedNames_.class, name = "unionReservedNames")
 })
 @JsonIgnoreProperties(ignoreUnknown = true)
-public abstract sealed class UnionReservedNames
-        permits UnionReservedNames.Known_,
-                UnionReservedNames.Unknown_,
-                UnionReservedNames.If,
-                UnionReservedNames.New,
-                UnionReservedNames.Interface,
-                UnionReservedNames.Void,
-                UnionReservedNames.Return,
-                UnionReservedNames.Private,
-                UnionReservedNames.Public,
-                UnionReservedNames.Int,
-                UnionReservedNames.Import,
-                UnionReservedNames.Final,
-                UnionReservedNames.Throws,
-                UnionReservedNames.Static,
-                UnionReservedNames.UnionReservedNames_,
-                UnionReservedNames.Unknown {
+public abstract sealed class UnionReservedNames {
     public static UnionReservedNames known(String value) {
         return new Known_(value);
     }
@@ -188,22 +172,7 @@ public abstract sealed class UnionReservedNames
 
     public abstract <T> T accept(Visitor<T> visitor);
 
-    public sealed interface Known
-            permits Known_,
-                    Unknown_,
-                    If,
-                    New,
-                    Interface,
-                    Void,
-                    Return,
-                    Private,
-                    Public,
-                    Int,
-                    Import,
-                    Final,
-                    Throws,
-                    Static,
-                    UnionReservedNames_ {}
+    public sealed interface Known {}
 
     @JsonTypeName("known")
     public static final class Known_ extends UnionReservedNames implements Known {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DialogueInterfaceGenerator.java
@@ -228,7 +228,6 @@ public final class DialogueInterfaceGenerator {
                     ErrorGenerationUtils.errorTypesClassName(error.getError().getNamespace()),
                     ErrorGenerationUtils.errorExceptionClassName(errorName));
             TypeSpec errorRecord = createRecordForEndpointErrorUtility(errorName, exceptionClassName, utilityClassName);
-            builder.addPermittedSubclass(utilityClassName.nestedClass(errorName));
             builder.addType(errorRecord);
 
             ClassName errorTypesClass = ClassName.get(
@@ -252,7 +251,6 @@ public final class DialogueInterfaceGenerator {
         TypeSpec unknownRecord =
                 createRecordForEndpointErrorUtility("Unknown", ClassName.get(RemoteException.class), utilityClassName);
         builder.addType(unknownRecord);
-        builder.addPermittedSubclass(utilityClassName.nestedClass("Unknown"));
         codeBlock.nextControlFlow("else").addStatement("return new $L(e)", unknownRecord.name());
         codeBlock.endControlFlow();
         fromBuilder.addCode(codeBlock.build());

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -130,10 +130,6 @@ public final class UnionGenerator {
                     .addAnnotation(generateJsonSubTypes(unionClass, typeDef.getUnion()))
                     .addAnnotation(ignoreUnknownAnnotation())
                     .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT, Modifier.SEALED)
-                    .addPermittedSubclasses(typeDef.getUnion().stream()
-                            .map(memberTypeDef -> sealedVariantClass(unionClass, memberTypeDef.getFieldName()))
-                            .toList())
-                    .addPermittedSubclass(unknownVariant)
                     .addTypes(generateSealedKnownInterface(unionClass, typeDef.getUnion()))
                     .addMethods(generateStaticFactories(
                             typeMapper, unionClass, typeDef.getUnion(), safetyEvaluator, options))
@@ -256,10 +252,6 @@ public final class UnionGenerator {
 
         return List.of(TypeSpec.interfaceBuilder(SEALED_KNOWN_INTERFACE)
                 .addModifiers(Modifier.PUBLIC, Modifier.SEALED)
-                .addPermittedSubclasses(memberTypeDefs.stream()
-                        .map(FieldDefinition::getFieldName)
-                        .map(fieldName -> sealedVariantClass(unionClass, fieldName))
-                        .toList())
                 .build());
     }
 


### PR DESCRIPTION
There is no need to use a `permits` clause for direct subclasses in the same compilation unit. These subclasses are always permitted.

https://docs.oracle.com/javase/specs/jls/se21/html/jls-8.html#jls-8.1.6