### PR TITLE
Add a handler for including standard endpoint request args

### DIFF
--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureContexts.java
@@ -28,6 +28,7 @@ import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.handlers.Cookie;
+import io.undertow.util.AttachmentKey;
 import io.undertow.util.HeaderValues;
 import java.net.SocketAddress;
 import java.security.cert.Certificate;
@@ -41,6 +42,9 @@ import javax.net.ssl.SSLSession;
 
 final class ConjureContexts implements Contexts {
     private static final SafeLogger log = SafeLoggerFactory.get(ConjureContexts.class);
+
+    private static final AttachmentKey<RequestContext> ATTACHMENT = AttachmentKey.create(RequestContext.class);
+
     private final RequestArgHandler requestArgHandler;
 
     ConjureContexts(RequestArgHandler requestArgHandler) {
@@ -49,7 +53,12 @@ final class ConjureContexts implements Contexts {
 
     @Override
     public RequestContext createContext(HttpServerExchange exchange, Endpoint _endpoint) {
-        return new ConjureServerRequestContext(exchange, requestArgHandler);
+        RequestContext context = exchange.getAttachment(ATTACHMENT);
+        if (context == null) {
+            context = new ConjureServerRequestContext(exchange, requestArgHandler);
+            exchange.putAttachment(ATTACHMENT, context);
+        }
+        return context;
     }
 
     private static final class ConjureServerRequestContext implements RequestContext {

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureHandler.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/ConjureHandler.java
@@ -240,6 +240,7 @@ public final class ConjureHandler implements HttpHandler {
                             // to provide user and trace information on exceptions.
                             endpoint -> Optional.of(new LoggingContextHandler(endpoint.handler())),
                             endpoint -> Optional.of(new TracedStateHandler(endpoint.handler())),
+                            endpoint -> Optional.of(new EndpointRequestArgHandler(endpoint, runtime.contexts())),
                             endpoint -> Optional.of(
                                     new ConjureExceptionHandler(endpoint.handler(), runtime.exceptionHandler())))
                     .build()

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/EndpointRequestArgHandler.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/EndpointRequestArgHandler.java
@@ -1,0 +1,35 @@
+package com.palantir.conjure.java.undertow.runtime;
+
+import com.palantir.conjure.java.undertow.lib.Contexts;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.conjure.java.undertow.lib.RequestContext;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeArg;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+
+final class EndpointRequestArgHandler implements HttpHandler {
+
+    private final Endpoint endpoint;
+    private final Contexts contexts;
+    private final Arg<String> endpointName;
+    private final Arg<String> serviceName;
+
+    EndpointRequestArgHandler(Endpoint endpoint, Contexts contexts) {
+        this.endpoint = endpoint;
+        this.contexts = contexts;
+        this.endpointName = SafeArg.of("_endpointName", endpoint.name());
+        this.serviceName = SafeArg.of("_serviceName", endpoint.serviceName());
+    }
+
+    /**
+     * Adds request args that identify the {@link Endpoint}.
+     */
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws Exception {
+        RequestContext requestContext = contexts.createContext(exchange, endpoint);
+        requestContext.requestArg(endpointName);
+        requestContext.requestArg(serviceName);
+        endpoint.handler().handleRequest(exchange);
+    }
+}

--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/EndpointRequestArgHandler.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/EndpointRequestArgHandler.java
@@ -1,3 +1,18 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.palantir.conjure.java.undertow.runtime;
 
 import com.palantir.conjure.java.undertow.lib.Contexts;

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/EndpointRequestArgHandlerTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/EndpointRequestArgHandlerTest.java
@@ -1,0 +1,55 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.undertow.runtime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import com.palantir.conjure.java.undertow.HttpServerExchanges;
+import com.palantir.conjure.java.undertow.lib.Endpoint;
+import com.palantir.logsafe.SafeArg;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.handlers.ResponseCodeHandler;
+import io.undertow.util.Methods;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+final class EndpointRequestArgHandlerTest {
+
+    @Mock
+    private RequestArgHandler requestArgHandler;
+
+    @Test
+    void testEndpointArgs() throws Exception {
+        Endpoint endpoint = Endpoint.builder()
+                .name("name")
+                .serviceName("service")
+                .handler(ResponseCodeHandler.HANDLE_200)
+                .method(Methods.OPTIONS)
+                .template("/template")
+                .build();
+        HttpHandler handler = new EndpointRequestArgHandler(endpoint, new ConjureContexts(requestArgHandler));
+        handler.handleRequest(HttpServerExchanges.createStub());
+
+        verify(requestArgHandler).arg(any(), eq(SafeArg.of("_endpointName", "name")));
+        verify(requestArgHandler).arg(any(), eq(SafeArg.of("_serviceName", "service")));
+    }
+}


### PR DESCRIPTION
## Before this PR
Request logs contain `method` and `path` and the combination of those can be used to identify the endpoint.

## After this PR
Request logs additional contain `_endpointName` and `_serviceName` for easier transparency into the Conjure endpoint that corresponds to this request. The intent is to make it easier to map these request logs back to the code and easier to filter logs on specific endpoints. 

I did also consider updating the code gen for the endpoints and leveraging the request context there instead. This felt simpler.

==COMMIT_MSG==
Add a handler for including standard endpoint request args.
==COMMIT_MSG==
