### PR TITLE
fix: avoid name collision in enum visitor builder for UNKNOWN member

### DIFF
--- a/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/EnumExample.java
@@ -163,7 +163,7 @@ public final class EnumExample {
             implements OneStageVisitorBuilder<T>,
                     TwoStageVisitorBuilder<T>,
                     OneHundredStageVisitorBuilder<T>,
-                    UnknownStageVisitorBuilder<T>,
+                    Unknown_StageVisitorBuilder<T>,
                     Completed_StageVisitorBuilder<T> {
         private Supplier<T> oneVisitor;
 
@@ -188,7 +188,7 @@ public final class EnumExample {
         }
 
         @Override
-        public UnknownStageVisitorBuilder<T> visitOneHundred(@Nonnull Supplier<T> oneHundredVisitor) {
+        public Unknown_StageVisitorBuilder<T> visitOneHundred(@Nonnull Supplier<T> oneHundredVisitor) {
             Preconditions.checkNotNull(oneHundredVisitor, "oneHundredVisitor cannot be null");
             this.oneHundredVisitor = oneHundredVisitor;
             return this;
@@ -249,10 +249,10 @@ public final class EnumExample {
     }
 
     public interface OneHundredStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> visitOneHundred(@Nonnull Supplier<T> oneHundredVisitor);
+        Unknown_StageVisitorBuilder<T> visitOneHundred(@Nonnull Supplier<T> oneHundredVisitor);
     }
 
-    public interface UnknownStageVisitorBuilder<T> {
+    public interface Unknown_StageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();

--- a/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/EnumNameTestExample.java
+++ b/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/EnumNameTestExample.java
@@ -124,7 +124,7 @@ public final class EnumNameTestExample {
     private static final class VisitorBuilder<T>
             implements IncompleteStageVisitorBuilder<T>,
                     CompletedStageVisitorBuilder<T>,
-                    UnknownStageVisitorBuilder<T>,
+                    Unknown_StageVisitorBuilder<T>,
                     Completed_StageVisitorBuilder<T> {
         private Supplier<T> incompleteVisitor;
 
@@ -140,7 +140,7 @@ public final class EnumNameTestExample {
         }
 
         @Override
-        public UnknownStageVisitorBuilder<T> visitCompleted(@Nonnull Supplier<T> completedVisitor) {
+        public Unknown_StageVisitorBuilder<T> visitCompleted(@Nonnull Supplier<T> completedVisitor) {
             Preconditions.checkNotNull(completedVisitor, "completedVisitor cannot be null");
             this.completedVisitor = completedVisitor;
             return this;
@@ -191,10 +191,10 @@ public final class EnumNameTestExample {
     }
 
     public interface CompletedStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> visitCompleted(@Nonnull Supplier<T> completedVisitor);
+        Unknown_StageVisitorBuilder<T> visitCompleted(@Nonnull Supplier<T> completedVisitor);
     }
 
-    public interface UnknownStageVisitorBuilder<T> {
+    public interface Unknown_StageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();

--- a/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/allexamples/com/palantir/product/SimpleEnum.java
@@ -111,13 +111,13 @@ public final class SimpleEnum {
     }
 
     private static final class VisitorBuilder<T>
-            implements ValueStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
+            implements ValueStageVisitorBuilder<T>, Unknown_StageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
         private Supplier<T> valueVisitor;
 
         private Function<@Safe String, T> unknownVisitor;
 
         @Override
-        public UnknownStageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor) {
+        public Unknown_StageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor) {
             Preconditions.checkNotNull(valueVisitor, "valueVisitor cannot be null");
             this.valueVisitor = valueVisitor;
             return this;
@@ -158,10 +158,10 @@ public final class SimpleEnum {
     }
 
     public interface ValueStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor);
+        Unknown_StageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor);
     }
 
-    public interface UnknownStageVisitorBuilder<T> {
+    public interface Unknown_StageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();

--- a/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/EnumExample.java
@@ -123,7 +123,7 @@ public final class EnumExample {
     private static final class VisitorBuilder<T>
             implements AStageVisitorBuilder<T>,
                     BStageVisitorBuilder<T>,
-                    UnknownStageVisitorBuilder<T>,
+                    Unknown_StageVisitorBuilder<T>,
                     Completed_StageVisitorBuilder<T> {
         private Supplier<T> aVisitor;
 
@@ -139,7 +139,7 @@ public final class EnumExample {
         }
 
         @Override
-        public UnknownStageVisitorBuilder<T> visitB(@Nonnull Supplier<T> bVisitor) {
+        public Unknown_StageVisitorBuilder<T> visitB(@Nonnull Supplier<T> bVisitor) {
             Preconditions.checkNotNull(bVisitor, "bVisitor cannot be null");
             this.bVisitor = bVisitor;
             return this;
@@ -190,10 +190,10 @@ public final class EnumExample {
     }
 
     public interface BStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> visitB(@Nonnull Supplier<T> bVisitor);
+        Unknown_StageVisitorBuilder<T> visitB(@Nonnull Supplier<T> bVisitor);
     }
 
-    public interface UnknownStageVisitorBuilder<T> {
+    public interface Unknown_StageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();

--- a/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/dialogue/com/palantir/product/SimpleEnum.java
@@ -111,13 +111,13 @@ public final class SimpleEnum {
     }
 
     private static final class VisitorBuilder<T>
-            implements ValueStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
+            implements ValueStageVisitorBuilder<T>, Unknown_StageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
         private Supplier<T> valueVisitor;
 
         private Function<@Safe String, T> unknownVisitor;
 
         @Override
-        public UnknownStageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor) {
+        public Unknown_StageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor) {
             Preconditions.checkNotNull(valueVisitor, "valueVisitor cannot be null");
             this.valueVisitor = valueVisitor;
             return this;
@@ -158,10 +158,10 @@ public final class SimpleEnum {
     }
 
     public interface ValueStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor);
+        Unknown_StageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor);
     }
 
-    public interface UnknownStageVisitorBuilder<T> {
+    public interface Unknown_StageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();

--- a/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/OptionalBinaryResponseMode.java
+++ b/conjure-java-core/src/integrationInput/java/endpointerrors/com/palantir/product/OptionalBinaryResponseMode.java
@@ -137,7 +137,7 @@ public final class OptionalBinaryResponseMode {
             implements PresentStageVisitorBuilder<T>,
                     AbsentStageVisitorBuilder<T>,
                     ErrorStageVisitorBuilder<T>,
-                    UnknownStageVisitorBuilder<T>,
+                    Unknown_StageVisitorBuilder<T>,
                     Completed_StageVisitorBuilder<T> {
         private Supplier<T> presentVisitor;
 
@@ -162,7 +162,7 @@ public final class OptionalBinaryResponseMode {
         }
 
         @Override
-        public UnknownStageVisitorBuilder<T> visitError(@Nonnull Supplier<T> errorVisitor) {
+        public Unknown_StageVisitorBuilder<T> visitError(@Nonnull Supplier<T> errorVisitor) {
             Preconditions.checkNotNull(errorVisitor, "errorVisitor cannot be null");
             this.errorVisitor = errorVisitor;
             return this;
@@ -224,10 +224,10 @@ public final class OptionalBinaryResponseMode {
     }
 
     public interface ErrorStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> visitError(@Nonnull Supplier<T> errorVisitor);
+        Unknown_StageVisitorBuilder<T> visitError(@Nonnull Supplier<T> errorVisitor);
     }
 
-    public interface UnknownStageVisitorBuilder<T> {
+    public interface Unknown_StageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();

--- a/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/errors/com/palantir/product/EnumExample.java
@@ -123,7 +123,7 @@ public final class EnumExample {
     private static final class VisitorBuilder<T>
             implements AStageVisitorBuilder<T>,
                     BStageVisitorBuilder<T>,
-                    UnknownStageVisitorBuilder<T>,
+                    Unknown_StageVisitorBuilder<T>,
                     Completed_StageVisitorBuilder<T> {
         private Supplier<T> aVisitor;
 
@@ -139,7 +139,7 @@ public final class EnumExample {
         }
 
         @Override
-        public UnknownStageVisitorBuilder<T> visitB(@Nonnull Supplier<T> bVisitor) {
+        public Unknown_StageVisitorBuilder<T> visitB(@Nonnull Supplier<T> bVisitor) {
             Preconditions.checkNotNull(bVisitor, "bVisitor cannot be null");
             this.bVisitor = bVisitor;
             return this;
@@ -190,10 +190,10 @@ public final class EnumExample {
     }
 
     public interface BStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> visitB(@Nonnull Supplier<T> bVisitor);
+        Unknown_StageVisitorBuilder<T> visitB(@Nonnull Supplier<T> bVisitor);
     }
 
-    public interface UnknownStageVisitorBuilder<T> {
+    public interface Unknown_StageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/EnumExample.java
@@ -123,7 +123,7 @@ public final class EnumExample {
     private static final class VisitorBuilder<T>
             implements AStageVisitorBuilder<T>,
                     BStageVisitorBuilder<T>,
-                    UnknownStageVisitorBuilder<T>,
+                    Unknown_StageVisitorBuilder<T>,
                     Completed_StageVisitorBuilder<T> {
         private Supplier<T> aVisitor;
 
@@ -139,7 +139,7 @@ public final class EnumExample {
         }
 
         @Override
-        public UnknownStageVisitorBuilder<T> visitB(@Nonnull Supplier<T> bVisitor) {
+        public Unknown_StageVisitorBuilder<T> visitB(@Nonnull Supplier<T> bVisitor) {
             Preconditions.checkNotNull(bVisitor, "bVisitor cannot be null");
             this.bVisitor = bVisitor;
             return this;
@@ -190,10 +190,10 @@ public final class EnumExample {
     }
 
     public interface BStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> visitB(@Nonnull Supplier<T> bVisitor);
+        Unknown_StageVisitorBuilder<T> visitB(@Nonnull Supplier<T> bVisitor);
     }
 
-    public interface UnknownStageVisitorBuilder<T> {
+    public interface Unknown_StageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();

--- a/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/exceptionthrowingdialogueinterfaces/com/palantir/product/SimpleEnum.java
@@ -111,13 +111,13 @@ public final class SimpleEnum {
     }
 
     private static final class VisitorBuilder<T>
-            implements ValueStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
+            implements ValueStageVisitorBuilder<T>, Unknown_StageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
         private Supplier<T> valueVisitor;
 
         private Function<@Safe String, T> unknownVisitor;
 
         @Override
-        public UnknownStageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor) {
+        public Unknown_StageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor) {
             Preconditions.checkNotNull(valueVisitor, "valueVisitor cannot be null");
             this.valueVisitor = valueVisitor;
             return this;
@@ -158,10 +158,10 @@ public final class SimpleEnum {
     }
 
     public interface ValueStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor);
+        Unknown_StageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor);
     }
 
-    public interface UnknownStageVisitorBuilder<T> {
+    public interface Unknown_StageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();

--- a/conjure-java-core/src/integrationInput/java/jersey/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/jersey/com/palantir/product/SimpleEnum.java
@@ -111,13 +111,13 @@ public final class SimpleEnum {
     }
 
     private static final class VisitorBuilder<T>
-            implements ValueStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
+            implements ValueStageVisitorBuilder<T>, Unknown_StageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
         private Supplier<T> valueVisitor;
 
         private Function<@Safe String, T> unknownVisitor;
 
         @Override
-        public UnknownStageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor) {
+        public Unknown_StageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor) {
             Preconditions.checkNotNull(valueVisitor, "valueVisitor cannot be null");
             this.valueVisitor = valueVisitor;
             return this;
@@ -158,10 +158,10 @@ public final class SimpleEnum {
     }
 
     public interface ValueStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor);
+        Unknown_StageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor);
     }
 
-    public interface UnknownStageVisitorBuilder<T> {
+    public interface Unknown_StageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();

--- a/conjure-java-core/src/integrationInput/java/template/com/palantir/product/EnumExample.java
+++ b/conjure-java-core/src/integrationInput/java/template/com/palantir/product/EnumExample.java
@@ -163,7 +163,7 @@ public final class EnumExample {
             implements OneStageVisitorBuilder<T>,
                     TwoStageVisitorBuilder<T>,
                     OneHundredStageVisitorBuilder<T>,
-                    UnknownStageVisitorBuilder<T>,
+                    Unknown_StageVisitorBuilder<T>,
                     Completed_StageVisitorBuilder<T> {
         private Supplier<T> oneVisitor;
 
@@ -188,7 +188,7 @@ public final class EnumExample {
         }
 
         @Override
-        public UnknownStageVisitorBuilder<T> visitOneHundred(@Nonnull Supplier<T> oneHundredVisitor) {
+        public Unknown_StageVisitorBuilder<T> visitOneHundred(@Nonnull Supplier<T> oneHundredVisitor) {
             Preconditions.checkNotNull(oneHundredVisitor, "oneHundredVisitor cannot be null");
             this.oneHundredVisitor = oneHundredVisitor;
             return this;
@@ -249,10 +249,10 @@ public final class EnumExample {
     }
 
     public interface OneHundredStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> visitOneHundred(@Nonnull Supplier<T> oneHundredVisitor);
+        Unknown_StageVisitorBuilder<T> visitOneHundred(@Nonnull Supplier<T> oneHundredVisitor);
     }
 
-    public interface UnknownStageVisitorBuilder<T> {
+    public interface Unknown_StageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();

--- a/conjure-java-core/src/integrationInput/java/template/com/palantir/product/EnumNameTestExample.java
+++ b/conjure-java-core/src/integrationInput/java/template/com/palantir/product/EnumNameTestExample.java
@@ -124,7 +124,7 @@ public final class EnumNameTestExample {
     private static final class VisitorBuilder<T>
             implements IncompleteStageVisitorBuilder<T>,
                     CompletedStageVisitorBuilder<T>,
-                    UnknownStageVisitorBuilder<T>,
+                    Unknown_StageVisitorBuilder<T>,
                     Completed_StageVisitorBuilder<T> {
         private Supplier<T> incompleteVisitor;
 
@@ -140,7 +140,7 @@ public final class EnumNameTestExample {
         }
 
         @Override
-        public UnknownStageVisitorBuilder<T> visitCompleted(@Nonnull Supplier<T> completedVisitor) {
+        public Unknown_StageVisitorBuilder<T> visitCompleted(@Nonnull Supplier<T> completedVisitor) {
             Preconditions.checkNotNull(completedVisitor, "completedVisitor cannot be null");
             this.completedVisitor = completedVisitor;
             return this;
@@ -191,10 +191,10 @@ public final class EnumNameTestExample {
     }
 
     public interface CompletedStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> visitCompleted(@Nonnull Supplier<T> completedVisitor);
+        Unknown_StageVisitorBuilder<T> visitCompleted(@Nonnull Supplier<T> completedVisitor);
     }
 
-    public interface UnknownStageVisitorBuilder<T> {
+    public interface Unknown_StageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();

--- a/conjure-java-core/src/integrationInput/java/template/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/template/com/palantir/product/SimpleEnum.java
@@ -111,13 +111,13 @@ public final class SimpleEnum {
     }
 
     private static final class VisitorBuilder<T>
-            implements ValueStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
+            implements ValueStageVisitorBuilder<T>, Unknown_StageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
         private Supplier<T> valueVisitor;
 
         private Function<@Safe String, T> unknownVisitor;
 
         @Override
-        public UnknownStageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor) {
+        public Unknown_StageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor) {
             Preconditions.checkNotNull(valueVisitor, "valueVisitor cannot be null");
             this.valueVisitor = valueVisitor;
             return this;
@@ -158,10 +158,10 @@ public final class SimpleEnum {
     }
 
     public interface ValueStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor);
+        Unknown_StageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor);
     }
 
-    public interface UnknownStageVisitorBuilder<T> {
+    public interface Unknown_StageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();

--- a/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/OptionalBinaryResponseMode.java
+++ b/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/OptionalBinaryResponseMode.java
@@ -137,7 +137,7 @@ public final class OptionalBinaryResponseMode {
             implements PresentStageVisitorBuilder<T>,
                     AbsentStageVisitorBuilder<T>,
                     ErrorStageVisitorBuilder<T>,
-                    UnknownStageVisitorBuilder<T>,
+                    Unknown_StageVisitorBuilder<T>,
                     Completed_StageVisitorBuilder<T> {
         private Supplier<T> presentVisitor;
 
@@ -162,7 +162,7 @@ public final class OptionalBinaryResponseMode {
         }
 
         @Override
-        public UnknownStageVisitorBuilder<T> visitError(@Nonnull Supplier<T> errorVisitor) {
+        public Unknown_StageVisitorBuilder<T> visitError(@Nonnull Supplier<T> errorVisitor) {
             Preconditions.checkNotNull(errorVisitor, "errorVisitor cannot be null");
             this.errorVisitor = errorVisitor;
             return this;
@@ -224,10 +224,10 @@ public final class OptionalBinaryResponseMode {
     }
 
     public interface ErrorStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> visitError(@Nonnull Supplier<T> errorVisitor);
+        Unknown_StageVisitorBuilder<T> visitError(@Nonnull Supplier<T> errorVisitor);
     }
 
-    public interface UnknownStageVisitorBuilder<T> {
+    public interface Unknown_StageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();

--- a/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/SimpleEnum.java
+++ b/conjure-java-core/src/integrationInput/java/undertow/com/palantir/product/SimpleEnum.java
@@ -111,13 +111,13 @@ public final class SimpleEnum {
     }
 
     private static final class VisitorBuilder<T>
-            implements ValueStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
+            implements ValueStageVisitorBuilder<T>, Unknown_StageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
         private Supplier<T> valueVisitor;
 
         private Function<@Safe String, T> unknownVisitor;
 
         @Override
-        public UnknownStageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor) {
+        public Unknown_StageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor) {
             Preconditions.checkNotNull(valueVisitor, "valueVisitor cannot be null");
             this.valueVisitor = valueVisitor;
             return this;
@@ -158,10 +158,10 @@ public final class SimpleEnum {
     }
 
     public interface ValueStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor);
+        Unknown_StageVisitorBuilder<T> visitValue(@Nonnull Supplier<T> valueVisitor);
     }
 
-    public interface UnknownStageVisitorBuilder<T> {
+    public interface Unknown_StageVisitorBuilder<T> {
         Completed_StageVisitorBuilder<T> visitUnknown(@Nonnull Function<@Safe String, T> unknownVisitor);
 
         Completed_StageVisitorBuilder<T> throwOnUnknown();

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java
@@ -66,6 +66,7 @@ public final class EnumGenerator {
     private static final TypeVariableName TYPE_VARIABLE = TypeVariableName.get("T");
     private static final String UNKNOWN_TYPE_PARAM_NAME = "unknownType";
     private static final String UNKNOWN_TYPE_NAME = "unknown";
+    private static final String UNKNOWN_HANDLER_STAGE = "unknown_";
     private static final String COMPLETED = "completed_";
     private static final String STAGE_VISITOR_BUILDER = "StageVisitorBuilder";
     private static final String VISITOR_FIELD_NAME_SUFFIX = "Visitor";
@@ -222,7 +223,7 @@ public final class EnumGenerator {
 
     private static Stream<String> stageEnumNames(Iterable<EnumValueDefinition> values) {
         return Stream.concat(
-                ImmutableList.copyOf(values).stream().map(EnumValueDefinition::getValue), Stream.of(UNKNOWN_TYPE_NAME));
+                ImmutableList.copyOf(values).stream().map(EnumValueDefinition::getValue), Stream.of(UNKNOWN_HANDLER_STAGE));
     }
 
     private static List<MethodSpec> generateMemberVisitMethods(Iterable<EnumValueDefinition> values) {
@@ -277,7 +278,7 @@ public final class EnumGenerator {
             String value = valueIter.next();
             String nextBuilderStageName = valueIter.hasNext() ? valueIter.peek() : COMPLETED;
             ClassName nextStageClassName = visitorStageInterfaceName(enclosingClass, nextBuilderStageName);
-            List<MethodSpec> methods = UNKNOWN_TYPE_NAME.equals(value)
+            List<MethodSpec> methods = UNKNOWN_HANDLER_STAGE.equals(value)
                     ? unknownSpecificVisitorPrototypes(visitResultType, nextStageClassName)
                     : ImmutableList.of(visitorBuilderSetterPrototype(value, visitResultType, nextStageClassName)
                             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
@@ -348,14 +349,15 @@ public final class EnumGenerator {
             Iterable<EnumValueDefinition> values, TypeVariableName visitResultType) {
         return stageEnumNames(values)
                 .map(value -> FieldSpec.builder(
-                                UNKNOWN_TYPE_NAME.equals(value)
+                                UNKNOWN_HANDLER_STAGE.equals(value)
                                         ? ParameterizedTypeName.get(
                                                 ClassName.get(Function.class),
                                                 UNKNOWN_MEMBER_TYPE.annotated(AnnotationSpec.builder(Safe.class)
                                                         .build()),
                                                 visitResultType)
                                         : visitorObjectTypeName(visitResultType),
-                                visitorFieldName(value),
+                                visitorFieldName(
+                                        UNKNOWN_HANDLER_STAGE.equals(value) ? UNKNOWN_TYPE_NAME : value),
                                 Modifier.PRIVATE)
                         .build())
                 .collect(Collectors.toList());
@@ -380,7 +382,7 @@ public final class EnumGenerator {
             String value = valueIter.next();
             String nextBuilderStage = valueIter.hasNext() ? valueIter.peek() : COMPLETED;
             ClassName nextVisitorStageClassName = visitorStageInterfaceName(enclosingClass, nextBuilderStage);
-            if (UNKNOWN_TYPE_NAME.equals(value)) {
+            if (UNKNOWN_HANDLER_STAGE.equals(value)) {
                 setterMethods.addAll(
                         unknownSpecificVisitorSetters(enclosingClass, visitResultType, nextVisitorStageClassName));
             } else {
@@ -535,12 +537,15 @@ public final class EnumGenerator {
     private static List<MethodSpec> allDelegatingVisitorMethods(
             Iterable<EnumValueDefinition> values, TypeName visitorResultType) {
         return stageEnumNames(values)
-                .map(value -> UNKNOWN_TYPE_NAME.equals(value)
-                        ? MethodSpec.methodBuilder(getVisitorMethodName(value))
+                .map(value -> UNKNOWN_HANDLER_STAGE.equals(value)
+                        ? MethodSpec.methodBuilder(VISIT_UNKNOWN_METHOD_NAME)
                                 .addModifiers(Modifier.PUBLIC)
                                 .addAnnotation(Override.class)
                                 .addParameter(UNKNOWN_MEMBER_TYPE, UNKNOWN_TYPE_PARAM_NAME)
-                                .addStatement("return $N.apply($N)", visitorFieldName(value), UNKNOWN_TYPE_PARAM_NAME)
+                                .addStatement(
+                                        "return $N.apply($N)",
+                                        visitorFieldName(UNKNOWN_TYPE_NAME),
+                                        UNKNOWN_TYPE_PARAM_NAME)
                                 .returns(visitorResultType)
                                 .build()
                         : MethodSpec.methodBuilder(getVisitorMethodName(value))

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumGeneratorTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/types/EnumGeneratorTest.java
@@ -1,0 +1,79 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.conjure.defs.Conjure;
+import com.palantir.conjure.defs.ConjureArgs;
+import com.palantir.conjure.defs.SafetyDeclarationRequirements;
+import com.palantir.conjure.java.Options;
+import com.palantir.conjure.spec.ConjureDefinition;
+import com.palantir.conjure.spec.EnumDefinition;
+import com.palantir.conjure.spec.EnumValueDefinition;
+import com.palantir.conjure.spec.TypeName;
+import com.palantir.conjure.visitor.TypeDefinitionVisitor;
+import com.palantir.javapoet.JavaFile;
+import java.io.File;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class EnumGeneratorTest {
+
+    private static final TypeName TEST_ENUM = TypeName.of("TestEnumWithUnknownMember", "com.test");
+
+    @Test
+    void visitorBuilderUsesUnderscoreForUnknownHandlerStage() {
+        String source = generateSource(parseEnum("src/test/resources/enum-one-value.yml"));
+
+        assertThat(source).contains("Unknown_StageVisitorBuilder");
+        assertThat(source).doesNotContain("interface UnknownStageVisitorBuilder");
+    }
+
+    @Test
+    void visitorBuilderAvoidsUnknownStageNameCollisionWhenEnumHasUnknownMember() {
+        EnumDefinition definition = EnumDefinition.builder()
+                .typeName(TEST_ENUM)
+                .values(EnumValueDefinition.builder().value("INCOMPLETE").build())
+                .values(EnumValueDefinition.builder().value("UNKNOWN").build())
+                .build();
+
+        String source = generateSource(definition);
+
+        assertThat(source).contains("interface UnknownStageVisitorBuilder");
+        assertThat(source).contains("interface Unknown_StageVisitorBuilder");
+        assertThat(source.split("interface UnknownStageVisitorBuilder", -1)).hasSize(2);
+        assertThat(source.split("interface Unknown_StageVisitorBuilder", -1)).hasSize(2);
+    }
+
+    private static EnumDefinition parseEnum(String yamlPath) {
+        ConjureDefinition conjureDef = Conjure.parse(ConjureArgs.builder()
+                .definitions(List.of(new File(yamlPath)))
+                .safetyDeclarations(SafetyDeclarationRequirements.ALLOWED)
+                .build());
+        return conjureDef.getTypes().stream()
+                .filter(typeDef -> typeDef.accept(TypeDefinitionVisitor.IS_ENUM))
+                .map(typeDef -> typeDef.accept(TypeDefinitionVisitor.ENUM))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static String generateSource(EnumDefinition definition) {
+        JavaFile file = EnumGenerator.generateEnumType(definition, Options.builder().build());
+        return file.toString();
+    }
+}

--- a/conjure-java-core/src/test/resources/enum-one-value.yml
+++ b/conjure-java-core/src/test/resources/enum-one-value.yml
@@ -1,0 +1,7 @@
+types:
+  definitions:
+    default-package: com.test
+    objects:
+      OneValueEnum:
+        values:
+          - ONE


### PR DESCRIPTION
## Summary

- When an enum defines a member named `UNKNOWN`, enum visitor builder generation previously emitted two interfaces named `UnknownStageVisitorBuilder`, which fails to compile (same class of bug as #2100 for `COMPLETED`).
- Name the unknown-value handler stage `unknown_` (generating `Unknown_StageVisitorBuilder`), matching the existing `completed_` / `Completed_StageVisitorBuilder` pattern for the final stage.
- Add `EnumGeneratorTest` covering normal enums and programmatic definitions that include an `UNKNOWN` member.

Fixes #2110

## Test plan

- [x] `./gradlew :conjure-java-core:test --tests "com.palantir.conjure.java.types.EnumGeneratorTest"`
- [x] `./gradlew :conjure-java-core:test --tests "com.palantir.conjure.java.types.EnumTests"`
- [x] `./gradlew :conjure-java-core:test --tests "com.palantir.conjure.java.parameterized.ParameterizedConjureGenerationTest"`