### PR TITLE
Don't chain `.exception` calls when constructing exception deserializers

### DIFF
--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceAsync.java
@@ -112,42 +112,42 @@ public interface ErrorServiceAsync {
                     .optionalInputStreamDeserializer(
                             createExceptionDeserializerArgs(new TypeMarker<Optional<InputStream>>() {}));
 
-            private <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
-                return ExceptionDeserializerArgs.<T>builder()
-                        .returnType(returnType)
-                        .exception(
-                                endpointerrors.com.palantir.another.EndpointSpecificErrors.DIFFERENT_PACKAGE.name(),
-                                new TypeMarker<
-                                        endpointerrors.com.palantir.another.EndpointSpecificErrors
-                                                .DifferentPackageSerializableError>() {},
-                                new TypeMarker<
-                                        endpointerrors.com.palantir.another.EndpointSpecificErrors
-                                                .DifferentPackageException>() {})
-                        .exception(
-                                TestErrors.COMPLICATED_PARAMETERS.name(),
-                                new TypeMarker<TestErrors.ComplicatedParametersSerializableError>() {},
-                                new TypeMarker<TestErrors.ComplicatedParametersException>() {})
-                        .exception(
-                                ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG_ERR.name(),
-                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgErrSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgErrException>() {})
-                        .exception(
-                                EndpointSpecificTwoErrors.DIFFERENT_NAMESPACE.name(),
-                                new TypeMarker<EndpointSpecificTwoErrors.DifferentNamespaceSerializableError>() {},
-                                new TypeMarker<EndpointSpecificTwoErrors.DifferentNamespaceException>() {})
-                        .exception(
-                                EndpointSpecificErrors.ENDPOINT_ERROR.name(),
-                                new TypeMarker<EndpointSpecificErrors.EndpointErrorSerializableError>() {},
-                                new TypeMarker<EndpointSpecificErrors.EndpointErrorException>() {})
-                        .exception(
-                                TestErrors.INVALID_ARGUMENT.name(),
-                                new TypeMarker<TestErrors.InvalidArgumentSerializableError>() {},
-                                new TypeMarker<TestErrors.InvalidArgumentException>() {})
-                        .exception(
-                                TestErrors.NOT_FOUND.name(),
-                                new TypeMarker<TestErrors.NotFoundSerializableError>() {},
-                                new TypeMarker<TestErrors.NotFoundException>() {})
-                        .build();
+            private static <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
+                ExceptionDeserializerArgs.Builder<T> builder =
+                        ExceptionDeserializerArgs.<T>builder().returnType(returnType);
+                builder.exception(
+                        endpointerrors.com.palantir.another.EndpointSpecificErrors.DIFFERENT_PACKAGE.name(),
+                        new TypeMarker<
+                                endpointerrors.com.palantir.another.EndpointSpecificErrors
+                                        .DifferentPackageSerializableError>() {},
+                        new TypeMarker<
+                                endpointerrors.com.palantir.another.EndpointSpecificErrors
+                                        .DifferentPackageException>() {});
+                builder.exception(
+                        TestErrors.COMPLICATED_PARAMETERS.name(),
+                        new TypeMarker<TestErrors.ComplicatedParametersSerializableError>() {},
+                        new TypeMarker<TestErrors.ComplicatedParametersException>() {});
+                builder.exception(
+                        ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG_ERR.name(),
+                        new TypeMarker<ConjureErrors.ConflictingCauseSafeArgErrSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ConflictingCauseSafeArgErrException>() {});
+                builder.exception(
+                        EndpointSpecificTwoErrors.DIFFERENT_NAMESPACE.name(),
+                        new TypeMarker<EndpointSpecificTwoErrors.DifferentNamespaceSerializableError>() {},
+                        new TypeMarker<EndpointSpecificTwoErrors.DifferentNamespaceException>() {});
+                builder.exception(
+                        EndpointSpecificErrors.ENDPOINT_ERROR.name(),
+                        new TypeMarker<EndpointSpecificErrors.EndpointErrorSerializableError>() {},
+                        new TypeMarker<EndpointSpecificErrors.EndpointErrorException>() {});
+                builder.exception(
+                        TestErrors.INVALID_ARGUMENT.name(),
+                        new TypeMarker<TestErrors.InvalidArgumentSerializableError>() {},
+                        new TypeMarker<TestErrors.InvalidArgumentException>() {});
+                builder.exception(
+                        TestErrors.NOT_FOUND.name(),
+                        new TypeMarker<TestErrors.NotFoundSerializableError>() {},
+                        new TypeMarker<TestErrors.NotFoundException>() {});
+                return builder.build();
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceBlocking.java
@@ -113,42 +113,42 @@ public interface ErrorServiceBlocking {
                     .optionalInputStreamDeserializer(
                             createExceptionDeserializerArgs(new TypeMarker<Optional<InputStream>>() {}));
 
-            private <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
-                return ExceptionDeserializerArgs.<T>builder()
-                        .returnType(returnType)
-                        .exception(
-                                endpointerrors.com.palantir.another.EndpointSpecificErrors.DIFFERENT_PACKAGE.name(),
-                                new TypeMarker<
-                                        endpointerrors.com.palantir.another.EndpointSpecificErrors
-                                                .DifferentPackageSerializableError>() {},
-                                new TypeMarker<
-                                        endpointerrors.com.palantir.another.EndpointSpecificErrors
-                                                .DifferentPackageException>() {})
-                        .exception(
-                                TestErrors.COMPLICATED_PARAMETERS.name(),
-                                new TypeMarker<TestErrors.ComplicatedParametersSerializableError>() {},
-                                new TypeMarker<TestErrors.ComplicatedParametersException>() {})
-                        .exception(
-                                ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG_ERR.name(),
-                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgErrSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgErrException>() {})
-                        .exception(
-                                EndpointSpecificTwoErrors.DIFFERENT_NAMESPACE.name(),
-                                new TypeMarker<EndpointSpecificTwoErrors.DifferentNamespaceSerializableError>() {},
-                                new TypeMarker<EndpointSpecificTwoErrors.DifferentNamespaceException>() {})
-                        .exception(
-                                EndpointSpecificErrors.ENDPOINT_ERROR.name(),
-                                new TypeMarker<EndpointSpecificErrors.EndpointErrorSerializableError>() {},
-                                new TypeMarker<EndpointSpecificErrors.EndpointErrorException>() {})
-                        .exception(
-                                TestErrors.INVALID_ARGUMENT.name(),
-                                new TypeMarker<TestErrors.InvalidArgumentSerializableError>() {},
-                                new TypeMarker<TestErrors.InvalidArgumentException>() {})
-                        .exception(
-                                TestErrors.NOT_FOUND.name(),
-                                new TypeMarker<TestErrors.NotFoundSerializableError>() {},
-                                new TypeMarker<TestErrors.NotFoundException>() {})
-                        .build();
+            private static <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
+                ExceptionDeserializerArgs.Builder<T> builder =
+                        ExceptionDeserializerArgs.<T>builder().returnType(returnType);
+                builder.exception(
+                        endpointerrors.com.palantir.another.EndpointSpecificErrors.DIFFERENT_PACKAGE.name(),
+                        new TypeMarker<
+                                endpointerrors.com.palantir.another.EndpointSpecificErrors
+                                        .DifferentPackageSerializableError>() {},
+                        new TypeMarker<
+                                endpointerrors.com.palantir.another.EndpointSpecificErrors
+                                        .DifferentPackageException>() {});
+                builder.exception(
+                        TestErrors.COMPLICATED_PARAMETERS.name(),
+                        new TypeMarker<TestErrors.ComplicatedParametersSerializableError>() {},
+                        new TypeMarker<TestErrors.ComplicatedParametersException>() {});
+                builder.exception(
+                        ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG_ERR.name(),
+                        new TypeMarker<ConjureErrors.ConflictingCauseSafeArgErrSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ConflictingCauseSafeArgErrException>() {});
+                builder.exception(
+                        EndpointSpecificTwoErrors.DIFFERENT_NAMESPACE.name(),
+                        new TypeMarker<EndpointSpecificTwoErrors.DifferentNamespaceSerializableError>() {},
+                        new TypeMarker<EndpointSpecificTwoErrors.DifferentNamespaceException>() {});
+                builder.exception(
+                        EndpointSpecificErrors.ENDPOINT_ERROR.name(),
+                        new TypeMarker<EndpointSpecificErrors.EndpointErrorSerializableError>() {},
+                        new TypeMarker<EndpointSpecificErrors.EndpointErrorException>() {});
+                builder.exception(
+                        TestErrors.INVALID_ARGUMENT.name(),
+                        new TypeMarker<TestErrors.InvalidArgumentSerializableError>() {},
+                        new TypeMarker<TestErrors.InvalidArgumentException>() {});
+                builder.exception(
+                        TestErrors.NOT_FOUND.name(),
+                        new TypeMarker<TestErrors.NotFoundSerializableError>() {},
+                        new TypeMarker<TestErrors.NotFoundException>() {});
+                return builder.build();
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EmptyPathServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EmptyPathServiceAsync.java
@@ -37,44 +37,43 @@ public interface EmptyPathServiceAsync {
             private final Deserializer<Boolean> emptyPathDeserializer =
                     _runtime.bodySerDe().deserializer(createExceptionDeserializerArgs(new TypeMarker<Boolean>() {}));
 
-            private <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
-                return ExceptionDeserializerArgs.<T>builder()
-                        .returnType(returnType)
-                        .exception(
+            private static <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
+                ExceptionDeserializerArgs.Builder<T> builder =
+                        ExceptionDeserializerArgs.<T>builder().returnType(returnType);
+                builder.exception(
+                        exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors.DIFFERENT_PACKAGE_ERROR
+                                .name(),
+                        new TypeMarker<
                                 exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
-                                        .DIFFERENT_PACKAGE_ERROR
-                                        .name(),
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
-                                                .DifferentPackageErrorSerializableError>() {},
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
-                                                .DifferentPackageErrorException>() {})
-                        .exception(
-                                ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG.name(),
-                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgException>() {})
-                        .exception(
-                                ConjureErrors.CONFLICTING_CAUSE_UNSAFE_ARG.name(),
-                                new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgException>() {})
-                        .exception(
-                                ConjureErrors.ERROR_WITH_COMPLEX_ARGS.name(),
-                                new TypeMarker<ConjureErrors.ErrorWithComplexArgsSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ErrorWithComplexArgsException>() {})
-                        .exception(
-                                ConjureErrors.INVALID_SERVICE_DEFINITION.name(),
-                                new TypeMarker<ConjureErrors.InvalidServiceDefinitionSerializableError>() {},
-                                new TypeMarker<ConjureErrors.InvalidServiceDefinitionException>() {})
-                        .exception(
-                                ConjureErrors.INVALID_TYPE_DEFINITION.name(),
-                                new TypeMarker<ConjureErrors.InvalidTypeDefinitionSerializableError>() {},
-                                new TypeMarker<ConjureErrors.InvalidTypeDefinitionException>() {})
-                        .exception(
-                                ConjureJavaErrors.JAVA_COMPILATION_FAILED.name(),
-                                new TypeMarker<ConjureJavaErrors.JavaCompilationFailedSerializableError>() {},
-                                new TypeMarker<ConjureJavaErrors.JavaCompilationFailedException>() {})
-                        .build();
+                                        .DifferentPackageErrorSerializableError>() {},
+                        new TypeMarker<
+                                exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
+                                        .DifferentPackageErrorException>() {});
+                builder.exception(
+                        ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG.name(),
+                        new TypeMarker<ConjureErrors.ConflictingCauseSafeArgSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ConflictingCauseSafeArgException>() {});
+                builder.exception(
+                        ConjureErrors.CONFLICTING_CAUSE_UNSAFE_ARG.name(),
+                        new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgException>() {});
+                builder.exception(
+                        ConjureErrors.ERROR_WITH_COMPLEX_ARGS.name(),
+                        new TypeMarker<ConjureErrors.ErrorWithComplexArgsSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ErrorWithComplexArgsException>() {});
+                builder.exception(
+                        ConjureErrors.INVALID_SERVICE_DEFINITION.name(),
+                        new TypeMarker<ConjureErrors.InvalidServiceDefinitionSerializableError>() {},
+                        new TypeMarker<ConjureErrors.InvalidServiceDefinitionException>() {});
+                builder.exception(
+                        ConjureErrors.INVALID_TYPE_DEFINITION.name(),
+                        new TypeMarker<ConjureErrors.InvalidTypeDefinitionSerializableError>() {},
+                        new TypeMarker<ConjureErrors.InvalidTypeDefinitionException>() {});
+                builder.exception(
+                        ConjureJavaErrors.JAVA_COMPILATION_FAILED.name(),
+                        new TypeMarker<ConjureJavaErrors.JavaCompilationFailedSerializableError>() {},
+                        new TypeMarker<ConjureJavaErrors.JavaCompilationFailedException>() {});
+                return builder.build();
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EmptyPathServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EmptyPathServiceBlocking.java
@@ -36,44 +36,43 @@ public interface EmptyPathServiceBlocking {
             private final Deserializer<Boolean> emptyPathDeserializer =
                     _runtime.bodySerDe().deserializer(createExceptionDeserializerArgs(new TypeMarker<Boolean>() {}));
 
-            private <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
-                return ExceptionDeserializerArgs.<T>builder()
-                        .returnType(returnType)
-                        .exception(
+            private static <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
+                ExceptionDeserializerArgs.Builder<T> builder =
+                        ExceptionDeserializerArgs.<T>builder().returnType(returnType);
+                builder.exception(
+                        exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors.DIFFERENT_PACKAGE_ERROR
+                                .name(),
+                        new TypeMarker<
                                 exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
-                                        .DIFFERENT_PACKAGE_ERROR
-                                        .name(),
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
-                                                .DifferentPackageErrorSerializableError>() {},
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
-                                                .DifferentPackageErrorException>() {})
-                        .exception(
-                                ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG.name(),
-                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgException>() {})
-                        .exception(
-                                ConjureErrors.CONFLICTING_CAUSE_UNSAFE_ARG.name(),
-                                new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgException>() {})
-                        .exception(
-                                ConjureErrors.ERROR_WITH_COMPLEX_ARGS.name(),
-                                new TypeMarker<ConjureErrors.ErrorWithComplexArgsSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ErrorWithComplexArgsException>() {})
-                        .exception(
-                                ConjureErrors.INVALID_SERVICE_DEFINITION.name(),
-                                new TypeMarker<ConjureErrors.InvalidServiceDefinitionSerializableError>() {},
-                                new TypeMarker<ConjureErrors.InvalidServiceDefinitionException>() {})
-                        .exception(
-                                ConjureErrors.INVALID_TYPE_DEFINITION.name(),
-                                new TypeMarker<ConjureErrors.InvalidTypeDefinitionSerializableError>() {},
-                                new TypeMarker<ConjureErrors.InvalidTypeDefinitionException>() {})
-                        .exception(
-                                ConjureJavaErrors.JAVA_COMPILATION_FAILED.name(),
-                                new TypeMarker<ConjureJavaErrors.JavaCompilationFailedSerializableError>() {},
-                                new TypeMarker<ConjureJavaErrors.JavaCompilationFailedException>() {})
-                        .build();
+                                        .DifferentPackageErrorSerializableError>() {},
+                        new TypeMarker<
+                                exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
+                                        .DifferentPackageErrorException>() {});
+                builder.exception(
+                        ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG.name(),
+                        new TypeMarker<ConjureErrors.ConflictingCauseSafeArgSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ConflictingCauseSafeArgException>() {});
+                builder.exception(
+                        ConjureErrors.CONFLICTING_CAUSE_UNSAFE_ARG.name(),
+                        new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgException>() {});
+                builder.exception(
+                        ConjureErrors.ERROR_WITH_COMPLEX_ARGS.name(),
+                        new TypeMarker<ConjureErrors.ErrorWithComplexArgsSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ErrorWithComplexArgsException>() {});
+                builder.exception(
+                        ConjureErrors.INVALID_SERVICE_DEFINITION.name(),
+                        new TypeMarker<ConjureErrors.InvalidServiceDefinitionSerializableError>() {},
+                        new TypeMarker<ConjureErrors.InvalidServiceDefinitionException>() {});
+                builder.exception(
+                        ConjureErrors.INVALID_TYPE_DEFINITION.name(),
+                        new TypeMarker<ConjureErrors.InvalidTypeDefinitionSerializableError>() {},
+                        new TypeMarker<ConjureErrors.InvalidTypeDefinitionException>() {});
+                builder.exception(
+                        ConjureJavaErrors.JAVA_COMPILATION_FAILED.name(),
+                        new TypeMarker<ConjureJavaErrors.JavaCompilationFailedSerializableError>() {},
+                        new TypeMarker<ConjureJavaErrors.JavaCompilationFailedException>() {});
+                return builder.build();
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteBinaryServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteBinaryServiceAsync.java
@@ -98,44 +98,43 @@ public interface EteBinaryServiceAsync {
                     .optionalInputStreamDeserializer(
                             createExceptionDeserializerArgs(new TypeMarker<Optional<InputStream>>() {}));
 
-            private <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
-                return ExceptionDeserializerArgs.<T>builder()
-                        .returnType(returnType)
-                        .exception(
+            private static <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
+                ExceptionDeserializerArgs.Builder<T> builder =
+                        ExceptionDeserializerArgs.<T>builder().returnType(returnType);
+                builder.exception(
+                        exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors.DIFFERENT_PACKAGE_ERROR
+                                .name(),
+                        new TypeMarker<
                                 exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
-                                        .DIFFERENT_PACKAGE_ERROR
-                                        .name(),
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
-                                                .DifferentPackageErrorSerializableError>() {},
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
-                                                .DifferentPackageErrorException>() {})
-                        .exception(
-                                ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG.name(),
-                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgException>() {})
-                        .exception(
-                                ConjureErrors.CONFLICTING_CAUSE_UNSAFE_ARG.name(),
-                                new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgException>() {})
-                        .exception(
-                                ConjureErrors.ERROR_WITH_COMPLEX_ARGS.name(),
-                                new TypeMarker<ConjureErrors.ErrorWithComplexArgsSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ErrorWithComplexArgsException>() {})
-                        .exception(
-                                ConjureErrors.INVALID_SERVICE_DEFINITION.name(),
-                                new TypeMarker<ConjureErrors.InvalidServiceDefinitionSerializableError>() {},
-                                new TypeMarker<ConjureErrors.InvalidServiceDefinitionException>() {})
-                        .exception(
-                                ConjureErrors.INVALID_TYPE_DEFINITION.name(),
-                                new TypeMarker<ConjureErrors.InvalidTypeDefinitionSerializableError>() {},
-                                new TypeMarker<ConjureErrors.InvalidTypeDefinitionException>() {})
-                        .exception(
-                                ConjureJavaErrors.JAVA_COMPILATION_FAILED.name(),
-                                new TypeMarker<ConjureJavaErrors.JavaCompilationFailedSerializableError>() {},
-                                new TypeMarker<ConjureJavaErrors.JavaCompilationFailedException>() {})
-                        .build();
+                                        .DifferentPackageErrorSerializableError>() {},
+                        new TypeMarker<
+                                exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
+                                        .DifferentPackageErrorException>() {});
+                builder.exception(
+                        ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG.name(),
+                        new TypeMarker<ConjureErrors.ConflictingCauseSafeArgSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ConflictingCauseSafeArgException>() {});
+                builder.exception(
+                        ConjureErrors.CONFLICTING_CAUSE_UNSAFE_ARG.name(),
+                        new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgException>() {});
+                builder.exception(
+                        ConjureErrors.ERROR_WITH_COMPLEX_ARGS.name(),
+                        new TypeMarker<ConjureErrors.ErrorWithComplexArgsSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ErrorWithComplexArgsException>() {});
+                builder.exception(
+                        ConjureErrors.INVALID_SERVICE_DEFINITION.name(),
+                        new TypeMarker<ConjureErrors.InvalidServiceDefinitionSerializableError>() {},
+                        new TypeMarker<ConjureErrors.InvalidServiceDefinitionException>() {});
+                builder.exception(
+                        ConjureErrors.INVALID_TYPE_DEFINITION.name(),
+                        new TypeMarker<ConjureErrors.InvalidTypeDefinitionSerializableError>() {},
+                        new TypeMarker<ConjureErrors.InvalidTypeDefinitionException>() {});
+                builder.exception(
+                        ConjureJavaErrors.JAVA_COMPILATION_FAILED.name(),
+                        new TypeMarker<ConjureJavaErrors.JavaCompilationFailedSerializableError>() {},
+                        new TypeMarker<ConjureJavaErrors.JavaCompilationFailedException>() {});
+                return builder.build();
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteBinaryServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteBinaryServiceBlocking.java
@@ -101,44 +101,43 @@ public interface EteBinaryServiceBlocking {
                     .optionalInputStreamDeserializer(
                             createExceptionDeserializerArgs(new TypeMarker<Optional<InputStream>>() {}));
 
-            private <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
-                return ExceptionDeserializerArgs.<T>builder()
-                        .returnType(returnType)
-                        .exception(
+            private static <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
+                ExceptionDeserializerArgs.Builder<T> builder =
+                        ExceptionDeserializerArgs.<T>builder().returnType(returnType);
+                builder.exception(
+                        exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors.DIFFERENT_PACKAGE_ERROR
+                                .name(),
+                        new TypeMarker<
                                 exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
-                                        .DIFFERENT_PACKAGE_ERROR
-                                        .name(),
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
-                                                .DifferentPackageErrorSerializableError>() {},
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
-                                                .DifferentPackageErrorException>() {})
-                        .exception(
-                                ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG.name(),
-                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgException>() {})
-                        .exception(
-                                ConjureErrors.CONFLICTING_CAUSE_UNSAFE_ARG.name(),
-                                new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgException>() {})
-                        .exception(
-                                ConjureErrors.ERROR_WITH_COMPLEX_ARGS.name(),
-                                new TypeMarker<ConjureErrors.ErrorWithComplexArgsSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ErrorWithComplexArgsException>() {})
-                        .exception(
-                                ConjureErrors.INVALID_SERVICE_DEFINITION.name(),
-                                new TypeMarker<ConjureErrors.InvalidServiceDefinitionSerializableError>() {},
-                                new TypeMarker<ConjureErrors.InvalidServiceDefinitionException>() {})
-                        .exception(
-                                ConjureErrors.INVALID_TYPE_DEFINITION.name(),
-                                new TypeMarker<ConjureErrors.InvalidTypeDefinitionSerializableError>() {},
-                                new TypeMarker<ConjureErrors.InvalidTypeDefinitionException>() {})
-                        .exception(
-                                ConjureJavaErrors.JAVA_COMPILATION_FAILED.name(),
-                                new TypeMarker<ConjureJavaErrors.JavaCompilationFailedSerializableError>() {},
-                                new TypeMarker<ConjureJavaErrors.JavaCompilationFailedException>() {})
-                        .build();
+                                        .DifferentPackageErrorSerializableError>() {},
+                        new TypeMarker<
+                                exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
+                                        .DifferentPackageErrorException>() {});
+                builder.exception(
+                        ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG.name(),
+                        new TypeMarker<ConjureErrors.ConflictingCauseSafeArgSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ConflictingCauseSafeArgException>() {});
+                builder.exception(
+                        ConjureErrors.CONFLICTING_CAUSE_UNSAFE_ARG.name(),
+                        new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgException>() {});
+                builder.exception(
+                        ConjureErrors.ERROR_WITH_COMPLEX_ARGS.name(),
+                        new TypeMarker<ConjureErrors.ErrorWithComplexArgsSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ErrorWithComplexArgsException>() {});
+                builder.exception(
+                        ConjureErrors.INVALID_SERVICE_DEFINITION.name(),
+                        new TypeMarker<ConjureErrors.InvalidServiceDefinitionSerializableError>() {},
+                        new TypeMarker<ConjureErrors.InvalidServiceDefinitionException>() {});
+                builder.exception(
+                        ConjureErrors.INVALID_TYPE_DEFINITION.name(),
+                        new TypeMarker<ConjureErrors.InvalidTypeDefinitionSerializableError>() {},
+                        new TypeMarker<ConjureErrors.InvalidTypeDefinitionException>() {});
+                builder.exception(
+                        ConjureJavaErrors.JAVA_COMPILATION_FAILED.name(),
+                        new TypeMarker<ConjureJavaErrors.JavaCompilationFailedSerializableError>() {},
+                        new TypeMarker<ConjureJavaErrors.JavaCompilationFailedException>() {});
+                return builder.build();
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteServiceAsync.java
@@ -452,44 +452,43 @@ public interface EteServiceAsync {
             private final Deserializer<SimpleUnion> unionDeserializer = _runtime.bodySerDe()
                     .deserializer(createExceptionDeserializerArgs(new TypeMarker<SimpleUnion>() {}));
 
-            private <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
-                return ExceptionDeserializerArgs.<T>builder()
-                        .returnType(returnType)
-                        .exception(
+            private static <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
+                ExceptionDeserializerArgs.Builder<T> builder =
+                        ExceptionDeserializerArgs.<T>builder().returnType(returnType);
+                builder.exception(
+                        exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors.DIFFERENT_PACKAGE_ERROR
+                                .name(),
+                        new TypeMarker<
                                 exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
-                                        .DIFFERENT_PACKAGE_ERROR
-                                        .name(),
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
-                                                .DifferentPackageErrorSerializableError>() {},
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
-                                                .DifferentPackageErrorException>() {})
-                        .exception(
-                                ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG.name(),
-                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgException>() {})
-                        .exception(
-                                ConjureErrors.CONFLICTING_CAUSE_UNSAFE_ARG.name(),
-                                new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgException>() {})
-                        .exception(
-                                ConjureErrors.ERROR_WITH_COMPLEX_ARGS.name(),
-                                new TypeMarker<ConjureErrors.ErrorWithComplexArgsSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ErrorWithComplexArgsException>() {})
-                        .exception(
-                                ConjureErrors.INVALID_SERVICE_DEFINITION.name(),
-                                new TypeMarker<ConjureErrors.InvalidServiceDefinitionSerializableError>() {},
-                                new TypeMarker<ConjureErrors.InvalidServiceDefinitionException>() {})
-                        .exception(
-                                ConjureErrors.INVALID_TYPE_DEFINITION.name(),
-                                new TypeMarker<ConjureErrors.InvalidTypeDefinitionSerializableError>() {},
-                                new TypeMarker<ConjureErrors.InvalidTypeDefinitionException>() {})
-                        .exception(
-                                ConjureJavaErrors.JAVA_COMPILATION_FAILED.name(),
-                                new TypeMarker<ConjureJavaErrors.JavaCompilationFailedSerializableError>() {},
-                                new TypeMarker<ConjureJavaErrors.JavaCompilationFailedException>() {})
-                        .build();
+                                        .DifferentPackageErrorSerializableError>() {},
+                        new TypeMarker<
+                                exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
+                                        .DifferentPackageErrorException>() {});
+                builder.exception(
+                        ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG.name(),
+                        new TypeMarker<ConjureErrors.ConflictingCauseSafeArgSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ConflictingCauseSafeArgException>() {});
+                builder.exception(
+                        ConjureErrors.CONFLICTING_CAUSE_UNSAFE_ARG.name(),
+                        new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgException>() {});
+                builder.exception(
+                        ConjureErrors.ERROR_WITH_COMPLEX_ARGS.name(),
+                        new TypeMarker<ConjureErrors.ErrorWithComplexArgsSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ErrorWithComplexArgsException>() {});
+                builder.exception(
+                        ConjureErrors.INVALID_SERVICE_DEFINITION.name(),
+                        new TypeMarker<ConjureErrors.InvalidServiceDefinitionSerializableError>() {},
+                        new TypeMarker<ConjureErrors.InvalidServiceDefinitionException>() {});
+                builder.exception(
+                        ConjureErrors.INVALID_TYPE_DEFINITION.name(),
+                        new TypeMarker<ConjureErrors.InvalidTypeDefinitionSerializableError>() {},
+                        new TypeMarker<ConjureErrors.InvalidTypeDefinitionException>() {});
+                builder.exception(
+                        ConjureJavaErrors.JAVA_COMPILATION_FAILED.name(),
+                        new TypeMarker<ConjureJavaErrors.JavaCompilationFailedSerializableError>() {},
+                        new TypeMarker<ConjureJavaErrors.JavaCompilationFailedException>() {});
+                return builder.build();
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteServiceBlocking.java
@@ -451,44 +451,43 @@ public interface EteServiceBlocking {
             private final Deserializer<SimpleUnion> unionDeserializer = _runtime.bodySerDe()
                     .deserializer(createExceptionDeserializerArgs(new TypeMarker<SimpleUnion>() {}));
 
-            private <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
-                return ExceptionDeserializerArgs.<T>builder()
-                        .returnType(returnType)
-                        .exception(
+            private static <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
+                ExceptionDeserializerArgs.Builder<T> builder =
+                        ExceptionDeserializerArgs.<T>builder().returnType(returnType);
+                builder.exception(
+                        exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors.DIFFERENT_PACKAGE_ERROR
+                                .name(),
+                        new TypeMarker<
                                 exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
-                                        .DIFFERENT_PACKAGE_ERROR
-                                        .name(),
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
-                                                .DifferentPackageErrorSerializableError>() {},
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
-                                                .DifferentPackageErrorException>() {})
-                        .exception(
-                                ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG.name(),
-                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ConflictingCauseSafeArgException>() {})
-                        .exception(
-                                ConjureErrors.CONFLICTING_CAUSE_UNSAFE_ARG.name(),
-                                new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgException>() {})
-                        .exception(
-                                ConjureErrors.ERROR_WITH_COMPLEX_ARGS.name(),
-                                new TypeMarker<ConjureErrors.ErrorWithComplexArgsSerializableError>() {},
-                                new TypeMarker<ConjureErrors.ErrorWithComplexArgsException>() {})
-                        .exception(
-                                ConjureErrors.INVALID_SERVICE_DEFINITION.name(),
-                                new TypeMarker<ConjureErrors.InvalidServiceDefinitionSerializableError>() {},
-                                new TypeMarker<ConjureErrors.InvalidServiceDefinitionException>() {})
-                        .exception(
-                                ConjureErrors.INVALID_TYPE_DEFINITION.name(),
-                                new TypeMarker<ConjureErrors.InvalidTypeDefinitionSerializableError>() {},
-                                new TypeMarker<ConjureErrors.InvalidTypeDefinitionException>() {})
-                        .exception(
-                                ConjureJavaErrors.JAVA_COMPILATION_FAILED.name(),
-                                new TypeMarker<ConjureJavaErrors.JavaCompilationFailedSerializableError>() {},
-                                new TypeMarker<ConjureJavaErrors.JavaCompilationFailedException>() {})
-                        .build();
+                                        .DifferentPackageErrorSerializableError>() {},
+                        new TypeMarker<
+                                exceptionthrowingdialogueinterfaces.com.palantir.another.ConjureErrors
+                                        .DifferentPackageErrorException>() {});
+                builder.exception(
+                        ConjureErrors.CONFLICTING_CAUSE_SAFE_ARG.name(),
+                        new TypeMarker<ConjureErrors.ConflictingCauseSafeArgSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ConflictingCauseSafeArgException>() {});
+                builder.exception(
+                        ConjureErrors.CONFLICTING_CAUSE_UNSAFE_ARG.name(),
+                        new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ConflictingCauseUnsafeArgException>() {});
+                builder.exception(
+                        ConjureErrors.ERROR_WITH_COMPLEX_ARGS.name(),
+                        new TypeMarker<ConjureErrors.ErrorWithComplexArgsSerializableError>() {},
+                        new TypeMarker<ConjureErrors.ErrorWithComplexArgsException>() {});
+                builder.exception(
+                        ConjureErrors.INVALID_SERVICE_DEFINITION.name(),
+                        new TypeMarker<ConjureErrors.InvalidServiceDefinitionSerializableError>() {},
+                        new TypeMarker<ConjureErrors.InvalidServiceDefinitionException>() {});
+                builder.exception(
+                        ConjureErrors.INVALID_TYPE_DEFINITION.name(),
+                        new TypeMarker<ConjureErrors.InvalidTypeDefinitionSerializableError>() {},
+                        new TypeMarker<ConjureErrors.InvalidTypeDefinitionException>() {});
+                builder.exception(
+                        ConjureJavaErrors.JAVA_COMPILATION_FAILED.name(),
+                        new TypeMarker<ConjureJavaErrors.JavaCompilationFailedSerializableError>() {},
+                        new TypeMarker<ConjureJavaErrors.JavaCompilationFailedException>() {});
+                return builder.build();
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/test/api/CookieServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/test/api/CookieServiceAsync.java
@@ -40,68 +40,66 @@ public interface CookieServiceAsync {
             private final Deserializer<Void> eatCookiesDeserializer = _runtime.bodySerDe()
                     .emptyBodyDeserializer(createExceptionDeserializerArgs(new TypeMarker<Void>() {}));
 
-            private <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
-                return ExceptionDeserializerArgs.<T>builder()
-                        .returnType(returnType)
-                        .exception(
-                                ConjureErrors.DIFFERENT_PACKAGE_ERROR.name(),
-                                new TypeMarker<ConjureErrors.DifferentPackageErrorSerializableError>() {},
-                                new TypeMarker<ConjureErrors.DifferentPackageErrorException>() {})
-                        .exception(
+            private static <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
+                ExceptionDeserializerArgs.Builder<T> builder =
+                        ExceptionDeserializerArgs.<T>builder().returnType(returnType);
+                builder.exception(
+                        ConjureErrors.DIFFERENT_PACKAGE_ERROR.name(),
+                        new TypeMarker<ConjureErrors.DifferentPackageErrorSerializableError>() {},
+                        new TypeMarker<ConjureErrors.DifferentPackageErrorException>() {});
+                builder.exception(
+                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
+                                .CONFLICTING_CAUSE_SAFE_ARG
+                                .name(),
+                        new TypeMarker<
                                 exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                        .CONFLICTING_CAUSE_SAFE_ARG
-                                        .name(),
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .ConflictingCauseSafeArgSerializableError>() {},
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .ConflictingCauseSafeArgException>() {})
-                        .exception(
+                                        .ConflictingCauseSafeArgSerializableError>() {},
+                        new TypeMarker<
                                 exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                        .CONFLICTING_CAUSE_UNSAFE_ARG
-                                        .name(),
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .ConflictingCauseUnsafeArgSerializableError>() {},
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .ConflictingCauseUnsafeArgException>() {})
-                        .exception(
+                                        .ConflictingCauseSafeArgException>() {});
+                builder.exception(
+                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
+                                .CONFLICTING_CAUSE_UNSAFE_ARG
+                                .name(),
+                        new TypeMarker<
                                 exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                        .ERROR_WITH_COMPLEX_ARGS
-                                        .name(),
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .ErrorWithComplexArgsSerializableError>() {},
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .ErrorWithComplexArgsException>() {})
-                        .exception(
+                                        .ConflictingCauseUnsafeArgSerializableError>() {},
+                        new TypeMarker<
                                 exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                        .INVALID_SERVICE_DEFINITION
-                                        .name(),
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .InvalidServiceDefinitionSerializableError>() {},
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .InvalidServiceDefinitionException>() {})
-                        .exception(
+                                        .ConflictingCauseUnsafeArgException>() {});
+                builder.exception(
+                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors.ERROR_WITH_COMPLEX_ARGS
+                                .name(),
+                        new TypeMarker<
                                 exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                        .INVALID_TYPE_DEFINITION
-                                        .name(),
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .InvalidTypeDefinitionSerializableError>() {},
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .InvalidTypeDefinitionException>() {})
-                        .exception(
-                                ConjureJavaErrors.JAVA_COMPILATION_FAILED.name(),
-                                new TypeMarker<ConjureJavaErrors.JavaCompilationFailedSerializableError>() {},
-                                new TypeMarker<ConjureJavaErrors.JavaCompilationFailedException>() {})
-                        .build();
+                                        .ErrorWithComplexArgsSerializableError>() {},
+                        new TypeMarker<
+                                exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
+                                        .ErrorWithComplexArgsException>() {});
+                builder.exception(
+                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
+                                .INVALID_SERVICE_DEFINITION
+                                .name(),
+                        new TypeMarker<
+                                exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
+                                        .InvalidServiceDefinitionSerializableError>() {},
+                        new TypeMarker<
+                                exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
+                                        .InvalidServiceDefinitionException>() {});
+                builder.exception(
+                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors.INVALID_TYPE_DEFINITION
+                                .name(),
+                        new TypeMarker<
+                                exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
+                                        .InvalidTypeDefinitionSerializableError>() {},
+                        new TypeMarker<
+                                exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
+                                        .InvalidTypeDefinitionException>() {});
+                builder.exception(
+                        ConjureJavaErrors.JAVA_COMPILATION_FAILED.name(),
+                        new TypeMarker<ConjureJavaErrors.JavaCompilationFailedSerializableError>() {},
+                        new TypeMarker<ConjureJavaErrors.JavaCompilationFailedException>() {});
+                return builder.build();
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/test/api/CookieServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/test/api/CookieServiceBlocking.java
@@ -39,68 +39,66 @@ public interface CookieServiceBlocking {
             private final Deserializer<Void> eatCookiesDeserializer = _runtime.bodySerDe()
                     .emptyBodyDeserializer(createExceptionDeserializerArgs(new TypeMarker<Void>() {}));
 
-            private <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
-                return ExceptionDeserializerArgs.<T>builder()
-                        .returnType(returnType)
-                        .exception(
-                                ConjureErrors.DIFFERENT_PACKAGE_ERROR.name(),
-                                new TypeMarker<ConjureErrors.DifferentPackageErrorSerializableError>() {},
-                                new TypeMarker<ConjureErrors.DifferentPackageErrorException>() {})
-                        .exception(
+            private static <T> ExceptionDeserializerArgs<T> createExceptionDeserializerArgs(TypeMarker<T> returnType) {
+                ExceptionDeserializerArgs.Builder<T> builder =
+                        ExceptionDeserializerArgs.<T>builder().returnType(returnType);
+                builder.exception(
+                        ConjureErrors.DIFFERENT_PACKAGE_ERROR.name(),
+                        new TypeMarker<ConjureErrors.DifferentPackageErrorSerializableError>() {},
+                        new TypeMarker<ConjureErrors.DifferentPackageErrorException>() {});
+                builder.exception(
+                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
+                                .CONFLICTING_CAUSE_SAFE_ARG
+                                .name(),
+                        new TypeMarker<
                                 exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                        .CONFLICTING_CAUSE_SAFE_ARG
-                                        .name(),
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .ConflictingCauseSafeArgSerializableError>() {},
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .ConflictingCauseSafeArgException>() {})
-                        .exception(
+                                        .ConflictingCauseSafeArgSerializableError>() {},
+                        new TypeMarker<
                                 exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                        .CONFLICTING_CAUSE_UNSAFE_ARG
-                                        .name(),
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .ConflictingCauseUnsafeArgSerializableError>() {},
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .ConflictingCauseUnsafeArgException>() {})
-                        .exception(
+                                        .ConflictingCauseSafeArgException>() {});
+                builder.exception(
+                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
+                                .CONFLICTING_CAUSE_UNSAFE_ARG
+                                .name(),
+                        new TypeMarker<
                                 exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                        .ERROR_WITH_COMPLEX_ARGS
-                                        .name(),
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .ErrorWithComplexArgsSerializableError>() {},
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .ErrorWithComplexArgsException>() {})
-                        .exception(
+                                        .ConflictingCauseUnsafeArgSerializableError>() {},
+                        new TypeMarker<
                                 exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                        .INVALID_SERVICE_DEFINITION
-                                        .name(),
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .InvalidServiceDefinitionSerializableError>() {},
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .InvalidServiceDefinitionException>() {})
-                        .exception(
+                                        .ConflictingCauseUnsafeArgException>() {});
+                builder.exception(
+                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors.ERROR_WITH_COMPLEX_ARGS
+                                .name(),
+                        new TypeMarker<
                                 exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                        .INVALID_TYPE_DEFINITION
-                                        .name(),
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .InvalidTypeDefinitionSerializableError>() {},
-                                new TypeMarker<
-                                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
-                                                .InvalidTypeDefinitionException>() {})
-                        .exception(
-                                ConjureJavaErrors.JAVA_COMPILATION_FAILED.name(),
-                                new TypeMarker<ConjureJavaErrors.JavaCompilationFailedSerializableError>() {},
-                                new TypeMarker<ConjureJavaErrors.JavaCompilationFailedException>() {})
-                        .build();
+                                        .ErrorWithComplexArgsSerializableError>() {},
+                        new TypeMarker<
+                                exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
+                                        .ErrorWithComplexArgsException>() {});
+                builder.exception(
+                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
+                                .INVALID_SERVICE_DEFINITION
+                                .name(),
+                        new TypeMarker<
+                                exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
+                                        .InvalidServiceDefinitionSerializableError>() {},
+                        new TypeMarker<
+                                exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
+                                        .InvalidServiceDefinitionException>() {});
+                builder.exception(
+                        exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors.INVALID_TYPE_DEFINITION
+                                .name(),
+                        new TypeMarker<
+                                exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
+                                        .InvalidTypeDefinitionSerializableError>() {},
+                        new TypeMarker<
+                                exceptionthrowingdialogueinterfaces.com.palantir.product.ConjureErrors
+                                        .InvalidTypeDefinitionException>() {});
+                builder.exception(
+                        ConjureJavaErrors.JAVA_COMPILATION_FAILED.name(),
+                        new TypeMarker<ConjureJavaErrors.JavaCompilationFailedSerializableError>() {},
+                        new TypeMarker<ConjureJavaErrors.JavaCompilationFailedException>() {});
+                return builder.build();
             }
 
             @Override

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DefaultStaticFactoryMethodGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DefaultStaticFactoryMethodGenerator.java
@@ -148,6 +148,10 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
                 name);
     }
 
+    /**
+     * This method intentionally generates code where each call to the builder is not chained but a separate method call
+     * and assignment. Having many chained method calls causes the Java compiler stack to overflow.
+     */
     private MethodSpec createHelperToConstructExceptionDeserializerArgs() {
         TypeVariableName typeVariableT = TypeVariableName.get("T");
         ParameterizedTypeName builderType =

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DefaultStaticFactoryMethodGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DefaultStaticFactoryMethodGenerator.java
@@ -150,16 +150,20 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
 
     private MethodSpec createHelperToConstructExceptionDeserializerArgs() {
         TypeVariableName typeVariableT = TypeVariableName.get("T");
+        ParameterizedTypeName builderType =
+                ParameterizedTypeName.get(ClassName.get(ExceptionDeserializerArgs.Builder.class), typeVariableT);
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("createExceptionDeserializerArgs")
                 .addTypeVariable(typeVariableT)
-                .addModifiers(Modifier.PRIVATE)
+                .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
                 .returns(ParameterizedTypeName.get(ClassName.get(ExceptionDeserializerArgs.class), typeVariableT))
                 .addParameter(ParameterizedTypeName.get(ClassName.get(TypeMarker.class), typeVariableT), "returnType");
 
-        CodeBlock.Builder exceptions = CodeBlock.builder()
-                .add("return $T.<$T>builder()", ExceptionDeserializerArgs.class, typeVariableT)
-                .add(".returnType(returnType)");
-        // Add exceptions from error definitions
+        CodeBlock.Builder code = CodeBlock.builder()
+                .addStatement(
+                        "$T builder = $T.<$T>builder().returnType(returnType)",
+                        builderType,
+                        ExceptionDeserializerArgs.class,
+                        typeVariableT);
         for (ErrorDefinition errorDef : errorDefinitions) {
             String errorName = errorDef.getErrorName().getName();
             ClassName errorClass = getClassNameInErrorsPackage(
@@ -168,16 +172,16 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
                     getClassNameInErrorsPackage(errorDef, ErrorGenerationUtils.serializableErrorClassName(errorName));
             ClassName exceptionClass =
                     getClassNameInErrorsPackage(errorDef, ErrorGenerationUtils.errorExceptionClassName(errorName));
-            exceptions.add(
-                    ".exception($T.name(), new $T<$T>() {}, new $T<$T>() {})",
+            code.addStatement(
+                    "builder.exception($T.name(), new $T<$T>() {}, new $T<$T>() {})",
                     errorClass,
                     TypeMarker.class,
                     serializableErrorClass,
                     TypeMarker.class,
                     exceptionClass);
         }
-        exceptions.add(".build();");
-        return methodBuilder.addCode(exceptions.build()).build();
+        code.addStatement("return builder.build()");
+        return methodBuilder.addCode(code.build()).build();
     }
 
     private ClassName getClassName(ServiceDefinition def) {


### PR DESCRIPTION
## Before this PR

When the `generateErrorParameterFormatRespectingDialogueInterfaces` is set, generated Dialogue interfaces are able to deserialize errors as exceptions. Currently, the exception deserializer is constructed as a single builder call, chaining a call to `.exception` for each error. 

https://github.com/palantir/conjure-java/blob/8ed34f38d374a747501b74e789476b5cf8a865aa/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteServiceBlocking.java#L454-L492

Some Conjure definitions have thousands of errors, leading to thousands of chained calls to `.exception`. This can cause the Java compiler stack to overflow: [1](https://issues.apache.org/jira/browse/MCOMPILER-325), [2](https://bugs.openjdk.org/browse/JDK-8177933?focusedId=14066535&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14066535)

## After this PR
==COMMIT_MSG==
Don't chain .exception calls when constructing exception deserializers
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

