### PR TITLE
disable X-XSS-Protection

### DIFF
--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/WebSecurityHandler.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/WebSecurityHandler.java
@@ -44,7 +44,8 @@ final class WebSecurityHandler implements HttpHandler {
             "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; frame-ancestors 'self';";
     private static final String CONTENT_TYPE_OPTIONS = "nosniff";
     private static final String FRAME_OPTIONS = "sameorigin";
-    private static final String XSS_PROTECTION = "1; mode=block";
+    // disable X-XSS-Protection per https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection
+    private static final String XSS_PROTECTION = "0";
 
     private static final String REFERRER_POLICY = "strict-origin-when-cross-origin";
 

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/WebSecurityHandlerTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/WebSecurityHandlerTest.java
@@ -81,7 +81,7 @@ public class WebSecurityHandlerTest {
         assertThat(connection.getHeaderField(HttpHeaders.X_CONTENT_TYPE_OPTIONS))
                 .isEqualTo("nosniff");
         assertThat(connection.getHeaderField(HttpHeaders.X_FRAME_OPTIONS)).isEqualTo("sameorigin");
-        assertThat(connection.getHeaderField(HttpHeaders.X_XSS_PROTECTION)).isEqualTo("1; mode=block");
+        assertThat(connection.getHeaderField(HttpHeaders.X_XSS_PROTECTION)).isEqualTo("0");
     }
 
     private static HttpURLConnection openConnectionToTestServer() {


### PR DESCRIPTION
## Before this PR
conjure-java-undertow-runtime automatically sets the value of `X-XSS-Protection` to `1; mode=block` on responses.

## After this PR
Set the value of `X-XSS-Protection` to `0`. This header is no longer recommended. See also
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection.
==COMMIT_MSG==
disable X-XSS-Protection
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

