### PR TITLE
Don't set X-XSS-Protection header

### DIFF
--- a/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/WebSecurityHandler.java
+++ b/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/WebSecurityHandler.java
@@ -34,8 +34,6 @@ import io.undertow.util.HttpString;
  *   <dd>https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
  *   <dt>Frame Options
  *   <dd>https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
- *   <dt>XSS Protection
- *   <dd>https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
  * </dl>
  */
 final class WebSecurityHandler implements HttpHandler {
@@ -44,8 +42,6 @@ final class WebSecurityHandler implements HttpHandler {
             "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; frame-ancestors 'self';";
     private static final String CONTENT_TYPE_OPTIONS = "nosniff";
     private static final String FRAME_OPTIONS = "sameorigin";
-    // disable X-XSS-Protection per https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection
-    private static final String XSS_PROTECTION = "0";
 
     private static final String REFERRER_POLICY = "strict-origin-when-cross-origin";
 
@@ -67,7 +63,6 @@ final class WebSecurityHandler implements HttpHandler {
         headers.put(Headers.REFERRER_POLICY, REFERRER_POLICY);
         headers.put(Headers.X_CONTENT_TYPE_OPTIONS, CONTENT_TYPE_OPTIONS);
         headers.put(Headers.X_FRAME_OPTIONS, FRAME_OPTIONS);
-        headers.put(Headers.X_XSS_PROTECTION, XSS_PROTECTION);
         String userAgent = exchange.getRequestHeaders().getFirst(Headers.USER_AGENT);
         if (userAgent != null) {
             // send the CSP header so that IE10 and IE11 recognise it

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/WebSecurityHandlerTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/WebSecurityHandlerTest.java
@@ -81,7 +81,6 @@ public class WebSecurityHandlerTest {
         assertThat(connection.getHeaderField(HttpHeaders.X_CONTENT_TYPE_OPTIONS))
                 .isEqualTo("nosniff");
         assertThat(connection.getHeaderField(HttpHeaders.X_FRAME_OPTIONS)).isEqualTo("sameorigin");
-        assertThat(connection.getHeaderField(HttpHeaders.X_XSS_PROTECTION)).isEqualTo("0");
     }
 
     private static HttpURLConnection openConnectionToTestServer() {


### PR DESCRIPTION
Follow up from https://github.com/palantir/conjure-java/pull/2975.

Browsers removed support for the [`X-XSS-Protection` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection) a long time ago:

| Browser | Removal Date | 
| :- | :- |
| Google Chrome | Chrome 78 - October 22, 2019 |
| Microsoft Edge | Edge 17 - April 30, 2018 |
| Apple Safari | Safari 15.4 - March 14, 2022 |
| Mozilla Firefox | _Never supported_ |

Per our [official browser support policy](https://www.palantir.com/docs/foundry/getting-help/supported-browsers-network-requirements), we do not support browsers released over two years ago:

> We fully support any version of the browsers listed below released within the past year. Older browser versions are partially supported up to the past two years, and browser versions released over two years ago are unsupported.

We are well past the support window for browsers that supported the `X-XSS-Protection` header. It should be acceptable to simply remove this code.