### PR TITLE
Adds `bytesRead()` method to `RequestContext`

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,7 +1,0 @@
-acceptedBreaks:
-  "8.69.0":
-    com.palantir.conjure.java:conjure-undertow-lib:
-    - code: "java.method.addedToInterface"
-      new: "method long com.palantir.conjure.java.undertow.lib.RequestContext::bytesRead()"
-      justification: "Add bytesRead() method to RequestContext. RequestContext is\
-        \ only implemented by conjure-java-undertow-runtime per its documented contract."

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,0 +1,7 @@
+acceptedBreaks:
+  "8.69.0":
+    com.palantir.conjure.java:conjure-undertow-lib:
+    - code: "java.method.addedToInterface"
+      new: "method long com.palantir.conjure.java.undertow.lib.RequestContext::bytesRead()"
+      justification: "Add bytesRead() method to RequestContext. RequestContext is\
+        \ only implemented by conjure-java-undertow-runtime per its documented contract."

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Attachments.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/Attachments.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.undertow.runtime;
 import com.palantir.tokens.auth.UnverifiedJsonWebToken;
 import io.undertow.util.AttachmentKey;
 import java.util.Optional;
+import java.util.function.LongSupplier;
 
 public final class Attachments {
 
@@ -26,6 +27,8 @@ public final class Attachments {
             AttachmentKey.create(Optional.class);
 
     public static final AttachmentKey<Throwable> FAILURE = AttachmentKey.create(Throwable.class);
+
+    static final AttachmentKey<LongSupplier> BYTES_READ = AttachmentKey.create(LongSupplier.class);
 
     private Attachments() {}
 }

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/BytesReadTracker.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/BytesReadTracker.java
@@ -27,10 +27,10 @@ import org.xnio.conduits.StreamSourceConduit;
 /** Tracks the number of bytes read from HTTP requests. */
 final class BytesReadTracker {
     static final ConduitWrapper<StreamSourceConduit> REQUEST_WRAPPER = (factory, exchange) -> {
-        BytesReadAccumulator accumulator = new BytesReadAccumulator();
+        ReadDataAccumulator accumulator = new ReadDataAccumulator();
         Preconditions.checkState(
                 exchange.putAttachment(Attachments.BYTES_READ, accumulator) == null,
-                "Bytes read tracker has already been registered");
+                "BytesReadTracker already registered on this exchange");
         return new BytesReceivedStreamSourceConduit(factory.create(), accumulator);
     };
 
@@ -39,9 +39,11 @@ final class BytesReadTracker {
         return longSupplier == null ? 0L : longSupplier.getAsLong();
     }
 
-    /** Accumulates bytes read from the request and is attached to the exchange for retrieval. */
-    private static final class BytesReadAccumulator implements ByteActivityCallback, LongSupplier {
+    /** Accumulates bytes read from the request and is attached to the request context for retrieval. */
+    private static final class ReadDataAccumulator implements ByteActivityCallback, LongSupplier {
         private long bytesRead = 0;
+
+        private ReadDataAccumulator() {}
 
         @Override
         public void activity(long bytes) {

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/BytesReadTracker.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/BytesReadTracker.java
@@ -1,0 +1,58 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import com.palantir.logsafe.Preconditions;
+import io.undertow.conduits.ByteActivityCallback;
+import io.undertow.conduits.BytesReceivedStreamSourceConduit;
+import io.undertow.server.ConduitWrapper;
+import io.undertow.server.HttpServerExchange;
+import java.util.function.LongSupplier;
+import org.xnio.conduits.StreamSourceConduit;
+
+/** Tracks the number of bytes read from HTTP requests. */
+final class BytesReadTracker {
+    static final ConduitWrapper<StreamSourceConduit> REQUEST_WRAPPER = (factory, exchange) -> {
+        BytesReadAccumulator accumulator = new BytesReadAccumulator();
+        Preconditions.checkState(
+                exchange.putAttachment(Attachments.BYTES_READ, accumulator) == null,
+                "Bytes read tracker has already been registered");
+        return new BytesReceivedStreamSourceConduit(factory.create(), accumulator);
+    };
+
+    static long getBytesRead(HttpServerExchange exchange) {
+        LongSupplier longSupplier = exchange.getAttachment(Attachments.BYTES_READ);
+        return longSupplier == null ? 0L : longSupplier.getAsLong();
+    }
+
+    /** Accumulates bytes read from the request and is attached to the exchange for retrieval. */
+    private static final class BytesReadAccumulator implements ByteActivityCallback, LongSupplier {
+        private long bytesRead = 0;
+
+        @Override
+        public void activity(long bytes) {
+            bytesRead += bytes;
+        }
+
+        @Override
+        public long getAsLong() {
+            return bytesRead;
+        }
+    }
+
+    private BytesReadTracker() {}
+}

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
@@ -61,6 +61,13 @@ final class ConjureContexts implements Contexts {
         ConjureServerRequestContext(HttpServerExchange exchange, RequestArgHandler requestArgHandler) {
             this.exchange = exchange;
             this.requestArgHandler = requestArgHandler;
+
+            exchange.addRequestWrapper(BytesReadTracker.REQUEST_WRAPPER);
+        }
+
+        @Override
+        public long bytesRead() {
+            return BytesReadTracker.getBytesRead(exchange);
         }
 
         @Override

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
@@ -48,6 +48,7 @@ final class ConjureContexts implements Contexts {
 
     @Override
     public RequestContext createContext(HttpServerExchange exchange, Endpoint _endpoint) {
+        exchange.addRequestWrapper(BytesReadTracker.REQUEST_WRAPPER);
         return new ConjureServerRequestContext(exchange, requestArgHandler);
     }
 
@@ -61,8 +62,6 @@ final class ConjureContexts implements Contexts {
         ConjureServerRequestContext(HttpServerExchange exchange, RequestArgHandler requestArgHandler) {
             this.exchange = exchange;
             this.requestArgHandler = requestArgHandler;
-
-            exchange.addRequestWrapper(BytesReadTracker.REQUEST_WRAPPER);
         }
 
         @Override

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/BytesReadTrackerTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/BytesReadTrackerTest.java
@@ -1,0 +1,99 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.conjure.java.undertow.lib.RequestContext;
+import io.undertow.Undertow;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public final class BytesReadTrackerTest {
+    private static final int PORT = 12345;
+    private static final String HOST = "localhost";
+
+    private CompletableFuture<Long> bytesRead = new CompletableFuture<>();
+    private Undertow server;
+    private ConjureContexts contexts;
+
+    @BeforeEach
+    public void before() {
+        bytesRead = new CompletableFuture<>();
+        contexts = new ConjureContexts(DefaultRequestArgHandler.INSTANCE);
+        server = Undertow.builder()
+                .addHttpListener(PORT, HOST)
+                .setHandler(exchange -> {
+                    RequestContext context = contexts.createContext(exchange, null);
+                    exchange.getRequestReceiver().receiveFullBytes((_e, _b) -> {
+                        bytesRead.complete(context.bytesRead());
+                    });
+                })
+                .build();
+        server.start();
+    }
+
+    @AfterEach
+    public void after() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void testCountsBytesRead_none() throws Exception {
+        sendRequest(0);
+        assertThat(bytesRead.join()).isZero();
+    }
+
+    @Test
+    public void testCountsBytesRead_some() throws Exception {
+        int some = 1000;
+        sendRequest(some);
+        assertThat(bytesRead.join()).isEqualTo(some);
+    }
+
+    @Test
+    public void testCountsBytesRead_lots() throws Exception {
+        int lots = 1024 * 1024;
+        sendRequest(lots);
+        assertThat(bytesRead.join()).isEqualTo(lots);
+    }
+
+    private void sendRequest(int bodySize) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection)
+                URI.create("http://" + HOST + ":" + PORT).toURL().openConnection();
+        connection.setRequestMethod("POST");
+        connection.setDoOutput(true);
+
+        if (bodySize > 0) {
+            byte[] data = new byte[bodySize];
+            try (OutputStream os = connection.getOutputStream()) {
+                os.write(data);
+            }
+        }
+
+        connection.getResponseCode(); // trigger request
+        connection.disconnect();
+    }
+}

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/BytesReadTrackerTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/BytesReadTrackerTest.java
@@ -18,11 +18,13 @@ package com.palantir.conjure.java.undertow.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.Iterables;
 import com.palantir.conjure.java.undertow.lib.RequestContext;
 import io.undertow.Undertow;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.AfterEach;
@@ -30,11 +32,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public final class BytesReadTrackerTest {
-    private static final int PORT = 12345;
     private static final String HOST = "localhost";
 
     private CompletableFuture<Long> bytesRead = new CompletableFuture<>();
     private Undertow server;
+    private int port;
     private ConjureContexts contexts;
 
     @BeforeEach
@@ -42,15 +44,19 @@ public final class BytesReadTrackerTest {
         bytesRead = new CompletableFuture<>();
         contexts = new ConjureContexts(DefaultRequestArgHandler.INSTANCE);
         server = Undertow.builder()
-                .addHttpListener(PORT, HOST)
+                .addHttpListener(0, HOST)
                 .setHandler(exchange -> {
                     RequestContext context = contexts.createContext(exchange, null);
-                    exchange.getRequestReceiver().receiveFullBytes((_e, _b) -> {
+                    exchange.getRequestReceiver().receiveFullBytes((_exch, _bytes) -> {
                         bytesRead.complete(context.bytesRead());
                     });
                 })
                 .build();
         server.start();
+
+        port = ((InetSocketAddress)
+                        Iterables.getOnlyElement(server.getListenerInfo()).getAddress())
+                .getPort();
     }
 
     @AfterEach
@@ -82,7 +88,7 @@ public final class BytesReadTrackerTest {
 
     private void sendRequest(int bodySize) throws IOException {
         HttpURLConnection connection = (HttpURLConnection)
-                URI.create("http://" + HOST + ":" + PORT).toURL().openConnection();
+                URI.create("http://" + HOST + ":" + port).toURL().openConnection();
         connection.setRequestMethod("POST");
         connection.setDoOutput(true);
 
@@ -93,7 +99,7 @@ public final class BytesReadTrackerTest {
             }
         }
 
-        connection.getResponseCode(); // trigger request
+        connection.getResponseCode();
         connection.disconnect();
     }
 }

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
@@ -51,10 +51,11 @@ public interface RequestContext {
     Optional<String> firstHeader(String headerName);
 
     /**
-     * Returns the number of bytes read from the request.
-     * Returns 0 if no bytes have been read yet.
+     * Returns the number of bytes read from the request, or zero if byte tracking is unavailable.
      */
-    long bytesRead();
+    default long bytesRead() {
+        return 0L;
+    }
 
     /**
      * Returns the value of the cookie named {@code cookieName}.

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
@@ -52,7 +52,7 @@ public interface RequestContext {
 
     /**
      * Returns the number of bytes read from the request.
-     * Returns 0 if byte tracking has not been initialized.
+     * Returns 0 if no bytes have been read yet.
      */
     long bytesRead();
 

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
@@ -51,6 +51,12 @@ public interface RequestContext {
     Optional<String> firstHeader(String headerName);
 
     /**
+     * Returns the number of bytes read from the request.
+     * Returns 0 if byte tracking has not been initialized.
+     */
+    long bytesRead();
+
+    /**
      * Returns the value of the cookie named {@code cookieName}.
      * An {@link Optional#empty()} is returned if no such cookie exists.
      */


### PR DESCRIPTION
This change exposes `bytesRead()` on `RequestContext` for use in application code. The implementation tracks bytes at the I/O layer via an Undertow conduit wrapper, providing accurate measurements with minimal overhead.

The byte count is stored using the existing attachment mechanism, in line with how the existing `UNVERIFIED_JWT` and `FAILURE` attachments are used. For requests with empty bodies, Undertow may not create an input conduit, in which case `bytesRead()` returns 0.

This change is a better version of https://github.com/palantir/conjure-java/pull/2771 because it exposes significantly less API surface area.

## After this PR
==COMMIT_MSG==
Adds `bytesRead()` method to `RequestContext`
==COMMIT_MSG==
