### PR TITLE
Set MAX_ENTITY_SIZE to -1 in `UndertowServiceEteTest`

### DIFF
--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/UndertowServiceEteTest.java
@@ -119,6 +119,7 @@ public final class UndertowServiceEteTest extends TestBase {
 
         server = Undertow.builder()
                 .setServerOption(UndertowOptions.DECODE_URL, false)
+                .setServerOption(UndertowOptions.MAX_ENTITY_SIZE, -1L)
                 .addHttpListener(0, "0.0.0.0")
                 .setHandler(Handlers.path().addPrefixPath("/test-example/api", handler))
                 .build();


### PR DESCRIPTION
## Before this PR
https://github.com/palantir/conjure-java/pull/2870 is failing `testBinaryServerSideFailureAfterFewBytesReceived` with a `Network transport failure` due to a broken pipe. This test actually tries to send a lot of bytes, and is breaking due to https://github.com/undertow-io/undertow/commit/ca61570b2685ea8d547ada07943cd92374aaf21d.

This would also prevent us from bumping Undertow to recent 2.3.x versions, which we are looking to do soon-ish

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Set MAX_ENTITY_SIZE to -1 in `UndertowServiceEteTest`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

