### PR TITLE
Memoize safety evaluator

### DIFF
--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/SafetyEvaluator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/SafetyEvaluator.java
@@ -38,6 +38,7 @@ import com.palantir.conjure.spec.TypeDefinition;
 import com.palantir.conjure.spec.TypeName;
 import com.palantir.conjure.spec.UnionDefinition;
 import com.palantir.logsafe.Preconditions;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -64,6 +65,7 @@ public final class SafetyEvaluator {
     public static final Optional<LogSafety> UNKNOWN_UNION_VARINT_SAFETY = Optional.empty();
 
     private final Map<TypeName, TypeDefinition> definitionMap;
+    private final Map<TypeName, Optional<LogSafety>> cache = new HashMap<>();
 
     public SafetyEvaluator(ConjureDefinition definition) {
         this(TypeFunctions.toTypesMap(definition));
@@ -75,12 +77,12 @@ public final class SafetyEvaluator {
 
     public Optional<LogSafety> evaluate(TypeDefinition def) {
         return Preconditions.checkNotNull(def, "TypeDefinition is required")
-                .accept(new TypeDefinitionSafetyVisitor(definitionMap, new HashSet<>()));
+                .accept(new TypeDefinitionSafetyVisitor(definitionMap, cache, new HashSet<>()));
     }
 
     public Optional<LogSafety> evaluate(Type type) {
         return Preconditions.checkNotNull(type, "TypeDefinition is required")
-                .accept(new TypeDefinitionSafetyVisitor(definitionMap, new HashSet<>()).fieldVisitor);
+                .accept(new TypeDefinitionSafetyVisitor(definitionMap, cache, new HashSet<>()).fieldVisitor);
     }
 
     public Optional<LogSafety> evaluate(Type type, Optional<LogSafety> declaredSafety) {
@@ -124,10 +126,16 @@ public final class SafetyEvaluator {
     }
 
     private static final class TypeDefinitionSafetyVisitor implements TypeDefinition.Visitor<Optional<LogSafety>> {
+        private final Map<TypeName, Optional<LogSafety>> cache;
         private final Set<TypeName> inProgress;
         private final Type.Visitor<Optional<LogSafety>> fieldVisitor;
+        private boolean encounteredCycle;
 
-        private TypeDefinitionSafetyVisitor(Map<TypeName, TypeDefinition> definitionMap, Set<TypeName> inProgress) {
+        private TypeDefinitionSafetyVisitor(
+                Map<TypeName, TypeDefinition> definitionMap,
+                Map<TypeName, Optional<LogSafety>> cache,
+                Set<TypeName> inProgress) {
+            this.cache = cache;
             this.inProgress = inProgress;
             this.fieldVisitor = new FieldSafetyVisitor(definitionMap, this);
         }
@@ -170,14 +178,28 @@ public final class SafetyEvaluator {
         }
 
         private Optional<LogSafety> with(TypeName typeName, Supplier<Optional<LogSafety>> task) {
+            Optional<LogSafety> cached = cache.get(typeName);
+            if (cached != null) {
+                return cached;
+            }
             if (!inProgress.add(typeName)) {
                 // Given recursive evaluation, we return the least restrictive type: SAFE.
+                encounteredCycle = true;
                 return OPTIONAL_OF_SAFE;
             }
+            boolean previousCycleState = encounteredCycle;
+            encounteredCycle = false;
             Optional<LogSafety> result = task.get();
+            boolean subtreeHadCycle = encounteredCycle;
+            encounteredCycle = previousCycleState || subtreeHadCycle;
             if (!inProgress.remove(typeName)) {
                 throw new IllegalStateException(
                         "Failed to remove " + typeName + " from in-progress, something is very wrong!");
+            }
+            // Only cache results where no cycle was encountered in the subtree,
+            // since cycle-breaking may produce different results depending on evaluation order.
+            if (!subtreeHadCycle) {
+                cache.put(typeName, result);
             }
             return result;
         }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/SafetyEvaluator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/SafetyEvaluator.java
@@ -184,26 +184,39 @@ public final class SafetyEvaluator {
         }
 
         private Optional<LogSafety> with(TypeName typeName, Supplier<Optional<LogSafety>> task) {
+            // Return memoized result if this type has already been fully evaluated.
+            // Note: cache values are Optional<LogSafety> which may be Optional.empty(),
+            // so we check for null (absent key) rather than emptiness.
             Optional<LogSafety> cached = cache.get(typeName);
             if (cached != null) {
                 return cached;
             }
             if (!inProgress.add(typeName)) {
                 // Given recursive evaluation, we return the least restrictive type: SAFE.
+                // Mark that this subtree's result depends on cycle-breaking.
                 encounteredCycle = true;
                 return OPTIONAL_OF_SAFE;
             }
+
+            // Save and reset cycle state so we can detect cycles within this type's subtree only.
             boolean previousCycleState = encounteredCycle;
             encounteredCycle = false;
+
             Optional<LogSafety> result = task.get();
+
             boolean subtreeHadCycle = encounteredCycle;
+            // Propagate cycle detection upward: if this subtree had a cycle, callers should know.
             encounteredCycle = previousCycleState || subtreeHadCycle;
+
             if (!inProgress.remove(typeName)) {
                 throw new IllegalStateException(
                         "Failed to remove " + typeName + " from in-progress, something is very wrong!");
             }
-            // Only cache results where no cycle was encountered in the subtree,
-            // since cycle-breaking may produce different results depending on evaluation order.
+
+            // Only cache results where no cycle was encountered in the subtree.
+            // When a cycle is broken with the SAFE heuristic, the result depends on which type
+            // was the entry point, so caching it would produce incorrect results if the same
+            // type is later evaluated from a different starting point.
             if (!subtreeHadCycle) {
                 cache.put(typeName, result);
             }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/SafetyEvaluator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/SafetyEvaluator.java
@@ -65,6 +65,9 @@ public final class SafetyEvaluator {
     public static final Optional<LogSafety> UNKNOWN_UNION_VARINT_SAFETY = Optional.empty();
 
     private final Map<TypeName, TypeDefinition> definitionMap;
+
+    // Memoization cache shared across all evaluate() calls on this instance. Avoids redundant recursive
+    // traversals of the type graph, which otherwise dominate generation time for large definitions.
     private final Map<TypeName, Optional<LogSafety>> cache = new HashMap<>();
 
     public SafetyEvaluator(ConjureDefinition definition) {
@@ -129,6 +132,9 @@ public final class SafetyEvaluator {
         private final Map<TypeName, Optional<LogSafety>> cache;
         private final Set<TypeName> inProgress;
         private final Type.Visitor<Optional<LogSafety>> fieldVisitor;
+
+        // Tracks whether cycle-breaking (the SAFE fallback for back-edges) was used anywhere
+        // in the current evaluation subtree. Used to decide whether a result is safe to cache.
         private boolean encounteredCycle;
 
         private TypeDefinitionSafetyVisitor(

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/SafetyEvaluatorTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/SafetyEvaluatorTest.java
@@ -366,6 +366,130 @@ class SafetyEvaluatorTest {
                 .hasValue(LogSafety.SAFE);
     }
 
+    @Test
+    void testCyclicTypes_bothSafe() {
+        // Foo has a field referencing Bar, Bar has a field referencing Foo.
+        // Both fields are marked safe, so both types should evaluate as safe.
+        TypeDefinition foo = TypeDefinition.object(ObjectDefinition.builder()
+                .typeName(FOO)
+                .fields(FieldDefinition.builder()
+                        .fieldName(FieldName.of("bar"))
+                        .type(Type.reference(BAR))
+                        .build())
+                .build());
+        TypeDefinition bar = TypeDefinition.object(ObjectDefinition.builder()
+                .typeName(BAR)
+                .fields(FieldDefinition.builder()
+                        .fieldName(FieldName.of("foo"))
+                        .type(Type.reference(FOO))
+                        .build())
+                .build());
+        ConjureDefinition conjureDef = ConjureDefinition.builder()
+                .version(1)
+                .types(foo)
+                .types(bar)
+                .build();
+        SafetyEvaluator evaluator = new SafetyEvaluator(conjureDef);
+        // Evaluation order should not matter for the result
+        assertThat(evaluator.evaluate(foo)).hasValue(LogSafety.SAFE);
+        assertThat(evaluator.evaluate(bar)).hasValue(LogSafety.SAFE);
+    }
+
+    @Test
+    void testCyclicTypes_withUnsafeField() {
+        // Foo references Bar, Bar references Foo and also has an unsafe string field.
+        // The unsafe field should propagate through the cycle.
+        TypeDefinition foo = TypeDefinition.object(ObjectDefinition.builder()
+                .typeName(FOO)
+                .fields(FieldDefinition.builder()
+                        .fieldName(FieldName.of("bar"))
+                        .type(Type.reference(BAR))
+                        .build())
+                .build());
+        TypeDefinition bar = TypeDefinition.object(ObjectDefinition.builder()
+                .typeName(BAR)
+                .fields(FieldDefinition.builder()
+                        .fieldName(FieldName.of("foo"))
+                        .type(Type.reference(FOO))
+                        .build())
+                .fields(FieldDefinition.builder()
+                        .fieldName(FieldName.of("unsafeField"))
+                        .type(Type.primitive(PrimitiveType.STRING))
+                        .safety(LogSafety.UNSAFE)
+                        .build())
+                .build());
+        ConjureDefinition conjureDef = ConjureDefinition.builder()
+                .version(1)
+                .types(foo)
+                .types(bar)
+                .build();
+        SafetyEvaluator evaluator = new SafetyEvaluator(conjureDef);
+        assertThat(evaluator.evaluate(bar)).hasValue(LogSafety.UNSAFE);
+        assertThat(evaluator.evaluate(foo)).hasValue(LogSafety.UNSAFE);
+    }
+
+    @Test
+    void testCyclicTypes_evaluationOrderIndependent() {
+        // Verifies that the cache does not cause different results depending on which
+        // type in a cycle is evaluated first.
+        TypeDefinition foo = TypeDefinition.object(ObjectDefinition.builder()
+                .typeName(FOO)
+                .fields(FieldDefinition.builder()
+                        .fieldName(FieldName.of("bar"))
+                        .type(Type.reference(BAR))
+                        .build())
+                .fields(FieldDefinition.builder()
+                        .fieldName(FieldName.of("unsafeField"))
+                        .type(Type.primitive(PrimitiveType.STRING))
+                        .safety(LogSafety.UNSAFE)
+                        .build())
+                .build());
+        TypeDefinition bar = TypeDefinition.object(ObjectDefinition.builder()
+                .typeName(BAR)
+                .fields(FieldDefinition.builder()
+                        .fieldName(FieldName.of("foo"))
+                        .type(Type.reference(FOO))
+                        .build())
+                .build());
+        ConjureDefinition conjureDef = ConjureDefinition.builder()
+                .version(1)
+                .types(foo)
+                .types(bar)
+                .build();
+
+        // Evaluate foo first, then bar
+        SafetyEvaluator evaluator1 = new SafetyEvaluator(conjureDef);
+        Optional<LogSafety> fooFirst = evaluator1.evaluate(foo);
+        Optional<LogSafety> barAfterFoo = evaluator1.evaluate(bar);
+
+        // Evaluate bar first, then foo
+        SafetyEvaluator evaluator2 = new SafetyEvaluator(conjureDef);
+        Optional<LogSafety> barFirst = evaluator2.evaluate(bar);
+        Optional<LogSafety> fooAfterBar = evaluator2.evaluate(foo);
+
+        // Results should be identical regardless of evaluation order
+        assertThat(fooFirst).isEqualTo(fooAfterBar);
+        assertThat(barAfterFoo).isEqualTo(barFirst);
+    }
+
+    @Test
+    void testSelfReferentialType() {
+        // A type that references itself (e.g. a linked list node)
+        TypeDefinition node = TypeDefinition.object(ObjectDefinition.builder()
+                .typeName(FOO)
+                .fields(FieldDefinition.builder()
+                        .fieldName(FieldName.of("next"))
+                        .type(Type.reference(FOO))
+                        .build())
+                .build());
+        ConjureDefinition conjureDef = ConjureDefinition.builder()
+                .version(1)
+                .types(node)
+                .build();
+        SafetyEvaluator evaluator = new SafetyEvaluator(conjureDef);
+        assertThat(evaluator.evaluate(node)).hasValue(LogSafety.SAFE);
+    }
+
     private static Stream<Arguments> getTypes(Type externalReference) {
         TypeDefinition objectType = TypeDefinition.object(ObjectDefinition.builder()
                 .typeName(FOO)

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/SafetyEvaluatorTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/SafetyEvaluatorTest.java
@@ -384,11 +384,8 @@ class SafetyEvaluatorTest {
                         .type(Type.reference(FOO))
                         .build())
                 .build());
-        ConjureDefinition conjureDef = ConjureDefinition.builder()
-                .version(1)
-                .types(foo)
-                .types(bar)
-                .build();
+        ConjureDefinition conjureDef =
+                ConjureDefinition.builder().version(1).types(foo).types(bar).build();
         SafetyEvaluator evaluator = new SafetyEvaluator(conjureDef);
         // Evaluation order should not matter for the result
         assertThat(evaluator.evaluate(foo)).hasValue(LogSafety.SAFE);
@@ -418,11 +415,8 @@ class SafetyEvaluatorTest {
                         .safety(LogSafety.UNSAFE)
                         .build())
                 .build());
-        ConjureDefinition conjureDef = ConjureDefinition.builder()
-                .version(1)
-                .types(foo)
-                .types(bar)
-                .build();
+        ConjureDefinition conjureDef =
+                ConjureDefinition.builder().version(1).types(foo).types(bar).build();
         SafetyEvaluator evaluator = new SafetyEvaluator(conjureDef);
         assertThat(evaluator.evaluate(bar)).hasValue(LogSafety.UNSAFE);
         assertThat(evaluator.evaluate(foo)).hasValue(LogSafety.UNSAFE);
@@ -451,11 +445,8 @@ class SafetyEvaluatorTest {
                         .type(Type.reference(FOO))
                         .build())
                 .build());
-        ConjureDefinition conjureDef = ConjureDefinition.builder()
-                .version(1)
-                .types(foo)
-                .types(bar)
-                .build();
+        ConjureDefinition conjureDef =
+                ConjureDefinition.builder().version(1).types(foo).types(bar).build();
 
         // Evaluate foo first, then bar
         SafetyEvaluator evaluator1 = new SafetyEvaluator(conjureDef);
@@ -482,10 +473,8 @@ class SafetyEvaluatorTest {
                         .type(Type.reference(FOO))
                         .build())
                 .build());
-        ConjureDefinition conjureDef = ConjureDefinition.builder()
-                .version(1)
-                .types(node)
-                .build();
+        ConjureDefinition conjureDef =
+                ConjureDefinition.builder().version(1).types(node).build();
         SafetyEvaluator evaluator = new SafetyEvaluator(conjureDef);
         assertThat(evaluator.evaluate(node)).hasValue(LogSafety.SAFE);
     }


### PR DESCRIPTION
## Memoize SafetyEvaluator type traversals

### Summary
- `SafetyEvaluator` now caches computed safety results per type, avoiding redundant recursive traversals of the type graph
- Results are only cached when no cycle was encountered during evaluation, preserving correctness for mutually-recursive type definitions

### Motivation

JFR profiling of `compileConjureObjects` on a large IR (~4600 types) showed that **74% of CPU time** was spent in `SafetyEvaluator`, with the top frames being `TypeDefinitionSafetyVisitor.with()` and `SafetyEvaluator.combine()`. Each call to `evaluate()` created a fresh visitor and re-traversed the entire reachable type graph from scratch. Since many types reference the same shared types, this resulted in massive redundant work — effectively O(n * m) where n is the number of types and m is the average reachable subgraph size.

### What changed

A `HashMap<TypeName, Optional<LogSafety>>` cache is shared across all evaluations on a `SafetyEvaluator` instance. Before traversing a type's subgraph, `with()` checks the cache and returns immediately on a hit. After evaluation, the result is cached — but only if no cycle-breaking occurred in the subtree, since the cycle-breaking heuristic (assume `SAFE`) produces results that depend on evaluation order and should not be persisted.

### Impact

Tested against a production IR with ~4600 types: `compileConjureObjects` dropped from **42s to 20s** in Gradle.

### Test plan
- [x] All existing conjure-java-core tests pass
- [x] Generated output verified identical to baseline against a production IR with ~4600 types

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Memoize safety evaluator
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

