### PR TITLE
ConjureAuthorizationExtractor: exceptions thrown by a custom JsonWebTokenHandler are not thrown as `Conjure:MalformedCredentials`

### DIFF
--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureAuthorizationExtractor.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureAuthorizationExtractor.java
@@ -90,11 +90,13 @@ final class ConjureAuthorizationExtractor implements AuthorizationExtractor {
         if (cookie == null) {
             throw new ServiceException(MISSING_CREDENTIAL_ERROR_TYPE);
         }
+        BearerToken token;
         try {
-            return setState(exchange, plainSerDe.deserializeBearerToken(cookie.getValue()));
+            token = plainSerDe.deserializeBearerToken(cookie.getValue());
         } catch (RuntimeException e) {
             throw new ServiceException(MALFORMED_CREDENTIAL_ERROR_TYPE, e);
         }
+        return setState(exchange, token);
     }
 
     @Override

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/AuthTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/AuthTest.java
@@ -30,6 +30,7 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.server.handlers.CookieImpl;
 import io.undertow.util.Headers;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
 public final class AuthTest {
@@ -155,6 +156,26 @@ public final class AuthTest {
 
         assertThatServiceExceptionThrownBy(() -> runtime.auth().cookie(exchange, cookieName))
                 .hasType(error);
+    }
+
+    @Test
+    public void testMalformedCookieStillReportedWhenHandlerWouldThrow() {
+        ErrorType handlerError = ErrorType.create(ErrorType.Code.INTERNAL, "Foo:Bar");
+        AtomicBoolean handlerFired = new AtomicBoolean();
+        UndertowRuntime runtime = ConjureUndertowRuntime.builder()
+                .jsonWebTokenHandler((_exchange, _token) -> {
+                    handlerFired.set(true);
+                    throw new ServiceException(handlerError);
+                })
+                .build();
+
+        String cookieName = "Auth-Token";
+        HttpServerExchange exchange = HttpServerExchanges.createStub();
+        exchange.setRequestCookie(new CookieImpl(cookieName, ""));
+
+        assertThatServiceExceptionThrownBy(() -> runtime.auth().cookie(exchange, cookieName))
+                .hasType(ErrorType.create(ErrorType.Code.UNAUTHORIZED, "Conjure:MalformedCredentials"));
+        assertThat(handlerFired).isFalse();
     }
 
     private static final class TestJsonWebTokenHandler implements JsonWebTokenHandler {

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/AuthTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/AuthTest.java
@@ -140,6 +140,23 @@ public final class AuthTest {
                 .hasType(error);
     }
 
+    @Test
+    public void testJsonWebHandlerThrowsWhenAuthCookieSet() {
+        ErrorType error = ErrorType.create(ErrorType.Code.INTERNAL, "Foo:Bar");
+        UndertowRuntime runtime = ConjureUndertowRuntime.builder()
+                .jsonWebTokenHandler((_exchange, _token) -> {
+                    throw new ServiceException(error);
+                })
+                .build();
+
+        String cookieName = "Auth-Token";
+        HttpServerExchange exchange = HttpServerExchanges.createStub();
+        exchange.setRequestCookie(new CookieImpl(cookieName, "token"));
+
+        assertThatServiceExceptionThrownBy(() -> runtime.auth().cookie(exchange, cookieName))
+                .hasType(error);
+    }
+
     private static final class TestJsonWebTokenHandler implements JsonWebTokenHandler {
         private boolean fired = false;
 


### PR DESCRIPTION
## Before this PR

In `ConjureAuthorizationExtractor#cookie`, `setState` is called inside the try block that wraps `BearerToken` deserialization:

setState eventually calls the server-supplied `JsonWebTokenHandler#handle`, which can throw. This makes 401s from custom handlers misleading because they're not `Conjure:MalformedCredentials`.

The header path already behaves correctly (it calls setState outside any try/catch).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
ConjureAuthorizationExtractor: exceptions thrown by a custom JsonWebTokenHandler are not thrown as `Conjure:MalformedCredentials`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

