### PR TITLE
[dnm] Prototype for ofType and ofGeneric TypeMarkers

### DIFF
--- a/conjure-java-core/src/integrationInput/java/asyncrequest/com/palantir/product/AsyncRequestProcessingTestServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/asyncrequest/com/palantir/product/AsyncRequestProcessingTestServiceEndpoints.java
@@ -58,7 +58,7 @@ public final class AsyncRequestProcessingTestServiceEndpoints implements Underto
         DelayEndpoint(UndertowRuntime runtime, UndertowAsyncRequestProcessingTestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(String.class), this);
         }
 
         @Override
@@ -113,7 +113,7 @@ public final class AsyncRequestProcessingTestServiceEndpoints implements Underto
         DelayFiveSecondTimeoutEndpoint(UndertowRuntime runtime, UndertowAsyncRequestProcessingTestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(String.class), this);
         }
 
         @Override
@@ -321,7 +321,7 @@ public final class AsyncRequestProcessingTestServiceEndpoints implements Underto
         FutureTraceIdEndpoint(UndertowRuntime runtime, UndertowAsyncRequestProcessingTestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Object>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(Object.class), this);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/ErrorServiceEndpoints.java
@@ -54,8 +54,8 @@ public final class ErrorServiceEndpoints implements UndertowService {
         TestBasicErrorEndpoint(UndertowRuntime runtime, UndertowErrorService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {}, this);
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(Boolean.class), this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(String.class), this);
         }
 
         @Override
@@ -105,8 +105,8 @@ public final class ErrorServiceEndpoints implements UndertowService {
         TestImportedErrorEndpoint(UndertowRuntime runtime, UndertowErrorService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {}, this);
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(Boolean.class), this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(String.class), this);
         }
 
         @Override
@@ -156,8 +156,9 @@ public final class ErrorServiceEndpoints implements UndertowService {
         TestMultipleErrorsAndPackagesEndpoint(UndertowRuntime runtime, UndertowErrorService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {}, this);
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+            this.deserializer = runtime.bodySerDe()
+                    .deserializer(TypeMarker.ofGeneric(Optional.class, TypeMarker.of(String.class)), this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(String.class), this);
         }
 
         @Override
@@ -208,7 +209,7 @@ public final class ErrorServiceEndpoints implements UndertowService {
         TestEmptyBodyEndpoint(UndertowRuntime runtime, UndertowErrorService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(Boolean.class), this);
         }
 
         @Override
@@ -255,7 +256,7 @@ public final class ErrorServiceEndpoints implements UndertowService {
         TestBinaryEndpoint(UndertowRuntime runtime, UndertowErrorService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(Boolean.class), this);
         }
 
         @Override
@@ -302,7 +303,7 @@ public final class ErrorServiceEndpoints implements UndertowService {
         TestOptionalBinaryEndpoint(UndertowRuntime runtime, UndertowErrorService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<OptionalBinaryResponseMode>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(OptionalBinaryResponseMode.class), this);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/externalfallbacktypes/com/palantir/product/external/ServiceUsingExternalTypesEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/externalfallbacktypes/com/palantir/product/external/ServiceUsingExternalTypesEndpoints.java
@@ -48,8 +48,12 @@ public final class ServiceUsingExternalTypesEndpoints implements UndertowService
         ExternalEndpoint(UndertowRuntime runtime, ServiceUsingExternalTypes delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<ImmutableList<String>>() {}, this);
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Map<String, String>>() {}, this);
+            this.deserializer = runtime.bodySerDe()
+                    .deserializer(TypeMarker.ofGeneric(ImmutableList.class, TypeMarker.of(String.class)), this);
+            this.serializer = runtime.bodySerDe()
+                    .serializer(
+                            TypeMarker.ofGeneric(Map.class, TypeMarker.of(String.class), TypeMarker.of(String.class)),
+                            this);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/servicevanilla/com/palantir/another/TestServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/servicevanilla/com/palantir/another/TestServiceEndpoints.java
@@ -86,7 +86,11 @@ public final class TestServiceEndpoints implements UndertowService {
         GetFileSystemsEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Map<String, BackingFileSystem>>() {}, this);
+            this.serializer = runtime.bodySerDe()
+                    .serializer(
+                            TypeMarker.ofGeneric(
+                                    Map.class, TypeMarker.of(String.class), TypeMarker.of(BackingFileSystem.class)),
+                            this);
         }
 
         @Override
@@ -139,8 +143,8 @@ public final class TestServiceEndpoints implements UndertowService {
         CreateDatasetEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<CreateDatasetRequest>() {}, this);
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Dataset>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(CreateDatasetRequest.class), this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(Dataset.class), this);
         }
 
         @Override
@@ -191,7 +195,8 @@ public final class TestServiceEndpoints implements UndertowService {
         GetDatasetEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<Dataset>>() {}, this);
+            this.serializer = runtime.bodySerDe()
+                    .serializer(TypeMarker.ofGeneric(Optional.class, TypeMarker.of(Dataset.class)), this);
         }
 
         @Override
@@ -395,7 +400,7 @@ public final class TestServiceEndpoints implements UndertowService {
         GetAliasedStringEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<AliasedString>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(AliasedString.class), this);
         }
 
         @Override
@@ -534,7 +539,8 @@ public final class TestServiceEndpoints implements UndertowService {
         GetBranchesEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Set<String>>() {}, this);
+            this.serializer =
+                    runtime.bodySerDe().serializer(TypeMarker.ofGeneric(Set.class, TypeMarker.of(String.class)), this);
         }
 
         @Override
@@ -585,7 +591,8 @@ public final class TestServiceEndpoints implements UndertowService {
         GetBranchesDeprecatedEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Set<String>>() {}, this);
+            this.serializer =
+                    runtime.bodySerDe().serializer(TypeMarker.ofGeneric(Set.class, TypeMarker.of(String.class)), this);
         }
 
         @Override
@@ -644,7 +651,8 @@ public final class TestServiceEndpoints implements UndertowService {
         GetBranchesDeprecatedForRemovalEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Set<String>>() {}, this);
+            this.serializer =
+                    runtime.bodySerDe().serializer(TypeMarker.ofGeneric(Set.class, TypeMarker.of(String.class)), this);
         }
 
         @Override
@@ -706,7 +714,8 @@ public final class TestServiceEndpoints implements UndertowService {
         ResolveBranchEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {}, this);
+            this.serializer = runtime.bodySerDe()
+                    .serializer(TypeMarker.ofGeneric(Optional.class, TypeMarker.of(String.class)), this);
         }
 
         @Override
@@ -762,7 +771,8 @@ public final class TestServiceEndpoints implements UndertowService {
         TestParamEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {}, this);
+            this.serializer = runtime.bodySerDe()
+                    .serializer(TypeMarker.ofGeneric(Optional.class, TypeMarker.of(String.class)), this);
         }
 
         @Override
@@ -819,8 +829,8 @@ public final class TestServiceEndpoints implements UndertowService {
         TestQueryParamsEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {}, this);
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Integer>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(String.class), this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(Integer.class), this);
         }
 
         @Override
@@ -878,7 +888,7 @@ public final class TestServiceEndpoints implements UndertowService {
         TestNoResponseQueryParamsEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(String.class), this);
         }
 
         @Override
@@ -934,7 +944,7 @@ public final class TestServiceEndpoints implements UndertowService {
         TestBooleanEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(Boolean.class), this);
         }
 
         @Override
@@ -980,7 +990,7 @@ public final class TestServiceEndpoints implements UndertowService {
         TestDoubleEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Double>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(Double.class), this);
         }
 
         @Override
@@ -1026,7 +1036,7 @@ public final class TestServiceEndpoints implements UndertowService {
         TestIntegerEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Integer>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(Integer.class), this);
         }
 
         @Override
@@ -1074,8 +1084,10 @@ public final class TestServiceEndpoints implements UndertowService {
         TestPostOptionalEndpoint(UndertowRuntime runtime, TestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {}, this);
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {}, this);
+            this.deserializer = runtime.bodySerDe()
+                    .deserializer(TypeMarker.ofGeneric(Optional.class, TypeMarker.of(String.class)), this);
+            this.serializer = runtime.bodySerDe()
+                    .serializer(TypeMarker.ofGeneric(Optional.class, TypeMarker.of(String.class)), this);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/EmptyPathServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/EmptyPathServiceEndpoints.java
@@ -41,7 +41,7 @@ public final class EmptyPathServiceEndpoints implements UndertowService {
         EmptyPathEndpoint(UndertowRuntime runtime, UndertowEmptyPathService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(Boolean.class), this);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/ErrorServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/ErrorServiceEndpoints.java
@@ -54,8 +54,8 @@ public final class ErrorServiceEndpoints implements UndertowService {
         TestBasicErrorEndpoint(UndertowRuntime runtime, UndertowErrorService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {}, this);
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(Boolean.class), this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(String.class), this);
         }
 
         @Override
@@ -105,8 +105,8 @@ public final class ErrorServiceEndpoints implements UndertowService {
         TestImportedErrorEndpoint(UndertowRuntime runtime, UndertowErrorService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {}, this);
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(Boolean.class), this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(String.class), this);
         }
 
         @Override
@@ -156,8 +156,9 @@ public final class ErrorServiceEndpoints implements UndertowService {
         TestMultipleErrorsAndPackagesEndpoint(UndertowRuntime runtime, UndertowErrorService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Optional<String>>() {}, this);
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+            this.deserializer = runtime.bodySerDe()
+                    .deserializer(TypeMarker.ofGeneric(Optional.class, TypeMarker.of(String.class)), this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(String.class), this);
         }
 
         @Override
@@ -208,7 +209,7 @@ public final class ErrorServiceEndpoints implements UndertowService {
         TestEmptyBodyEndpoint(UndertowRuntime runtime, UndertowErrorService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(Boolean.class), this);
         }
 
         @Override
@@ -255,7 +256,7 @@ public final class ErrorServiceEndpoints implements UndertowService {
         TestBinaryEndpoint(UndertowRuntime runtime, UndertowErrorService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Boolean>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(Boolean.class), this);
         }
 
         @Override
@@ -302,7 +303,7 @@ public final class ErrorServiceEndpoints implements UndertowService {
         TestOptionalBinaryEndpoint(UndertowRuntime runtime, UndertowErrorService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<OptionalBinaryResponseMode>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(OptionalBinaryResponseMode.class), this);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/EteServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/EteServiceEndpoints.java
@@ -94,7 +94,7 @@ public final class EteServiceEndpoints implements UndertowService {
         StringEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(String.class), this);
         }
 
         @Override
@@ -145,7 +145,7 @@ public final class EteServiceEndpoints implements UndertowService {
         IntegerEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Integer>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(Integer.class), this);
         }
 
         @Override
@@ -191,7 +191,7 @@ public final class EteServiceEndpoints implements UndertowService {
         Double_Endpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Double>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(Double.class), this);
         }
 
         @Override
@@ -237,7 +237,7 @@ public final class EteServiceEndpoints implements UndertowService {
         Boolean_Endpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Boolean>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(Boolean.class), this);
         }
 
         @Override
@@ -283,7 +283,7 @@ public final class EteServiceEndpoints implements UndertowService {
         SafelongEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<SafeLong>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(SafeLong.class), this);
         }
 
         @Override
@@ -329,7 +329,7 @@ public final class EteServiceEndpoints implements UndertowService {
         RidEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<ResourceIdentifier>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(ResourceIdentifier.class), this);
         }
 
         @Override
@@ -375,7 +375,7 @@ public final class EteServiceEndpoints implements UndertowService {
         BearertokenEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<BearerToken>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(BearerToken.class), this);
         }
 
         @Override
@@ -421,7 +421,8 @@ public final class EteServiceEndpoints implements UndertowService {
         OptionalStringEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {}, this);
+            this.serializer = runtime.bodySerDe()
+                    .serializer(TypeMarker.ofGeneric(Optional.class, TypeMarker.of(String.class)), this);
         }
 
         @Override
@@ -471,7 +472,8 @@ public final class EteServiceEndpoints implements UndertowService {
         OptionalEmptyEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<String>>() {}, this);
+            this.serializer = runtime.bodySerDe()
+                    .serializer(TypeMarker.ofGeneric(Optional.class, TypeMarker.of(String.class)), this);
         }
 
         @Override
@@ -521,7 +523,7 @@ public final class EteServiceEndpoints implements UndertowService {
         DatetimeEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<OffsetDateTime>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(OffsetDateTime.class), this);
         }
 
         @Override
@@ -610,7 +612,7 @@ public final class EteServiceEndpoints implements UndertowService {
         PathEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(String.class), this);
         }
 
         @Override
@@ -659,7 +661,7 @@ public final class EteServiceEndpoints implements UndertowService {
         ExternalLongPathEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Long>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(Long.class), this);
         }
 
         @Override
@@ -708,7 +710,8 @@ public final class EteServiceEndpoints implements UndertowService {
         OptionalExternalLongQueryEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<Long>>() {}, this);
+            this.serializer = runtime.bodySerDe()
+                    .serializer(TypeMarker.ofGeneric(Optional.class, TypeMarker.of(Long.class)), this);
         }
 
         @Override
@@ -763,8 +766,8 @@ public final class EteServiceEndpoints implements UndertowService {
         NotNullBodyEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<StringAliasExample>() {}, this);
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<StringAliasExample>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(StringAliasExample.class), this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(StringAliasExample.class), this);
         }
 
         @Override
@@ -811,7 +814,7 @@ public final class EteServiceEndpoints implements UndertowService {
         AliasOneEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<StringAliasExample>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(StringAliasExample.class), this);
         }
 
         @Override
@@ -862,7 +865,7 @@ public final class EteServiceEndpoints implements UndertowService {
         OptionalAliasOneEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<StringAliasExample>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(StringAliasExample.class), this);
         }
 
         @Override
@@ -915,7 +918,7 @@ public final class EteServiceEndpoints implements UndertowService {
         AliasTwoEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<NestedStringAliasExample>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(NestedStringAliasExample.class), this);
         }
 
         @Override
@@ -970,9 +973,9 @@ public final class EteServiceEndpoints implements UndertowService {
             this.runtime = runtime;
             this.delegate = delegate;
             this.deserializer = runtime.bodySerDe()
-                    .deserializer(new TypeMarker<allexamples.com.palantir.product.StringAliasExample>() {}, this);
+                    .deserializer(TypeMarker.of(allexamples.com.palantir.product.StringAliasExample.class), this);
             this.serializer = runtime.bodySerDe()
-                    .serializer(new TypeMarker<allexamples.com.palantir.product.StringAliasExample>() {}, this);
+                    .serializer(TypeMarker.of(allexamples.com.palantir.product.StringAliasExample.class), this);
         }
 
         @Override
@@ -1024,10 +1027,16 @@ public final class EteServiceEndpoints implements UndertowService {
             this.delegate = delegate;
             this.deserializer = runtime.bodySerDe()
                     .deserializer(
-                            new TypeMarker<Optional<allexamples.com.palantir.product.StringAliasExample>>() {}, this);
+                            TypeMarker.ofGeneric(
+                                    Optional.class,
+                                    TypeMarker.of(allexamples.com.palantir.product.StringAliasExample.class)),
+                            this);
             this.serializer = runtime.bodySerDe()
                     .serializer(
-                            new TypeMarker<Optional<allexamples.com.palantir.product.StringAliasExample>>() {}, this);
+                            TypeMarker.ofGeneric(
+                                    Optional.class,
+                                    TypeMarker.of(allexamples.com.palantir.product.StringAliasExample.class)),
+                            this);
         }
 
         @Override
@@ -1081,7 +1090,10 @@ public final class EteServiceEndpoints implements UndertowService {
             this.delegate = delegate;
             this.serializer = runtime.bodySerDe()
                     .serializer(
-                            new TypeMarker<Optional<allexamples.com.palantir.product.StringAliasExample>>() {}, this);
+                            TypeMarker.ofGeneric(
+                                    Optional.class,
+                                    TypeMarker.of(allexamples.com.palantir.product.StringAliasExample.class)),
+                            this);
         }
 
         @Override
@@ -1179,7 +1191,7 @@ public final class EteServiceEndpoints implements UndertowService {
         EnumQueryEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<SimpleEnum>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(SimpleEnum.class), this);
         }
 
         @Override
@@ -1230,7 +1242,8 @@ public final class EteServiceEndpoints implements UndertowService {
         EnumListQueryEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<List<SimpleEnum>>() {}, this);
+            this.serializer = runtime.bodySerDe()
+                    .serializer(TypeMarker.ofGeneric(List.class, TypeMarker.of(SimpleEnum.class)), this);
         }
 
         @Override
@@ -1281,7 +1294,8 @@ public final class EteServiceEndpoints implements UndertowService {
         OptionalEnumQueryEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<SimpleEnum>>() {}, this);
+            this.serializer = runtime.bodySerDe()
+                    .serializer(TypeMarker.ofGeneric(Optional.class, TypeMarker.of(SimpleEnum.class)), this);
         }
 
         @Override
@@ -1336,7 +1350,7 @@ public final class EteServiceEndpoints implements UndertowService {
         EnumHeaderEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<SimpleEnum>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(SimpleEnum.class), this);
         }
 
         @Override
@@ -1387,7 +1401,7 @@ public final class EteServiceEndpoints implements UndertowService {
         JsonErrorsHeaderEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(String.class), this);
         }
 
         @Override
@@ -1436,7 +1450,7 @@ public final class EteServiceEndpoints implements UndertowService {
         ErrorParameterSerializationEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(String.class), this);
         }
 
         @Override
@@ -1485,7 +1499,8 @@ public final class EteServiceEndpoints implements UndertowService {
         AliasLongEndpointEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<Optional<LongAlias>>() {}, this);
+            this.serializer = runtime.bodySerDe()
+                    .serializer(TypeMarker.ofGeneric(Optional.class, TypeMarker.of(LongAlias.class)), this);
         }
 
         @Override
@@ -1592,8 +1607,12 @@ public final class EteServiceEndpoints implements UndertowService {
         ReceiveListOfOptionalsEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<ImmutableList<Optional<String>>>() {}, this);
+            this.deserializer = runtime.bodySerDe()
+                    .deserializer(
+                            TypeMarker.ofGeneric(
+                                    ImmutableList.class,
+                                    TypeMarker.ofGeneric(Optional.class, TypeMarker.of(String.class))),
+                            this);
         }
 
         @Override
@@ -1640,8 +1659,12 @@ public final class EteServiceEndpoints implements UndertowService {
         ReceiveSetOfOptionalsEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer =
-                    runtime.bodySerDe().deserializer(new TypeMarker<ImmutableSet<Optional<String>>>() {}, this);
+            this.deserializer = runtime.bodySerDe()
+                    .deserializer(
+                            TypeMarker.ofGeneric(
+                                    ImmutableSet.class,
+                                    TypeMarker.ofGeneric(Optional.class, TypeMarker.of(String.class))),
+                            this);
         }
 
         @Override
@@ -1688,7 +1711,8 @@ public final class EteServiceEndpoints implements UndertowService {
         ReceiveListOfStringsEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<ImmutableList<String>>() {}, this);
+            this.deserializer = runtime.bodySerDe()
+                    .deserializer(TypeMarker.ofGeneric(ImmutableList.class, TypeMarker.of(String.class)), this);
         }
 
         @Override
@@ -1737,8 +1761,8 @@ public final class EteServiceEndpoints implements UndertowService {
         UnionEndpoint(UndertowRuntime runtime, UndertowEteService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<SimpleUnion>() {}, this);
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<SimpleUnion>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(SimpleUnion.class), this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(SimpleUnion.class), this);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/ExternalLongTestServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/ExternalLongTestServiceEndpoints.java
@@ -49,7 +49,7 @@ public final class ExternalLongTestServiceEndpoints implements UndertowService {
         TestDangerousLongEndpoint(UndertowRuntime runtime, UndertowExternalLongTestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Long>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(Long.class), this);
         }
 
         @Override
@@ -96,7 +96,7 @@ public final class ExternalLongTestServiceEndpoints implements UndertowService {
         TestSafeExternalLongEndpoint(UndertowRuntime runtime, UndertowExternalLongTestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Long>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(Long.class), this);
         }
 
         @Override
@@ -143,7 +143,7 @@ public final class ExternalLongTestServiceEndpoints implements UndertowService {
         TestLongEndpoint(UndertowRuntime runtime, UndertowExternalLongTestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<Long>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(Long.class), this);
         }
 
         @Override
@@ -190,7 +190,7 @@ public final class ExternalLongTestServiceEndpoints implements UndertowService {
         TestDangerousLongAliasEndpoint(UndertowRuntime runtime, UndertowExternalLongTestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<DangerousLongAlias>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(DangerousLongAlias.class), this);
         }
 
         @Override
@@ -237,7 +237,7 @@ public final class ExternalLongTestServiceEndpoints implements UndertowService {
         TestSafeExternalLongAliasEndpoint(UndertowRuntime runtime, UndertowExternalLongTestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<SafeLongAlias>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(SafeLongAlias.class), this);
         }
 
         @Override
@@ -284,7 +284,7 @@ public final class ExternalLongTestServiceEndpoints implements UndertowService {
         TestLongAliasEndpoint(UndertowRuntime runtime, UndertowExternalLongTestService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<ExternalLongAlias>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(ExternalLongAlias.class), this);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/undertowasync/test/api/AsyncMarkersEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/undertowasync/test/api/AsyncMarkersEndpoints.java
@@ -48,7 +48,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
         AsyncMarkerEndpoint(UndertowRuntime runtime, AsyncMarkers delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(String.class), this);
         }
 
         @Override
@@ -100,7 +100,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
         AsyncTagEndpoint(UndertowRuntime runtime, AsyncMarkers delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(String.class), this);
         }
 
         @Override
@@ -155,7 +155,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
         SyncEndpoint(UndertowRuntime runtime, AsyncMarkers delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(String.class), this);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/undertowasyncdisabled/test/api/AsyncMarkersEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/undertowasyncdisabled/test/api/AsyncMarkersEndpoints.java
@@ -48,7 +48,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
         AsyncMarkerEndpoint(UndertowRuntime runtime, AsyncMarkers delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(String.class), this);
         }
 
         @Override
@@ -95,7 +95,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
         AsyncTagEndpoint(UndertowRuntime runtime, AsyncMarkers delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(String.class), this);
         }
 
         @Override
@@ -150,7 +150,7 @@ public final class AsyncMarkersEndpoints implements UndertowService {
         SyncEndpoint(UndertowRuntime runtime, AsyncMarkers delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(String.class), this);
         }
 
         @Override

--- a/conjure-java-core/src/integrationInput/java/undertownamecollisions/com/palantir/product/NameCollisionServiceEndpoints.java
+++ b/conjure-java-core/src/integrationInput/java/undertownamecollisions/com/palantir/product/NameCollisionServiceEndpoints.java
@@ -57,8 +57,8 @@ public final class NameCollisionServiceEndpoints implements UndertowService {
         IntEndpoint(UndertowRuntime runtime, UndertowNameCollisionService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {}, this);
-            this.serializer = runtime.bodySerDe().serializer(new TypeMarker<String>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(String.class), this);
+            this.serializer = runtime.bodySerDe().serializer(TypeMarker.of(String.class), this);
         }
 
         @Override
@@ -123,7 +123,7 @@ public final class NameCollisionServiceEndpoints implements UndertowService {
         NoContextEndpoint(UndertowRuntime runtime, UndertowNameCollisionService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(String.class), this);
         }
 
         @Override
@@ -171,7 +171,7 @@ public final class NameCollisionServiceEndpoints implements UndertowService {
         ContextEndpoint(UndertowRuntime runtime, UndertowNameCollisionService delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.deserializer = runtime.bodySerDe().deserializer(new TypeMarker<String>() {}, this);
+            this.deserializer = runtime.bodySerDe().deserializer(TypeMarker.of(String.class), this);
         }
 
         @Override

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java
@@ -287,10 +287,10 @@ final class UndertowServiceHandlerGenerator {
                             FieldSpec.builder(type, DESERIALIZER_VAR_NAME, Modifier.PRIVATE, Modifier.FINAL)
                                     .build());
                     ctorBuilder.addStatement(
-                            "this.$1N = $2N.bodySerDe().deserializer(new $3T() {}, this)",
+                            "this.$1N = $2N.bodySerDe().deserializer($3L, this)",
                             DESERIALIZER_VAR_NAME,
                             RUNTIME_VAR_NAME,
-                            ParameterizedTypeName.get(ClassName.get(TypeMarker.class), typeName));
+                            typeMarker(typeName));
                 });
 
         endpointDefinition.getReturns().ifPresent(returnType -> {
@@ -301,10 +301,10 @@ final class UndertowServiceHandlerGenerator {
                 endpointBuilder.addField(FieldSpec.builder(type, SERIALIZER_VAR_NAME, Modifier.PRIVATE, Modifier.FINAL)
                         .build());
                 ctorBuilder.addStatement(
-                        "this.$1N = $2N.bodySerDe().serializer(new $3T() {}, this)",
+                        "this.$1N = $2N.bodySerDe().serializer($3L, this)",
                         SERIALIZER_VAR_NAME,
                         RUNTIME_VAR_NAME,
-                        ParameterizedTypeName.get(ClassName.get(TypeMarker.class), typeName));
+                        typeMarker(typeName));
             }
         });
 
@@ -404,6 +404,19 @@ final class UndertowServiceHandlerGenerator {
     private static final ClassName IMMUTABLE_LIST_NAME = ClassName.get(ImmutableList.class);
     private static final ClassName SET_NAME = ClassName.get(Set.class);
     private static final ClassName IMMUTABLE_SET_NAME = ClassName.get(ImmutableSet.class);
+
+    private static CodeBlock typeMarker(TypeName typeName) {
+        if (typeName instanceof ClassName className) {
+            return CodeBlock.of("$T.of($T.class)", TypeMarker.class, className);
+        }
+        if (typeName instanceof ParameterizedTypeName parameterizedTypeName) {
+            CodeBlock.Builder result =
+                    CodeBlock.builder().add("$T.ofGeneric($T.class", TypeMarker.class, parameterizedTypeName.rawType());
+            parameterizedTypeName.typeArguments().forEach(typeArgument -> result.add(", $L", typeMarker(typeArgument)));
+            return result.add(")").build();
+        }
+        throw new SafeIllegalStateException("Unsupported type marker type", SafeArg.of("type", typeName));
+    }
 
     private TypeName immutableCollection(TypeName input) {
         // Note that only the outermost collection is considered for replacement to avoid

--- a/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/TypeMarkersTest.java
+++ b/conjure-java-undertow-runtime/src/test/java/com/palantir/conjure/java/undertow/runtime/TypeMarkersTest.java
@@ -31,6 +31,23 @@ import org.junit.jupiter.api.Test;
 public class TypeMarkersTest {
 
     @Test
+    public void testFactoryForClass() {
+        TypeMarker<String> marker = TypeMarker.of(String.class);
+
+        assertThat(marker.getType()).isEqualTo(String.class);
+    }
+
+    @Test
+    public void testFactoryForGenericType() {
+        TypeMarker<List<Optional<String>>> marker =
+                TypeMarker.ofGeneric(List.class, TypeMarker.ofGeneric(Optional.class, TypeMarker.of(String.class)));
+
+        assertThat(marker).isEqualTo(new TypeMarker<List<Optional<String>>>() {});
+        assertThat(marker.getType().getTypeName()).isEqualTo("java.util.List<java.util.Optional<java.lang.String>>");
+        assertThat(marker.getClass()).isEqualTo(TypeMarker.of(String.class).getClass());
+    }
+
+    @Test
     public void testIsOptional_optional() {
         assertThat(TypeMarkers.isOptional(new TypeMarker<Optional<String>>() {}))
                 .isTrue();

--- a/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/TypeMarker.java
+++ b/conjure-undertow-lib/src/main/java/com/palantir/conjure/java/undertow/lib/TypeMarker.java
@@ -21,6 +21,8 @@ import com.palantir.logsafe.SafeArg;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Captures generic type information.
@@ -79,14 +81,110 @@ public abstract class TypeMarker<T> {
         return "TypeMarker{type=" + type + '}';
     }
 
-    /** Create a new {@link TypeMarker} instance wrapping the provided {@link Type}. */
-    public static TypeMarker<?> of(Type type) {
-        return new WrappingTypeMarker(type);
+    /** Create a new {@link TypeMarker} instance wrapping the provided class. */
+    public static <T> TypeMarker<T> of(Class<T> type) {
+        return new WrappingTypeMarker<>(type);
     }
 
-    private static final class WrappingTypeMarker extends TypeMarker<Object> {
+    /** Create a new {@link TypeMarker} instance wrapping the provided {@link Type}. */
+    public static TypeMarker<?> of(Type type) {
+        return new WrappingTypeMarker<>(type);
+    }
+
+    /**
+     * Creates a type marker for a parameterized type. The returned type is inferred from the invocation context, so
+     * callers must ensure it matches {@code rawType} and {@code typeArguments}.
+     */
+    @SafeVarargs
+    public static <T> TypeMarker<T> ofGeneric(Class<?> rawType, TypeMarker<?>... typeArguments) {
+        Preconditions.checkNotNull(rawType, "Raw type is required");
+        TypeMarker<?>[] checkedTypeArguments = Preconditions.checkNotNull(typeArguments, "Type arguments are required");
+        int expectedTypeArguments = rawType.getTypeParameters().length;
+        Preconditions.checkArgument(
+                expectedTypeArguments > 0, "Raw type is not generic", SafeArg.of("rawType", rawType));
+        Preconditions.checkArgument(
+                expectedTypeArguments == checkedTypeArguments.length,
+                "Incorrect number of type arguments",
+                SafeArg.of("rawType", rawType),
+                SafeArg.of("expected", expectedTypeArguments),
+                SafeArg.of("actual", checkedTypeArguments.length));
+        Type[] types = new Type[checkedTypeArguments.length];
+        for (int index = 0; index < checkedTypeArguments.length; index++) {
+            types[index] = Preconditions.checkNotNull(checkedTypeArguments[index], "Type argument is required")
+                    .getType();
+        }
+        return new WrappingTypeMarker<>(new ParameterizedTypeImpl(rawType, types));
+    }
+
+    private static final class WrappingTypeMarker<T> extends TypeMarker<T> {
         private WrappingTypeMarker(Type type) {
             super(type);
+        }
+    }
+
+    private static final class ParameterizedTypeImpl implements ParameterizedType {
+        private final Class<?> rawType;
+        private final Type ownerType;
+        private final Type[] typeArguments;
+
+        private ParameterizedTypeImpl(Class<?> rawType, Type[] typeArguments) {
+            this.rawType = rawType;
+            this.ownerType = rawType.getDeclaringClass();
+            this.typeArguments = typeArguments.clone();
+        }
+
+        @Override
+        public Type[] getActualTypeArguments() {
+            return typeArguments.clone();
+        }
+
+        @Override
+        public Type getRawType() {
+            return rawType;
+        }
+
+        @Override
+        public Type getOwnerType() {
+            return ownerType;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof ParameterizedType that)) {
+                return false;
+            }
+            return Objects.equals(ownerType, that.getOwnerType())
+                    && Objects.equals(rawType, that.getRawType())
+                    && Arrays.equals(typeArguments, that.getActualTypeArguments());
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(typeArguments) ^ Objects.hashCode(ownerType) ^ Objects.hashCode(rawType);
+        }
+
+        @Override
+        public String getTypeName() {
+            return toString();
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder result = new StringBuilder(rawType.getTypeName());
+            if (typeArguments.length > 0) {
+                result.append('<');
+                for (int index = 0; index < typeArguments.length; index++) {
+                    if (index > 0) {
+                        result.append(", ");
+                    }
+                    result.append(typeArguments[index].getTypeName());
+                }
+                result.append('>');
+            }
+            return result.toString();
         }
     }
 }

--- a/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
+++ b/conjure-undertow-processor/src/main/java/com/palantir/conjure/java/undertow/processor/generate/ConjureUndertowEndpointsGenerator.java
@@ -205,11 +205,10 @@ public final class ConjureUndertowEndpointsGenerator {
                                         .build())
                                 .constructorInitializer(CodeBlock.builder()
                                         .addStatement(
-                                                "this.$N = $L.deserializer(new $T<$T>() {}, $N, this)",
+                                                "this.$N = $L.deserializer($L, $N, this)",
                                                 deserializerFieldName,
                                                 deserializerFactory,
-                                                TypeMarker.class,
-                                                requestBodyType,
+                                                typeMarker(requestBodyType),
                                                 RUNTIME_NAME)
                                         .build())
                                 .build());
@@ -457,11 +456,10 @@ public final class ConjureUndertowEndpointsGenerator {
                             .build())
                     .constructorInitializer(CodeBlock.builder()
                             .addStatement(
-                                    "this.$N = $L.serializer(new $T<$T>() {}, $N, this)",
+                                    "this.$N = $L.serializer($L, $N, this)",
                                     returnType.serializerFieldName(),
                                     returnType.serializerFactory(),
-                                    TypeMarker.class,
-                                    responseTypeName,
+                                    typeMarker(responseTypeName),
                                     RUNTIME_NAME)
                             .build())
                     .build());
@@ -823,6 +821,19 @@ public final class ConjureUndertowEndpointsGenerator {
             .put(ClassName.get(ListMultimap.class), ImmutableListMultimap.class)
             .put(ClassName.get(SetMultimap.class), ImmutableSetMultimap.class)
             .buildOrThrow();
+
+    private static CodeBlock typeMarker(TypeName typeName) {
+        if (typeName instanceof ClassName className) {
+            return CodeBlock.of("$T.of($T.class)", TypeMarker.class, className);
+        }
+        if (typeName instanceof ParameterizedTypeName parameterizedTypeName) {
+            CodeBlock.Builder result =
+                    CodeBlock.builder().add("$T.ofGeneric($T.class", TypeMarker.class, parameterizedTypeName.rawType());
+            parameterizedTypeName.typeArguments().forEach(typeArgument -> result.add(", $L", typeMarker(typeArgument)));
+            return result.add(")").build();
+        }
+        throw new SafeIllegalStateException("Unsupported type marker type", SafeArg.of("type", typeName));
+    }
 
     private static TypeName immutableCollection(TypeName input) {
         if (input instanceof ParameterizedTypeName parameterized) {

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/CollectionBodyParamEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/CollectionBodyParamEndpoints.java.generated
@@ -58,8 +58,8 @@ public final class CollectionBodyParamEndpoints implements UndertowService {
         CollectionEndpoint(UndertowRuntime runtime, CollectionBodyParam delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.valuesDeserializer =
-                    DefaultSerDe.INSTANCE.deserializer(new TypeMarker<ImmutableList<String>>() {}, runtime, this);
+            this.valuesDeserializer = DefaultSerDe.INSTANCE.deserializer(
+                    TypeMarker.ofGeneric(ImmutableList.class, TypeMarker.of(String.class)), runtime, this);
         }
 
         @Override
@@ -105,8 +105,8 @@ public final class CollectionBodyParamEndpoints implements UndertowService {
         ListEndpoint(UndertowRuntime runtime, CollectionBodyParam delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.valuesDeserializer =
-                    DefaultSerDe.INSTANCE.deserializer(new TypeMarker<ImmutableList<String>>() {}, runtime, this);
+            this.valuesDeserializer = DefaultSerDe.INSTANCE.deserializer(
+                    TypeMarker.ofGeneric(ImmutableList.class, TypeMarker.of(String.class)), runtime, this);
         }
 
         @Override
@@ -152,8 +152,8 @@ public final class CollectionBodyParamEndpoints implements UndertowService {
         SetEndpoint(UndertowRuntime runtime, CollectionBodyParam delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.valuesDeserializer =
-                    DefaultSerDe.INSTANCE.deserializer(new TypeMarker<ImmutableSet<String>>() {}, runtime, this);
+            this.valuesDeserializer = DefaultSerDe.INSTANCE.deserializer(
+                    TypeMarker.ofGeneric(ImmutableSet.class, TypeMarker.of(String.class)), runtime, this);
         }
 
         @Override
@@ -200,7 +200,9 @@ public final class CollectionBodyParamEndpoints implements UndertowService {
             this.runtime = runtime;
             this.delegate = delegate;
             this.valuesDeserializer = DefaultSerDe.INSTANCE.deserializer(
-                    new TypeMarker<ImmutableMap<String, String>>() {}, runtime, this);
+                    TypeMarker.ofGeneric(ImmutableMap.class, TypeMarker.of(String.class), TypeMarker.of(String.class)),
+                    runtime,
+                    this);
         }
 
         @Override
@@ -246,8 +248,8 @@ public final class CollectionBodyParamEndpoints implements UndertowService {
         MultisetEndpoint(UndertowRuntime runtime, CollectionBodyParam delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.valuesDeserializer =
-                    DefaultSerDe.INSTANCE.deserializer(new TypeMarker<ImmutableMultiset<String>>() {}, runtime, this);
+            this.valuesDeserializer = DefaultSerDe.INSTANCE.deserializer(
+                    TypeMarker.ofGeneric(ImmutableMultiset.class, TypeMarker.of(String.class)), runtime, this);
         }
 
         @Override
@@ -294,7 +296,10 @@ public final class CollectionBodyParamEndpoints implements UndertowService {
             this.runtime = runtime;
             this.delegate = delegate;
             this.valuesDeserializer = DefaultSerDe.INSTANCE.deserializer(
-                    new TypeMarker<ImmutableListMultimap<String, String>>() {}, runtime, this);
+                    TypeMarker.ofGeneric(
+                            ImmutableListMultimap.class, TypeMarker.of(String.class), TypeMarker.of(String.class)),
+                    runtime,
+                    this);
         }
 
         @Override
@@ -341,7 +346,10 @@ public final class CollectionBodyParamEndpoints implements UndertowService {
             this.runtime = runtime;
             this.delegate = delegate;
             this.valuesDeserializer = DefaultSerDe.INSTANCE.deserializer(
-                    new TypeMarker<ImmutableListMultimap<String, String>>() {}, runtime, this);
+                    TypeMarker.ofGeneric(
+                            ImmutableListMultimap.class, TypeMarker.of(String.class), TypeMarker.of(String.class)),
+                    runtime,
+                    this);
         }
 
         @Override
@@ -388,7 +396,10 @@ public final class CollectionBodyParamEndpoints implements UndertowService {
             this.runtime = runtime;
             this.delegate = delegate;
             this.valuesDeserializer = DefaultSerDe.INSTANCE.deserializer(
-                    new TypeMarker<ImmutableSetMultimap<String, String>>() {}, runtime, this);
+                    TypeMarker.ofGeneric(
+                            ImmutableSetMultimap.class, TypeMarker.of(String.class), TypeMarker.of(String.class)),
+                    runtime,
+                    this);
         }
 
         @Override

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/CookieParamsEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/CookieParamsEndpoints.java.generated
@@ -68,7 +68,7 @@ public final class CookieParamsEndpoints implements UndertowService {
                     "optionalIntCookie", ParamDecoders.optionalIntegerParamDecoder(runtime.plainSerDe()));
             this.decoderCookieDeserializer =
                     new CookieDeserializer<>("decoderCookie", CookieParams.StringParamDecoder.INSTANCE);
-            this.cookieParamsSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+            this.cookieParamsSerializer = DefaultSerDe.INSTANCE.serializer(TypeMarker.of(String.class), runtime, this);
         }
 
         @Override

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderServiceEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DefaultDecoderServiceEndpoints.java.generated
@@ -154,7 +154,7 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                     "createFactory",
                     ParamDecoders.complexCollectionParamDecoder(
                             runtime.plainSerDe(), DefaultDecoderService.CreateFactory::create));
-            this.queryParamSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+            this.queryParamSerializer = DefaultSerDe.INSTANCE.serializer(TypeMarker.of(String.class), runtime, this);
         }
 
         @Override
@@ -333,7 +333,7 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                     "createFactory",
                     ParamDecoders.complexCollectionParamDecoder(
                             runtime.plainSerDe(), DefaultDecoderService.CreateFactory::create));
-            this.formParamSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+            this.formParamSerializer = DefaultSerDe.INSTANCE.serializer(TypeMarker.of(String.class), runtime, this);
         }
 
         @Override
@@ -491,7 +491,7 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                     "createFactory",
                     ParamDecoders.complexCollectionParamDecoder(
                             runtime.plainSerDe(), DefaultDecoderService.CreateFactory::create));
-            this.headersSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+            this.headersSerializer = DefaultSerDe.INSTANCE.serializer(TypeMarker.of(String.class), runtime, this);
         }
 
         @Override
@@ -623,7 +623,7 @@ public final class DefaultDecoderServiceEndpoints implements UndertowService {
                     "createFactory",
                     ParamDecoders.complexParamDecoder(
                             runtime.plainSerDe(), DefaultDecoderService.CreateFactory::create));
-            this.pathParamSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+            this.pathParamSerializer = DefaultSerDe.INSTANCE.serializer(TypeMarker.of(String.class), runtime, this);
         }
 
         @Override

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DeprecatedEndpointResourceEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DeprecatedEndpointResourceEndpoints.java.generated
@@ -48,7 +48,7 @@ public final class DeprecatedEndpointResourceEndpoints implements UndertowServic
         PingEndpoint(UndertowRuntime runtime, DeprecatedEndpointResource delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.pingSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+            this.pingSerializer = DefaultSerDe.INSTANCE.serializer(TypeMarker.of(String.class), runtime, this);
         }
 
         @Override

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DeprecatedResourceEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/DeprecatedResourceEndpoints.java.generated
@@ -49,7 +49,7 @@ public final class DeprecatedResourceEndpoints implements UndertowService {
         PingEndpoint(UndertowRuntime runtime, DeprecatedResource delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.pingSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+            this.pingSerializer = DefaultSerDe.INSTANCE.serializer(TypeMarker.of(String.class), runtime, this);
         }
 
         @Override

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/ExtendsNestedEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/ExtendsNestedEndpoints.java.generated
@@ -89,7 +89,7 @@ public final class ExtendsNestedEndpoints implements UndertowService {
         GreetEndpoint(UndertowRuntime runtime, ExtendsNested delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.greetSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+            this.greetSerializer = DefaultSerDe.INSTANCE.serializer(TypeMarker.of(String.class), runtime, this);
         }
 
         @Override

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/ExtendsSimpleInterfaceEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/ExtendsSimpleInterfaceEndpoints.java.generated
@@ -89,7 +89,7 @@ public final class ExtendsSimpleInterfaceEndpoints implements UndertowService {
         GreetEndpoint(UndertowRuntime runtime, ExtendsSimpleInterface delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.greetSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+            this.greetSerializer = DefaultSerDe.INSTANCE.serializer(TypeMarker.of(String.class), runtime, this);
         }
 
         @Override

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/GenericImplEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/GenericImplEndpoints.java.generated
@@ -58,13 +58,13 @@ public final class GenericImplEndpoints implements UndertowService {
         GenericEndpoint(UndertowRuntime runtime, GenericImpl delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.inputDeserializer = DefaultSerDe.INSTANCE.deserializer(new TypeMarker<String>() {}, runtime, this);
+            this.inputDeserializer = DefaultSerDe.INSTANCE.deserializer(TypeMarker.of(String.class), runtime, this);
             this.pathParamDeserializer = new PathParamDeserializer<>(
                     "pathParam",
                     ParamDecoders.complexParamDecoder(runtime.plainSerDe(), GenericImpl.ParamExample::valueOf));
             this.queryParamDeserializer = new QueryParamDeserializer<>(
                     "queryParam", ParamDecoders.integerCollectionParamDecoder(runtime.plainSerDe()));
-            this.genericSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<Boolean>() {}, runtime, this);
+            this.genericSerializer = DefaultSerDe.INSTANCE.serializer(TypeMarker.of(Boolean.class), runtime, this);
         }
 
         @Override

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/MultipleBodyInterfaceEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/MultipleBodyInterfaceEndpoints.java.generated
@@ -49,9 +49,9 @@ public final class MultipleBodyInterfaceEndpoints implements UndertowService {
         PostEndpoint(UndertowRuntime runtime, MultipleBodyInterface delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.oneDeserializer = DefaultSerDe.INSTANCE.deserializer(new TypeMarker<String>() {}, runtime, this);
-            this.twoDeserializer = DefaultSerDe.INSTANCE.deserializer(new TypeMarker<String>() {}, runtime, this);
-            this.threeDeserializer = DefaultSerDe.INSTANCE.deserializer(new TypeMarker<String>() {}, runtime, this);
+            this.oneDeserializer = DefaultSerDe.INSTANCE.deserializer(TypeMarker.of(String.class), runtime, this);
+            this.twoDeserializer = DefaultSerDe.INSTANCE.deserializer(TypeMarker.of(String.class), runtime, this);
+            this.threeDeserializer = DefaultSerDe.INSTANCE.deserializer(TypeMarker.of(String.class), runtime, this);
         }
 
         @Override

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/OverloadedResourceEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/OverloadedResourceEndpoints.java.generated
@@ -49,7 +49,7 @@ public final class OverloadedResourceEndpoints implements UndertowService {
         EndpointEndpoint_0(UndertowRuntime runtime, OverloadedResource delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.endpointSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+            this.endpointSerializer = DefaultSerDe.INSTANCE.serializer(TypeMarker.of(String.class), runtime, this);
         }
 
         @Override
@@ -102,7 +102,7 @@ public final class OverloadedResourceEndpoints implements UndertowService {
             this.delegate = delegate;
             this.valueDeserializer =
                     new QueryParamDeserializer<>("q", ParamDecoders.stringCollectionParamDecoder(runtime.plainSerDe()));
-            this.endpointSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+            this.endpointSerializer = DefaultSerDe.INSTANCE.serializer(TypeMarker.of(String.class), runtime, this);
         }
 
         @Override

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/PrimitiveBodyParamEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/PrimitiveBodyParamEndpoints.java.generated
@@ -46,7 +46,7 @@ public final class PrimitiveBodyParamEndpoints implements UndertowService {
             this.runtime = runtime;
             this.delegate = delegate;
             this.countDeserializer = PrimitiveBodyParam.IntParamDeserializerFactory.INSTANCE.deserializer(
-                    new TypeMarker<Integer>() {}, runtime, this);
+                    TypeMarker.of(Integer.class), runtime, this);
         }
 
         @Override

--- a/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/SafeLoggableParamsEndpoints.java.generated
+++ b/conjure-undertow-processor/src/test/resources/com/palantir/conjure/java/undertow/processor/sample/SafeLoggableParamsEndpoints.java.generated
@@ -381,7 +381,7 @@ public final class SafeLoggableParamsEndpoints implements UndertowService {
             this.contextDeserializer = new QueryParamDeserializer<>(
                     "context", ParamDecoders.stringCollectionParamDecoder(runtime.plainSerDe()));
             this.safeLoggingReusesContextSerializer =
-                    DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+                    DefaultSerDe.INSTANCE.serializer(TypeMarker.of(String.class), runtime, this);
         }
 
         @Override
@@ -437,8 +437,8 @@ public final class SafeLoggableParamsEndpoints implements UndertowService {
         BodyParamEndpoint(UndertowRuntime runtime, SafeLoggableParams delegate) {
             this.runtime = runtime;
             this.delegate = delegate;
-            this.bodyDeserializer = DefaultSerDe.INSTANCE.deserializer(new TypeMarker<String>() {}, runtime, this);
-            this.bodyParamSerializer = DefaultSerDe.INSTANCE.serializer(new TypeMarker<String>() {}, runtime, this);
+            this.bodyDeserializer = DefaultSerDe.INSTANCE.deserializer(TypeMarker.of(String.class), runtime, this);
+            this.bodyParamSerializer = DefaultSerDe.INSTANCE.serializer(TypeMarker.of(String.class), runtime, this);
         }
 
         @Override


### PR DESCRIPTION
Generated Conjure code creates anon TypeMarker subclasses liberally. This is done in order to capture generic type information for parameterized classes. Since type erasure prevents directly passing in generic type information as a constructor argument for TypeMarker, the full paramaterized type must come from a subtype, and obtained with getGenericSuperclass(). 

As far as I can tell, the anon TypeMarker subclasses are also generated for non-paramaterized types for the sake of uniformity.

The major drawback is that these TypeMarker classes pollute the class space, and end up consuming material amounts of metaspace. 

Introduce an ofGeneric factory for TypeMarker that accepts the generic type arguments for the paramaterized type as a list, and use the of factory method for TypeMarkers that encapsulate non-paramaterized types. It is, however, not actually typesafe at compile time. 