### PR TITLE
Fix unit test import

### DIFF
--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -86,8 +86,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import sealedunions.com.palantir.product.CamelCaseUnion;
+import sealedunions.com.palantir.product.SimpleUnion;
 import sealedunions.com.palantir.product.UnionReservedNames;
-import undertow.com.palantir.product.SimpleUnion;
 
 @Execution(ExecutionMode.CONCURRENT)
 public final class WireFormatTests {
@@ -934,11 +934,10 @@ public final class WireFormatTests {
 
     @Test
     void testSealedUnionType_wireFormatBackCompatWithLegacyImpl() throws IOException {
-        sealedunions.com.palantir.product.SimpleUnion sealedUnionFoo =
-                sealedunions.com.palantir.product.SimpleUnion.foo("foo");
+        SimpleUnion sealedUnionFoo = SimpleUnion.foo("foo");
         // Validate that we are using the implementation with sealed classes.
-        assertThat(sealedUnionFoo).isInstanceOf(sealedunions.com.palantir.product.SimpleUnion.Foo.class);
-        assertThat(mapper.writeValueAsString(SimpleUnion.foo("foo")))
+        assertThat(sealedUnionFoo).isInstanceOf(SimpleUnion.Foo.class);
+        assertThat(mapper.writeValueAsString(undertow.com.palantir.product.SimpleUnion.foo("foo")))
                 .isEqualTo(mapper.writeValueAsString(sealedUnionFoo));
     }
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
We have other tests which expect`SimpleUnion` to be a sealed union

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

