### PR TITLE
Add RequestContext method to read attachments

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -3,5 +3,4 @@ acceptedBreaks:
     com.palantir.conjure.java:conjure-undertow-lib:
     - code: "java.method.addedToInterface"
       new: "method <T> java.util.Optional<T> com.palantir.conjure.java.undertow.lib.RequestContext::attachment(io.undertow.util.AttachmentKey<T>)"
-      justification: "Add attachment() method to RequestContext, following the pattern\
-        \ of cookie(). RequestContext is only implemented by conjure-java-undertow-runtime."
+      justification: "Add attachment() method to RequestContext, following the pattern of cookie(). RequestContext is only implemented by conjure-java-undertow-runtime."

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,0 +1,7 @@
+acceptedBreaks:
+  "8.68.0":
+    com.palantir.conjure.java:conjure-undertow-lib:
+    - code: "java.method.addedToInterface"
+      new: "method <T> java.util.Optional<T> com.palantir.conjure.java.undertow.lib.RequestContext::attachment(io.undertow.util.AttachmentKey<T>)"
+      justification: "Add attachment() method to RequestContext, following the pattern\
+        \ of cookie(). RequestContext is only implemented by conjure-java-undertow-runtime."

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -952,7 +952,8 @@ public final class WireFormatTests {
         SimpleUnion sealedUnionFoo = SimpleUnion.foo("foo");
         // Validate that we are using the implementation with sealed classes.
         assertThat(sealedUnionFoo).isInstanceOf(SimpleUnion.Foo.class);
-        assertThat(SimpleUnion.foo("foo").toString()).isEqualTo(sealedUnionFoo.toString());
+        assertThat(undertow.com.palantir.product.SimpleUnion.foo("foo").toString())
+                .isEqualTo(sealedUnionFoo.toString());
     }
 
     private static final class TestVisitor implements UnionTypeExample.Visitor<Integer> {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/WireFormatTests.java
@@ -949,10 +949,9 @@ public final class WireFormatTests {
      */
     @Test
     void testSealedInterfaceUnionType_toStringBackCompatWithLegacyImpl() throws IOException {
-        sealedunions.com.palantir.product.SimpleUnion sealedUnionFoo =
-                sealedunions.com.palantir.product.SimpleUnion.foo("foo");
+        SimpleUnion sealedUnionFoo = SimpleUnion.foo("foo");
         // Validate that we are using the implementation with sealed classes.
-        assertThat(sealedUnionFoo).isInstanceOf(sealedunions.com.palantir.product.SimpleUnion.Foo.class);
+        assertThat(sealedUnionFoo).isInstanceOf(SimpleUnion.Foo.class);
         assertThat(SimpleUnion.foo("foo").toString()).isEqualTo(sealedUnionFoo.toString());
     }
 

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
@@ -28,6 +28,7 @@ import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.handlers.Cookie;
+import io.undertow.util.AttachmentKey;
 import io.undertow.util.HeaderValues;
 import java.security.cert.Certificate;
 import java.util.Collections;
@@ -79,6 +80,11 @@ final class ConjureContexts implements Contexts {
         @Override
         public Optional<String> firstHeader(String headerName) {
             return Optional.ofNullable(exchange.getRequestHeaders().getFirst(headerName));
+        }
+
+        @Override
+        public <T> Optional<T> attachment(AttachmentKey<T> attachmentKey) {
+            return Optional.ofNullable(exchange.getAttachment(attachmentKey));
         }
 
         @Override

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.Unsafe;
+import io.undertow.util.AttachmentKey;
 import java.security.cert.Certificate;
 import java.util.List;
 import java.util.Optional;
@@ -49,6 +50,12 @@ public interface RequestContext {
      * An {@link Optional#empty()} is returned if no such header exists.
      */
     Optional<String> firstHeader(String headerName);
+
+    /**
+     * Returns the attachment associated with the given {@code key}.
+     * An {@link Optional#empty()} is returned if no such attachment exists.
+     */
+    <T> Optional<T> attachment(AttachmentKey<T> key);
 
     /**
      * Returns the value of the cookie named {@code cookieName}.


### PR DESCRIPTION
## Before this PR

Adds an `attachment()` method to `RequestContext` to read `HttpServerExchange` attachments. This enables retrieving current request size from Witchcraft's `BytesReadHandler` in application code.

`RequestContext` is internal-only per its javadoc, so adding methods should be safe.


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add `RequestContext` method to read attachments.
==COMMIT_MSG==