### PR TITLE
Update example in conjure-undertow-annotations

### DIFF
--- a/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/SafeLoggableParams.java
+++ b/conjure-undertow-processor/src/test/java/com/palantir/conjure/java/undertow/processor/sample/SafeLoggableParams.java
@@ -63,6 +63,6 @@ public interface SafeLoggableParams {
             @Safe @Handle.QueryParam("context") String context,
             RequestContext requestContext);
 
-    @Handle(method = HttpMethod.GET, path = "/safeLoggingBody")
+    @Handle(method = HttpMethod.POST, path = "/safeLoggingBody")
     String bodyParam(@Safe @Handle.Body String body);
 }

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/SafeLoggableParamsEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/SafeLoggableParamsEndpoints.java.generated
@@ -456,7 +456,7 @@ public final class SafeLoggableParamsEndpoints implements UndertowService {
 
         @Override
         public HttpString method() {
-            return Methods.GET;
+            return Methods.POST;
         }
 
         @Override


### PR DESCRIPTION
## Before this PR
According to RFC 7231:

> A payload within a GET request message has no defined semantics;
sending a payload body on a GET request might cause some existing implementations to reject the request.

We shouldn't have an example GET request with a body.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Update example in conjure-undertow-annotations
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

