### PR TITLE
Add test to check that sealed unions are serialized the same way as legacy unions

### DIFF
--- a/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/SimpleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/SimpleUnion.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
@@ -17,6 +18,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.IntFunction;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
@@ -28,18 +30,37 @@ import javax.annotation.processing.Generated;
         property = "type",
         visible = true,
         defaultImpl = SimpleUnion.Unknown.class)
-@JsonSubTypes(@JsonSubTypes.Type(value = SimpleUnion.Value.class, name = "value"))
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = SimpleUnion.Foo.class, name = "foo"),
+    @JsonSubTypes.Type(value = SimpleUnion.Bar.class, name = "bar"),
+    @JsonSubTypes.Type(value = SimpleUnion.Baz.class, name = "baz")
+})
 @JsonIgnoreProperties(ignoreUnknown = true)
-public abstract sealed class SimpleUnion permits SimpleUnion.Value, SimpleUnion.Unknown {
-    public static SimpleUnion value(@Safe String value) {
-        return new Value(value);
+public abstract sealed class SimpleUnion
+        permits SimpleUnion.Foo, SimpleUnion.Bar, SimpleUnion.Baz, SimpleUnion.Unknown {
+    public static SimpleUnion foo(String value) {
+        return new Foo(value);
+    }
+
+    public static SimpleUnion bar(int value) {
+        return new Bar(value);
+    }
+
+    public static SimpleUnion baz(SafeLong value) {
+        return new Baz(value);
     }
 
     public static SimpleUnion unknown(@Safe String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
-            case "value":
+            case "foo":
                 throw new SafeIllegalArgumentException(
-                        "Unknown type cannot be created as the provided type is known: value");
+                        "Unknown type cannot be created as the provided type is known: foo");
+            case "bar":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: bar");
+            case "baz":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: baz");
             default:
                 return new Unknown(type, Collections.singletonMap(type, value));
         }
@@ -56,39 +77,39 @@ public abstract sealed class SimpleUnion permits SimpleUnion.Value, SimpleUnion.
 
     public abstract <T> T accept(Visitor<T> visitor);
 
-    public sealed interface Known permits Value {}
+    public sealed interface Known permits Foo, Bar, Baz {}
 
-    @JsonTypeName("value")
-    public static final class Value extends SimpleUnion implements Known {
+    @JsonTypeName("foo")
+    public static final class Foo extends SimpleUnion implements Known {
         private final String value;
 
         @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-        private Value(@JsonSetter("value") @Nonnull String value) {
-            Preconditions.checkNotNull(value, "value cannot be null");
+        private Foo(@JsonSetter("foo") @Nonnull String value) {
+            Preconditions.checkNotNull(value, "foo cannot be null");
             this.value = value;
         }
 
         @JsonProperty(index = 0)
         private String type() {
-            return "value";
+            return "foo";
         }
 
-        @JsonProperty("value")
+        @JsonProperty("foo")
         public String value() {
             return value;
         }
 
         @Override
         public <T> T accept(Visitor<T> visitor) {
-            return visitor.visitValue(value);
+            return visitor.visitFoo(value);
         }
 
         @Override
         public boolean equals(@Nullable Object other) {
-            return this == other || (other instanceof Value && equalTo((Value) other));
+            return this == other || (other instanceof Foo && equalTo((Foo) other));
         }
 
-        private boolean equalTo(Value other) {
+        private boolean equalTo(Foo other) {
             return this.value.equals(other.value);
         }
 
@@ -99,7 +120,97 @@ public abstract sealed class SimpleUnion permits SimpleUnion.Value, SimpleUnion.
 
         @Override
         public String toString() {
-            return "SimpleUnion.Value{value: " + value + '}';
+            return "SimpleUnion.Foo{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("bar")
+    public static final class Bar extends SimpleUnion implements Known {
+        private final int value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private Bar(@JsonSetter("bar") @Nonnull int value) {
+            Preconditions.checkNotNull(value, "bar cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(index = 0)
+        private String type() {
+            return "bar";
+        }
+
+        @JsonProperty("bar")
+        public int value() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitBar(value);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof Bar && equalTo((Bar) other));
+        }
+
+        private boolean equalTo(Bar other) {
+            return this.value == other.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return this.value;
+        }
+
+        @Override
+        public String toString() {
+            return "SimpleUnion.Bar{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("baz")
+    public static final class Baz extends SimpleUnion implements Known {
+        private final SafeLong value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private Baz(@JsonSetter("baz") @Nonnull SafeLong value) {
+            Preconditions.checkNotNull(value, "baz cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(index = 0)
+        private String type() {
+            return "baz";
+        }
+
+        @JsonProperty("baz")
+        public SafeLong value() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitBaz(value);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof Baz && equalTo((Baz) other));
+        }
+
+        private boolean equalTo(Baz other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.value.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "SimpleUnion.Baz{value: " + value + '}';
         }
     }
 
@@ -164,25 +275,51 @@ public abstract sealed class SimpleUnion permits SimpleUnion.Value, SimpleUnion.
     }
 
     public interface Visitor<T> {
-        T visitValue(@Safe String value);
+        T visitFoo(String value);
+
+        T visitBar(int value);
+
+        T visitBaz(SafeLong value);
 
         T visitUnknown(@Safe String unknownType);
 
-        static <T> ValueStageVisitorBuilder<T> builder() {
+        static <T> BarStageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
         }
     }
 
     private static final class VisitorBuilder<T>
-            implements ValueStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
-        private Function<@Safe String, T> valueVisitor;
+            implements BarStageVisitorBuilder<T>,
+                    BazStageVisitorBuilder<T>,
+                    FooStageVisitorBuilder<T>,
+                    UnknownStageVisitorBuilder<T>,
+                    Completed_StageVisitorBuilder<T> {
+        private IntFunction<T> barVisitor;
+
+        private Function<SafeLong, T> bazVisitor;
+
+        private Function<String, T> fooVisitor;
 
         private Function<String, T> unknownVisitor;
 
         @Override
-        public UnknownStageVisitorBuilder<T> value(@Nonnull Function<@Safe String, T> valueVisitor) {
-            Preconditions.checkNotNull(valueVisitor, "valueVisitor cannot be null");
-            this.valueVisitor = valueVisitor;
+        public BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor) {
+            Preconditions.checkNotNull(barVisitor, "barVisitor cannot be null");
+            this.barVisitor = barVisitor;
+            return this;
+        }
+
+        @Override
+        public FooStageVisitorBuilder<T> baz(@Nonnull Function<SafeLong, T> bazVisitor) {
+            Preconditions.checkNotNull(bazVisitor, "bazVisitor cannot be null");
+            this.bazVisitor = bazVisitor;
+            return this;
+        }
+
+        @Override
+        public UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor) {
+            Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
+            this.fooVisitor = fooVisitor;
             return this;
         }
 
@@ -204,12 +341,24 @@ public abstract sealed class SimpleUnion permits SimpleUnion.Value, SimpleUnion.
 
         @Override
         public Visitor<T> build() {
-            final Function<@Safe String, T> valueVisitor = this.valueVisitor;
+            final IntFunction<T> barVisitor = this.barVisitor;
+            final Function<SafeLong, T> bazVisitor = this.bazVisitor;
+            final Function<String, T> fooVisitor = this.fooVisitor;
             final Function<String, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
-                public T visitValue(@Safe String value) {
-                    return valueVisitor.apply(value);
+                public T visitBar(int value) {
+                    return barVisitor.apply(value);
+                }
+
+                @Override
+                public T visitBaz(SafeLong value) {
+                    return bazVisitor.apply(value);
+                }
+
+                @Override
+                public T visitFoo(String value) {
+                    return fooVisitor.apply(value);
                 }
 
                 @Override
@@ -220,8 +369,16 @@ public abstract sealed class SimpleUnion permits SimpleUnion.Value, SimpleUnion.
         }
     }
 
-    public interface ValueStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> value(@Nonnull Function<@Safe String, T> valueVisitor);
+    public interface BarStageVisitorBuilder<T> {
+        BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor);
+    }
+
+    public interface BazStageVisitorBuilder<T> {
+        FooStageVisitorBuilder<T> baz(@Nonnull Function<SafeLong, T> bazVisitor);
+    }
+
+    public interface FooStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/SimpleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/SimpleUnion.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
@@ -18,6 +19,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.IntFunction;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
@@ -36,15 +38,29 @@ public final class SimpleUnion {
         return value;
     }
 
-    public static SimpleUnion value(@Safe String value) {
-        return new SimpleUnion(new ValueWrapper(value));
+    public static SimpleUnion foo(String value) {
+        return new SimpleUnion(new FooWrapper(value));
+    }
+
+    public static SimpleUnion bar(int value) {
+        return new SimpleUnion(new BarWrapper(value));
+    }
+
+    public static SimpleUnion baz(SafeLong value) {
+        return new SimpleUnion(new BazWrapper(value));
     }
 
     public static SimpleUnion unknown(@Safe String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
-            case "value":
+            case "foo":
                 throw new SafeIllegalArgumentException(
-                        "Unknown type cannot be created as the provided type is known: value");
+                        "Unknown type cannot be created as the provided type is known: foo");
+            case "bar":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: bar");
+            case "baz":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: baz");
             default:
                 return new SimpleUnion(new UnknownWrapper(type, Collections.singletonMap(type, value)));
         }
@@ -74,25 +90,51 @@ public final class SimpleUnion {
     }
 
     public interface Visitor<T> {
-        T visitValue(@Safe String value);
+        T visitFoo(String value);
+
+        T visitBar(int value);
+
+        T visitBaz(SafeLong value);
 
         T visitUnknown(@Safe String unknownType);
 
-        static <T> ValueStageVisitorBuilder<T> builder() {
+        static <T> BarStageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
         }
     }
 
     private static final class VisitorBuilder<T>
-            implements ValueStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
-        private Function<@Safe String, T> valueVisitor;
+            implements BarStageVisitorBuilder<T>,
+                    BazStageVisitorBuilder<T>,
+                    FooStageVisitorBuilder<T>,
+                    UnknownStageVisitorBuilder<T>,
+                    Completed_StageVisitorBuilder<T> {
+        private IntFunction<T> barVisitor;
+
+        private Function<SafeLong, T> bazVisitor;
+
+        private Function<String, T> fooVisitor;
 
         private Function<String, T> unknownVisitor;
 
         @Override
-        public UnknownStageVisitorBuilder<T> value(@Nonnull Function<@Safe String, T> valueVisitor) {
-            Preconditions.checkNotNull(valueVisitor, "valueVisitor cannot be null");
-            this.valueVisitor = valueVisitor;
+        public BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor) {
+            Preconditions.checkNotNull(barVisitor, "barVisitor cannot be null");
+            this.barVisitor = barVisitor;
+            return this;
+        }
+
+        @Override
+        public FooStageVisitorBuilder<T> baz(@Nonnull Function<SafeLong, T> bazVisitor) {
+            Preconditions.checkNotNull(bazVisitor, "bazVisitor cannot be null");
+            this.bazVisitor = bazVisitor;
+            return this;
+        }
+
+        @Override
+        public UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor) {
+            Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
+            this.fooVisitor = fooVisitor;
             return this;
         }
 
@@ -114,12 +156,24 @@ public final class SimpleUnion {
 
         @Override
         public Visitor<T> build() {
-            final Function<@Safe String, T> valueVisitor = this.valueVisitor;
+            final IntFunction<T> barVisitor = this.barVisitor;
+            final Function<SafeLong, T> bazVisitor = this.bazVisitor;
+            final Function<String, T> fooVisitor = this.fooVisitor;
             final Function<String, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
-                public T visitValue(@Safe String value) {
-                    return valueVisitor.apply(value);
+                public T visitBar(int value) {
+                    return barVisitor.apply(value);
+                }
+
+                @Override
+                public T visitBaz(SafeLong value) {
+                    return bazVisitor.apply(value);
+                }
+
+                @Override
+                public T visitFoo(String value) {
+                    return fooVisitor.apply(value);
                 }
 
                 @Override
@@ -130,8 +184,16 @@ public final class SimpleUnion {
         }
     }
 
-    public interface ValueStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> value(@Nonnull Function<@Safe String, T> valueVisitor);
+    public interface BarStageVisitorBuilder<T> {
+        BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor);
+    }
+
+    public interface BazStageVisitorBuilder<T> {
+        FooStageVisitorBuilder<T> baz(@Nonnull Function<SafeLong, T> bazVisitor);
+    }
+
+    public interface FooStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {
@@ -150,43 +212,47 @@ public final class SimpleUnion {
             property = "type",
             visible = true,
             defaultImpl = UnknownWrapper.class)
-    @JsonSubTypes(@JsonSubTypes.Type(ValueWrapper.class))
+    @JsonSubTypes({
+        @JsonSubTypes.Type(FooWrapper.class),
+        @JsonSubTypes.Type(BarWrapper.class),
+        @JsonSubTypes.Type(BazWrapper.class)
+    })
     @JsonIgnoreProperties(ignoreUnknown = true)
     private interface Base {
         <T> T accept(Visitor<T> visitor);
     }
 
-    @JsonTypeName("value")
-    private static final class ValueWrapper implements Base {
+    @JsonTypeName("foo")
+    private static final class FooWrapper implements Base {
         private final String value;
 
         @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-        private ValueWrapper(@JsonSetter("value") @Nonnull String value) {
-            Preconditions.checkNotNull(value, "value cannot be null");
+        private FooWrapper(@JsonSetter("foo") @Nonnull String value) {
+            Preconditions.checkNotNull(value, "foo cannot be null");
             this.value = value;
         }
 
         @JsonProperty(value = "type", index = 0)
         private String getType() {
-            return "value";
+            return "foo";
         }
 
-        @JsonProperty("value")
+        @JsonProperty("foo")
         private String getValue() {
             return value;
         }
 
         @Override
         public <T> T accept(Visitor<T> visitor) {
-            return visitor.visitValue(value);
+            return visitor.visitFoo(value);
         }
 
         @Override
         public boolean equals(@Nullable Object other) {
-            return this == other || (other instanceof ValueWrapper && equalTo((ValueWrapper) other));
+            return this == other || (other instanceof FooWrapper && equalTo((FooWrapper) other));
         }
 
-        private boolean equalTo(ValueWrapper other) {
+        private boolean equalTo(FooWrapper other) {
             return this.value.equals(other.value);
         }
 
@@ -197,7 +263,97 @@ public final class SimpleUnion {
 
         @Override
         public String toString() {
-            return "ValueWrapper{value: " + value + '}';
+            return "FooWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("bar")
+    private static final class BarWrapper implements Base {
+        private final int value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private BarWrapper(@JsonSetter("bar") @Nonnull int value) {
+            Preconditions.checkNotNull(value, "bar cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(value = "type", index = 0)
+        private String getType() {
+            return "bar";
+        }
+
+        @JsonProperty("bar")
+        private int getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitBar(value);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof BarWrapper && equalTo((BarWrapper) other));
+        }
+
+        private boolean equalTo(BarWrapper other) {
+            return this.value == other.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return this.value;
+        }
+
+        @Override
+        public String toString() {
+            return "BarWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("baz")
+    private static final class BazWrapper implements Base {
+        private final SafeLong value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private BazWrapper(@JsonSetter("baz") @Nonnull SafeLong value) {
+            Preconditions.checkNotNull(value, "baz cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(value = "type", index = 0)
+        private String getType() {
+            return "baz";
+        }
+
+        @JsonProperty("baz")
+        private SafeLong getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitBaz(value);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof BazWrapper && equalTo((BazWrapper) other));
+        }
+
+        private boolean equalTo(BazWrapper other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.value.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "BazWrapper{value: " + value + '}';
         }
     }
 

--- a/conjure-java-core/src/integrationInput/java/jersey/com/palantir/product/SimpleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/jersey/com/palantir/product/SimpleUnion.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
@@ -18,6 +19,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.IntFunction;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
@@ -36,15 +38,29 @@ public final class SimpleUnion {
         return value;
     }
 
-    public static SimpleUnion value(@Safe String value) {
-        return new SimpleUnion(new ValueWrapper(value));
+    public static SimpleUnion foo(String value) {
+        return new SimpleUnion(new FooWrapper(value));
+    }
+
+    public static SimpleUnion bar(int value) {
+        return new SimpleUnion(new BarWrapper(value));
+    }
+
+    public static SimpleUnion baz(SafeLong value) {
+        return new SimpleUnion(new BazWrapper(value));
     }
 
     public static SimpleUnion unknown(@Safe String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
-            case "value":
+            case "foo":
                 throw new SafeIllegalArgumentException(
-                        "Unknown type cannot be created as the provided type is known: value");
+                        "Unknown type cannot be created as the provided type is known: foo");
+            case "bar":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: bar");
+            case "baz":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: baz");
             default:
                 return new SimpleUnion(new UnknownWrapper(type, Collections.singletonMap(type, value)));
         }
@@ -74,25 +90,51 @@ public final class SimpleUnion {
     }
 
     public interface Visitor<T> {
-        T visitValue(@Safe String value);
+        T visitFoo(String value);
+
+        T visitBar(int value);
+
+        T visitBaz(SafeLong value);
 
         T visitUnknown(@Safe String unknownType);
 
-        static <T> ValueStageVisitorBuilder<T> builder() {
+        static <T> BarStageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
         }
     }
 
     private static final class VisitorBuilder<T>
-            implements ValueStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
-        private Function<@Safe String, T> valueVisitor;
+            implements BarStageVisitorBuilder<T>,
+                    BazStageVisitorBuilder<T>,
+                    FooStageVisitorBuilder<T>,
+                    UnknownStageVisitorBuilder<T>,
+                    Completed_StageVisitorBuilder<T> {
+        private IntFunction<T> barVisitor;
+
+        private Function<SafeLong, T> bazVisitor;
+
+        private Function<String, T> fooVisitor;
 
         private Function<String, T> unknownVisitor;
 
         @Override
-        public UnknownStageVisitorBuilder<T> value(@Nonnull Function<@Safe String, T> valueVisitor) {
-            Preconditions.checkNotNull(valueVisitor, "valueVisitor cannot be null");
-            this.valueVisitor = valueVisitor;
+        public BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor) {
+            Preconditions.checkNotNull(barVisitor, "barVisitor cannot be null");
+            this.barVisitor = barVisitor;
+            return this;
+        }
+
+        @Override
+        public FooStageVisitorBuilder<T> baz(@Nonnull Function<SafeLong, T> bazVisitor) {
+            Preconditions.checkNotNull(bazVisitor, "bazVisitor cannot be null");
+            this.bazVisitor = bazVisitor;
+            return this;
+        }
+
+        @Override
+        public UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor) {
+            Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
+            this.fooVisitor = fooVisitor;
             return this;
         }
 
@@ -114,12 +156,24 @@ public final class SimpleUnion {
 
         @Override
         public Visitor<T> build() {
-            final Function<@Safe String, T> valueVisitor = this.valueVisitor;
+            final IntFunction<T> barVisitor = this.barVisitor;
+            final Function<SafeLong, T> bazVisitor = this.bazVisitor;
+            final Function<String, T> fooVisitor = this.fooVisitor;
             final Function<String, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
-                public T visitValue(@Safe String value) {
-                    return valueVisitor.apply(value);
+                public T visitBar(int value) {
+                    return barVisitor.apply(value);
+                }
+
+                @Override
+                public T visitBaz(SafeLong value) {
+                    return bazVisitor.apply(value);
+                }
+
+                @Override
+                public T visitFoo(String value) {
+                    return fooVisitor.apply(value);
                 }
 
                 @Override
@@ -130,8 +184,16 @@ public final class SimpleUnion {
         }
     }
 
-    public interface ValueStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> value(@Nonnull Function<@Safe String, T> valueVisitor);
+    public interface BarStageVisitorBuilder<T> {
+        BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor);
+    }
+
+    public interface BazStageVisitorBuilder<T> {
+        FooStageVisitorBuilder<T> baz(@Nonnull Function<SafeLong, T> bazVisitor);
+    }
+
+    public interface FooStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {
@@ -150,43 +212,47 @@ public final class SimpleUnion {
             property = "type",
             visible = true,
             defaultImpl = UnknownWrapper.class)
-    @JsonSubTypes(@JsonSubTypes.Type(ValueWrapper.class))
+    @JsonSubTypes({
+        @JsonSubTypes.Type(FooWrapper.class),
+        @JsonSubTypes.Type(BarWrapper.class),
+        @JsonSubTypes.Type(BazWrapper.class)
+    })
     @JsonIgnoreProperties(ignoreUnknown = true)
     private interface Base {
         <T> T accept(Visitor<T> visitor);
     }
 
-    @JsonTypeName("value")
-    private static final class ValueWrapper implements Base {
+    @JsonTypeName("foo")
+    private static final class FooWrapper implements Base {
         private final String value;
 
         @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-        private ValueWrapper(@JsonSetter("value") @Nonnull String value) {
-            Preconditions.checkNotNull(value, "value cannot be null");
+        private FooWrapper(@JsonSetter("foo") @Nonnull String value) {
+            Preconditions.checkNotNull(value, "foo cannot be null");
             this.value = value;
         }
 
         @JsonProperty(value = "type", index = 0)
         private String getType() {
-            return "value";
+            return "foo";
         }
 
-        @JsonProperty("value")
+        @JsonProperty("foo")
         private String getValue() {
             return value;
         }
 
         @Override
         public <T> T accept(Visitor<T> visitor) {
-            return visitor.visitValue(value);
+            return visitor.visitFoo(value);
         }
 
         @Override
         public boolean equals(@Nullable Object other) {
-            return this == other || (other instanceof ValueWrapper && equalTo((ValueWrapper) other));
+            return this == other || (other instanceof FooWrapper && equalTo((FooWrapper) other));
         }
 
-        private boolean equalTo(ValueWrapper other) {
+        private boolean equalTo(FooWrapper other) {
             return this.value.equals(other.value);
         }
 
@@ -197,7 +263,97 @@ public final class SimpleUnion {
 
         @Override
         public String toString() {
-            return "ValueWrapper{value: " + value + '}';
+            return "FooWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("bar")
+    private static final class BarWrapper implements Base {
+        private final int value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private BarWrapper(@JsonSetter("bar") @Nonnull int value) {
+            Preconditions.checkNotNull(value, "bar cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(value = "type", index = 0)
+        private String getType() {
+            return "bar";
+        }
+
+        @JsonProperty("bar")
+        private int getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitBar(value);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof BarWrapper && equalTo((BarWrapper) other));
+        }
+
+        private boolean equalTo(BarWrapper other) {
+            return this.value == other.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return this.value;
+        }
+
+        @Override
+        public String toString() {
+            return "BarWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("baz")
+    private static final class BazWrapper implements Base {
+        private final SafeLong value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private BazWrapper(@JsonSetter("baz") @Nonnull SafeLong value) {
+            Preconditions.checkNotNull(value, "baz cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(value = "type", index = 0)
+        private String getType() {
+            return "baz";
+        }
+
+        @JsonProperty("baz")
+        private SafeLong getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitBaz(value);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof BazWrapper && equalTo((BazWrapper) other));
+        }
+
+        private boolean equalTo(BazWrapper other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.value.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "BazWrapper{value: " + value + '}';
         }
     }
 

--- a/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/SimpleUnion.java
+++ b/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/SimpleUnion.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
@@ -18,6 +19,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.IntFunction;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
@@ -36,15 +38,29 @@ public final class SimpleUnion {
         return value;
     }
 
-    public static SimpleUnion value(@Safe String value) {
-        return new SimpleUnion(new ValueWrapper(value));
+    public static SimpleUnion foo(String value) {
+        return new SimpleUnion(new FooWrapper(value));
+    }
+
+    public static SimpleUnion bar(int value) {
+        return new SimpleUnion(new BarWrapper(value));
+    }
+
+    public static SimpleUnion baz(SafeLong value) {
+        return new SimpleUnion(new BazWrapper(value));
     }
 
     public static SimpleUnion unknown(@Safe String type, Object value) {
         switch (Preconditions.checkNotNull(type, "Type is required")) {
-            case "value":
+            case "foo":
                 throw new SafeIllegalArgumentException(
-                        "Unknown type cannot be created as the provided type is known: value");
+                        "Unknown type cannot be created as the provided type is known: foo");
+            case "bar":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: bar");
+            case "baz":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: baz");
             default:
                 return new SimpleUnion(new UnknownWrapper(type, Collections.singletonMap(type, value)));
         }
@@ -74,25 +90,51 @@ public final class SimpleUnion {
     }
 
     public interface Visitor<T> {
-        T visitValue(@Safe String value);
+        T visitFoo(String value);
+
+        T visitBar(int value);
+
+        T visitBaz(SafeLong value);
 
         T visitUnknown(@Safe String unknownType);
 
-        static <T> ValueStageVisitorBuilder<T> builder() {
+        static <T> BarStageVisitorBuilder<T> builder() {
             return new VisitorBuilder<T>();
         }
     }
 
     private static final class VisitorBuilder<T>
-            implements ValueStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
-        private Function<@Safe String, T> valueVisitor;
+            implements BarStageVisitorBuilder<T>,
+                    BazStageVisitorBuilder<T>,
+                    FooStageVisitorBuilder<T>,
+                    UnknownStageVisitorBuilder<T>,
+                    Completed_StageVisitorBuilder<T> {
+        private IntFunction<T> barVisitor;
+
+        private Function<SafeLong, T> bazVisitor;
+
+        private Function<String, T> fooVisitor;
 
         private Function<String, T> unknownVisitor;
 
         @Override
-        public UnknownStageVisitorBuilder<T> value(@Nonnull Function<@Safe String, T> valueVisitor) {
-            Preconditions.checkNotNull(valueVisitor, "valueVisitor cannot be null");
-            this.valueVisitor = valueVisitor;
+        public BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor) {
+            Preconditions.checkNotNull(barVisitor, "barVisitor cannot be null");
+            this.barVisitor = barVisitor;
+            return this;
+        }
+
+        @Override
+        public FooStageVisitorBuilder<T> baz(@Nonnull Function<SafeLong, T> bazVisitor) {
+            Preconditions.checkNotNull(bazVisitor, "bazVisitor cannot be null");
+            this.bazVisitor = bazVisitor;
+            return this;
+        }
+
+        @Override
+        public UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor) {
+            Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
+            this.fooVisitor = fooVisitor;
             return this;
         }
 
@@ -114,12 +156,24 @@ public final class SimpleUnion {
 
         @Override
         public Visitor<T> build() {
-            final Function<@Safe String, T> valueVisitor = this.valueVisitor;
+            final IntFunction<T> barVisitor = this.barVisitor;
+            final Function<SafeLong, T> bazVisitor = this.bazVisitor;
+            final Function<String, T> fooVisitor = this.fooVisitor;
             final Function<String, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
-                public T visitValue(@Safe String value) {
-                    return valueVisitor.apply(value);
+                public T visitBar(int value) {
+                    return barVisitor.apply(value);
+                }
+
+                @Override
+                public T visitBaz(SafeLong value) {
+                    return bazVisitor.apply(value);
+                }
+
+                @Override
+                public T visitFoo(String value) {
+                    return fooVisitor.apply(value);
                 }
 
                 @Override
@@ -130,8 +184,16 @@ public final class SimpleUnion {
         }
     }
 
-    public interface ValueStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> value(@Nonnull Function<@Safe String, T> valueVisitor);
+    public interface BarStageVisitorBuilder<T> {
+        BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor);
+    }
+
+    public interface BazStageVisitorBuilder<T> {
+        FooStageVisitorBuilder<T> baz(@Nonnull Function<SafeLong, T> bazVisitor);
+    }
+
+    public interface FooStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {
@@ -150,43 +212,47 @@ public final class SimpleUnion {
             property = "type",
             visible = true,
             defaultImpl = UnknownWrapper.class)
-    @JsonSubTypes(@JsonSubTypes.Type(ValueWrapper.class))
+    @JsonSubTypes({
+        @JsonSubTypes.Type(FooWrapper.class),
+        @JsonSubTypes.Type(BarWrapper.class),
+        @JsonSubTypes.Type(BazWrapper.class)
+    })
     @JsonIgnoreProperties(ignoreUnknown = true)
     private interface Base {
         <T> T accept(Visitor<T> visitor);
     }
 
-    @JsonTypeName("value")
-    private static final class ValueWrapper implements Base {
+    @JsonTypeName("foo")
+    private static final class FooWrapper implements Base {
         private final String value;
 
         @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-        private ValueWrapper(@JsonSetter("value") @Nonnull String value) {
-            Preconditions.checkNotNull(value, "value cannot be null");
+        private FooWrapper(@JsonSetter("foo") @Nonnull String value) {
+            Preconditions.checkNotNull(value, "foo cannot be null");
             this.value = value;
         }
 
         @JsonProperty(value = "type", index = 0)
         private String getType() {
-            return "value";
+            return "foo";
         }
 
-        @JsonProperty("value")
+        @JsonProperty("foo")
         private String getValue() {
             return value;
         }
 
         @Override
         public <T> T accept(Visitor<T> visitor) {
-            return visitor.visitValue(value);
+            return visitor.visitFoo(value);
         }
 
         @Override
         public boolean equals(@Nullable Object other) {
-            return this == other || (other instanceof ValueWrapper && equalTo((ValueWrapper) other));
+            return this == other || (other instanceof FooWrapper && equalTo((FooWrapper) other));
         }
 
-        private boolean equalTo(ValueWrapper other) {
+        private boolean equalTo(FooWrapper other) {
             return this.value.equals(other.value);
         }
 
@@ -197,7 +263,97 @@ public final class SimpleUnion {
 
         @Override
         public String toString() {
-            return "ValueWrapper{value: " + value + '}';
+            return "FooWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("bar")
+    private static final class BarWrapper implements Base {
+        private final int value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private BarWrapper(@JsonSetter("bar") @Nonnull int value) {
+            Preconditions.checkNotNull(value, "bar cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(value = "type", index = 0)
+        private String getType() {
+            return "bar";
+        }
+
+        @JsonProperty("bar")
+        private int getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitBar(value);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof BarWrapper && equalTo((BarWrapper) other));
+        }
+
+        private boolean equalTo(BarWrapper other) {
+            return this.value == other.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return this.value;
+        }
+
+        @Override
+        public String toString() {
+            return "BarWrapper{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("baz")
+    private static final class BazWrapper implements Base {
+        private final SafeLong value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private BazWrapper(@JsonSetter("baz") @Nonnull SafeLong value) {
+            Preconditions.checkNotNull(value, "baz cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(value = "type", index = 0)
+        private String getType() {
+            return "baz";
+        }
+
+        @JsonProperty("baz")
+        private SafeLong getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitBaz(value);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof BazWrapper && equalTo((BazWrapper) other));
+        }
+
+        private boolean equalTo(BazWrapper other) {
+            return this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.value.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "BazWrapper{value: " + value + '}';
         }
     }
 

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -640,8 +640,8 @@ public final class UndertowServiceEteTest extends TestBase {
 
     @Test
     void testSealedUnionParameter() {
-        assertThat(client.union(AuthHeader.valueOf("authHeader"), SimpleUnion.foo("foo")))
-                .isEqualTo(SimpleUnion.foo("foo"));
+        assertThat(client.union(AuthHeader.valueOf("authHeader"), SimpleUnion.value("foo")))
+                .isEqualTo(SimpleUnion.value("foo"));
     }
 
     private static Map<String, String> filterKeys(Map<String, String> map, List<String> keysToFilter) {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -640,8 +640,8 @@ public final class UndertowServiceEteTest extends TestBase {
 
     @Test
     void testSealedUnionParameter() {
-        assertThat(client.union(AuthHeader.valueOf("authHeader"), SimpleUnion.value("foo")))
-                .isEqualTo(SimpleUnion.value("foo"));
+        assertThat(client.union(AuthHeader.valueOf("authHeader"), SimpleUnion.foo("foo")))
+                .isEqualTo(SimpleUnion.foo("foo"));
     }
 
     private static Map<String, String> filterKeys(Map<String, String> map, List<String> keysToFilter) {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/UnionTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/UnionTests.java
@@ -249,6 +249,17 @@ class UnionTests {
         assertThat(simpleUnion.toString()).contains(expected);
     }
 
+    @Test
+    void sealedUnionsAreSerializedTheSameAsLegacyUnions() throws IOException {
+        String expected = "foo";
+        SimpleUnion simpleUnion = SimpleUnion.foo(expected);
+        undertow.com.palantir.product.SimpleUnion simpleLegacyUnion =
+                undertow.com.palantir.product.SimpleUnion.foo(expected);
+        String serialized = MAPPER.writeValueAsString(simpleUnion);
+        String serializedLegacy = MAPPER.writeValueAsString(simpleLegacyUnion);
+        assertThat(serialized).isEqualTo(serializedLegacy);
+    }
+
     private Void failOnKnownType(String type, Object value) {
         Fail.fail(
                 "Visited known type when expected unknown type",

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/UnionTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/UnionTests.java
@@ -249,17 +249,6 @@ class UnionTests {
         assertThat(simpleUnion.toString()).contains(expected);
     }
 
-    @Test
-    void sealedUnionsAreSerializedTheSameAsLegacyUnions() throws IOException {
-        String expected = "foo";
-        SimpleUnion simpleUnion = SimpleUnion.foo(expected);
-        undertow.com.palantir.product.SimpleUnion simpleLegacyUnion =
-                undertow.com.palantir.product.SimpleUnion.foo(expected);
-        String serialized = MAPPER.writeValueAsString(simpleUnion);
-        String serializedLegacy = MAPPER.writeValueAsString(simpleLegacyUnion);
-        assertThat(serialized).isEqualTo(serializedLegacy);
-    }
-
     private Void failOnKnownType(String type, Object value) {
         Fail.fail(
                 "Visited known type when expected unknown type",

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -86,8 +86,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import sealedunions.com.palantir.product.CamelCaseUnion;
-import sealedunions.com.palantir.product.SimpleUnion;
 import sealedunions.com.palantir.product.UnionReservedNames;
+import undertow.com.palantir.product.SimpleUnion;
 
 @Execution(ExecutionMode.CONCURRENT)
 public final class WireFormatTests {
@@ -939,8 +939,12 @@ public final class WireFormatTests {
 
     @Test
     void testSealedInterfaceUnionType_wireFormatBackCompatWithLegacyImpl() throws IOException {
+        sealedunions.com.palantir.product.SimpleUnion sealedUnionFoo =
+                sealedunions.com.palantir.product.SimpleUnion.foo("foo");
+        // Validate that we are using the implementation with sealed classes.
+        assertThat(sealedUnionFoo).isInstanceOf(sealedunions.com.palantir.product.SimpleUnion.Foo.class);
         assertThat(mapper.writeValueAsString(SimpleUnion.foo("foo")))
-                .isEqualTo(mapper.writeValueAsString(undertow.com.palantir.product.SimpleUnion.foo("foo")));
+                .isEqualTo(mapper.writeValueAsString(sealedUnionFoo));
     }
 
     private static final class TestVisitor implements UnionTypeExample.Visitor<Integer> {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -937,6 +937,12 @@ public final class WireFormatTests {
                 .isEqualTo(CamelCaseUnion.camelCasedField("test"));
     }
 
+    @Test
+    void testSealedInterfaceUnionType_wireFormatBackCompatWithLegacyImpl() throws IOException {
+        assertThat(mapper.writeValueAsString(SimpleUnion.foo("foo")))
+                .isEqualTo(mapper.writeValueAsString(undertow.com.palantir.product.SimpleUnion.foo("foo")));
+    }
+
     private static final class TestVisitor implements UnionTypeExample.Visitor<Integer> {
         @Override
         public Integer visitStringExample(StringExample stringExampleValue) {

--- a/conjure-java-core/src/test/resources/ete-service.yml
+++ b/conjure-java-core/src/test/resources/ete-service.yml
@@ -23,9 +23,9 @@ types:
         alias: Long
       SimpleUnion:
         union:
-          value:
-            type: string
-            safety: safe
+          foo: string
+          bar: integer
+          baz: safelong
 
 services:
   EmptyPathService:


### PR DESCRIPTION
## Before this PR
Add a small test to validate that the same Conjure union object is serialized the same way whether using the sealed classes implementation or the legacy implementation.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add test to check that sealed unions are serialized the same way as legacy unions
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

