### PR TITLE
Also deduplicate Serializer fields in generated dialogue

### DIFF
--- a/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/EteServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/EteServiceAsync.java
@@ -251,7 +251,7 @@ public interface EteServiceAsync {
                     new TypeMarker<NestedStringAliasExample>() {};
 
             private static final TypeMarker<allexamples.com.palantir.product.StringAliasExample>
-                    stringAliasExample1pxrnbvTypeMarker =
+                    stringAliasExample2TypeMarker =
                             new TypeMarker<allexamples.com.palantir.product.StringAliasExample>() {};
 
             private static final TypeMarker<Optional<allexamples.com.palantir.product.StringAliasExample>>
@@ -321,8 +321,7 @@ public interface EteServiceAsync {
                     _runtime.bodySerDe().deserializer(nestedStringAliasExampleTypeMarker);
 
             private final Deserializer<allexamples.com.palantir.product.StringAliasExample>
-                    stringAliasExample1pxrnbvDeserializer =
-                            _runtime.bodySerDe().deserializer(stringAliasExample1pxrnbvTypeMarker);
+                    stringAliasExample2Deserializer = _runtime.bodySerDe().deserializer(stringAliasExample2TypeMarker);
 
             private final Deserializer<Optional<allexamples.com.palantir.product.StringAliasExample>>
                     optionalStringAliasExampleDeserializer =
@@ -350,8 +349,7 @@ public interface EteServiceAsync {
                     _runtime.bodySerDe().serializer(stringAliasExampleTypeMarker);
 
             private final Serializer<allexamples.com.palantir.product.StringAliasExample>
-                    stringAliasExample1pxrnbvSerializer =
-                            _runtime.bodySerDe().serializer(stringAliasExample1pxrnbvTypeMarker);
+                    stringAliasExample2Serializer = _runtime.bodySerDe().serializer(stringAliasExample2TypeMarker);
 
             private final Serializer<Optional<allexamples.com.palantir.product.StringAliasExample>>
                     optionalStringAliasExampleSerializer =
@@ -623,12 +621,9 @@ public interface EteServiceAsync {
                     AuthHeader authHeader, allexamples.com.palantir.product.StringAliasExample notNullBody) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(stringAliasExample1pxrnbvSerializer.serialize(notNullBody));
+                _request.body(stringAliasExample2Serializer.serialize(notNullBody));
                 return _runtime.clients()
-                        .call(
-                                notNullBodyExternalImportChannel,
-                                _request.build(),
-                                stringAliasExample1pxrnbvDeserializer);
+                        .call(notNullBodyExternalImportChannel, _request.build(), stringAliasExample2Deserializer);
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/EteServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/EteServiceAsync.java
@@ -271,6 +271,14 @@ public interface EteServiceAsync {
 
             private static final TypeMarker<SimpleUnion> simpleUnionTypeMarker = new TypeMarker<SimpleUnion>() {};
 
+            private static final TypeMarker<List<Optional<String>>> listOptionalStringTypeMarker =
+                    new TypeMarker<List<Optional<String>>>() {};
+
+            private static final TypeMarker<Set<Optional<String>>> setOptionalStringTypeMarker =
+                    new TypeMarker<Set<Optional<String>>>() {};
+
+            private static final TypeMarker<List<String>> listStringTypeMarker = new TypeMarker<List<String>>() {};
+
             private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
 
             private final Deserializer<String> stringDeserializer =
@@ -338,6 +346,29 @@ public interface EteServiceAsync {
             private final Deserializer<SimpleUnion> simpleUnionDeserializer =
                     _runtime.bodySerDe().deserializer(simpleUnionTypeMarker);
 
+            private final Serializer<StringAliasExample> stringAliasExampleSerializer =
+                    _runtime.bodySerDe().serializer(stringAliasExampleTypeMarker);
+
+            private final Serializer<allexamples.com.palantir.product.StringAliasExample>
+                    stringAliasExample1pxrnbvSerializer =
+                            _runtime.bodySerDe().serializer(stringAliasExample1pxrnbvTypeMarker);
+
+            private final Serializer<Optional<allexamples.com.palantir.product.StringAliasExample>>
+                    optionalStringAliasExampleSerializer =
+                            _runtime.bodySerDe().serializer(optionalStringAliasExampleTypeMarker);
+
+            private final Serializer<List<Optional<String>>> listOptionalStringSerializer =
+                    _runtime.bodySerDe().serializer(listOptionalStringTypeMarker);
+
+            private final Serializer<Set<Optional<String>>> setOptionalStringSerializer =
+                    _runtime.bodySerDe().serializer(setOptionalStringTypeMarker);
+
+            private final Serializer<List<String>> listStringSerializer =
+                    _runtime.bodySerDe().serializer(listStringTypeMarker);
+
+            private final Serializer<SimpleUnion> simpleUnionSerializer =
+                    _runtime.bodySerDe().serializer(simpleUnionTypeMarker);
+
             private final EndpointChannel stringChannel = _endpointChannelFactory.endpoint(DialogueEteEndpoints.string);
 
             private final EndpointChannel integerChannel =
@@ -376,9 +407,6 @@ public interface EteServiceAsync {
             private final EndpointChannel optionalExternalLongQueryChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.optionalExternalLongQuery);
 
-            private final Serializer<StringAliasExample> notNullBodySerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<StringAliasExample>() {});
-
             private final EndpointChannel notNullBodyChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.notNullBody);
 
@@ -391,17 +419,8 @@ public interface EteServiceAsync {
             private final EndpointChannel aliasTwoChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.aliasTwo);
 
-            private final Serializer<allexamples.com.palantir.product.StringAliasExample>
-                    notNullBodyExternalImportSerializer = _runtime.bodySerDe()
-                            .serializer(new TypeMarker<allexamples.com.palantir.product.StringAliasExample>() {});
-
             private final EndpointChannel notNullBodyExternalImportChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.notNullBodyExternalImport);
-
-            private final Serializer<Optional<allexamples.com.palantir.product.StringAliasExample>>
-                    optionalBodyExternalImportSerializer = _runtime.bodySerDe()
-                            .serializer(
-                                    new TypeMarker<Optional<allexamples.com.palantir.product.StringAliasExample>>() {});
 
             private final EndpointChannel optionalBodyExternalImportChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.optionalBodyExternalImport);
@@ -436,26 +455,14 @@ public interface EteServiceAsync {
             private final EndpointChannel complexQueryParametersChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.complexQueryParameters);
 
-            private final Serializer<List<Optional<String>>> receiveListOfOptionalsSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<List<Optional<String>>>() {});
-
             private final EndpointChannel receiveListOfOptionalsChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.receiveListOfOptionals);
-
-            private final Serializer<Set<Optional<String>>> receiveSetOfOptionalsSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<Set<Optional<String>>>() {});
 
             private final EndpointChannel receiveSetOfOptionalsChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.receiveSetOfOptionals);
 
-            private final Serializer<List<String>> receiveListOfStringsSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<List<String>>() {});
-
             private final EndpointChannel receiveListOfStringsChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.receiveListOfStrings);
-
-            private final Serializer<SimpleUnion> unionSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<SimpleUnion>() {});
 
             private final EndpointChannel unionChannel = _endpointChannelFactory.endpoint(DialogueEteEndpoints.union);
 
@@ -573,7 +580,7 @@ public interface EteServiceAsync {
                     AuthHeader authHeader, StringAliasExample notNullBody) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(notNullBodySerializer.serialize(notNullBody));
+                _request.body(stringAliasExampleSerializer.serialize(notNullBody));
                 return _runtime.clients().call(notNullBodyChannel, _request.build(), stringAliasExampleDeserializer);
             }
 
@@ -616,7 +623,7 @@ public interface EteServiceAsync {
                     AuthHeader authHeader, allexamples.com.palantir.product.StringAliasExample notNullBody) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(notNullBodyExternalImportSerializer.serialize(notNullBody));
+                _request.body(stringAliasExample1pxrnbvSerializer.serialize(notNullBody));
                 return _runtime.clients()
                         .call(
                                 notNullBodyExternalImportChannel,
@@ -630,7 +637,7 @@ public interface EteServiceAsync {
                             AuthHeader authHeader, Optional<allexamples.com.palantir.product.StringAliasExample> body) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(optionalBodyExternalImportSerializer.serialize(body));
+                _request.body(optionalStringAliasExampleSerializer.serialize(body));
                 return _runtime.clients()
                         .call(
                                 optionalBodyExternalImportChannel,
@@ -759,7 +766,7 @@ public interface EteServiceAsync {
             public ListenableFuture<Void> receiveListOfOptionals(AuthHeader authHeader, List<Optional<String>> value) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(receiveListOfOptionalsSerializer.serialize(value));
+                _request.body(listOptionalStringSerializer.serialize(value));
                 return _runtime.clients().call(receiveListOfOptionalsChannel, _request.build(), voidDeserializer);
             }
 
@@ -767,7 +774,7 @@ public interface EteServiceAsync {
             public ListenableFuture<Void> receiveSetOfOptionals(AuthHeader authHeader, Set<Optional<String>> value) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(receiveSetOfOptionalsSerializer.serialize(value));
+                _request.body(setOptionalStringSerializer.serialize(value));
                 return _runtime.clients().call(receiveSetOfOptionalsChannel, _request.build(), voidDeserializer);
             }
 
@@ -775,7 +782,7 @@ public interface EteServiceAsync {
             public ListenableFuture<Void> receiveListOfStrings(AuthHeader authHeader, List<String> value) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(receiveListOfStringsSerializer.serialize(value));
+                _request.body(listStringSerializer.serialize(value));
                 return _runtime.clients().call(receiveListOfStringsChannel, _request.build(), voidDeserializer);
             }
 
@@ -783,7 +790,7 @@ public interface EteServiceAsync {
             public ListenableFuture<SimpleUnion> union(AuthHeader authHeader, SimpleUnion value) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(unionSerializer.serialize(value));
+                _request.body(simpleUnionSerializer.serialize(value));
                 return _runtime.clients().call(unionChannel, _request.build(), simpleUnionDeserializer);
             }
 

--- a/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/EteServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/EteServiceBlocking.java
@@ -250,7 +250,7 @@ public interface EteServiceBlocking {
                     new TypeMarker<NestedStringAliasExample>() {};
 
             private static final TypeMarker<allexamples.com.palantir.product.StringAliasExample>
-                    stringAliasExample1pxrnbvTypeMarker =
+                    stringAliasExample2TypeMarker =
                             new TypeMarker<allexamples.com.palantir.product.StringAliasExample>() {};
 
             private static final TypeMarker<Optional<allexamples.com.palantir.product.StringAliasExample>>
@@ -320,8 +320,7 @@ public interface EteServiceBlocking {
                     _runtime.bodySerDe().deserializer(nestedStringAliasExampleTypeMarker);
 
             private final Deserializer<allexamples.com.palantir.product.StringAliasExample>
-                    stringAliasExample1pxrnbvDeserializer =
-                            _runtime.bodySerDe().deserializer(stringAliasExample1pxrnbvTypeMarker);
+                    stringAliasExample2Deserializer = _runtime.bodySerDe().deserializer(stringAliasExample2TypeMarker);
 
             private final Deserializer<Optional<allexamples.com.palantir.product.StringAliasExample>>
                     optionalStringAliasExampleDeserializer =
@@ -349,8 +348,7 @@ public interface EteServiceBlocking {
                     _runtime.bodySerDe().serializer(stringAliasExampleTypeMarker);
 
             private final Serializer<allexamples.com.palantir.product.StringAliasExample>
-                    stringAliasExample1pxrnbvSerializer =
-                            _runtime.bodySerDe().serializer(stringAliasExample1pxrnbvTypeMarker);
+                    stringAliasExample2Serializer = _runtime.bodySerDe().serializer(stringAliasExample2TypeMarker);
 
             private final Serializer<Optional<allexamples.com.palantir.product.StringAliasExample>>
                     optionalStringAliasExampleSerializer =
@@ -623,12 +621,10 @@ public interface EteServiceBlocking {
                     AuthHeader authHeader, allexamples.com.palantir.product.StringAliasExample notNullBody) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(stringAliasExample1pxrnbvSerializer.serialize(notNullBody));
+                _request.body(stringAliasExample2Serializer.serialize(notNullBody));
                 return _runtime.clients()
                         .callBlocking(
-                                notNullBodyExternalImportChannel,
-                                _request.build(),
-                                stringAliasExample1pxrnbvDeserializer);
+                                notNullBodyExternalImportChannel, _request.build(), stringAliasExample2Deserializer);
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/EteServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/EteServiceBlocking.java
@@ -270,6 +270,14 @@ public interface EteServiceBlocking {
 
             private static final TypeMarker<SimpleUnion> simpleUnionTypeMarker = new TypeMarker<SimpleUnion>() {};
 
+            private static final TypeMarker<List<Optional<String>>> listOptionalStringTypeMarker =
+                    new TypeMarker<List<Optional<String>>>() {};
+
+            private static final TypeMarker<Set<Optional<String>>> setOptionalStringTypeMarker =
+                    new TypeMarker<Set<Optional<String>>>() {};
+
+            private static final TypeMarker<List<String>> listStringTypeMarker = new TypeMarker<List<String>>() {};
+
             private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
 
             private final Deserializer<String> stringDeserializer =
@@ -337,6 +345,29 @@ public interface EteServiceBlocking {
             private final Deserializer<SimpleUnion> simpleUnionDeserializer =
                     _runtime.bodySerDe().deserializer(simpleUnionTypeMarker);
 
+            private final Serializer<StringAliasExample> stringAliasExampleSerializer =
+                    _runtime.bodySerDe().serializer(stringAliasExampleTypeMarker);
+
+            private final Serializer<allexamples.com.palantir.product.StringAliasExample>
+                    stringAliasExample1pxrnbvSerializer =
+                            _runtime.bodySerDe().serializer(stringAliasExample1pxrnbvTypeMarker);
+
+            private final Serializer<Optional<allexamples.com.palantir.product.StringAliasExample>>
+                    optionalStringAliasExampleSerializer =
+                            _runtime.bodySerDe().serializer(optionalStringAliasExampleTypeMarker);
+
+            private final Serializer<List<Optional<String>>> listOptionalStringSerializer =
+                    _runtime.bodySerDe().serializer(listOptionalStringTypeMarker);
+
+            private final Serializer<Set<Optional<String>>> setOptionalStringSerializer =
+                    _runtime.bodySerDe().serializer(setOptionalStringTypeMarker);
+
+            private final Serializer<List<String>> listStringSerializer =
+                    _runtime.bodySerDe().serializer(listStringTypeMarker);
+
+            private final Serializer<SimpleUnion> simpleUnionSerializer =
+                    _runtime.bodySerDe().serializer(simpleUnionTypeMarker);
+
             private final EndpointChannel stringChannel = _endpointChannelFactory.endpoint(DialogueEteEndpoints.string);
 
             private final EndpointChannel integerChannel =
@@ -375,9 +406,6 @@ public interface EteServiceBlocking {
             private final EndpointChannel optionalExternalLongQueryChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.optionalExternalLongQuery);
 
-            private final Serializer<StringAliasExample> notNullBodySerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<StringAliasExample>() {});
-
             private final EndpointChannel notNullBodyChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.notNullBody);
 
@@ -390,17 +418,8 @@ public interface EteServiceBlocking {
             private final EndpointChannel aliasTwoChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.aliasTwo);
 
-            private final Serializer<allexamples.com.palantir.product.StringAliasExample>
-                    notNullBodyExternalImportSerializer = _runtime.bodySerDe()
-                            .serializer(new TypeMarker<allexamples.com.palantir.product.StringAliasExample>() {});
-
             private final EndpointChannel notNullBodyExternalImportChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.notNullBodyExternalImport);
-
-            private final Serializer<Optional<allexamples.com.palantir.product.StringAliasExample>>
-                    optionalBodyExternalImportSerializer = _runtime.bodySerDe()
-                            .serializer(
-                                    new TypeMarker<Optional<allexamples.com.palantir.product.StringAliasExample>>() {});
 
             private final EndpointChannel optionalBodyExternalImportChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.optionalBodyExternalImport);
@@ -435,26 +454,14 @@ public interface EteServiceBlocking {
             private final EndpointChannel complexQueryParametersChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.complexQueryParameters);
 
-            private final Serializer<List<Optional<String>>> receiveListOfOptionalsSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<List<Optional<String>>>() {});
-
             private final EndpointChannel receiveListOfOptionalsChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.receiveListOfOptionals);
-
-            private final Serializer<Set<Optional<String>>> receiveSetOfOptionalsSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<Set<Optional<String>>>() {});
 
             private final EndpointChannel receiveSetOfOptionalsChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.receiveSetOfOptionals);
 
-            private final Serializer<List<String>> receiveListOfStringsSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<List<String>>() {});
-
             private final EndpointChannel receiveListOfStringsChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.receiveListOfStrings);
-
-            private final Serializer<SimpleUnion> unionSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<SimpleUnion>() {});
 
             private final EndpointChannel unionChannel = _endpointChannelFactory.endpoint(DialogueEteEndpoints.union);
 
@@ -572,7 +579,7 @@ public interface EteServiceBlocking {
             public StringAliasExample notNullBody(AuthHeader authHeader, StringAliasExample notNullBody) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(notNullBodySerializer.serialize(notNullBody));
+                _request.body(stringAliasExampleSerializer.serialize(notNullBody));
                 return _runtime.clients()
                         .callBlocking(notNullBodyChannel, _request.build(), stringAliasExampleDeserializer);
             }
@@ -616,7 +623,7 @@ public interface EteServiceBlocking {
                     AuthHeader authHeader, allexamples.com.palantir.product.StringAliasExample notNullBody) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(notNullBodyExternalImportSerializer.serialize(notNullBody));
+                _request.body(stringAliasExample1pxrnbvSerializer.serialize(notNullBody));
                 return _runtime.clients()
                         .callBlocking(
                                 notNullBodyExternalImportChannel,
@@ -629,7 +636,7 @@ public interface EteServiceBlocking {
                     AuthHeader authHeader, Optional<allexamples.com.palantir.product.StringAliasExample> body) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(optionalBodyExternalImportSerializer.serialize(body));
+                _request.body(optionalStringAliasExampleSerializer.serialize(body));
                 return _runtime.clients()
                         .callBlocking(
                                 optionalBodyExternalImportChannel,
@@ -754,7 +761,7 @@ public interface EteServiceBlocking {
             public void receiveListOfOptionals(AuthHeader authHeader, List<Optional<String>> value) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(receiveListOfOptionalsSerializer.serialize(value));
+                _request.body(listOptionalStringSerializer.serialize(value));
                 _runtime.clients().callBlocking(receiveListOfOptionalsChannel, _request.build(), voidDeserializer);
             }
 
@@ -762,7 +769,7 @@ public interface EteServiceBlocking {
             public void receiveSetOfOptionals(AuthHeader authHeader, Set<Optional<String>> value) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(receiveSetOfOptionalsSerializer.serialize(value));
+                _request.body(setOptionalStringSerializer.serialize(value));
                 _runtime.clients().callBlocking(receiveSetOfOptionalsChannel, _request.build(), voidDeserializer);
             }
 
@@ -770,7 +777,7 @@ public interface EteServiceBlocking {
             public void receiveListOfStrings(AuthHeader authHeader, List<String> value) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(receiveListOfStringsSerializer.serialize(value));
+                _request.body(listStringSerializer.serialize(value));
                 _runtime.clients().callBlocking(receiveListOfStringsChannel, _request.build(), voidDeserializer);
             }
 
@@ -778,7 +785,7 @@ public interface EteServiceBlocking {
             public SimpleUnion union(AuthHeader authHeader, SimpleUnion value) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(unionSerializer.serialize(value));
+                _request.body(simpleUnionSerializer.serialize(value));
                 return _runtime.clients().callBlocking(unionChannel, _request.build(), simpleUnionDeserializer);
             }
 

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceAsync.java
@@ -64,6 +64,14 @@ public interface ErrorServiceAsync {
             private static final TypeMarker<Optional<InputStream>> optionalInputStreamTypeMarker =
                     new TypeMarker<Optional<InputStream>>() {};
 
+            private static final TypeMarker<Boolean> booleanTypeMarker = new TypeMarker<Boolean>() {};
+
+            private static final TypeMarker<Optional<String>> optionalStringTypeMarker =
+                    new TypeMarker<Optional<String>>() {};
+
+            private static final TypeMarker<OptionalBinaryResponseMode> optionalBinaryResponseModeTypeMarker =
+                    new TypeMarker<OptionalBinaryResponseMode>() {};
+
             private static final ExceptionDeserializerArgs<String> stringExceptionArgs =
                     createExceptionDeserializerArgs(stringTypeMarker);
 
@@ -90,38 +98,29 @@ public interface ErrorServiceAsync {
             private final Deserializer<Optional<InputStream>> optionalInputStreamDeserializer =
                     _runtime.bodySerDe().optionalInputStreamDeserializer(optionalInputStreamExceptionArgs);
 
-            private final Serializer<Boolean> testBasicErrorSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
+            private final Serializer<Boolean> booleanSerializer =
+                    _runtime.bodySerDe().serializer(booleanTypeMarker);
+
+            private final Serializer<Optional<String>> optionalStringSerializer =
+                    _runtime.bodySerDe().serializer(optionalStringTypeMarker);
+
+            private final Serializer<OptionalBinaryResponseMode> optionalBinaryResponseModeSerializer =
+                    _runtime.bodySerDe().serializer(optionalBinaryResponseModeTypeMarker);
 
             private final EndpointChannel testBasicErrorChannel =
                     _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testBasicError);
 
-            private final Serializer<Boolean> testImportedErrorSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
-
             private final EndpointChannel testImportedErrorChannel =
                     _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testImportedError);
-
-            private final Serializer<Optional<String>> testMultipleErrorsAndPackagesSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {});
 
             private final EndpointChannel testMultipleErrorsAndPackagesChannel =
                     _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testMultipleErrorsAndPackages);
 
-            private final Serializer<Boolean> testEmptyBodySerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
-
             private final EndpointChannel testEmptyBodyChannel =
                     _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testEmptyBody);
 
-            private final Serializer<Boolean> testBinarySerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
-
             private final EndpointChannel testBinaryChannel =
                     _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testBinary);
-
-            private final Serializer<OptionalBinaryResponseMode> testOptionalBinarySerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<OptionalBinaryResponseMode>() {});
 
             private final EndpointChannel testOptionalBinaryChannel =
                     _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testOptionalBinary);
@@ -141,7 +140,7 @@ public interface ErrorServiceAsync {
             public ListenableFuture<String> testBasicError(AuthHeader authHeader, boolean shouldThrowError) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testBasicErrorSerializer.serialize(shouldThrowError));
+                _request.body(booleanSerializer.serialize(shouldThrowError));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -154,7 +153,7 @@ public interface ErrorServiceAsync {
             public ListenableFuture<String> testImportedError(AuthHeader authHeader, boolean shouldThrowError) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testImportedErrorSerializer.serialize(shouldThrowError));
+                _request.body(booleanSerializer.serialize(shouldThrowError));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -168,7 +167,7 @@ public interface ErrorServiceAsync {
                     AuthHeader authHeader, Optional<String> errorToThrow) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testMultipleErrorsAndPackagesSerializer.serialize(errorToThrow));
+                _request.body(optionalStringSerializer.serialize(errorToThrow));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -182,7 +181,7 @@ public interface ErrorServiceAsync {
             public ListenableFuture<Void> testEmptyBody(AuthHeader authHeader, boolean shouldThrowError) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testEmptyBodySerializer.serialize(shouldThrowError));
+                _request.body(booleanSerializer.serialize(shouldThrowError));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -195,7 +194,7 @@ public interface ErrorServiceAsync {
             public ListenableFuture<InputStream> testBinary(AuthHeader authHeader, boolean shouldThrowError) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testBinarySerializer.serialize(shouldThrowError));
+                _request.body(booleanSerializer.serialize(shouldThrowError));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -209,7 +208,7 @@ public interface ErrorServiceAsync {
                     AuthHeader authHeader, OptionalBinaryResponseMode mode) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testOptionalBinarySerializer.serialize(mode));
+                _request.body(optionalBinaryResponseModeSerializer.serialize(mode));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceBlocking.java
@@ -65,6 +65,14 @@ public interface ErrorServiceBlocking {
             private static final TypeMarker<Optional<InputStream>> optionalInputStreamTypeMarker =
                     new TypeMarker<Optional<InputStream>>() {};
 
+            private static final TypeMarker<Boolean> booleanTypeMarker = new TypeMarker<Boolean>() {};
+
+            private static final TypeMarker<Optional<String>> optionalStringTypeMarker =
+                    new TypeMarker<Optional<String>>() {};
+
+            private static final TypeMarker<OptionalBinaryResponseMode> optionalBinaryResponseModeTypeMarker =
+                    new TypeMarker<OptionalBinaryResponseMode>() {};
+
             private static final ExceptionDeserializerArgs<String> stringExceptionArgs =
                     createExceptionDeserializerArgs(stringTypeMarker);
 
@@ -91,38 +99,29 @@ public interface ErrorServiceBlocking {
             private final Deserializer<Optional<InputStream>> optionalInputStreamDeserializer =
                     _runtime.bodySerDe().optionalInputStreamDeserializer(optionalInputStreamExceptionArgs);
 
-            private final Serializer<Boolean> testBasicErrorSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
+            private final Serializer<Boolean> booleanSerializer =
+                    _runtime.bodySerDe().serializer(booleanTypeMarker);
+
+            private final Serializer<Optional<String>> optionalStringSerializer =
+                    _runtime.bodySerDe().serializer(optionalStringTypeMarker);
+
+            private final Serializer<OptionalBinaryResponseMode> optionalBinaryResponseModeSerializer =
+                    _runtime.bodySerDe().serializer(optionalBinaryResponseModeTypeMarker);
 
             private final EndpointChannel testBasicErrorChannel =
                     _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testBasicError);
 
-            private final Serializer<Boolean> testImportedErrorSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
-
             private final EndpointChannel testImportedErrorChannel =
                     _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testImportedError);
-
-            private final Serializer<Optional<String>> testMultipleErrorsAndPackagesSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {});
 
             private final EndpointChannel testMultipleErrorsAndPackagesChannel =
                     _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testMultipleErrorsAndPackages);
 
-            private final Serializer<Boolean> testEmptyBodySerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
-
             private final EndpointChannel testEmptyBodyChannel =
                     _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testEmptyBody);
 
-            private final Serializer<Boolean> testBinarySerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {});
-
             private final EndpointChannel testBinaryChannel =
                     _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testBinary);
-
-            private final Serializer<OptionalBinaryResponseMode> testOptionalBinarySerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<OptionalBinaryResponseMode>() {});
 
             private final EndpointChannel testOptionalBinaryChannel =
                     _endpointChannelFactory.endpoint(DialogueErrorEndpoints.testOptionalBinary);
@@ -142,7 +141,7 @@ public interface ErrorServiceBlocking {
             public String testBasicError(AuthHeader authHeader, boolean shouldThrowError) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testBasicErrorSerializer.serialize(shouldThrowError));
+                _request.body(booleanSerializer.serialize(shouldThrowError));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -155,7 +154,7 @@ public interface ErrorServiceBlocking {
             public String testImportedError(AuthHeader authHeader, boolean shouldThrowError) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testImportedErrorSerializer.serialize(shouldThrowError));
+                _request.body(booleanSerializer.serialize(shouldThrowError));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -168,7 +167,7 @@ public interface ErrorServiceBlocking {
             public String testMultipleErrorsAndPackages(AuthHeader authHeader, Optional<String> errorToThrow) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testMultipleErrorsAndPackagesSerializer.serialize(errorToThrow));
+                _request.body(optionalStringSerializer.serialize(errorToThrow));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -182,7 +181,7 @@ public interface ErrorServiceBlocking {
             public void testEmptyBody(AuthHeader authHeader, boolean shouldThrowError) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testEmptyBodySerializer.serialize(shouldThrowError));
+                _request.body(booleanSerializer.serialize(shouldThrowError));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -195,7 +194,7 @@ public interface ErrorServiceBlocking {
             public InputStream testBinary(AuthHeader authHeader, boolean shouldThrowError) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testBinarySerializer.serialize(shouldThrowError));
+                _request.body(booleanSerializer.serialize(shouldThrowError));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -208,7 +207,7 @@ public interface ErrorServiceBlocking {
             public Optional<InputStream> testOptionalBinary(AuthHeader authHeader, OptionalBinaryResponseMode mode) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testOptionalBinarySerializer.serialize(mode));
+                _request.body(optionalBinaryResponseModeSerializer.serialize(mode));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteServiceAsync.java
@@ -254,7 +254,7 @@ public interface EteServiceAsync {
                     new TypeMarker<NestedStringAliasExample>() {};
 
             private static final TypeMarker<allexamples.com.palantir.product.StringAliasExample>
-                    stringAliasExample1pxrnbvTypeMarker =
+                    stringAliasExample2TypeMarker =
                             new TypeMarker<allexamples.com.palantir.product.StringAliasExample>() {};
 
             private static final TypeMarker<Optional<allexamples.com.palantir.product.StringAliasExample>>
@@ -328,8 +328,7 @@ public interface EteServiceAsync {
                             createExceptionDeserializerArgs(nestedStringAliasExampleTypeMarker);
 
             private static final ExceptionDeserializerArgs<allexamples.com.palantir.product.StringAliasExample>
-                    stringAliasExample1pxrnbvExceptionArgs =
-                            createExceptionDeserializerArgs(stringAliasExample1pxrnbvTypeMarker);
+                    stringAliasExample2ExceptionArgs = createExceptionDeserializerArgs(stringAliasExample2TypeMarker);
 
             private static final ExceptionDeserializerArgs<
                             Optional<allexamples.com.palantir.product.StringAliasExample>>
@@ -399,8 +398,8 @@ public interface EteServiceAsync {
                     _runtime.bodySerDe().deserializer(nestedStringAliasExampleExceptionArgs);
 
             private final Deserializer<allexamples.com.palantir.product.StringAliasExample>
-                    stringAliasExample1pxrnbvDeserializer =
-                            _runtime.bodySerDe().deserializer(stringAliasExample1pxrnbvExceptionArgs);
+                    stringAliasExample2Deserializer =
+                            _runtime.bodySerDe().deserializer(stringAliasExample2ExceptionArgs);
 
             private final Deserializer<Optional<allexamples.com.palantir.product.StringAliasExample>>
                     optionalStringAliasExampleDeserializer =
@@ -428,8 +427,7 @@ public interface EteServiceAsync {
                     _runtime.bodySerDe().serializer(stringAliasExampleTypeMarker);
 
             private final Serializer<allexamples.com.palantir.product.StringAliasExample>
-                    stringAliasExample1pxrnbvSerializer =
-                            _runtime.bodySerDe().serializer(stringAliasExample1pxrnbvTypeMarker);
+                    stringAliasExample2Serializer = _runtime.bodySerDe().serializer(stringAliasExample2TypeMarker);
 
             private final Serializer<Optional<allexamples.com.palantir.product.StringAliasExample>>
                     optionalStringAliasExampleSerializer =
@@ -797,17 +795,14 @@ public interface EteServiceAsync {
                     AuthHeader authHeader, allexamples.com.palantir.product.StringAliasExample notNullBody) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(stringAliasExample1pxrnbvSerializer.serialize(notNullBody));
+                _request.body(stringAliasExample2Serializer.serialize(notNullBody));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
                             _runtime.bodySerDe().errorParameterFormat().get().toString());
                 }
                 return _runtime.clients()
-                        .call(
-                                notNullBodyExternalImportChannel,
-                                _request.build(),
-                                stringAliasExample1pxrnbvDeserializer);
+                        .call(notNullBodyExternalImportChannel, _request.build(), stringAliasExample2Deserializer);
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteServiceAsync.java
@@ -276,6 +276,14 @@ public interface EteServiceAsync {
 
             private static final TypeMarker<SimpleUnion> simpleUnionTypeMarker = new TypeMarker<SimpleUnion>() {};
 
+            private static final TypeMarker<List<Optional<String>>> listOptionalStringTypeMarker =
+                    new TypeMarker<List<Optional<String>>>() {};
+
+            private static final TypeMarker<Set<Optional<String>>> setOptionalStringTypeMarker =
+                    new TypeMarker<Set<Optional<String>>>() {};
+
+            private static final TypeMarker<List<String>> listStringTypeMarker = new TypeMarker<List<String>>() {};
+
             private static final ExceptionDeserializerArgs<String> stringExceptionArgs =
                     createExceptionDeserializerArgs(stringTypeMarker);
 
@@ -416,6 +424,29 @@ public interface EteServiceAsync {
             private final Deserializer<SimpleUnion> simpleUnionDeserializer =
                     _runtime.bodySerDe().deserializer(simpleUnionExceptionArgs);
 
+            private final Serializer<StringAliasExample> stringAliasExampleSerializer =
+                    _runtime.bodySerDe().serializer(stringAliasExampleTypeMarker);
+
+            private final Serializer<allexamples.com.palantir.product.StringAliasExample>
+                    stringAliasExample1pxrnbvSerializer =
+                            _runtime.bodySerDe().serializer(stringAliasExample1pxrnbvTypeMarker);
+
+            private final Serializer<Optional<allexamples.com.palantir.product.StringAliasExample>>
+                    optionalStringAliasExampleSerializer =
+                            _runtime.bodySerDe().serializer(optionalStringAliasExampleTypeMarker);
+
+            private final Serializer<List<Optional<String>>> listOptionalStringSerializer =
+                    _runtime.bodySerDe().serializer(listOptionalStringTypeMarker);
+
+            private final Serializer<Set<Optional<String>>> setOptionalStringSerializer =
+                    _runtime.bodySerDe().serializer(setOptionalStringTypeMarker);
+
+            private final Serializer<List<String>> listStringSerializer =
+                    _runtime.bodySerDe().serializer(listStringTypeMarker);
+
+            private final Serializer<SimpleUnion> simpleUnionSerializer =
+                    _runtime.bodySerDe().serializer(simpleUnionTypeMarker);
+
             private final EndpointChannel stringChannel = _endpointChannelFactory.endpoint(DialogueEteEndpoints.string);
 
             private final EndpointChannel integerChannel =
@@ -454,9 +485,6 @@ public interface EteServiceAsync {
             private final EndpointChannel optionalExternalLongQueryChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.optionalExternalLongQuery);
 
-            private final Serializer<StringAliasExample> notNullBodySerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<StringAliasExample>() {});
-
             private final EndpointChannel notNullBodyChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.notNullBody);
 
@@ -469,17 +497,8 @@ public interface EteServiceAsync {
             private final EndpointChannel aliasTwoChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.aliasTwo);
 
-            private final Serializer<allexamples.com.palantir.product.StringAliasExample>
-                    notNullBodyExternalImportSerializer = _runtime.bodySerDe()
-                            .serializer(new TypeMarker<allexamples.com.palantir.product.StringAliasExample>() {});
-
             private final EndpointChannel notNullBodyExternalImportChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.notNullBodyExternalImport);
-
-            private final Serializer<Optional<allexamples.com.palantir.product.StringAliasExample>>
-                    optionalBodyExternalImportSerializer = _runtime.bodySerDe()
-                            .serializer(
-                                    new TypeMarker<Optional<allexamples.com.palantir.product.StringAliasExample>>() {});
 
             private final EndpointChannel optionalBodyExternalImportChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.optionalBodyExternalImport);
@@ -514,26 +533,14 @@ public interface EteServiceAsync {
             private final EndpointChannel complexQueryParametersChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.complexQueryParameters);
 
-            private final Serializer<List<Optional<String>>> receiveListOfOptionalsSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<List<Optional<String>>>() {});
-
             private final EndpointChannel receiveListOfOptionalsChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.receiveListOfOptionals);
-
-            private final Serializer<Set<Optional<String>>> receiveSetOfOptionalsSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<Set<Optional<String>>>() {});
 
             private final EndpointChannel receiveSetOfOptionalsChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.receiveSetOfOptionals);
 
-            private final Serializer<List<String>> receiveListOfStringsSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<List<String>>() {});
-
             private final EndpointChannel receiveListOfStringsChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.receiveListOfStrings);
-
-            private final Serializer<SimpleUnion> unionSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<SimpleUnion>() {});
 
             private final EndpointChannel unionChannel = _endpointChannelFactory.endpoint(DialogueEteEndpoints.union);
 
@@ -727,7 +734,7 @@ public interface EteServiceAsync {
                     AuthHeader authHeader, StringAliasExample notNullBody) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(notNullBodySerializer.serialize(notNullBody));
+                _request.body(stringAliasExampleSerializer.serialize(notNullBody));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -790,7 +797,7 @@ public interface EteServiceAsync {
                     AuthHeader authHeader, allexamples.com.palantir.product.StringAliasExample notNullBody) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(notNullBodyExternalImportSerializer.serialize(notNullBody));
+                _request.body(stringAliasExample1pxrnbvSerializer.serialize(notNullBody));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -809,7 +816,7 @@ public interface EteServiceAsync {
                             AuthHeader authHeader, Optional<allexamples.com.palantir.product.StringAliasExample> body) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(optionalBodyExternalImportSerializer.serialize(body));
+                _request.body(optionalStringAliasExampleSerializer.serialize(body));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -993,7 +1000,7 @@ public interface EteServiceAsync {
             public ListenableFuture<Void> receiveListOfOptionals(AuthHeader authHeader, List<Optional<String>> value) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(receiveListOfOptionalsSerializer.serialize(value));
+                _request.body(listOptionalStringSerializer.serialize(value));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -1006,7 +1013,7 @@ public interface EteServiceAsync {
             public ListenableFuture<Void> receiveSetOfOptionals(AuthHeader authHeader, Set<Optional<String>> value) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(receiveSetOfOptionalsSerializer.serialize(value));
+                _request.body(setOptionalStringSerializer.serialize(value));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -1019,7 +1026,7 @@ public interface EteServiceAsync {
             public ListenableFuture<Void> receiveListOfStrings(AuthHeader authHeader, List<String> value) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(receiveListOfStringsSerializer.serialize(value));
+                _request.body(listStringSerializer.serialize(value));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -1032,7 +1039,7 @@ public interface EteServiceAsync {
             public ListenableFuture<SimpleUnion> union(AuthHeader authHeader, SimpleUnion value) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(unionSerializer.serialize(value));
+                _request.body(simpleUnionSerializer.serialize(value));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteServiceBlocking.java
@@ -275,6 +275,14 @@ public interface EteServiceBlocking {
 
             private static final TypeMarker<SimpleUnion> simpleUnionTypeMarker = new TypeMarker<SimpleUnion>() {};
 
+            private static final TypeMarker<List<Optional<String>>> listOptionalStringTypeMarker =
+                    new TypeMarker<List<Optional<String>>>() {};
+
+            private static final TypeMarker<Set<Optional<String>>> setOptionalStringTypeMarker =
+                    new TypeMarker<Set<Optional<String>>>() {};
+
+            private static final TypeMarker<List<String>> listStringTypeMarker = new TypeMarker<List<String>>() {};
+
             private static final ExceptionDeserializerArgs<String> stringExceptionArgs =
                     createExceptionDeserializerArgs(stringTypeMarker);
 
@@ -415,6 +423,29 @@ public interface EteServiceBlocking {
             private final Deserializer<SimpleUnion> simpleUnionDeserializer =
                     _runtime.bodySerDe().deserializer(simpleUnionExceptionArgs);
 
+            private final Serializer<StringAliasExample> stringAliasExampleSerializer =
+                    _runtime.bodySerDe().serializer(stringAliasExampleTypeMarker);
+
+            private final Serializer<allexamples.com.palantir.product.StringAliasExample>
+                    stringAliasExample1pxrnbvSerializer =
+                            _runtime.bodySerDe().serializer(stringAliasExample1pxrnbvTypeMarker);
+
+            private final Serializer<Optional<allexamples.com.palantir.product.StringAliasExample>>
+                    optionalStringAliasExampleSerializer =
+                            _runtime.bodySerDe().serializer(optionalStringAliasExampleTypeMarker);
+
+            private final Serializer<List<Optional<String>>> listOptionalStringSerializer =
+                    _runtime.bodySerDe().serializer(listOptionalStringTypeMarker);
+
+            private final Serializer<Set<Optional<String>>> setOptionalStringSerializer =
+                    _runtime.bodySerDe().serializer(setOptionalStringTypeMarker);
+
+            private final Serializer<List<String>> listStringSerializer =
+                    _runtime.bodySerDe().serializer(listStringTypeMarker);
+
+            private final Serializer<SimpleUnion> simpleUnionSerializer =
+                    _runtime.bodySerDe().serializer(simpleUnionTypeMarker);
+
             private final EndpointChannel stringChannel = _endpointChannelFactory.endpoint(DialogueEteEndpoints.string);
 
             private final EndpointChannel integerChannel =
@@ -453,9 +484,6 @@ public interface EteServiceBlocking {
             private final EndpointChannel optionalExternalLongQueryChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.optionalExternalLongQuery);
 
-            private final Serializer<StringAliasExample> notNullBodySerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<StringAliasExample>() {});
-
             private final EndpointChannel notNullBodyChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.notNullBody);
 
@@ -468,17 +496,8 @@ public interface EteServiceBlocking {
             private final EndpointChannel aliasTwoChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.aliasTwo);
 
-            private final Serializer<allexamples.com.palantir.product.StringAliasExample>
-                    notNullBodyExternalImportSerializer = _runtime.bodySerDe()
-                            .serializer(new TypeMarker<allexamples.com.palantir.product.StringAliasExample>() {});
-
             private final EndpointChannel notNullBodyExternalImportChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.notNullBodyExternalImport);
-
-            private final Serializer<Optional<allexamples.com.palantir.product.StringAliasExample>>
-                    optionalBodyExternalImportSerializer = _runtime.bodySerDe()
-                            .serializer(
-                                    new TypeMarker<Optional<allexamples.com.palantir.product.StringAliasExample>>() {});
 
             private final EndpointChannel optionalBodyExternalImportChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.optionalBodyExternalImport);
@@ -513,26 +532,14 @@ public interface EteServiceBlocking {
             private final EndpointChannel complexQueryParametersChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.complexQueryParameters);
 
-            private final Serializer<List<Optional<String>>> receiveListOfOptionalsSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<List<Optional<String>>>() {});
-
             private final EndpointChannel receiveListOfOptionalsChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.receiveListOfOptionals);
-
-            private final Serializer<Set<Optional<String>>> receiveSetOfOptionalsSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<Set<Optional<String>>>() {});
 
             private final EndpointChannel receiveSetOfOptionalsChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.receiveSetOfOptionals);
 
-            private final Serializer<List<String>> receiveListOfStringsSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<List<String>>() {});
-
             private final EndpointChannel receiveListOfStringsChannel =
                     _endpointChannelFactory.endpoint(DialogueEteEndpoints.receiveListOfStrings);
-
-            private final Serializer<SimpleUnion> unionSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<SimpleUnion>() {});
 
             private final EndpointChannel unionChannel = _endpointChannelFactory.endpoint(DialogueEteEndpoints.union);
 
@@ -726,7 +733,7 @@ public interface EteServiceBlocking {
             public StringAliasExample notNullBody(AuthHeader authHeader, StringAliasExample notNullBody) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(notNullBodySerializer.serialize(notNullBody));
+                _request.body(stringAliasExampleSerializer.serialize(notNullBody));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -790,7 +797,7 @@ public interface EteServiceBlocking {
                     AuthHeader authHeader, allexamples.com.palantir.product.StringAliasExample notNullBody) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(notNullBodyExternalImportSerializer.serialize(notNullBody));
+                _request.body(stringAliasExample1pxrnbvSerializer.serialize(notNullBody));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -808,7 +815,7 @@ public interface EteServiceBlocking {
                     AuthHeader authHeader, Optional<allexamples.com.palantir.product.StringAliasExample> body) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(optionalBodyExternalImportSerializer.serialize(body));
+                _request.body(optionalStringAliasExampleSerializer.serialize(body));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -988,7 +995,7 @@ public interface EteServiceBlocking {
             public void receiveListOfOptionals(AuthHeader authHeader, List<Optional<String>> value) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(receiveListOfOptionalsSerializer.serialize(value));
+                _request.body(listOptionalStringSerializer.serialize(value));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -1001,7 +1008,7 @@ public interface EteServiceBlocking {
             public void receiveSetOfOptionals(AuthHeader authHeader, Set<Optional<String>> value) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(receiveSetOfOptionalsSerializer.serialize(value));
+                _request.body(setOptionalStringSerializer.serialize(value));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -1014,7 +1021,7 @@ public interface EteServiceBlocking {
             public void receiveListOfStrings(AuthHeader authHeader, List<String> value) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(receiveListOfStringsSerializer.serialize(value));
+                _request.body(listStringSerializer.serialize(value));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -1027,7 +1034,7 @@ public interface EteServiceBlocking {
             public SimpleUnion union(AuthHeader authHeader, SimpleUnion value) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(unionSerializer.serialize(value));
+                _request.body(simpleUnionSerializer.serialize(value));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EteServiceBlocking.java
@@ -253,7 +253,7 @@ public interface EteServiceBlocking {
                     new TypeMarker<NestedStringAliasExample>() {};
 
             private static final TypeMarker<allexamples.com.palantir.product.StringAliasExample>
-                    stringAliasExample1pxrnbvTypeMarker =
+                    stringAliasExample2TypeMarker =
                             new TypeMarker<allexamples.com.palantir.product.StringAliasExample>() {};
 
             private static final TypeMarker<Optional<allexamples.com.palantir.product.StringAliasExample>>
@@ -327,8 +327,7 @@ public interface EteServiceBlocking {
                             createExceptionDeserializerArgs(nestedStringAliasExampleTypeMarker);
 
             private static final ExceptionDeserializerArgs<allexamples.com.palantir.product.StringAliasExample>
-                    stringAliasExample1pxrnbvExceptionArgs =
-                            createExceptionDeserializerArgs(stringAliasExample1pxrnbvTypeMarker);
+                    stringAliasExample2ExceptionArgs = createExceptionDeserializerArgs(stringAliasExample2TypeMarker);
 
             private static final ExceptionDeserializerArgs<
                             Optional<allexamples.com.palantir.product.StringAliasExample>>
@@ -398,8 +397,8 @@ public interface EteServiceBlocking {
                     _runtime.bodySerDe().deserializer(nestedStringAliasExampleExceptionArgs);
 
             private final Deserializer<allexamples.com.palantir.product.StringAliasExample>
-                    stringAliasExample1pxrnbvDeserializer =
-                            _runtime.bodySerDe().deserializer(stringAliasExample1pxrnbvExceptionArgs);
+                    stringAliasExample2Deserializer =
+                            _runtime.bodySerDe().deserializer(stringAliasExample2ExceptionArgs);
 
             private final Deserializer<Optional<allexamples.com.palantir.product.StringAliasExample>>
                     optionalStringAliasExampleDeserializer =
@@ -427,8 +426,7 @@ public interface EteServiceBlocking {
                     _runtime.bodySerDe().serializer(stringAliasExampleTypeMarker);
 
             private final Serializer<allexamples.com.palantir.product.StringAliasExample>
-                    stringAliasExample1pxrnbvSerializer =
-                            _runtime.bodySerDe().serializer(stringAliasExample1pxrnbvTypeMarker);
+                    stringAliasExample2Serializer = _runtime.bodySerDe().serializer(stringAliasExample2TypeMarker);
 
             private final Serializer<Optional<allexamples.com.palantir.product.StringAliasExample>>
                     optionalStringAliasExampleSerializer =
@@ -797,7 +795,7 @@ public interface EteServiceBlocking {
                     AuthHeader authHeader, allexamples.com.palantir.product.StringAliasExample notNullBody) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(stringAliasExample1pxrnbvSerializer.serialize(notNullBody));
+                _request.body(stringAliasExample2Serializer.serialize(notNullBody));
                 if (_runtime.bodySerDe().errorParameterFormat().isPresent()) {
                     _request.putHeaderParams(
                             "Accept-Conjure-Error-Parameter-Format",
@@ -805,9 +803,7 @@ public interface EteServiceBlocking {
                 }
                 return _runtime.clients()
                         .callBlocking(
-                                notNullBodyExternalImportChannel,
-                                _request.build(),
-                                stringAliasExample1pxrnbvDeserializer);
+                                notNullBodyExternalImportChannel, _request.build(), stringAliasExample2Deserializer);
             }
 
             @Override

--- a/conjure-java-core/src/integrationInput/java/excludeasyncinterfaces/com/palantir/another/TestServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/excludeasyncinterfaces/com/palantir/another/TestServiceBlocking.java
@@ -202,8 +202,6 @@ public interface TestServiceBlocking {
             private static final TypeMarker<CreateDatasetRequest> createDatasetRequestTypeMarker =
                     new TypeMarker<CreateDatasetRequest>() {};
 
-            private static final TypeMarker<InputStream> inputStreamTypeMarker = new TypeMarker<InputStream>() {};
-
             private static final TypeMarker<String> stringTypeMarker = new TypeMarker<String>() {};
 
             private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
@@ -240,9 +238,6 @@ public interface TestServiceBlocking {
 
             private final Serializer<CreateDatasetRequest> createDatasetRequestSerializer =
                     _runtime.bodySerDe().serializer(createDatasetRequestTypeMarker);
-
-            private final Serializer<InputStream> inputStreamSerializer =
-                    _runtime.bodySerDe().serializer(inputStreamTypeMarker);
 
             private final Serializer<String> stringSerializer =
                     _runtime.bodySerDe().serializer(stringTypeMarker);

--- a/conjure-java-core/src/integrationInput/java/excludeasyncinterfaces/com/palantir/another/TestServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/excludeasyncinterfaces/com/palantir/another/TestServiceBlocking.java
@@ -199,6 +199,13 @@ public interface TestServiceBlocking {
 
             private static final TypeMarker<Double> doubleTypeMarker = new TypeMarker<Double>() {};
 
+            private static final TypeMarker<CreateDatasetRequest> createDatasetRequestTypeMarker =
+                    new TypeMarker<CreateDatasetRequest>() {};
+
+            private static final TypeMarker<InputStream> inputStreamTypeMarker = new TypeMarker<InputStream>() {};
+
+            private static final TypeMarker<String> stringTypeMarker = new TypeMarker<String>() {};
+
             private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
 
             private final Deserializer<Map<String, BackingFileSystem>> mapStringBackingFileSystemDeserializer =
@@ -231,11 +238,20 @@ public interface TestServiceBlocking {
             private final Deserializer<Double> doubleDeserializer =
                     _runtime.bodySerDe().deserializer(doubleTypeMarker);
 
+            private final Serializer<CreateDatasetRequest> createDatasetRequestSerializer =
+                    _runtime.bodySerDe().serializer(createDatasetRequestTypeMarker);
+
+            private final Serializer<InputStream> inputStreamSerializer =
+                    _runtime.bodySerDe().serializer(inputStreamTypeMarker);
+
+            private final Serializer<String> stringSerializer =
+                    _runtime.bodySerDe().serializer(stringTypeMarker);
+
+            private final Serializer<Optional<String>> optionalStringSerializer =
+                    _runtime.bodySerDe().serializer(optionalStringTypeMarker);
+
             private final EndpointChannel getFileSystemsChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.getFileSystems);
-
-            private final Serializer<CreateDatasetRequest> createDatasetSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<CreateDatasetRequest>() {});
 
             private final EndpointChannel createDatasetChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.createDataset);
@@ -258,9 +274,6 @@ public interface TestServiceBlocking {
             private final EndpointChannel uploadRawDataChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.uploadRawData);
 
-            private final Serializer<InputStream> uploadAliasedRawDataSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<InputStream>() {});
-
             private final EndpointChannel uploadAliasedRawDataChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.uploadAliasedRawData);
 
@@ -279,14 +292,8 @@ public interface TestServiceBlocking {
             private final EndpointChannel testParamChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.testParam);
 
-            private final Serializer<String> testQueryParamsSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<String>() {});
-
             private final EndpointChannel testQueryParamsChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.testQueryParams);
-
-            private final Serializer<String> testNoResponseQueryParamsSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<String>() {});
 
             private final EndpointChannel testNoResponseQueryParamsChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.testNoResponseQueryParams);
@@ -299,9 +306,6 @@ public interface TestServiceBlocking {
 
             private final EndpointChannel testIntegerChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.testInteger);
-
-            private final Serializer<Optional<String>> testPostOptionalSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {});
 
             private final EndpointChannel testPostOptionalChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.testPostOptional);
@@ -324,7 +328,7 @@ public interface TestServiceBlocking {
             public Dataset createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(createDatasetSerializer.serialize(request));
+                _request.body(createDatasetRequestSerializer.serialize(request));
                 _request.putHeaderParams("Test-Header", _plainSerDe.serializeString(testHeaderArg));
                 return _runtime.clients().callBlocking(createDatasetChannel, _request.build(), datasetDeserializer);
             }
@@ -456,7 +460,7 @@ public interface TestServiceBlocking {
                     String query) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testQueryParamsSerializer.serialize(query));
+                _request.body(stringSerializer.serialize(query));
                 _request.putQueryParams("different", _plainSerDe.serializeRid(something));
                 if (optionalMiddle.isPresent()) {
                     _request.putQueryParams("optionalMiddle", _plainSerDe.serializeRid(optionalMiddle.get()));
@@ -482,7 +486,7 @@ public interface TestServiceBlocking {
                     String query) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testNoResponseQueryParamsSerializer.serialize(query));
+                _request.body(stringSerializer.serialize(query));
                 _request.putQueryParams("different", _plainSerDe.serializeRid(something));
                 if (optionalMiddle.isPresent()) {
                     _request.putQueryParams("optionalMiddle", _plainSerDe.serializeRid(optionalMiddle.get()));
@@ -522,7 +526,7 @@ public interface TestServiceBlocking {
             public Optional<String> testPostOptional(AuthHeader authHeader, Optional<String> maybeString) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testPostOptionalSerializer.serialize(maybeString));
+                _request.body(optionalStringSerializer.serialize(maybeString));
                 return _runtime.clients()
                         .callBlocking(testPostOptionalChannel, _request.build(), optionalStringDeserializer);
             }

--- a/conjure-java-core/src/integrationInput/java/externalfallbacktypes/com/palantir/product/external/ServiceUsingExternalTypesAsync.java
+++ b/conjure-java-core/src/integrationInput/java/externalfallbacktypes/com/palantir/product/external/ServiceUsingExternalTypesAsync.java
@@ -34,13 +34,15 @@ public interface ServiceUsingExternalTypesAsync {
             private static final TypeMarker<Map<String, String>> mapStringStringTypeMarker =
                     new TypeMarker<Map<String, String>>() {};
 
+            private static final TypeMarker<List<String>> listStringTypeMarker = new TypeMarker<List<String>>() {};
+
             private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
 
             private final Deserializer<Map<String, String>> mapStringStringDeserializer =
                     _runtime.bodySerDe().deserializer(mapStringStringTypeMarker);
 
-            private final Serializer<List<String>> externalSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<List<String>>() {});
+            private final Serializer<List<String>> listStringSerializer =
+                    _runtime.bodySerDe().serializer(listStringTypeMarker);
 
             private final EndpointChannel externalChannel =
                     _endpointChannelFactory.endpoint(DialogueServiceUsingExternalTypesEndpoints.external);
@@ -49,7 +51,7 @@ public interface ServiceUsingExternalTypesAsync {
             public ListenableFuture<Map<String, String>> external(String path, List<String> body) {
                 Request.Builder _request = Request.builder();
                 _request.putPathParams("path", _plainSerDe.serializeString(path));
-                _request.body(externalSerializer.serialize(body));
+                _request.body(listStringSerializer.serialize(body));
                 return _runtime.clients().call(externalChannel, _request.build(), mapStringStringDeserializer);
             }
 

--- a/conjure-java-core/src/integrationInput/java/externalfallbacktypes/com/palantir/product/external/ServiceUsingExternalTypesBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/externalfallbacktypes/com/palantir/product/external/ServiceUsingExternalTypesBlocking.java
@@ -34,13 +34,15 @@ public interface ServiceUsingExternalTypesBlocking {
             private static final TypeMarker<Map<String, String>> mapStringStringTypeMarker =
                     new TypeMarker<Map<String, String>>() {};
 
+            private static final TypeMarker<List<String>> listStringTypeMarker = new TypeMarker<List<String>>() {};
+
             private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
 
             private final Deserializer<Map<String, String>> mapStringStringDeserializer =
                     _runtime.bodySerDe().deserializer(mapStringStringTypeMarker);
 
-            private final Serializer<List<String>> externalSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<List<String>>() {});
+            private final Serializer<List<String>> listStringSerializer =
+                    _runtime.bodySerDe().serializer(listStringTypeMarker);
 
             private final EndpointChannel externalChannel =
                     _endpointChannelFactory.endpoint(DialogueServiceUsingExternalTypesEndpoints.external);
@@ -49,7 +51,7 @@ public interface ServiceUsingExternalTypesBlocking {
             public Map<String, String> external(String path, List<String> body) {
                 Request.Builder _request = Request.builder();
                 _request.putPathParams("path", _plainSerDe.serializeString(path));
-                _request.body(externalSerializer.serialize(body));
+                _request.body(listStringSerializer.serialize(body));
                 return _runtime.clients().callBlocking(externalChannel, _request.build(), mapStringStringDeserializer);
             }
 

--- a/conjure-java-core/src/integrationInput/java/servicevanilla/com/palantir/another/TestServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/servicevanilla/com/palantir/another/TestServiceAsync.java
@@ -202,6 +202,13 @@ public interface TestServiceAsync {
 
             private static final TypeMarker<Double> doubleTypeMarker = new TypeMarker<Double>() {};
 
+            private static final TypeMarker<CreateDatasetRequest> createDatasetRequestTypeMarker =
+                    new TypeMarker<CreateDatasetRequest>() {};
+
+            private static final TypeMarker<InputStream> inputStreamTypeMarker = new TypeMarker<InputStream>() {};
+
+            private static final TypeMarker<String> stringTypeMarker = new TypeMarker<String>() {};
+
             private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
 
             private final Deserializer<Map<String, BackingFileSystem>> mapStringBackingFileSystemDeserializer =
@@ -234,11 +241,20 @@ public interface TestServiceAsync {
             private final Deserializer<Double> doubleDeserializer =
                     _runtime.bodySerDe().deserializer(doubleTypeMarker);
 
+            private final Serializer<CreateDatasetRequest> createDatasetRequestSerializer =
+                    _runtime.bodySerDe().serializer(createDatasetRequestTypeMarker);
+
+            private final Serializer<InputStream> inputStreamSerializer =
+                    _runtime.bodySerDe().serializer(inputStreamTypeMarker);
+
+            private final Serializer<String> stringSerializer =
+                    _runtime.bodySerDe().serializer(stringTypeMarker);
+
+            private final Serializer<Optional<String>> optionalStringSerializer =
+                    _runtime.bodySerDe().serializer(optionalStringTypeMarker);
+
             private final EndpointChannel getFileSystemsChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.getFileSystems);
-
-            private final Serializer<CreateDatasetRequest> createDatasetSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<CreateDatasetRequest>() {});
 
             private final EndpointChannel createDatasetChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.createDataset);
@@ -261,9 +277,6 @@ public interface TestServiceAsync {
             private final EndpointChannel uploadRawDataChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.uploadRawData);
 
-            private final Serializer<InputStream> uploadAliasedRawDataSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<InputStream>() {});
-
             private final EndpointChannel uploadAliasedRawDataChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.uploadAliasedRawData);
 
@@ -282,14 +295,8 @@ public interface TestServiceAsync {
             private final EndpointChannel testParamChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.testParam);
 
-            private final Serializer<String> testQueryParamsSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<String>() {});
-
             private final EndpointChannel testQueryParamsChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.testQueryParams);
-
-            private final Serializer<String> testNoResponseQueryParamsSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<String>() {});
 
             private final EndpointChannel testNoResponseQueryParamsChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.testNoResponseQueryParams);
@@ -302,9 +309,6 @@ public interface TestServiceAsync {
 
             private final EndpointChannel testIntegerChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.testInteger);
-
-            private final Serializer<Optional<String>> testPostOptionalSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {});
 
             private final EndpointChannel testPostOptionalChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.testPostOptional);
@@ -328,7 +332,7 @@ public interface TestServiceAsync {
                     AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(createDatasetSerializer.serialize(request));
+                _request.body(createDatasetRequestSerializer.serialize(request));
                 _request.putHeaderParams("Test-Header", _plainSerDe.serializeString(testHeaderArg));
                 return _runtime.clients().call(createDatasetChannel, _request.build(), datasetDeserializer);
             }
@@ -463,7 +467,7 @@ public interface TestServiceAsync {
                     String query) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testQueryParamsSerializer.serialize(query));
+                _request.body(stringSerializer.serialize(query));
                 _request.putQueryParams("different", _plainSerDe.serializeRid(something));
                 if (optionalMiddle.isPresent()) {
                     _request.putQueryParams("optionalMiddle", _plainSerDe.serializeRid(optionalMiddle.get()));
@@ -489,7 +493,7 @@ public interface TestServiceAsync {
                     String query) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testNoResponseQueryParamsSerializer.serialize(query));
+                _request.body(stringSerializer.serialize(query));
                 _request.putQueryParams("different", _plainSerDe.serializeRid(something));
                 if (optionalMiddle.isPresent()) {
                     _request.putQueryParams("optionalMiddle", _plainSerDe.serializeRid(optionalMiddle.get()));
@@ -530,7 +534,7 @@ public interface TestServiceAsync {
                     AuthHeader authHeader, Optional<String> maybeString) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testPostOptionalSerializer.serialize(maybeString));
+                _request.body(optionalStringSerializer.serialize(maybeString));
                 return _runtime.clients().call(testPostOptionalChannel, _request.build(), optionalStringDeserializer);
             }
 

--- a/conjure-java-core/src/integrationInput/java/servicevanilla/com/palantir/another/TestServiceAsync.java
+++ b/conjure-java-core/src/integrationInput/java/servicevanilla/com/palantir/another/TestServiceAsync.java
@@ -205,8 +205,6 @@ public interface TestServiceAsync {
             private static final TypeMarker<CreateDatasetRequest> createDatasetRequestTypeMarker =
                     new TypeMarker<CreateDatasetRequest>() {};
 
-            private static final TypeMarker<InputStream> inputStreamTypeMarker = new TypeMarker<InputStream>() {};
-
             private static final TypeMarker<String> stringTypeMarker = new TypeMarker<String>() {};
 
             private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
@@ -243,9 +241,6 @@ public interface TestServiceAsync {
 
             private final Serializer<CreateDatasetRequest> createDatasetRequestSerializer =
                     _runtime.bodySerDe().serializer(createDatasetRequestTypeMarker);
-
-            private final Serializer<InputStream> inputStreamSerializer =
-                    _runtime.bodySerDe().serializer(inputStreamTypeMarker);
 
             private final Serializer<String> stringSerializer =
                     _runtime.bodySerDe().serializer(stringTypeMarker);

--- a/conjure-java-core/src/integrationInput/java/servicevanilla/com/palantir/another/TestServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/servicevanilla/com/palantir/another/TestServiceBlocking.java
@@ -202,8 +202,6 @@ public interface TestServiceBlocking {
             private static final TypeMarker<CreateDatasetRequest> createDatasetRequestTypeMarker =
                     new TypeMarker<CreateDatasetRequest>() {};
 
-            private static final TypeMarker<InputStream> inputStreamTypeMarker = new TypeMarker<InputStream>() {};
-
             private static final TypeMarker<String> stringTypeMarker = new TypeMarker<String>() {};
 
             private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
@@ -240,9 +238,6 @@ public interface TestServiceBlocking {
 
             private final Serializer<CreateDatasetRequest> createDatasetRequestSerializer =
                     _runtime.bodySerDe().serializer(createDatasetRequestTypeMarker);
-
-            private final Serializer<InputStream> inputStreamSerializer =
-                    _runtime.bodySerDe().serializer(inputStreamTypeMarker);
 
             private final Serializer<String> stringSerializer =
                     _runtime.bodySerDe().serializer(stringTypeMarker);

--- a/conjure-java-core/src/integrationInput/java/servicevanilla/com/palantir/another/TestServiceBlocking.java
+++ b/conjure-java-core/src/integrationInput/java/servicevanilla/com/palantir/another/TestServiceBlocking.java
@@ -199,6 +199,13 @@ public interface TestServiceBlocking {
 
             private static final TypeMarker<Double> doubleTypeMarker = new TypeMarker<Double>() {};
 
+            private static final TypeMarker<CreateDatasetRequest> createDatasetRequestTypeMarker =
+                    new TypeMarker<CreateDatasetRequest>() {};
+
+            private static final TypeMarker<InputStream> inputStreamTypeMarker = new TypeMarker<InputStream>() {};
+
+            private static final TypeMarker<String> stringTypeMarker = new TypeMarker<String>() {};
+
             private final PlainSerDe _plainSerDe = _runtime.plainSerDe();
 
             private final Deserializer<Map<String, BackingFileSystem>> mapStringBackingFileSystemDeserializer =
@@ -231,11 +238,20 @@ public interface TestServiceBlocking {
             private final Deserializer<Double> doubleDeserializer =
                     _runtime.bodySerDe().deserializer(doubleTypeMarker);
 
+            private final Serializer<CreateDatasetRequest> createDatasetRequestSerializer =
+                    _runtime.bodySerDe().serializer(createDatasetRequestTypeMarker);
+
+            private final Serializer<InputStream> inputStreamSerializer =
+                    _runtime.bodySerDe().serializer(inputStreamTypeMarker);
+
+            private final Serializer<String> stringSerializer =
+                    _runtime.bodySerDe().serializer(stringTypeMarker);
+
+            private final Serializer<Optional<String>> optionalStringSerializer =
+                    _runtime.bodySerDe().serializer(optionalStringTypeMarker);
+
             private final EndpointChannel getFileSystemsChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.getFileSystems);
-
-            private final Serializer<CreateDatasetRequest> createDatasetSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<CreateDatasetRequest>() {});
 
             private final EndpointChannel createDatasetChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.createDataset);
@@ -258,9 +274,6 @@ public interface TestServiceBlocking {
             private final EndpointChannel uploadRawDataChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.uploadRawData);
 
-            private final Serializer<InputStream> uploadAliasedRawDataSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<InputStream>() {});
-
             private final EndpointChannel uploadAliasedRawDataChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.uploadAliasedRawData);
 
@@ -279,14 +292,8 @@ public interface TestServiceBlocking {
             private final EndpointChannel testParamChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.testParam);
 
-            private final Serializer<String> testQueryParamsSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<String>() {});
-
             private final EndpointChannel testQueryParamsChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.testQueryParams);
-
-            private final Serializer<String> testNoResponseQueryParamsSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<String>() {});
 
             private final EndpointChannel testNoResponseQueryParamsChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.testNoResponseQueryParams);
@@ -299,9 +306,6 @@ public interface TestServiceBlocking {
 
             private final EndpointChannel testIntegerChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.testInteger);
-
-            private final Serializer<Optional<String>> testPostOptionalSerializer =
-                    _runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {});
 
             private final EndpointChannel testPostOptionalChannel =
                     _endpointChannelFactory.endpoint(DialogueTestEndpoints.testPostOptional);
@@ -324,7 +328,7 @@ public interface TestServiceBlocking {
             public Dataset createDataset(AuthHeader authHeader, String testHeaderArg, CreateDatasetRequest request) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(createDatasetSerializer.serialize(request));
+                _request.body(createDatasetRequestSerializer.serialize(request));
                 _request.putHeaderParams("Test-Header", _plainSerDe.serializeString(testHeaderArg));
                 return _runtime.clients().callBlocking(createDatasetChannel, _request.build(), datasetDeserializer);
             }
@@ -456,7 +460,7 @@ public interface TestServiceBlocking {
                     String query) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testQueryParamsSerializer.serialize(query));
+                _request.body(stringSerializer.serialize(query));
                 _request.putQueryParams("different", _plainSerDe.serializeRid(something));
                 if (optionalMiddle.isPresent()) {
                     _request.putQueryParams("optionalMiddle", _plainSerDe.serializeRid(optionalMiddle.get()));
@@ -482,7 +486,7 @@ public interface TestServiceBlocking {
                     String query) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testNoResponseQueryParamsSerializer.serialize(query));
+                _request.body(stringSerializer.serialize(query));
                 _request.putQueryParams("different", _plainSerDe.serializeRid(something));
                 if (optionalMiddle.isPresent()) {
                     _request.putQueryParams("optionalMiddle", _plainSerDe.serializeRid(optionalMiddle.get()));
@@ -522,7 +526,7 @@ public interface TestServiceBlocking {
             public Optional<String> testPostOptional(AuthHeader authHeader, Optional<String> maybeString) {
                 Request.Builder _request = Request.builder();
                 _request.putHeaderParams("Authorization", authHeader.toString());
-                _request.body(testPostOptionalSerializer.serialize(maybeString));
+                _request.body(optionalStringSerializer.serialize(maybeString));
                 return _runtime.clients()
                         .callBlocking(testPostOptionalChannel, _request.build(), optionalStringDeserializer);
             }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DefaultStaticFactoryMethodGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DefaultStaticFactoryMethodGenerator.java
@@ -188,7 +188,7 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
             endpoint.getArgs().stream()
                     .filter(arg -> arg.getParamType().accept(ParameterTypeVisitor.IS_BODY))
                     .findAny()
-                    .filter(body -> !body.getType().accept(TypeVisitor.IS_BINARY))
+                    .filter(body -> !parameterTypes.isBinary(body.getType()))
                     .ifPresent(body -> {
                         TypeName bodyClassName = Primitives.box(returnTypes.baseType(body.getType()));
                         String baseName = fieldBaseNames.computeIfAbsent(
@@ -473,9 +473,7 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
         return param.getParamType().accept(new ParameterType.Visitor<CodeBlock>() {
             @Override
             public CodeBlock visitBody(BodyParameterType value) {
-                if (parameterTypes
-                        .baseType(param.getType())
-                        .equals(parameterTypes.baseType(Type.primitive(PrimitiveType.BINARY)))) {
+                if (parameterTypes.isBinary(param.getType())) {
                     return CodeBlock.of(
                             "$L.body($L.bodySerDe().serialize($L));",
                             REQUEST,

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DefaultStaticFactoryMethodGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DefaultStaticFactoryMethodGenerator.java
@@ -346,16 +346,19 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
 
     /**
      * Computes a unique camelCase field base name for a given TypeName. If the derived name collides with an
-     * already-used name, a deterministic hash suffix is appended.
+     * already-used name, a numeric suffix is appended.
      */
     private static String uniqueFieldBaseName(TypeName typeName, Set<String> usedNames) {
         String base = typeNameToFieldBase(typeName);
         if (usedNames.add(base)) {
             return base;
         }
-        String candidate = base + deterministicHash(typeName);
-        usedNames.add(candidate);
-        return candidate;
+        for (int suffix = 2; ; suffix++) {
+            String candidate = base + suffix;
+            if (usedNames.add(candidate)) {
+                return candidate;
+            }
+        }
     }
 
     private static String deterministicHash(TypeName typeName) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DefaultStaticFactoryMethodGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DefaultStaticFactoryMethodGenerator.java
@@ -144,6 +144,7 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
                 .build();
     }
 
+    @SuppressWarnings("checkstyle:cyclomaticcomplexity")
     private SerDeFieldsContext collectSerDeFields(ServiceDefinition def, boolean isErrorRespecting) {
         Map<TypeName, String> fieldBaseNames = new HashMap<>();
         Map<TypeName, String> typeMarkerFields = new LinkedHashMap<>();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DefaultStaticFactoryMethodGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/DefaultStaticFactoryMethodGenerator.java
@@ -29,7 +29,6 @@ import com.palantir.conjure.spec.AuthType;
 import com.palantir.conjure.spec.BodyParameterType;
 import com.palantir.conjure.spec.CookieAuthType;
 import com.palantir.conjure.spec.EndpointDefinition;
-import com.palantir.conjure.spec.EndpointName;
 import com.palantir.conjure.spec.ErrorDefinition;
 import com.palantir.conjure.spec.ExternalReference;
 import com.palantir.conjure.spec.HeaderAuthType;
@@ -122,11 +121,13 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
             impl.addMethod(createHelperToConstructExceptionDeserializerArgs());
         }
 
-        ReturnTypeFieldsContext context = collectReturnTypeFields(def, isErrorRespecting);
-        generateTypeMarkerFields(impl, context, isErrorRespecting);
+        SerDeFieldsContext context = collectSerDeFields(def, isErrorRespecting);
+        generateTypeMarkerFields(impl, context);
         generateExceptionArgsFields(impl, context);
         generateDeserializerFields(impl, context, isErrorRespecting);
-        generateEndpointImplementations(impl, def, context.endpointToDeserializerField());
+        generateSerializerFields(impl, context);
+        generateEndpointImplementations(
+                impl, def, context.endpointToSerializerField(), context.endpointToDeserializerField());
 
         impl.addMethod(DefaultStaticFactoryMethodGenerator.toStringMethod(className));
 
@@ -143,12 +144,15 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
                 .build();
     }
 
-    private ReturnTypeFieldsContext collectReturnTypeFields(ServiceDefinition def, boolean isErrorRespecting) {
+    private SerDeFieldsContext collectSerDeFields(ServiceDefinition def, boolean isErrorRespecting) {
+        Map<TypeName, String> fieldBaseNames = new HashMap<>();
         Map<TypeName, String> typeMarkerFields = new LinkedHashMap<>();
         Map<TypeName, String> exceptionArgsFields = new LinkedHashMap<>();
         Map<TypeName, String> deserializerFieldNames = new LinkedHashMap<>();
         Map<TypeName, DeserializerType> deserializerTypes = new LinkedHashMap<>();
+        Map<TypeName, String> serializerFieldNames = new LinkedHashMap<>();
         Map<String, String> endpointToDeserializerField = new HashMap<>();
+        Map<String, String> endpointToSerializerField = new HashMap<>();
         Set<String> usedBaseNames = new HashSet<>();
 
         for (EndpointDefinition endpoint : def.getEndpoints()) {
@@ -159,9 +163,12 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
                 continue;
             }
 
+            String baseName = fieldBaseNames.computeIfAbsent(
+                    returnClassName, typeName -> uniqueFieldBaseName(typeName, usedBaseNames));
             if (!deserializerFieldNames.containsKey(returnClassName)) {
-                String baseName = uniqueFieldBaseName(returnClassName, usedBaseNames);
-                typeMarkerFields.put(returnClassName, baseName + "TypeMarker");
+                if (isErrorRespecting || endpoint.getReturns().isPresent()) {
+                    typeMarkerFields.put(returnClassName, baseName + "TypeMarker");
+                }
                 if (isErrorRespecting) {
                     exceptionArgsFields.put(returnClassName, baseName + "ExceptionArgs");
                 }
@@ -176,31 +183,42 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
                     endpoint.getEndpointName().get(), deserializerFieldNames.get(returnClassName));
         }
 
-        return new ReturnTypeFieldsContext(
+        for (EndpointDefinition endpoint : def.getEndpoints()) {
+            endpoint.getArgs().stream()
+                    .filter(arg -> arg.getParamType().accept(ParameterTypeVisitor.IS_BODY))
+                    .findAny()
+                    .filter(body -> !body.getType().accept(TypeVisitor.IS_BINARY))
+                    .ifPresent(body -> {
+                        TypeName bodyClassName = Primitives.box(returnTypes.baseType(body.getType()));
+                        String baseName = fieldBaseNames.computeIfAbsent(
+                                bodyClassName, typeName -> uniqueFieldBaseName(typeName, usedBaseNames));
+                        typeMarkerFields.putIfAbsent(bodyClassName, baseName + "TypeMarker");
+                        serializerFieldNames.putIfAbsent(bodyClassName, baseName + "Serializer");
+                        endpointToSerializerField.put(
+                                endpoint.getEndpointName().get(), serializerFieldNames.get(bodyClassName));
+                    });
+        }
+
+        return new SerDeFieldsContext(
                 typeMarkerFields,
                 exceptionArgsFields,
                 deserializerFieldNames,
                 deserializerTypes,
-                endpointToDeserializerField);
+                serializerFieldNames,
+                endpointToDeserializerField,
+                endpointToSerializerField);
     }
 
-    private static void generateTypeMarkerFields(
-            TypeSpec.Builder impl, ReturnTypeFieldsContext context, boolean isErrorRespecting) {
-        context.typeMarkerFields().forEach((typeName, fieldName) -> {
-            DeserializerType deserType = context.deserializerTypes().get(typeName);
-            if (!isErrorRespecting && deserType == DeserializerType.EMPTY_BODY) {
-                // Non-error empty body deserializer does not need a TypeMarker
-                return;
-            }
-            impl.addField(
-                    FieldSpec.builder(ParameterizedTypeName.get(ClassName.get(TypeMarker.class), typeName), fieldName)
-                            .addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
-                            .initializer("new $T<$T>() {}", TypeMarker.class, typeName)
-                            .build());
-        });
+    private static void generateTypeMarkerFields(TypeSpec.Builder impl, SerDeFieldsContext context) {
+        context.typeMarkerFields()
+                .forEach((typeName, fieldName) -> impl.addField(FieldSpec.builder(
+                                ParameterizedTypeName.get(ClassName.get(TypeMarker.class), typeName), fieldName)
+                        .addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+                        .initializer("new $T<$T>() {}", TypeMarker.class, typeName)
+                        .build()));
     }
 
-    private static void generateExceptionArgsFields(TypeSpec.Builder impl, ReturnTypeFieldsContext context) {
+    private static void generateExceptionArgsFields(TypeSpec.Builder impl, SerDeFieldsContext context) {
         context.exceptionArgsFields().forEach((typeName, fieldName) -> {
             impl.addField(FieldSpec.builder(
                             ParameterizedTypeName.get(ClassName.get(ExceptionDeserializerArgs.class), typeName),
@@ -214,7 +232,7 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
     }
 
     private static void generateDeserializerFields(
-            TypeSpec.Builder impl, ReturnTypeFieldsContext context, boolean isErrorRespecting) {
+            TypeSpec.Builder impl, SerDeFieldsContext context, boolean isErrorRespecting) {
         context.deserializerFieldNames().forEach((typeName, fieldName) -> {
             ParameterizedTypeName deserializerType =
                     ParameterizedTypeName.get(ClassName.get(Deserializer.class), typeName);
@@ -227,8 +245,20 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
         });
     }
 
+    private static void generateSerializerFields(TypeSpec.Builder impl, SerDeFieldsContext context) {
+        context.serializerFieldNames()
+                .forEach((typeName, fieldName) -> impl.addField(FieldSpec.builder(
+                                ParameterizedTypeName.get(ClassName.get(Serializer.class), typeName), fieldName)
+                        .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                        .initializer(
+                                "$L.bodySerDe().serializer($L)",
+                                StaticFactoryMethodGenerator.RUNTIME,
+                                context.typeMarkerFields().get(typeName))
+                        .build()));
+    }
+
     private static CodeBlock createDeserializerInitializer(
-            DeserializerType deserType, TypeName typeName, ReturnTypeFieldsContext context, boolean isErrorRespecting) {
+            DeserializerType deserType, TypeName typeName, SerDeFieldsContext context, boolean isErrorRespecting) {
         if (isErrorRespecting) {
             String argsField = context.exceptionArgsFields().get(typeName);
             return switch (deserType) {
@@ -265,16 +295,13 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
     }
 
     private void generateEndpointImplementations(
-            TypeSpec.Builder impl, ServiceDefinition def, Map<String, String> endpointToDeserializerField) {
+            TypeSpec.Builder impl,
+            ServiceDefinition def,
+            Map<String, String> endpointToSerializerField,
+            Map<String, String> endpointToDeserializerField) {
         def.getEndpoints().forEach(endpoint -> {
-            endpoint.getArgs().stream()
-                    .filter(arg -> arg.getParamType().accept(ParameterTypeVisitor.IS_BODY))
-                    .findAny()
-                    .flatMap(body -> serializer(endpoint.getEndpointName(), body.getType()))
-                    .ifPresent(impl::addField);
-
             impl.addField(bindEndpointChannel(def, endpoint));
-            impl.addMethod(clientImpl(endpoint, endpointToDeserializerField));
+            impl.addMethod(clientImpl(endpoint, endpointToSerializerField, endpointToDeserializerField));
         });
     }
 
@@ -367,23 +394,10 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
                 .build();
     }
 
-    private Optional<FieldSpec> serializer(EndpointName endpointName, Type type) {
-        if (type.accept(TypeVisitor.IS_BINARY)) {
-            return Optional.empty();
-        }
-        TypeName className = Primitives.box(returnTypes.baseType(type));
-        ParameterizedTypeName deserializerType = ParameterizedTypeName.get(ClassName.get(Serializer.class), className);
-        return Optional.of(FieldSpec.builder(deserializerType, endpointName + "Serializer")
-                .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
-                .initializer(
-                        "$L.bodySerDe().serializer(new $T<$T>() {})",
-                        StaticFactoryMethodGenerator.RUNTIME,
-                        TypeMarker.class,
-                        className)
-                .build());
-    }
-
-    private MethodSpec clientImpl(EndpointDefinition def, Map<String, String> endpointToDeserializerField) {
+    private MethodSpec clientImpl(
+            EndpointDefinition def,
+            Map<String, String> endpointToSerializerField,
+            Map<String, String> endpointToDeserializerField) {
         List<ParameterSpec> params = parameterTypes.implementationMethodParams(def);
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(
                         def.getEndpointName().get())
@@ -406,7 +420,7 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
                 .ifPresent(requestParams::add);
 
         def.getArgs().stream()
-                .map(param -> generateParam(def.getEndpointName().get(), param))
+                .map(param -> generateParam(def.getEndpointName().get(), param, endpointToSerializerField))
                 .forEach(requestParams::add);
 
         CodeBlock request = CodeBlock.builder()
@@ -453,7 +467,8 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
         return methodType.switchBy(returnTypes.baseType(def.getReturns()), returnTypes.async(def.getReturns()));
     }
 
-    private CodeBlock generateParam(String endpointName, ArgumentDefinition param) {
+    private CodeBlock generateParam(
+            String endpointName, ArgumentDefinition param, Map<String, String> endpointToSerializerField) {
         return param.getParamType().accept(new ParameterType.Visitor<CodeBlock>() {
             @Override
             public CodeBlock visitBody(BodyParameterType value) {
@@ -466,7 +481,11 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
                             StaticFactoryMethodGenerator.RUNTIME,
                             param.getArgName());
                 }
-                return CodeBlock.of("$L.body($LSerializer.serialize($L));", REQUEST, endpointName, param.getArgName());
+                return CodeBlock.of(
+                        "$L.body($L.serialize($L));",
+                        REQUEST,
+                        endpointToSerializerField.get(endpointName),
+                        param.getArgName());
             }
 
             @Override
@@ -678,12 +697,14 @@ public final class DefaultStaticFactoryMethodGenerator implements StaticFactoryM
         OPTIONAL_BINARY;
     }
 
-    private record ReturnTypeFieldsContext(
+    private record SerDeFieldsContext(
             Map<TypeName, String> typeMarkerFields,
             Map<TypeName, String> exceptionArgsFields,
             Map<TypeName, String> deserializerFieldNames,
             Map<TypeName, DeserializerType> deserializerTypes,
-            Map<String, String> endpointToDeserializerField) {}
+            Map<TypeName, String> serializerFieldNames,
+            Map<String, String> endpointToDeserializerField,
+            Map<String, String> endpointToSerializerField) {}
 
     private DeserializerType getDeserializerType(Optional<Type> type, TypeName className) {
         if (type.isEmpty()) {

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/ParameterTypeMapper.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/dialogue/ParameterTypeMapper.java
@@ -33,6 +33,7 @@ import com.palantir.conjure.spec.MapType;
 import com.palantir.conjure.spec.OptionalType;
 import com.palantir.conjure.spec.ParameterType;
 import com.palantir.conjure.spec.PathParameterType;
+import com.palantir.conjure.spec.PrimitiveType;
 import com.palantir.conjure.spec.QueryParameterType;
 import com.palantir.conjure.spec.SetType;
 import com.palantir.conjure.spec.Type;
@@ -54,6 +55,10 @@ public final class ParameterTypeMapper {
 
     public TypeName baseType(Type type) {
         return parameterTypes.getClassName(type);
+    }
+
+    public boolean isBinary(Type type) {
+        return baseType(type).equals(baseType(Type.primitive(PrimitiveType.BINARY)));
     }
 
     public List<ParameterSpec> interfaceMethodParams(EndpointDefinition endpointDef) {

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/DialogueServiceGeneratorTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/DialogueServiceGeneratorTests.java
@@ -67,6 +67,14 @@ public final class DialogueServiceGeneratorTests extends TestBase {
         // Generated files contain imports
         assertThat(compiledFileContent(src, "test/api/with/imports/ImportServiceBlocking.java"))
                 .contains("import com.palantir.product.StringExample;");
+
+        String testService = compiledFileContent(src, "com/palantir/another/TestServiceBlocking.java");
+        assertThat(testService)
+                .as("Identical body types share a serializer")
+                .containsOnlyOnce("private final Serializer<String> stringSerializer");
+        assertThat(testService)
+                .as("Binary body aliases do not produce serializer fields")
+                .doesNotContain("Serializer<InputStream>", "TypeMarker<InputStream>");
     }
 
     @Test


### PR DESCRIPTION
In addition to collecting and hoisting Deserializers, apply this approach to Serializers as well. This should be at least safe as the parent change, since like deserializers, serializers should be reused, and unlike deserializers, they don't have any endpoint information.

This allows for hoisting and deduplication of all TypeMarkers, instead of just the types used for deserialization.
