### PR TITLE
Disable `DangerousToStringDoNotLog` error prone check for integration tests

### DIFF
--- a/conjure-java-core/build.gradle
+++ b/conjure-java-core/build.gradle
@@ -32,6 +32,7 @@ tasks.checkstyleIntegrationInput.enabled = false
 tasks.named('compileIntegrationInputJava', JavaCompile) {
     options.errorprone.disable 'IncubatingMethod'
     options.errorprone.disable 'DeprecatedApiUsage'
+    options.errorprone.disable 'DangerousToStringDoNotLog'
 }
 
 dependencies {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Currently, `toString` methods for objects that contain fields annotated `DoNotLog` will include the `DoNotLog` fields. We will generate new `toString` methods that omit these fields but this will be rolled out with a flag - so the errorprone check will still catch test cases where the flag is disabled. We should disable this check so that we are able to upgrade baseline-error-prone in this repo (e.g. [this is a blocked PR](https://github.com/palantir/conjure-java/pull/2868))

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Disable `DangerousToStringDoNotLog` error prone check for integration tests
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

