### PR TITLE
Add RequestContext method to get source address

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,0 +1,6 @@
+acceptedBreaks:
+  "8.78.0":
+    com.palantir.conjure.java:conjure-undertow-lib:
+    - code: "java.method.addedToInterface"
+      new: "method java.net.InetSocketAddress com.palantir.conjure.java.undertow.lib.RequestContext::sourceAddress()"
+      justification: "Added method to interface that should not have external implementations"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -2,5 +2,5 @@ acceptedBreaks:
   "8.78.0":
     com.palantir.conjure.java:conjure-undertow-lib:
     - code: "java.method.addedToInterface"
-      new: "method java.net.InetSocketAddress com.palantir.conjure.java.undertow.lib.RequestContext::sourceAddress()"
+      new: "method java.util.Optional<java.net.SocketAddress> com.palantir.conjure.java.undertow.lib.RequestContext::peerAddress()"
       justification: "Added method to interface that should not have external implementations"

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
@@ -29,6 +29,7 @@ import com.palantir.logsafe.logger.SafeLoggerFactory;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.handlers.Cookie;
 import io.undertow.util.HeaderValues;
+import java.net.InetSocketAddress;
 import java.security.cert.Certificate;
 import java.util.Collections;
 import java.util.Deque;
@@ -109,6 +110,11 @@ final class ConjureContexts implements Contexts {
         @Override
         public void requestArg(Arg<?> arg) {
             requestArgHandler.arg(exchange, arg);
+        }
+
+        @Override
+        public InetSocketAddress sourceAddress() {
+            return exchange.getSourceAddress();
         }
 
         @Override

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
@@ -29,7 +29,7 @@ import com.palantir.logsafe.logger.SafeLoggerFactory;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.handlers.Cookie;
 import io.undertow.util.HeaderValues;
-import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.security.cert.Certificate;
 import java.util.Collections;
 import java.util.Deque;
@@ -113,8 +113,8 @@ final class ConjureContexts implements Contexts {
         }
 
         @Override
-        public InetSocketAddress sourceAddress() {
-            return exchange.getSourceAddress();
+        public Optional<SocketAddress> peerAddress() {
+            return Optional.ofNullable(exchange.getConnection().getPeerAddress());
         }
 
         @Override

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.Unsafe;
+import java.net.InetSocketAddress;
 import java.security.cert.Certificate;
 import java.util.List;
 import java.util.Optional;
@@ -66,6 +67,8 @@ public interface RequestContext {
      * Implementations may choose to include this data in the request log.
      */
     void requestArg(Arg<?> arg);
+
+    InetSocketAddress sourceAddress();
 
     /**
      * Returns the client certificates associated with the connection used to make the current request.

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/RequestContext.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.Unsafe;
-import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.security.cert.Certificate;
 import java.util.List;
 import java.util.Optional;
@@ -68,7 +68,10 @@ public interface RequestContext {
      */
     void requestArg(Arg<?> arg);
 
-    InetSocketAddress sourceAddress();
+    /**
+     * Returns the socket address associated with the connection used to make the current request.
+     */
+    Optional<SocketAddress> peerAddress();
 
     /**
      * Returns the client certificates associated with the connection used to make the current request.


### PR DESCRIPTION
There are a number of existing use cases for wanting to know the source address of a request. For example, to include in audit logs.

Today we use `HttpServerExchange` directly for these code paths, but it would be nice to be able to use the read-only `ReqeustContext` instead. This information feels aligned with the purpose of `RequestContext` (to provide read-only information about a request) and seems reasonable to include here.