### PR TITLE
Rethrow cookie parsing failure as IllegalArgumentException

### DIFF
--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureAuthorizationExtractor.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureAuthorizationExtractor.java
@@ -20,6 +20,7 @@ import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.conjure.java.undertow.lib.AuthorizationExtractor;
 import com.palantir.conjure.java.undertow.lib.PlainSerDe;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
 import com.palantir.tokens.auth.UnverifiedJsonWebToken;
@@ -77,7 +78,13 @@ final class ConjureAuthorizationExtractor implements AuthorizationExtractor {
      */
     @Override
     public BearerToken cookie(HttpServerExchange exchange, String cookieName) {
-        Cookie cookie = exchange.getRequestCookie(cookieName);
+        Cookie cookie;
+        try {
+            cookie = exchange.getRequestCookie(cookieName);
+        } catch (IllegalStateException e) {
+            // An IllegalStateException is thrown if the number of request cookies exceeds the configured maximum
+            throw new SafeIllegalArgumentException("Failed to parse request cookies", e);
+        }
         if (cookie == null) {
             throw new ServiceException(MISSING_CREDENTIAL_ERROR_TYPE);
         }

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
@@ -23,6 +23,7 @@ import com.palantir.conjure.java.undertow.lib.Contexts;
 import com.palantir.conjure.java.undertow.lib.Endpoint;
 import com.palantir.conjure.java.undertow.lib.RequestContext;
 import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import io.undertow.server.HttpServerExchange;
@@ -82,7 +83,17 @@ final class ConjureContexts implements Contexts {
 
         @Override
         public Optional<String> cookie(String cookieName) {
-            return Optional.ofNullable(exchange.getRequestCookie(cookieName)).map(Cookie::getValue);
+            Cookie cookie;
+            try {
+                cookie = exchange.getRequestCookie(cookieName);
+            } catch (IllegalStateException e) {
+                // An IllegalStateException is thrown if the number of request cookies exceeds the configured maximum
+                throw new SafeIllegalArgumentException("Failed to parse request cookies", e);
+            }
+            if (cookie == null) {
+                return Optional.empty();
+            }
+            return Optional.of(cookie.getValue());
         }
 
         @Override

--- a/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/CookieDeserializer.java
+++ b/conjure-undertow-annotations/src/main/java/com/palantir/conjure/java/undertow/annotations/CookieDeserializer.java
@@ -36,7 +36,13 @@ public final class CookieDeserializer<T> implements Deserializer<T> {
 
     @Override
     public T deserialize(HttpServerExchange exchange) throws IOException {
-        Cookie cookie = exchange.getRequestCookie(cookieName);
+        Cookie cookie;
+        try {
+            cookie = exchange.getRequestCookie(cookieName);
+        } catch (IllegalStateException e) {
+            // An IllegalStateException is thrown if the number of request cookies exceeds the configured maximum
+            throw new SafeIllegalArgumentException("Failed to parse request cookies", e);
+        }
         if (cookie == null) {
             return decoder.noValuePresent()
                     .orElseThrow(() -> new SafeIllegalArgumentException(


### PR DESCRIPTION
## Before this PR

If a request contains more cookies than the configured maximum (200 by default), then the `HttpServerExchange` methods to obtain cookies will throw an `IllegalStateException`. This can result in false positives for internal errors monitors.

```
java.lang.IllegalStateException: {throwable0_message}
	at io.undertow.util.Cookies.createCookie(Cookies.java:397)
	at io.undertow.util.Cookies.parseCookie(Cookies.java:291)
	at io.undertow.util.Cookies.parseRequestCookies(Cookies.java:246)
	at io.undertow.util.Cookies.parseRequestCookies(Cookies.java:224)
	at io.undertow.util.Cookies.parseRequestCookies(Cookies.java:215)
	at io.undertow.server.HttpServerExchange.requestCookies(HttpServerExchange.java:1248)
	at io.undertow.server.HttpServerExchange.getRequestCookie(HttpServerExchange.java:1229)
	at com.palantir.conjure.java.undertow.runtime.ConjureContexts$ConjureServerRequestContext.cookie(ConjureContexts.java:85)
	...
```

## After this PR

Catch these exceptions and re-throw them as `SafeIllegalArgumentException`.